### PR TITLE
Improve logging & reduce sync rule update delay

### DIFF
--- a/packages/rsocket-router/src/router/types.ts
+++ b/packages/rsocket-router/src/router/types.ts
@@ -1,4 +1,4 @@
-import {router as micro_router} from '@journeyapps-platform/micro';
+import { router as micro_router } from '@journeyapps-platform/micro';
 import * as t from 'ts-codec';
 import { OnExtensionSubscriber, OnNextSubscriber, OnTerminalSubscriber } from 'rsocket-core';
 import { SocketRouterObserver } from './SocketRouterListener.js';

--- a/packages/service-core/src/metrics/Metrics.ts
+++ b/packages/service-core/src/metrics/Metrics.ts
@@ -146,14 +146,16 @@ export class Metrics {
     }
     micro.logger.info('Configuring telemetry.');
 
-    micro.logger.info(`
+    micro.logger.info(
+      `
 Attention:
 PowerSync collects completely anonymous telemetry regarding usage.
 This information is used to shape our roadmap to better serve our customers.
 You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
 https://docs.powersync.com/self-hosting/telemetry
 Anonymous telemetry is currently: ${options.disable_telemetry_sharing ? 'disabled' : 'enabled'}
-    `.trim());
+    `.trim()
+    );
 
     const configuredExporters: MetricReader[] = [];
 
@@ -167,7 +169,7 @@ Anonymous telemetry is currently: ${options.disable_telemetry_sharing ? 'disable
         exporter: new OTLPMetricExporter({
           url: options.internal_metrics_endpoint
         }),
-        exportIntervalMillis: 1000 * 60 * 5  // 5 minutes
+        exportIntervalMillis: 1000 * 60 * 5 // 5 minutes
       });
 
       configuredExporters.push(periodicExporter);

--- a/packages/service-core/src/replication/ErrorRateLimiter.ts
+++ b/packages/service-core/src/replication/ErrorRateLimiter.ts
@@ -12,7 +12,8 @@ export class DefaultErrorRateLimiter implements ErrorRateLimiter {
 
   async waitUntilAllowed(options?: { signal?: AbortSignal | undefined } | undefined): Promise<void> {
     const delay = Math.max(0, this.nextAllowed - Date.now());
-    this.setDelay(5_000);
+    // Minimum delay between connections, even without errors
+    this.setDelay(500);
     await setTimeout(delay, undefined, { signal: options?.signal });
   }
 

--- a/packages/service-core/src/storage/MongoBucketStorage.ts
+++ b/packages/service-core/src/storage/MongoBucketStorage.ts
@@ -350,12 +350,12 @@ export class MongoBucketStorage implements BucketStorageFactory {
 
     if (!instance) {
       const manager = locks.createMongoLockManager(this.db.locks, {
-          name: `instance-id-insertion-lock`
+        name: `instance-id-insertion-lock`
       });
 
       await manager.lock(async () => {
         await this.db.instance.insertOne({
-          _id: uuid(),
+          _id: uuid()
         });
       });
 

--- a/packages/service-core/src/storage/mongo/MongoBucketBatch.ts
+++ b/packages/service-core/src/storage/mongo/MongoBucketBatch.ts
@@ -463,10 +463,8 @@ export class MongoBucketBatch implements BucketStorageBatch {
 
     await this.withTransaction(async () => {
       flushTry += 1;
-      if (flushTry == 1) {
-        micro.logger.info(`${this.slot_name} ${description}`);
-      } else if (flushTry % 10 == 0) {
-        micro.logger.info(`${this.slot_name} ${description} ops - try ${flushTry}`);
+      if (flushTry % 10 == 0) {
+        micro.logger.info(`${this.slot_name} ${description} - try ${flushTry}`);
       }
       if (flushTry > 20 && Date.now() > lastTry) {
         throw new Error('Max transaction tries exceeded');

--- a/packages/service-core/src/util/config/compound-config-collector.ts
+++ b/packages/service-core/src/util/config/compound-config-collector.ts
@@ -121,7 +121,8 @@ export class CompoundConfigCollector {
       migrations: baseConfig.migrations,
       telemetry: {
         disable_telemetry_sharing: baseConfig.telemetry?.disable_telemetry_sharing ?? false,
-        internal_service_endpoint: baseConfig.telemetry?.internal_service_endpoint ?? 'https://pulse.journeyapps.com/v1/metrics'
+        internal_service_endpoint:
+          baseConfig.telemetry?.internal_service_endpoint ?? 'https://pulse.journeyapps.com/v1/metrics'
       },
       slot_name_prefix: connections[0]?.slot_name_prefix ?? 'powersync_'
     };

--- a/packages/types/src/config/PowerSyncConfig.ts
+++ b/packages/types/src/config/PowerSyncConfig.ts
@@ -142,10 +142,12 @@ export const powerSyncConfig = t.object({
     })
     .optional(),
 
-  telemetry: t.object({
-    disable_telemetry_sharing: t.boolean,
-    internal_service_endpoint: t.string.optional()
-  }).optional()
+  telemetry: t
+    .object({
+      disable_telemetry_sharing: t.boolean,
+      internal_service_endpoint: t.string.optional()
+    })
+    .optional()
 });
 
 export type PowerSyncConfig = t.Decoded<typeof powerSyncConfig>;


### PR DESCRIPTION
Improve replication logging to include additional debug info, such as batch size and current oplog position.

Before:
```
powersync_abc_10_def Flushing 610 ops
```

Now:
```
12:44:54.889 INFO powersync_10 Flushed 610 + 0 + 610 updates, 359kb. Last op_id: 2459024
```

Also reduce the 5s delay between connection attempts to 500ms, since this delay is always triggered when updating sync rules.