### PR TITLE
Incrementally calculate checksums per connection & include empty buckets

### DIFF
--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -230,7 +230,16 @@ export interface SyncRulesBucketStorage {
     options?: BucketDataBatchOptions
   ): AsyncIterable<util.SyncBucketData>;
 
-  getChecksums(checkpoint: util.OpId, buckets: string[]): Promise<util.BucketChecksum[]>;
+  /**
+   * Compute checksums for a given list of buckets.
+   *
+   * If fromCheckpoint is specified, the result is a diff. Otherwise, it is the full checksum.
+   */
+  getChecksums(
+    checkpoint: util.OpId,
+    fromCheckpoint: util.OpId | null,
+    buckets: string[]
+  ): Promise<util.BucketChecksum[]>;
 
   /**
    * Terminate the sync rules.

--- a/packages/service-core/test/src/__snapshots__/sync.test.ts.snap
+++ b/packages/service-core/test/src/__snapshots__/sync.test.ts.snap
@@ -12,7 +12,13 @@ exports[`sync - mongodb > expiring token 1`] = `
 [
   {
     "checkpoint": {
-      "buckets": [],
+      "buckets": [
+        {
+          "bucket": "mybucket[]",
+          "checksum": 0,
+          "count": 0,
+        },
+      ],
       "last_op_id": "0",
       "write_checkpoint": undefined,
     },
@@ -135,7 +141,13 @@ exports[`sync - mongodb > sync updates to global data 1`] = `
 [
   {
     "checkpoint": {
-      "buckets": [],
+      "buckets": [
+        {
+          "bucket": "mybucket[]",
+          "checksum": 0,
+          "count": 0,
+        },
+      ],
       "last_op_id": "0",
       "write_checkpoint": undefined,
     },

--- a/packages/service-core/test/src/data_storage.test.ts
+++ b/packages/service-core/test/src/data_storage.test.ts
@@ -252,7 +252,7 @@ bucket_definitions:
       { op: 'REMOVE', object_id: 'test1', checksum: c2 }
     ]);
 
-    const checksums = await storage.getChecksums(checkpoint, ['global[]']);
+    const checksums = await storage.getChecksums(checkpoint, null, ['global[]']);
     expect(checksums).toEqual([
       {
         bucket: 'global[]',
@@ -599,7 +599,7 @@ bucket_definitions:
       { op: 'REMOVE', object_id: 'test1', checksum: c2 }
     ]);
 
-    const checksums = await storage.getChecksums(checkpoint, ['global[]']);
+    const checksums = await storage.getChecksums(checkpoint, null, ['global[]']);
     expect(checksums).toEqual([
       {
         bucket: 'global[]',
@@ -713,7 +713,7 @@ bucket_definitions:
       { op: 'REMOVE', object_id: 'test1', checksum: c2 }
     ]);
 
-    const checksums = await storage.getChecksums(checkpoint, ['global[]']);
+    const checksums = await storage.getChecksums(checkpoint, null, ['global[]']);
     expect(checksums).toEqual([
       {
         bucket: 'global[]',

--- a/packages/service-core/test/src/large_batch.test.ts
+++ b/packages/service-core/test/src/large_batch.test.ts
@@ -49,7 +49,7 @@ function defineBatchTests(factory: StorageFactory) {
       const checkpoint = await context.getCheckpoint({ timeout: 100_000 });
       const duration = Date.now() - start;
       const used = Math.round(process.memoryUsage().heapUsed / 1024 / 1024);
-      const checksum = await context.storage!.getChecksums(checkpoint, ['global[]']);
+      const checksum = await context.storage!.getChecksums(checkpoint, null, ['global[]']);
       expect(checksum[0].count).toEqual(operation_count);
       const perSecond = Math.round((operation_count / duration) * 1000);
       console.log(`${operation_count} ops in ${duration}ms ${perSecond} ops/s. ${used}MB heap`);
@@ -100,7 +100,7 @@ function defineBatchTests(factory: StorageFactory) {
 
         const checkpoint = await context.getCheckpoint({ timeout: 100_000 });
         const duration = Date.now() - start;
-        const checksum = await context.storage!.getChecksums(checkpoint, ['global[]']);
+        const checksum = await context.storage!.getChecksums(checkpoint, null, ['global[]']);
         expect(checksum[0].count).toEqual(operation_count);
         const perSecond = Math.round((operation_count / duration) * 1000);
         console.log(`${operation_count} ops in ${duration}ms ${perSecond} ops/s.`);
@@ -156,7 +156,7 @@ function defineBatchTests(factory: StorageFactory) {
       const checkpoint = await context.getCheckpoint({ timeout: 50_000 });
       const duration = Date.now() - start;
       const used = Math.round(process.memoryUsage().heapUsed / 1024 / 1024);
-      const checksum = await context.storage!.getChecksums(checkpoint, ['global[]']);
+      const checksum = await context.storage!.getChecksums(checkpoint, null, ['global[]']);
       expect(checksum[0].count).toEqual(operationCount);
       const perSecond = Math.round((operationCount / duration) * 1000);
       // This number depends on the test machine, so we keep the test significantly
@@ -173,7 +173,7 @@ function defineBatchTests(factory: StorageFactory) {
       const checkpoint2 = await context.getCheckpoint({ timeout: 20_000 });
       const truncateDuration = Date.now() - truncateStart;
 
-      const checksum2 = await context.storage!.getChecksums(checkpoint2, ['global[]']);
+      const checksum2 = await context.storage!.getChecksums(checkpoint2, null, ['global[]']);
       const truncateCount = checksum2[0].count - checksum[0].count;
       expect(truncateCount).toEqual(numTransactions * perTransaction);
       const truncatePerSecond = Math.round((truncateCount / truncateDuration) * 1000);


### PR DESCRIPTION
## Incremental checksums

Bucket operations are always additive (operations are only added at the end of the bucket, never removed or modified). This makes it easy to calculate checksums incrementally.

This changes the checksum calculation to be incremental per connection - we only get the checksum for operations since the last checkpoint from the database, instead of recalculating checksums for the entire checkpoint on every change. This doesn't reduce the latency on initial connection, but does significantly reduce the latency and database overhead for any changes processed after that.

Future improvements could cache checksums across different connections and/or users, in memory or in database storage.

## Empty buckets

This now also returns zero checksums for empty buckets to the client, instead of omitting the bucket. This does not affect synced data on the client, but helps with diagnosing sync issues.

