### PR TITLE
Fix date parsing in replication

### DIFF
--- a/.changeset/stale-walls-mix.md
+++ b/.changeset/stale-walls-mix.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+'@powersync/service-jpgwire': patch
+---
+
+Fix date parsing in replication for dates further back than 100 AD.

--- a/packages/jpgwire/package.json
+++ b/packages/jpgwire/package.json
@@ -18,8 +18,9 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "pgwire": "github:kagis/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87",
+    "@powersync/service-jsonbig": "workspace:^",
     "@powersync/service-types": "workspace:^",
-    "@powersync/service-jsonbig": "workspace:^"
+    "date-fns": "^3.6.0",
+    "pgwire": "github:kagis/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87"
   }
 }

--- a/packages/service-core/test/src/pg_test.test.ts
+++ b/packages/service-core/test/src/pg_test.test.ts
@@ -200,6 +200,8 @@ VALUES(10, ARRAY['null']::TEXT[]);
 
     expect(transformed[8]).toMatchObject({
       id: 9n,
+      // 10022-02-03 12:13:14+03 - out of range of both our date parsing logic, and sqlite's date functions
+      // We can consider just preserving the source string as an alternative if this causes issues.
       timestamptz: null
     });
   }

--- a/packages/service-core/test/src/pg_test.test.ts
+++ b/packages/service-core/test/src/pg_test.test.ts
@@ -86,6 +86,12 @@ VALUES(6, 'epoch'::timestamp, 'epoch'::timestamptz);
 
 INSERT INTO test_data(id, timestamp, timestamptz)
 VALUES(7, 'infinity'::timestamp, 'infinity'::timestamptz);
+
+INSERT INTO test_data(id, timestamptz)
+VALUES(8, '0022-02-03 12:13:14+03'::timestamptz);
+
+INSERT INTO test_data(id, timestamptz)
+VALUES(9, '10022-02-03 12:13:14+03'::timestamptz);
     `);
   }
 
@@ -185,6 +191,16 @@ VALUES(10, ARRAY['null']::TEXT[]);
       id: 7n,
       timestamp: '9999-12-31 23:59:59',
       timestamptz: '9999-12-31 23:59:59Z'
+    });
+
+    expect(transformed[7]).toMatchObject({
+      id: 8n,
+      timestamptz: '0022-02-03 09:13:14Z'
+    });
+
+    expect(transformed[8]).toMatchObject({
+      id: 9n,
+      timestamptz: null
     });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@powersync/service-types':
         specifier: workspace:^
         version: link:../types
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       pgwire:
         specifier: github:kagis/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87
         version: https://codeload.github.com/kagis/pgwire/tar.gz/f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87
@@ -2031,6 +2034,9 @@ packages:
   data-view-byte-offset@1.0.0:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
+
+  date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -6875,6 +6881,8 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
+
+  date-fns@3.6.0: {}
 
   debug@2.6.9:
     dependencies:


### PR DESCRIPTION
Dates such as `0022-02-03 12:13:14+03` previously caused the entire replication to fail and restart. This fixes the parsing to handle a wider date range, and return null for dates not supported at all.
