### PR TITLE
[Fix] Update lru-cache package

### DIFF
--- a/.changeset/sour-tables-battle.md
+++ b/.changeset/sour-tables-battle.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Updated `lru-cache` dependency minimum version to prevent downstream consumers of package using broken version.

--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -36,7 +36,7 @@
     "ipaddr.js": "^2.1.0",
     "ix": "^5.0.0",
     "jose": "^4.15.1",
-    "lru-cache": "^10.0.1",
+    "lru-cache": "^10.2.2",
     "mongodb": "^6.5.0",
     "node-fetch": "^3.3.2",
     "pgwire": "github:kagis/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ importers:
         version: 2.27.3
       '@journeyapps-platform/deploy-cli':
         specifier: ^4.4.6
-        version: 4.4.7(@octokit/core@6.1.2)(@types/node@18.11.11)(typescript@4.9.5)
+        version: 4.4.7(@octokit/core@4.2.4(encoding@0.1.13))(@types/node@18.11.11)(encoding@0.1.13)(typescript@4.9.5)
       '@journeyapps-platform/deploy-config':
         specifier: ^3.1.0
         version: 3.1.0
       '@journeyapps-platform/deploy-transformers':
         specifier: ^1.2.32
-        version: 1.2.33(@octokit/core@6.1.2)(@types/node@18.11.11)(typescript@4.9.5)
+        version: 1.2.33(@octokit/core@4.2.4(encoding@0.1.13))(@types/node@18.11.11)(encoding@0.1.13)(typescript@4.9.5)
       '@journeyapps-platform/formatter-cli':
         specifier: ^3.1.9
         version: 3.1.9
@@ -91,7 +91,7 @@ importers:
     dependencies:
       '@journeyapps-platform/micro':
         specifier: ^17.0.1
-        version: 17.0.1
+        version: 17.0.1(encoding@0.1.13)(socks@2.8.3)
       rsocket-core:
         specifier: 1.0.0-alpha.3
         version: 1.0.0-alpha.3
@@ -128,10 +128,10 @@ importers:
     dependencies:
       '@journeyapps-platform/micro':
         specifier: ^17.0.1
-        version: 17.0.1
+        version: 17.0.1(encoding@0.1.13)(socks@2.8.3)
       '@journeyapps-platform/micro-migrate':
         specifier: ^4.0.1
-        version: 4.0.1
+        version: 4.0.1(socks@2.8.3)
       '@opentelemetry/api':
         specifier: ~1.8.0
         version: 1.8.0
@@ -187,11 +187,11 @@ importers:
         specifier: ^4.15.1
         version: 4.15.5
       lru-cache:
-        specifier: ^10.0.1
+        specifier: ^10.2.2
         version: 10.2.2
       mongodb:
         specifier: ^6.5.0
-        version: 6.6.2
+        version: 6.6.2(socks@2.8.3)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -222,7 +222,7 @@ importers:
         version: 5.4.5
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5)
+        version: 4.3.2(typescript@5.4.5)(vite@5.2.11(@types/node@18.11.11))
       vitest:
         specifier: ^0.34.6
         version: 0.34.6
@@ -265,10 +265,10 @@ importers:
         version: 8.4.1
       '@journeyapps-platform/micro':
         specifier: ^17.0.1
-        version: 17.0.1
+        version: 17.0.1(encoding@0.1.13)(socks@2.8.3)
       '@journeyapps-platform/micro-migrate':
         specifier: ^4.0.1
-        version: 4.0.1
+        version: 4.0.1(socks@2.8.3)
       '@opentelemetry/api':
         specifier: ~1.6.0
         version: 1.6.0
@@ -325,7 +325,7 @@ importers:
         version: 10.2.2
       mongodb:
         specifier: ^6.5.0
-        version: 6.6.2
+        version: 6.6.2(socks@2.8.3)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -867,21 +867,9 @@ packages:
     resolution: {integrity: sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==}
     engines: {node: '>= 14'}
 
-  '@octokit/auth-token@5.1.1':
-    resolution: {integrity: sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==}
-    engines: {node: '>= 18'}
-
   '@octokit/core@4.2.4':
     resolution: {integrity: sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==}
     engines: {node: '>= 14'}
-
-  '@octokit/core@6.1.2':
-    resolution: {integrity: sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==}
-    engines: {node: '>= 18'}
-
-  '@octokit/endpoint@10.1.1':
-    resolution: {integrity: sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==}
-    engines: {node: '>= 18'}
 
   '@octokit/endpoint@7.0.6':
     resolution: {integrity: sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==}
