### PR TITLE
feature: Added support for user parameters in sync rules.

### DIFF
--- a/.changeset/witty-ducks-work.md
+++ b/.changeset/witty-ducks-work.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': minor
+---
+
+Added support for user parameters when making a StreamingSyncRequest.

--- a/packages/service-core/src/routes/socket-route.ts
+++ b/packages/service-core/src/routes/socket-route.ts
@@ -34,7 +34,11 @@ export const sync_stream_reactive: SocketRouteGenerator = (router) =>
 
       const controller = new AbortController();
 
-      const syncParams: SyncParameters = normalizeTokenParameters(context.token_payload?.parameters ?? {});
+      const syncParams: SyncParameters = normalizeTokenParameters(
+        context.token_payload?.parameters ?? {},
+        params.parameters ?? {}
+      );
+
       const storage = system.storage;
       // Sanity check before we start the stream
       const cp = await storage.getActiveCheckpoint();

--- a/packages/service-core/src/routes/sync-stream.ts
+++ b/packages/service-core/src/routes/sync-stream.ts
@@ -30,7 +30,10 @@ export const syncStreamed: RouteGenerator = (router) =>
       }
 
       const params: util.StreamingSyncRequest = payload.params;
-      const syncParams: SyncParameters = normalizeTokenParameters(payload.context.token_payload!.parameters ?? {});
+      const syncParams: SyncParameters = normalizeTokenParameters(
+        payload.context.token_payload!.parameters ?? {},
+        payload.params.parameters ?? {}
+      );
 
       const storage = system.storage;
       // Sanity check before we start the stream

--- a/packages/service-core/src/util/protocol-types.ts
+++ b/packages/service-core/src/util/protocol-types.ts
@@ -89,7 +89,12 @@ export const StreamingSyncRequest = t.object({
   /**
    * Data is received in a serialized BSON Buffer
    */
-  binary_data: t.boolean.optional()
+  binary_data: t.boolean.optional(),
+
+  /**
+   * Client parameters to be passed to the sync rules.
+   */
+  parameters: t.record(t.string).optional()
 });
 
 export type StreamingSyncRequest = t.Decoded<typeof StreamingSyncRequest>;

--- a/packages/service-core/src/util/protocol-types.ts
+++ b/packages/service-core/src/util/protocol-types.ts
@@ -94,7 +94,7 @@ export const StreamingSyncRequest = t.object({
   /**
    * Client parameters to be passed to the sync rules.
    */
-  parameters: t.record(t.string).optional()
+  parameters: t.record(t.any).optional()
 });
 
 export type StreamingSyncRequest = t.Decoded<typeof StreamingSyncRequest>;


### PR DESCRIPTION
# Description
This PR introduces the ability to pass parameters from a client SDK to the sync rules.
Parameters are available in the sync rules under `user_parameters` (only supported `token_parameters` until now). Client PR [here](https://github.com/powersync-ja/powersync-js/pull/204) 

For example:
```
bucket_definitions:
  user_lists:
    parameters: select id as list_id from lists where owner_id = user_parameters.client_variable_test
    data:
      - SELECT * FROM lists where id = bucket.list_id
```

# Testing
Verified values pull through via self-host project.
