### PR TITLE
Fix snapshot performance issues

### DIFF
--- a/.changeset/tender-emus-beat.md
+++ b/.changeset/tender-emus-beat.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix performance issues and improve logging for initial snapshot replication.

--- a/.changeset/tender-emus-drum.md
+++ b/.changeset/tender-emus-drum.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-jpgwire': patch
+---
+
+Fix performance issue when reading a lot of data from a socket.

--- a/packages/service-core/src/replication/WalStream.ts
+++ b/packages/service-core/src/replication/WalStream.ts
@@ -274,7 +274,7 @@ WHERE  oid = $1::regclass`,
       params: [{ value: table.qualifiedName, type: 'varchar' }]
     });
     const row = results.rows[0];
-    if (row?.[0] ?? -1n == -1n) {
+    if ((row?.[0] ?? -1n) == -1n) {
       return '?';
     } else {
       return `~${row[0]}`;

--- a/packages/service-core/src/storage/mongo/OperationBatch.ts
+++ b/packages/service-core/src/storage/mongo/OperationBatch.ts
@@ -12,7 +12,7 @@ const MAX_BATCH_COUNT = 2000;
 /**
  * Maximum size of operations in the batch (estimated).
  */
-const MAX_RECORD_BATCH_SIZE = 14_000_000;
+const MAX_RECORD_BATCH_SIZE = 5_000_000;
 
 /**
  * Maximum size of size of current_data documents we lookup at a time.


### PR DESCRIPTION
## pgwire socket reads

The previous logic for reading from a postgres socket would read all available data, then "unshift" any "unused" data back onto the socket.

This meant that:
1. Backpressure on the socket did not function, which could cause the internal buffer to grow indefinitely.
2. As the internal buffer grew, reading got slower.

Those two issues compounded, resulting in much slower reads, and high memory usage. This would happen any time a lot of data is sent over the socket - specifically initial snapshot replication of large tables, but could also affect logical replication.

The fix is to just read as much data as requested.

## Reduced flushing

The previous logic would do an explicit "flush" for every chunk of rows read for the initial table snapshot. These chunks are quite small - as little as 16KB each, which made this quite inefficient.

The explicit flush is removed, now just relying on the implicit flush when the internal batch size limit is reached.

## Other changes

 * Reduce internal batch size limit
 * Fix table size estimation for logs
 * Fix "Replicating" logs which were often skipped

## Performance test

Test case:
 * 20k rows, 10kb data each (200MB total)
 * Each row is part of two buckets

Before: Unknown, aborted after 4 minutes, having only replicated 2.6k rows.
After reduced flushing: 2min 10s
After reduced flushing and socket read fix: 12.5s
