### PR TITLE
Fix teardown process not exiting after errors

### DIFF
--- a/.changeset/rotten-candles-float.md
+++ b/.changeset/rotten-candles-float.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix teardown command not terminating after some errors.

--- a/packages/service-core/src/runner/teardown.ts
+++ b/packages/service-core/src/runner/teardown.ts
@@ -33,9 +33,10 @@ async function terminateReplicator(
       source_db: connection,
       lock
     });
-    console.log('terminating', stream.slot_name);
+
+    micro.logger.info(`Terminating replication slot ${stream.slot_name}`);
     await stream.terminate();
-    console.log('terminated', stream.slot_name);
+    micro.logger.info(`Terminated replication slot ${stream.slot_name}`);
   } finally {
     await lock.release();
   }
@@ -76,16 +77,32 @@ async function terminateReplicators(
 export async function teardown(runnerConfig: utils.RunnerConfig) {
   const config = await utils.loadConfig(runnerConfig);
   const mongoDB = storage.createPowerSyncMongo(config.storage);
-  await db.mongo.waitForAuth(mongoDB.db);
+  try {
+    micro.logger.info(`Waiting for auth`);
+    await db.mongo.waitForAuth(mongoDB.db);
 
-  const bucketStorage = new storage.MongoBucketStorage(mongoDB, { slot_name_prefix: config.slot_name_prefix });
-  const connection = config.connection;
+    const bucketStorage = new storage.MongoBucketStorage(mongoDB, { slot_name_prefix: config.slot_name_prefix });
+    const connection = config.connection;
 
-  if (connection) {
-    await terminateReplicators(bucketStorage, connection);
+    micro.logger.info(`Terminating replication slots`);
+
+    if (connection) {
+      await terminateReplicators(bucketStorage, connection);
+    }
+
+    const database = mongoDB.db;
+    micro.logger.info(`Dropping database ${database.namespace}`);
+    await database.dropDatabase();
+    micro.logger.info(`Done`);
+    await mongoDB.client.close();
+
+    // If there was an error connecting to postgress, the process may stay open indefinitely.
+    // This forces an exit.
+    // We do not consider those errors a teardown failure.
+    process.exit(0);
+  } catch (e) {
+    micro.logger.error(`Teardown failure`);
+    await mongoDB.client.close();
+    process.exit(1);
   }
-
-  const database = mongoDB.db;
-  await database.dropDatabase();
-  await mongoDB.client.close();
 }

--- a/packages/service-core/src/runner/teardown.ts
+++ b/packages/service-core/src/runner/teardown.ts
@@ -101,7 +101,7 @@ export async function teardown(runnerConfig: utils.RunnerConfig) {
     // We do not consider those errors a teardown failure.
     process.exit(0);
   } catch (e) {
-    micro.logger.error(`Teardown failure`);
+    micro.logger.error(`Teardown failure`, e);
     await mongoDB.client.close();
     process.exit(1);
   }


### PR DESCRIPTION
If we fail to connect to the postgres instance, the process does not terminate (errors such as `PgError: getaddrinfo ENOTFOUND`). I tried to find the cause using [wtfnode](https://www.npmjs.com/package/wtfnode), but it did not report anything significant. The workaround of `process.exit()` works.

This also adds better logging to the teardown job.
