### PR TITLE
Fix schema validation of parameter queries

### DIFF
--- a/.changeset/sour-beers-cover.md
+++ b/.changeset/sour-beers-cover.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-sync-rules': patch
+'@powersync/service-core': patch
+'powersync-open-service': patch
+---
+
+Fix schema validation for parameter queries.

--- a/packages/sync-rules/package.json
+++ b/packages/sync-rules/package.json
@@ -14,7 +14,9 @@
   "type": "module",
   "scripts": {
     "clean": "rm -r ./dist && tsc -b --clean",
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "build:tests": "tsc -b test/tsconfig.json",
+    "test": "vitest"
   },
   "dependencies": {
     "@powersync/service-jsonbig": "workspace:^",
@@ -24,6 +26,7 @@
     "yaml": "^2.3.1"
   },
   "devDependencies": {
-    "@types/node": "18.11.11"
+    "@types/node": "18.11.11",
+    "vitest": "^0.34.6"
   }
 }

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -57,7 +57,7 @@ export class SqlBucketDescriptor {
     };
   }
 
-  addParameterQuery(sql: string, schema?: SourceSchema): QueryParseResult {
+  addParameterQuery(sql: string, schema: SourceSchema | undefined): QueryParseResult {
     const parameterQuery = SqlParameterQuery.fromSql(this.name, sql, schema);
     if (this.bucket_parameters == null) {
       this.bucket_parameters = parameterQuery.bucket_parameters;

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -88,7 +88,7 @@ export class SqlSyncRules implements SyncRules {
 
       if (parameters instanceof Scalar) {
         rules.withScalar(parameters, (q) => {
-          return descriptor.addParameterQuery(q);
+          return descriptor.addParameterQuery(q, schema);
         });
       } else if (parameters instanceof YAMLSeq) {
         for (let item of parameters.items) {

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -1,4 +1,4 @@
-import { SQL_FUNCTIONS_CALL, cast, jsonExtract } from '@powersync/service-sync-rules';
+import { SQL_FUNCTIONS_CALL, cast, jsonExtract } from '../../src/index.js';
 import { describe, expect, test } from 'vitest';
 
 const fn = SQL_FUNCTIONS_CALL;

--- a/packages/sync-rules/test/src/sql_operators.test.ts
+++ b/packages/sync-rules/test/src/sql_operators.test.ts
@@ -1,4 +1,4 @@
-import { evaluateOperator } from '@powersync/service-sync-rules';
+import { evaluateOperator } from '../../src/index.js';
 import { describe, expect, test } from 'vitest';
 
 describe('SQL operators', () => {

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -983,7 +983,7 @@ bucket_definitions:
     ]);
   });
 
-  test.only('progate parameter schema errors', () => {
+  test('progate parameter schema errors', () => {
     const rules = SqlSyncRules.fromYaml(
       `
 bucket_definitions:

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -10,9 +10,8 @@ import {
   SqlSyncRules,
   StaticSchema,
   normalizeTokenParameters
-} from '@powersync/service-sync-rules';
+} from '../../src/index.js';
 import { describe, expect, test } from 'vitest';
-import { SourceTable } from '../../src/storage/SourceTable.js';
 
 class TestSourceTable implements SourceTableInterface {
   readonly connectionTag = DEFAULT_TAG;
@@ -857,10 +856,10 @@ bucket_definitions:
   test('types', () => {
     const schema = new StaticSchema([
       {
-        tag: SourceTable.DEFAULT_TAG,
+        tag: DEFAULT_TAG,
         schemas: [
           {
-            name: SourceTable.DEFAULT_SCHEMA,
+            name: DEFAULT_SCHEMA,
             tables: [
               {
                 name: 'assets',
@@ -924,10 +923,10 @@ bucket_definitions:
   test('validate columns', () => {
     const schema = new StaticSchema([
       {
-        tag: SourceTable.DEFAULT_TAG,
+        tag: DEFAULT_TAG,
         schemas: [
           {
-            name: SourceTable.DEFAULT_SCHEMA,
+            name: DEFAULT_SCHEMA,
             tables: [
               {
                 name: 'assets',
@@ -985,10 +984,10 @@ bucket_definitions:
   test('schema generation', () => {
     const schema = new StaticSchema([
       {
-        tag: SourceTable.DEFAULT_TAG,
+        tag: DEFAULT_TAG,
         schemas: [
           {
-            name: SourceTable.DEFAULT_SCHEMA,
+            name: DEFAULT_SCHEMA,
             tables: [
               {
                 name: 'assets',

--- a/packages/sync-rules/test/tsconfig.json
+++ b/packages/sync-rules/test/tsconfig.json
@@ -6,10 +6,7 @@
     "baseUrl": "./",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "sourceMap": true,
-    "paths": {
-      "@/*": ["../src/*"]
-    }
+    "sourceMap": true
   },
   "include": ["src"],
   "references": [

--- a/packages/sync-rules/test/tsconfig.json
+++ b/packages/sync-rules/test/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true,
+    "baseUrl": "./",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "paths": {
+      "@/*": ["../src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../"
+    }
+  ]
+}

--- a/packages/sync-rules/vitest.config.ts
+++ b/packages/sync-rules/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [],
+  test: {}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       '@types/node':
         specifier: 18.11.11
         version: 18.11.11
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6
 
   packages/types:
     dependencies:
@@ -4955,7 +4958,7 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.25.0
       '@prisma/instrumentation': 5.15.0
       '@sentry/core': 8.9.2
-      '@sentry/opentelemetry': 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.6.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)
+      '@sentry/opentelemetry': 8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)
       '@sentry/types': 8.9.2
       '@sentry/utils': 8.9.2
     optionalDependencies:
@@ -4963,7 +4966,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.6.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)':
+  '@sentry/opentelemetry@8.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
This version picks up the schema issue correctly (array of parameter queries):
![image](https://github.com/powersync-ja/powersync-service/assets/94081/27577080-c2b2-43d7-b1b5-de471481296a)

While this one doesn't (single parameter query):
![image](https://github.com/powersync-ja/powersync-service/assets/94081/044e827f-73e5-4dda-8160-773ef58e66b4)

The issue was the schema not being passed to the function in this specific case, causing schema validation to be bypassed.

This PR also moves pure sync-rule related tests to the sync-rules package, which simplifies the testing cycle a bit.