### PR TITLE
Fix "Cannot convert a BigInt value to a number"

### DIFF
--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -37,7 +37,7 @@
     "ix": "^5.0.0",
     "jose": "^4.15.1",
     "lru-cache": "^10.2.2",
-    "mongodb": "^6.5.0",
+    "mongodb": "^6.7.0",
     "node-fetch": "^3.3.2",
     "pgwire": "github:kagis/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87",
     "ts-codec": "^1.2.2",

--- a/packages/service-core/src/storage/mongo/db.ts
+++ b/packages/service-core/src/storage/mongo/db.ts
@@ -45,9 +45,6 @@ export class PowerSyncMongo {
     this.client = client;
 
     const db = client.db(options?.database, {
-      // Note this issue with useBigInt64: https://jira.mongodb.org/browse/NODE-6165
-      // Unfortunately there is no workaround if we want to continue using bigint.
-      // We selectively disable this in individual queries where we don't need that.
       ...BSON_DESERIALIZE_OPTIONS
     });
     this.db = db;

--- a/packages/service-core/src/storage/mongo/util.ts
+++ b/packages/service-core/src/storage/mongo/util.ts
@@ -83,6 +83,6 @@ export async function readSingleBatch<T>(cursor: mongo.FindCursor<T>): Promise<{
 }
 
 export const BSON_DESERIALIZE_OPTIONS: bson.DeserializeOptions = {
-  // use bigint instead of long
+  // use bigint instead of Long
   useBigInt64: true
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: ^10.2.2
         version: 10.2.2
       mongodb:
-        specifier: ^6.5.0
-        version: 6.6.2(socks@2.8.3)
+        specifier: ^6.7.0
+        version: 6.7.0(socks@2.8.3)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -324,8 +324,8 @@ importers:
         specifier: ^10.0.1
         version: 10.2.2
       mongodb:
-        specifier: ^6.5.0
-        version: 6.6.2(socks@2.8.3)
+        specifier: ^6.7.0
+        version: 6.7.0(socks@2.8.3)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -3158,8 +3158,8 @@ packages:
   mongodb-connection-string-url@3.0.1:
     resolution: {integrity: sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==}
 
-  mongodb@6.6.2:
-    resolution: {integrity: sha512-ZF9Ugo2JCG/GfR7DEb4ypfyJJyiKbg5qBYKRintebj8+DNS33CyGMkWbrS9lara+u+h+yEOGSRiLhFO/g1s1aw==}
+  mongodb@6.7.0:
+    resolution: {integrity: sha512-TMKyHdtMcO0fYBNORiYdmM25ijsHs+Njs963r4Tro4OQZzqYigAzYQouwWRg4OIaiLRUEGUh/1UAcH5lxdSLIA==}
     engines: {node: '>=16.20.1'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.188.0
@@ -5165,7 +5165,7 @@ snapshots:
       bson: 6.7.0
       kafkajs: 2.2.4
       lodash: 4.17.21
-      mongodb: 6.6.2(socks@2.8.3)
+      mongodb: 6.7.0(socks@2.8.3)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -5192,7 +5192,7 @@ snapshots:
   '@journeyapps-platform/micro-locks@2.0.1(socks@2.8.3)':
     dependencies:
       bson: 6.7.0
-      mongodb: 6.6.2(socks@2.8.3)
+      mongodb: 6.7.0(socks@2.8.3)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -5233,7 +5233,7 @@ snapshots:
     dependencies:
       '@journeyapps-platform/micro-db': 3.0.2
       bson: 6.7.0
-      mongodb: 6.6.2(socks@2.8.3)
+      mongodb: 6.7.0(socks@2.8.3)
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
@@ -8138,7 +8138,7 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 13.0.0
 
-  mongodb@6.6.2(socks@2.8.3):
+  mongodb@6.7.0(socks@2.8.3):
     dependencies:
       '@mongodb-js/saslprep': 1.1.7
       bson: 6.7.0

--- a/service/package.json
+++ b/service/package.json
@@ -31,7 +31,7 @@
     "ix": "^5.0.0",
     "jose": "^4.15.1",
     "lru-cache": "^10.0.1",
-    "mongodb": "^6.5.0",
+    "mongodb": "^6.7.0",
     "node-fetch": "^3.3.2",
     "pgwire": "github:kagis/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87",
     "ts-codec": "^1.2.2",


### PR DESCRIPTION
Bump mongodb driver to fix "TypeError: "Cannot convert a BigInt value to a number" - [NODE-6165](https://jira.mongodb.org/browse/NODE-6165) / https://github.com/mongodb/node-mongodb-native/pull/4109

This typically occurred when a new MongoDB primary was selected while data queries are active.