@@ -891,15 +879,8 @@ packages:
     resolution: {integrity: sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==}
     engines: {node: '>= 14'}
 
-  '@octokit/graphql@8.1.1':
-    resolution: {integrity: sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==}
-    engines: {node: '>= 18'}
-
   '@octokit/openapi-types@18.1.1':
     resolution: {integrity: sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw==}
-
-  '@octokit/openapi-types@22.2.0':
-    resolution: {integrity: sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==}
 
   '@octokit/plugin-paginate-rest@6.1.2':
     resolution: {integrity: sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==}
@@ -922,17 +903,9 @@ packages:
     resolution: {integrity: sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==}
     engines: {node: '>= 14'}
 
-  '@octokit/request-error@6.1.1':
-    resolution: {integrity: sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==}
-    engines: {node: '>= 18'}
-
   '@octokit/request@6.2.8':
     resolution: {integrity: sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==}
     engines: {node: '>= 14'}
-
-  '@octokit/request@9.1.1':
-    resolution: {integrity: sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==}
-    engines: {node: '>= 18'}
 
   '@octokit/rest@19.0.13':
     resolution: {integrity: sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==}
@@ -943,9 +916,6 @@ packages:
 
   '@octokit/types@10.0.0':
     resolution: {integrity: sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==}
-
-  '@octokit/types@13.5.0':
-    resolution: {integrity: sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==}
 
   '@octokit/types@9.3.2':
     resolution: {integrity: sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==}
@@ -1741,9 +1711,6 @@ packages:
 
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
-
-  before-after-hook@3.0.2:
-    resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
   better-ajv-errors@1.2.0:
     resolution: {integrity: sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==}
@@ -3511,7 +3478,6 @@ packages:
 
   pgwire@https://codeload.github.com/kagis/pgwire/tar.gz/f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87:
     resolution: {tarball: https://codeload.github.com/kagis/pgwire/tar.gz/f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87}
-    name: pgwire
     version: 0.7.0
     engines: {node: '>=14.18.0'}
 
@@ -4400,9 +4366,6 @@ packages:
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
-  universal-user-agent@7.0.2:
-    resolution: {integrity: sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==}
-
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -5036,12 +4999,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
-  '@journeyapps-platform/ci-tools@3.0.7(@octokit/core@6.1.2)':
+  '@journeyapps-platform/ci-tools@3.0.7(@octokit/core@4.2.4(encoding@0.1.13))(encoding@0.1.13)':
     dependencies:
       '@journeyapps-platform/cli-logger': 2.14.8
-      '@octokit/plugin-rest-endpoint-methods': 7.2.3(@octokit/core@6.1.2)
-      '@octokit/rest': 19.0.13
-      node-fetch: 2.7.0
+      '@octokit/plugin-rest-endpoint-methods': 7.2.3(@octokit/core@4.2.4(encoding@0.1.13))
+      '@octokit/rest': 19.0.13(encoding@0.1.13)
+      node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - '@octokit/core'
       - encoding
@@ -5050,9 +5013,9 @@ snapshots:
     dependencies:
       chalk: 4.1.2
 
-  '@journeyapps-platform/deploy-cli@4.4.7(@octokit/core@6.1.2)(@types/node@18.11.11)(typescript@4.9.5)':
+  '@journeyapps-platform/deploy-cli@4.4.7(@octokit/core@4.2.4(encoding@0.1.13))(@types/node@18.11.11)(encoding@0.1.13)(typescript@4.9.5)':
     dependencies:
-      '@journeyapps-platform/ci-tools': 3.0.7(@octokit/core@6.1.2)
+      '@journeyapps-platform/ci-tools': 3.0.7(@octokit/core@4.2.4(encoding@0.1.13))(encoding@0.1.13)
       '@journeyapps-platform/cli-logger': 2.14.8
       '@journeyapps-platform/deploy-config': 3.1.0
       '@journeyapps-platform/filesystem': 3.0.1
@@ -5076,9 +5039,9 @@ snapshots:
       js-yaml: 4.1.0
       lodash: 4.17.21
 
-  '@journeyapps-platform/deploy-transformers@1.2.33(@octokit/core@6.1.2)(@types/node@18.11.11)(typescript@4.9.5)':
+  '@journeyapps-platform/deploy-transformers@1.2.33(@octokit/core@4.2.4(encoding@0.1.13))(@types/node@18.11.11)(encoding@0.1.13)(typescript@4.9.5)':
     dependencies:
-      '@journeyapps-platform/deploy-cli': 4.4.7(@octokit/core@6.1.2)(@types/node@18.11.11)(typescript@4.9.5)
+      '@journeyapps-platform/deploy-cli': 4.4.7(@octokit/core@4.2.4(encoding@0.1.13))(@types/node@18.11.11)(encoding@0.1.13)(typescript@4.9.5)
       inquirer: 8.2.6
     transitivePeerDependencies:
       - '@octokit/core'
@@ -5135,14 +5098,14 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
-  '@journeyapps-platform/micro-authorizers@6.0.0':
+  '@journeyapps-platform/micro-authorizers@6.0.0(encoding@0.1.13)':
     dependencies:
       '@journeyapps-platform/micro-errors': 3.0.0
       '@journeyapps-platform/micro-logger': 3.0.0
       '@journeyapps-platform/micro-schema': 6.0.1
       jose: 4.15.5
       lru-cache: 7.18.3
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -5188,12 +5151,12 @@ snapshots:
 
   '@journeyapps-platform/micro-errors@3.0.0': {}
 
-  '@journeyapps-platform/micro-events@2.0.1':
+  '@journeyapps-platform/micro-events@2.0.1(socks@2.8.3)':
     dependencies:
       '@journeyapps-platform/micro-alerts': 4.0.0
       '@journeyapps-platform/micro-errors': 3.0.0
       '@journeyapps-platform/micro-kafka': 8.0.1
-      '@journeyapps-platform/micro-locks': 2.0.1
+      '@journeyapps-platform/micro-locks': 2.0.1(socks@2.8.3)
       '@journeyapps-platform/micro-logger': 3.0.0
       '@journeyapps-platform/micro-schema': 6.0.1
       '@journeyapps-platform/micro-streaming': 5.0.1
@@ -5202,7 +5165,7 @@ snapshots:
       bson: 6.7.0
       kafkajs: 2.2.4
       lodash: 4.17.21
-      mongodb: 6.6.2
+      mongodb: 6.6.2(socks@2.8.3)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -5226,10 +5189,10 @@ snapshots:
       lodash: 4.17.21
       uuid: 9.0.1
 
-  '@journeyapps-platform/micro-locks@2.0.1':
+  '@journeyapps-platform/micro-locks@2.0.1(socks@2.8.3)':
     dependencies:
       bson: 6.7.0
-      mongodb: 6.6.2
+      mongodb: 6.6.2(socks@2.8.3)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -5251,11 +5214,11 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.3.0
 
-  '@journeyapps-platform/micro-migrate@4.0.1':
+  '@journeyapps-platform/micro-migrate@4.0.1(socks@2.8.3)':
     dependencies:
       '@journeyapps-platform/micro-async-hooks': 2.0.0
       '@journeyapps-platform/micro-logger': 3.0.0
-      '@journeyapps-platform/micro-mongo': 5.0.1
+      '@journeyapps-platform/micro-mongo': 5.0.1(socks@2.8.3)
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
@@ -5266,11 +5229,11 @@ snapshots:
       - snappy
       - socks
 
-  '@journeyapps-platform/micro-mongo@5.0.1':
+  '@journeyapps-platform/micro-mongo@5.0.1(socks@2.8.3)':
     dependencies:
       '@journeyapps-platform/micro-db': 3.0.2
       bson: 6.7.0
-      mongodb: 6.6.2
+      mongodb: 6.6.2(socks@2.8.3)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -5418,20 +5381,20 @@ snapshots:
       lodash: 4.17.21
       zod: 3.23.8
 
-  '@journeyapps-platform/micro@17.0.1':
+  '@journeyapps-platform/micro@17.0.1(encoding@0.1.13)(socks@2.8.3)':
     dependencies:
       '@journeyapps-platform/micro-alerts': 4.0.0
       '@journeyapps-platform/micro-async-hooks': 2.0.0
-      '@journeyapps-platform/micro-authorizers': 6.0.0
+      '@journeyapps-platform/micro-authorizers': 6.0.0(encoding@0.1.13)
       '@journeyapps-platform/micro-codecs': 3.0.1
       '@journeyapps-platform/micro-db': 3.0.2
       '@journeyapps-platform/micro-errors': 3.0.0
-      '@journeyapps-platform/micro-events': 2.0.1
+      '@journeyapps-platform/micro-events': 2.0.1(socks@2.8.3)
       '@journeyapps-platform/micro-kafka': 8.0.1
-      '@journeyapps-platform/micro-locks': 2.0.1
+      '@journeyapps-platform/micro-locks': 2.0.1(socks@2.8.3)
       '@journeyapps-platform/micro-logger': 3.0.0
       '@journeyapps-platform/micro-metrics': 5.0.0
-      '@journeyapps-platform/micro-mongo': 5.0.1
+      '@journeyapps-platform/micro-mongo': 5.0.1(socks@2.8.3)
       '@journeyapps-platform/micro-repl': 4.0.0
       '@journeyapps-platform/micro-router': 7.0.1
       '@journeyapps-platform/micro-router-docs': 2.0.0
@@ -5595,13 +5558,11 @@ snapshots:
 
   '@octokit/auth-token@3.0.4': {}
 
-  '@octokit/auth-token@5.1.1': {}
-
-  '@octokit/core@4.2.4':
+  '@octokit/core@4.2.4(encoding@0.1.13)':
     dependencies:
       '@octokit/auth-token': 3.0.4
-      '@octokit/graphql': 5.0.6
-      '@octokit/request': 6.2.8
+      '@octokit/graphql': 5.0.6(encoding@0.1.13)
+      '@octokit/request': 6.2.8(encoding@0.1.13)
       '@octokit/request-error': 3.0.3
       '@octokit/types': 9.3.2
       before-after-hook: 2.2.3
@@ -5609,63 +5570,35 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@octokit/core@6.1.2':
-    dependencies:
-      '@octokit/auth-token': 5.1.1
-      '@octokit/graphql': 8.1.1
-      '@octokit/request': 9.1.1
-      '@octokit/request-error': 6.1.1
-      '@octokit/types': 13.5.0
-      before-after-hook: 3.0.2
-      universal-user-agent: 7.0.2
-
-  '@octokit/endpoint@10.1.1':
-    dependencies:
-      '@octokit/types': 13.5.0
-      universal-user-agent: 7.0.2
-
   '@octokit/endpoint@7.0.6':
     dependencies:
       '@octokit/types': 9.3.2
       is-plain-object: 5.0.0
       universal-user-agent: 6.0.1
 
-  '@octokit/graphql@5.0.6':
+  '@octokit/graphql@5.0.6(encoding@0.1.13)':
     dependencies:
-      '@octokit/request': 6.2.8
+      '@octokit/request': 6.2.8(encoding@0.1.13)
       '@octokit/types': 9.3.2
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
       - encoding
 
-  '@octokit/graphql@8.1.1':
-    dependencies:
-      '@octokit/request': 9.1.1
-      '@octokit/types': 13.5.0
-      universal-user-agent: 7.0.2
-
   '@octokit/openapi-types@18.1.1': {}
 
-  '@octokit/openapi-types@22.2.0': {}
-
-  '@octokit/plugin-paginate-rest@6.1.2(@octokit/core@4.2.4)':
+  '@octokit/plugin-paginate-rest@6.1.2(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
+      '@octokit/core': 4.2.4(encoding@0.1.13)
       '@octokit/tsconfig': 1.0.2
       '@octokit/types': 9.3.2
 
-  '@octokit/plugin-request-log@1.0.4(@octokit/core@4.2.4)':
+  '@octokit/plugin-request-log@1.0.4(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
+      '@octokit/core': 4.2.4(encoding@0.1.13)
 
-  '@octokit/plugin-rest-endpoint-methods@7.2.3(@octokit/core@4.2.4)':
+  '@octokit/plugin-rest-endpoint-methods@7.2.3(@octokit/core@4.2.4(encoding@0.1.13))':
     dependencies:
-      '@octokit/core': 4.2.4
-      '@octokit/types': 10.0.0
-
-  '@octokit/plugin-rest-endpoint-methods@7.2.3(@octokit/core@6.1.2)':
-    dependencies:
-      '@octokit/core': 6.1.2
+      '@octokit/core': 4.2.4(encoding@0.1.13)
       '@octokit/types': 10.0.0
 
   '@octokit/request-error@3.0.3':
@@ -5674,34 +5607,23 @@ snapshots:
       deprecation: 2.3.1
       once: 1.4.0
 
-  '@octokit/request-error@6.1.1':
-    dependencies:
-      '@octokit/types': 13.5.0
-
-  '@octokit/request@6.2.8':
+  '@octokit/request@6.2.8(encoding@0.1.13)':
     dependencies:
       '@octokit/endpoint': 7.0.6
       '@octokit/request-error': 3.0.3
       '@octokit/types': 9.3.2
       is-plain-object: 5.0.0
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
       - encoding
 
-  '@octokit/request@9.1.1':
+  '@octokit/rest@19.0.13(encoding@0.1.13)':
     dependencies:
-      '@octokit/endpoint': 10.1.1
-      '@octokit/request-error': 6.1.1
-      '@octokit/types': 13.5.0
-      universal-user-agent: 7.0.2
-
-  '@octokit/rest@19.0.13':
-    dependencies:
-      '@octokit/core': 4.2.4
-      '@octokit/plugin-paginate-rest': 6.1.2(@octokit/core@4.2.4)
-      '@octokit/plugin-request-log': 1.0.4(@octokit/core@4.2.4)
-      '@octokit/plugin-rest-endpoint-methods': 7.2.3(@octokit/core@4.2.4)
+      '@octokit/core': 4.2.4(encoding@0.1.13)
+      '@octokit/plugin-paginate-rest': 6.1.2(@octokit/core@4.2.4(encoding@0.1.13))
+      '@octokit/plugin-request-log': 1.0.4(@octokit/core@4.2.4(encoding@0.1.13))
+      '@octokit/plugin-rest-endpoint-methods': 7.2.3(@octokit/core@4.2.4(encoding@0.1.13))
     transitivePeerDependencies:
       - encoding
 
@@ -5710,10 +5632,6 @@ snapshots:
   '@octokit/types@10.0.0':
     dependencies:
       '@octokit/openapi-types': 18.1.1
-
-  '@octokit/types@13.5.0':
-    dependencies:
-      '@octokit/openapi-types': 22.2.0
 
   '@octokit/types@9.3.2':
     dependencies:
@@ -6437,11 +6355,11 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.14.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.14.0
 
   ajv-formats@3.0.1(ajv@8.14.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.14.0
 
   ajv@8.14.0:
@@ -6568,8 +6486,6 @@ snapshots:
   base64-js@1.5.1: {}
 
   before-after-hook@2.2.3: {}
-
-  before-after-hook@3.0.2: {}
 
   better-ajv-errors@1.2.0(ajv@8.14.0):
     dependencies:
@@ -6962,6 +6878,7 @@ snapshots:
   debug@4.3.4(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 5.5.0
 
   debuglog@1.0.1: {}
@@ -8221,11 +8138,13 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 13.0.0
 
-  mongodb@6.6.2:
+  mongodb@6.6.2(socks@2.8.3):
     dependencies:
       '@mongodb-js/saslprep': 1.1.7
       bson: 6.7.0
       mongodb-connection-string-url: 3.0.1
+    optionalDependencies:
+      socks: 2.8.3
 
   moo@0.5.2: {}
 
@@ -8254,9 +8173,11 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-fetch@3.3.2:
     dependencies:
@@ -9459,7 +9380,7 @@ snapshots:
       plimit-lit: 1.6.1
 
   tsconfck@3.0.3(typescript@5.4.5):
-    dependencies:
+    optionalDependencies:
       typescript: 5.4.5
 
   tsconfig@7.0.0:
@@ -9585,8 +9506,6 @@ snapshots:
 
   universal-user-agent@6.0.1: {}
 
-  universal-user-agent@7.0.2: {}
-
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
@@ -9659,22 +9578,24 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5):
+  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.2.11(@types/node@18.11.11)):
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.4.5)
+    optionalDependencies:
+      vite: 5.2.11(@types/node@18.11.11)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
   vite@5.2.11(@types/node@18.11.11):
     dependencies:
-      '@types/node': 18.11.11
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.18.0
     optionalDependencies:
+      '@types/node': 18.11.11
       fsevents: 2.3.3
 
   vitest@0.34.6:


### PR DESCRIPTION
# Overview

The current version range for the `lru-cache` package is `^10.0.1`. Version `10.2.0` contains a broken import/export declaration in its `package.json` file.  The `mjs` folder is not present in the `dist` folder. 

<img width="1151" alt="image" src="https://github.com/powersync-ja/powersync-service/assets/51082125/3595dca0-055e-4bc6-9315-ed5f0912e469">

Updating the version range will ensure consumers of the `@powersync/service-core` package don't install the broken version. 
