### PR TITLE
Expressions on parameters

### DIFF
--- a/.changeset/cyan-doors-tap.md
+++ b/.changeset/cyan-doors-tap.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-sync-rules': minor
+'@powersync/service-core': patch
+'powersync-open-service': patch
+---
+
+Support expressions on request parameters in parameter queries.

--- a/.github/workflows/development_image_release.yaml
+++ b/.github/workflows/development_image_release.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           version: 9

--- a/.github/workflows/development_packages_release.yaml
+++ b/.github/workflows/development_packages_release.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           version: 9

--- a/.github/workflows/packages_release.yaml
+++ b/.github/workflows/packages_release.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           version: 9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           version: 9

--- a/packages/sync-rules/README.md
+++ b/packages/sync-rules/README.md
@@ -1,3 +1,129 @@
 # powersync-sync-rules
 
 A library containing logic for PowerSync sync rules.
+
+This is not intended to be used directly by users of PowerSync. If you are interested in the internals, read on.
+
+# Overview
+
+A core design constraint is that sync rules define two operations:
+
+1. Given a data row, compute a list of buckets that it belongs to.
+2. Given an authenticated user, return a list of buckets for the user.
+
+This implementation of sync rules use SQL queries to declaratively define those operations using familiar SQL operations.
+
+We define (1) using data queries, and (2) using parameter queries.
+
+Example:
+
+```yaml
+bucket_definitions:
+  by_org:
+    # parameter query
+    # This defines bucket parameters are `bucket.org_id`
+    parameters: select org_id from users where id = token_parameters.user_id
+    # data query
+    data:
+      - select * from documents where org_id = bucket.org_id
+```
+
+For the above example, a document with `org_id: 'org1'` will belong to a single bucket `by_org["org1"]`. Similarly, a user with `org_id: 'org1'` will sync the bucket `by_org["org1"]`.
+
+An important aspect is that none of these SQL queries are actually executed against any SQL database. Instead, it is used to pre-process data before storing the data in a format for efficient sync operations.
+
+When data is replicated from the source database to PowerSync, we do two things for each row:
+
+1. Evaluate data queries on the row: `syncRules.evaluateRow(row)`.
+2. Evaluate parameter queries on the row: `syncRules.evaluateParameterRow(row)`.
+
+Data queries also have the option to transform the row instead of just using `select *`. We store the transformed data for each of the buckets it belongs to.
+
+# Query Structure
+
+## Data queries
+
+A data query is turned into a function `(row) => Array<{bucket, data}>`. The main implementation is in the `SqlDataQuery` class.
+
+The main clauses in a data query are the ones comparing bucket parameters, for example `WHERE documents.document_org_id = bucket.bucket_org_id`. In this case, a document with `document_org_id: 'org1'` will have a bucket parameter of `bucket_org_id: 'org1'`.
+
+A data query must match each bucket parameter. To be able to always compute the bucket ids, there are major limitations on the operators supported with bucket parameters, as well as how expressions can be combined using AND and OR.
+
+The WHERE clause of a data query is compiled into a `ParameterMatchClause`.
+
+Query clauses are structured as follows:
+
+```SQL
+'literal' -- StaticValueClause
+mytable.column -- RowValueClause
+fn(mytable.column) -- RowValueClause. This includes most operators.
+bucket.param -- ParameterValueClause
+fn(bucket.param) -- Error: not allowed
+
+mytable.column = mytable.other_column -- RowValueClause
+mytable.column = bucket.param -- ParameterMatchClause
+bucket.param IN mytable.some_array -- ParameterMatchClause
+(mytable.column1 = bucket.param1) AND (mytable.column2 = bucket.param2) -- ParameterMatchClause
+(mytable.column1 = bucket.param) OR (mytable.column2 = bucket.param) -- ParameterMatchClause
+```
+
+## Parameter Queries
+
+There are two types of parameter queries:
+
+1. Queries without tables. These just operate on request parameters. Example: `select token_parameters.user_id`. Thes are implemented in the `StaticSqlParameterQuery` class.
+2. Queries with tables. Example: `select org_id from users where id = token_parameters.user_id`. These use parameter tables, and are implemented in `SqlParameterQuery`. These are used to pre-process rows in the parameter tables for efficient lookup later.
+
+### StaticSqlParameterQuery
+
+These are effecitively just a function of `(request) => Array[{bucket}]`. These queries can select values from request parameters, and apply filters from request parameters.
+
+The WHERE filter is a ParameterMatchClause that operates on the request parameters.
+The bucket parameters are each a RowValueClause that operates on the request parameters.
+
+Compiled expression clauses are structured as follows:
+
+```SQL
+'literal' -- StaticValueClause
+token_parameters.param -- RowValueClause
+fn(token_parameters.param) -- RowValueClause. This includes most operators.
+```
+
+The implementation may be refactored to be more consistent with `SqlParameterQuery` in the future - using `RowValueClause` for request parameters is not ideal.
+
+### SqlParameterQuery
+
+These queries pre-process parameter tables to effectively create an "index" for efficient queries when syncing.
+
+For a parameter query `select org_id from users where users.org_id = token_parameters.org_id and lower(users.email) = token_parameters.email`, this would effectively create an index on `users.org_id, lower(users.email)`. These indexes are referred to as "lookup" values. Only direct equality lookups are supported on these indexes currently (including the IN operator). Support for more general queries such as "greater than" operators may be added later.
+
+A SqlParameterQuery defines the following operations:
+
+1. `evaluateParameterRow(row)`: Given a parameter row, compute the lookup index entries.
+2. `getLookups(request)`: Given request parameters, compute the lookup index entries we need to find.
+3. `queryBucketIds(request)`: Uses `getLookups(request)`, combined with a database lookup, to compute bucket ids from request parameters.
+
+The compiled query is based on the following:
+
+1. WHERE clause compiled into a `ParameterMatchClause`. This computes the lookup index.
+2. `lookup_extractors`: Set of `RowValueClause`. Each of these represent a SELECT clause based on a row value, e.g. `SELECT users.org_id`. These are evaluated during the `evaluateParameterRow` call.
+3. `static_extractors`. Set of `RowValueClause`. Each of these represent a SELECT clause based on a request parameter, e.g. `SELECT token_parameters.user_id`. These are evaluated during the `queryBucketIds` call.
+
+Compiled expression clauses are structured as follows:
+
+```SQL
+'literal' -- StaticValueClause
+mytable.column -- RowValueClause
+fn(mytable.column) -- RowValueClause. This includes most operators.
+token_parameters.param -- ParameterValueClause
+fn(token_parameters.param) -- ParameterValueClause
+fn(mytable.column, token_parameters.param) -- Error: not allowed
+
+mytable.column = mytable.other_column -- RowValueClause
+mytable.column = token_parameters.param -- ParameterMatchClause
+token_parameters.param IN mytable.some_array -- ParameterMatchClause
+mytable.some_value IN token_parameters.some_array -- ParameterMatchClause
+
+(mytable.column1 = token_parameters.param1) AND (mytable.column2 = token_parameters.param2) -- ParameterMatchClause
+(mytable.column1 = token_parameters.param) OR (mytable.column2 = token_parameters.param) -- ParameterMatchClause
+```

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -196,7 +196,7 @@ export class SqlDataQuery {
   evaluateRow(table: SourceTableInterface, row: SqliteRow): EvaluationResult[] {
     try {
       const tables = { [this.table!]: this.addSpecialParameters(table, row) };
-      const bucketParameters = this.filter!.filter(tables);
+      const bucketParameters = this.filter!.filterRow(tables);
       const bucketIds = bucketParameters.map((params) =>
         getBucketId(this.descriptor_name!, this.bucket_parameters!, params)
       );

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -78,7 +78,10 @@ export class SqlDataQuery {
     });
     const filter = tools.compileWhereClause(where);
 
-    const allParams = new Set([...filter.bucketParameters!, ...bucket_parameters.map((p) => `bucket.${p}`)]);
+    const allParams = new Set([
+      ...filter.bucketParameters!.map((p) => p.key),
+      ...bucket_parameters.map((p) => `bucket.${p}`)
+    ]);
     if (
       (!filter.error && allParams.size != filter.bucketParameters!.length) ||
       allParams.size != bucket_parameters.length

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -78,19 +78,18 @@ export class SqlDataQuery {
     });
     const filter = tools.compileWhereClause(where);
 
-    const allParams = new Set<string>([
-      ...filter.inputParameters!.map((p) => p.key),
-      ...bucket_parameters.map((p) => `bucket.${p}`)
-    ]);
+    const inputParameterNames = filter.inputParameters!.map((p) => p.key);
+    const bucketParameterNames = bucket_parameters.map((p) => `bucket.${p}`);
+    const allParams = new Set<string>([...inputParameterNames, ...bucketParameterNames]);
     if (
       (!filter.error && allParams.size != filter.inputParameters!.length) ||
       allParams.size != bucket_parameters.length
     ) {
       rows.errors.push(
         new SqlRuleError(
-          `Query must cover all bucket parameters: ${JSONBig.stringify(bucket_parameters)} != ${JSONBig.stringify(
-            filter.inputParameters
-          )}`,
+          `Query must cover all bucket parameters. Expected: ${JSONBig.stringify(
+            bucketParameterNames
+          )} Got: ${JSONBig.stringify(inputParameterNames)}`,
           sql,
           q._location
         )

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -78,18 +78,18 @@ export class SqlDataQuery {
     });
     const filter = tools.compileWhereClause(where);
 
-    const allParams = new Set([
-      ...filter.bucketParameters!.map((p) => p.key),
+    const allParams = new Set<string>([
+      ...filter.inputParameters!.map((p) => p.key),
       ...bucket_parameters.map((p) => `bucket.${p}`)
     ]);
     if (
-      (!filter.error && allParams.size != filter.bucketParameters!.length) ||
+      (!filter.error && allParams.size != filter.inputParameters!.length) ||
       allParams.size != bucket_parameters.length
     ) {
       rows.errors.push(
         new SqlRuleError(
           `Query must cover all bucket parameters: ${JSONBig.stringify(bucket_parameters)} != ${JSONBig.stringify(
-            filter.bucketParameters
+            filter.inputParameters
           )}`,
           sql,
           q._location

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -11,7 +11,7 @@ import {
   SqliteJsonRow,
   SqliteJsonValue,
   SqliteRow,
-  StaticRowValueClause,
+  RowValueClause,
   SyncParameters
 } from './types.js';
 import { SqlRuleError } from './errors.js';
@@ -103,7 +103,7 @@ export class SqlParameterQuery {
     rows.filter = filter;
     rows.descriptor_name = descriptor_name;
     rows.bucket_parameters = bucket_parameters;
-    rows.input_parameters = filter.bucketParameters!;
+    rows.input_parameters = filter.inputParameters!;
     const expandedParams = rows.input_parameters!.filter((param) => param.expands);
     if (expandedParams.length > 1) {
       rows.errors.push(new SqlRuleError('Cannot have multiple array input parameters', sql));
@@ -157,12 +157,12 @@ export class SqlParameterQuery {
   /**
    * Example: SELECT *user.id* FROM users WHERE ...
    */
-  lookup_extractors: Record<string, StaticRowValueClause> = {};
+  lookup_extractors: Record<string, RowValueClause> = {};
 
   /**
    * Example: SELECT *token_parameters.user_id*
    */
-  static_extractors: Record<string, StaticRowValueClause> = {};
+  static_extractors: Record<string, RowValueClause> = {};
 
   filter?: ParameterMatchClause;
   descriptor_name?: string;

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -182,7 +182,7 @@ export class SqlParameterQuery {
       [this.table!]: row
     };
     try {
-      const filterParameters = this.filter!.filter(tables);
+      const filterParameters = this.filter!.filterRow(tables);
       let result: EvaluatedParametersResult[] = [];
       for (let filterParamSet of filterParameters) {
         let lookup: SqliteJsonValue[] = [this.descriptor_name!, this.id!];

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -91,6 +91,7 @@ export class SqlParameterQuery {
       parameter_tables: ['token_parameters', 'user_parameters'],
       sql,
       supports_expanding_parameters: true,
+      supports_parameter_expressions: true,
       schema: querySchema
     });
     const where = q.where;

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -1,5 +1,5 @@
 import { SelectedColumn, SelectFromStatement } from 'pgsql-ast-parser';
-import { ParameterMatchClause, SqliteJsonValue, StaticRowValueClause, SyncParameters } from './types.js';
+import { ParameterMatchClause, SqliteJsonValue, RowValueClause, SyncParameters } from './types.js';
 import { SqlTools } from './sql_filters.js';
 import { getBucketId, isJsonValue } from './utils.js';
 import { SqlRuleError } from './errors.js';
@@ -51,7 +51,7 @@ export class StaticSqlParameterQuery {
 
   sql?: string;
   columns?: SelectedColumn[];
-  static_extractors: Record<string, StaticRowValueClause> = {};
+  static_extractors: Record<string, RowValueClause> = {};
   descriptor_name?: string;
   /** _Output_ bucket parameters */
   bucket_parameters?: string[];

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -64,7 +64,7 @@ export class StaticSqlParameterQuery {
 
   getStaticBucketIds(parameters: SyncParameters): string[] {
     const tables = { token_parameters: parameters.token_parameters, user_parameters: parameters.user_parameters };
-    const filtered = this.filter!.filter(tables);
+    const filtered = this.filter!.filterRow(tables);
     if (filtered.length == 0) {
       return [];
     }

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -267,11 +267,7 @@ export class SqlTools {
           // 3. static, parameterMatch
           // (bucket.param = 'something') = staticValue
           // To implement this, we need to ensure the static value here can only be true.
-          return this.error(
-            `Bucket parameter clauses cannot currently be combined with other operators`,
-
-            expr
-          );
+          return this.error(`Parameter match clauses cannot be used here`, expr);
         } else {
           throw new Error('Unexpected');
         }
@@ -524,16 +520,16 @@ export class SqlTools {
         if (argsType == 'static' || argsType == 'param') {
           argsType = 'param';
         } else {
-          return this.error(`Cannot combine table values and parameters in function call arguments`, debugArg);
+          return this.error(`Cannot use table values and parameters in the same clauses`, debugArg);
         }
       } else if (isRowValueClause(clause)) {
         if (argsType == 'static' || argsType == 'row') {
           argsType = 'row';
         } else {
-          return this.error(`Cannot combine table values and parameters in function call arguments`, debugArg);
+          return this.error(`Cannot use table values and parameters in the same clauses`, debugArg);
         }
       } else {
-        return this.error(`Bucket parameters are not supported in function call arguments`, debugArg);
+        return this.error(`Parameter match clauses cannot be used here`, debugArg);
       }
     }
 

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -360,14 +360,18 @@ export class SqlTools {
       }
     } else if (expr.type == 'call' && expr.function?.name != null) {
       const fn = expr.function.name;
-      const fnImpl = SQL_FUNCTIONS[fn];
-      if (fnImpl == null) {
-        return this.error(`Function '${fn}' is not defined`, expr);
-      }
+      if (expr.function.schema == null) {
+        const fnImpl = SQL_FUNCTIONS[fn];
+        if (fnImpl == null) {
+          return this.error(`Function '${fn}' is not defined`, expr);
+        }
 
-      const argClauses = expr.args.map((arg) => this.compileClause(arg));
-      const composed = this.composeFunction(fnImpl, argClauses, expr.args);
-      return composed;
+        const argClauses = expr.args.map((arg) => this.compileClause(arg));
+        const composed = this.composeFunction(fnImpl, argClauses, expr.args);
+        return composed;
+      } else {
+        return this.error(`Function '${expr.function.schema}.${fn}' is not defined`, expr);
+      }
     } else if (expr.type == 'member') {
       const operand = this.compileClause(expr.operand);
 

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -178,15 +178,7 @@ export class SqlTools {
         return this.error(`Schema is not supported in column references`, expr);
       }
       if (this.isParameterRef(expr)) {
-        const param = this.getParameterRef(expr)!;
-        const [table, column] = param.split('.');
-        return {
-          key: param,
-          lookupParameterValue: (parameters) => {
-            const pt: SqliteJsonRow | undefined = (parameters as any)[table];
-            return pt?.[column] ?? null;
-          }
-        } satisfies ParameterValueClause;
+        return this.getParameterRefClause(expr);
       } else if (this.isTableRef(expr)) {
         const table = this.getTableName(expr);
         this.checkRef(table, expr);
@@ -466,10 +458,16 @@ export class SqlTools {
     }
   }
 
-  getParameterRef(expr: Expr) {
-    if (this.isParameterRef(expr)) {
-      return `${expr.table!.name}.${expr.name}`;
-    }
+  getParameterRefClause(expr: ExprRef): ParameterValueClause {
+    const table = expr.table!.name;
+    const column = expr.name;
+    return {
+      key: `${table}.${column}`,
+      lookupParameterValue: (parameters) => {
+        const pt: SqliteJsonRow | undefined = (parameters as any)[table];
+        return pt?.[column] ?? null;
+      }
+    } satisfies ParameterValueClause;
   }
 
   refHasSchema(ref: ExprRef) {

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -554,7 +554,6 @@ export class SqlTools {
         }
       } satisfies RowValueClause;
     } else if (argsType == 'param') {
-      // TODO: make sure this is properly unique & predictable
       const argStrings = argClauses.map((e) => {
         if (isParameterValueClause(e)) {
           return e.key;

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -1,5 +1,5 @@
 import { JSONBig } from '@powersync/service-jsonbig';
-import { SQLITE_FALSE, SQLITE_TRUE, sqliteBool } from './sql_support.js';
+import { SQLITE_FALSE, SQLITE_TRUE, sqliteBool, sqliteNot } from './sql_support.js';
 import { SqliteValue } from './types.js';
 import { jsonValueToSqlite } from './utils.js';
 // Declares @syncpoint/wkx module
@@ -745,6 +745,28 @@ export const OPERATOR_IS_NULL: SqlFunction = {
   debugName: 'operator_is_null',
   call(value: SqliteValue) {
     return evaluateOperator('IS', value, null);
+  },
+  parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
+  getReturnType(_args) {
+    return ExpressionType.INTEGER;
+  }
+};
+
+export const OPERATOR_IS_NOT_NULL: SqlFunction = {
+  debugName: 'operator_is_not_null',
+  call(value: SqliteValue) {
+    return evaluateOperator('IS NOT', value, null);
+  },
+  parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
+  getReturnType(_args) {
+    return ExpressionType.INTEGER;
+  }
+};
+
+export const OPERATOR_NOT: SqlFunction = {
+  debugName: 'operator_not',
+  call(value: SqliteValue) {
+    return sqliteNot(value);
   },
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(_args) {

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -6,7 +6,7 @@ import { jsonValueToSqlite } from './utils.js';
 // This allows for consumers of this lib to resolve types correctly
 /// <reference types="./wkx.d.ts" />
 import wkx from '@syncpoint/wkx';
-import { ExpressionType, TYPE_INTEGER } from './ExpressionType.js';
+import { ExpressionType, SqliteType, TYPE_INTEGER } from './ExpressionType.js';
 
 export const BASIC_OPERATORS = new Set<string>([
   '=',
@@ -773,6 +773,25 @@ export const OPERATOR_NOT: SqlFunction = {
     return ExpressionType.INTEGER;
   }
 };
+
+export function castOperator(castTo: string | undefined): SqlFunction | null {
+  if (castTo == null || !CAST_TYPES.has(castTo)) {
+    return null;
+  }
+  return {
+    debugName: `operator_cast_${castTo}`,
+    call(value: SqliteValue) {
+      if (value == null) {
+        return null;
+      }
+      return cast(value, castTo!);
+    },
+    parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
+    getReturnType(_args) {
+      return ExpressionType.fromTypeText(castTo as SqliteType);
+    }
+  };
+}
 
 export interface ParseDateFlags {
   /**

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -160,34 +160,6 @@ const json_extract: SqlFunction = {
   }
 };
 
-export const JSON_EXTRACT_JSON_OPERATOR: SqlFunction = {
-  debugName: '->',
-  call(json: SqliteValue, path: SqliteValue) {
-    return jsonExtract(json, path, '->');
-  },
-  parameters: [
-    { name: 'json', type: ExpressionType.ANY, optional: false },
-    { name: 'path', type: ExpressionType.ANY, optional: false }
-  ],
-  getReturnType(args) {
-    return ExpressionType.ANY_JSON;
-  }
-};
-
-export const JSON_EXTRACT_SQL_OPERATOR: SqlFunction = {
-  debugName: '->>',
-  call(json: SqliteValue, path: SqliteValue) {
-    return jsonExtract(json, path, '->>');
-  },
-  parameters: [
-    { name: 'json', type: ExpressionType.ANY, optional: false },
-    { name: 'path', type: ExpressionType.ANY, optional: false }
-  ],
-  getReturnType(args) {
-    return ExpressionType.ANY_JSON;
-  }
-};
-
 const json_array_length: SqlFunction = {
   debugName: 'json_array_length',
   call(json: SqliteValue, path?: SqliteValue) {
@@ -740,6 +712,45 @@ export function jsonExtract(sourceValue: SqliteValue, path: SqliteValue, operato
     return jsonValueToSqlite(value as string | number | bigint | boolean | null);
   }
 }
+
+export const OPERATOR_JSON_EXTRACT_JSON: SqlFunction = {
+  debugName: 'operator->',
+  call(json: SqliteValue, path: SqliteValue) {
+    return jsonExtract(json, path, '->');
+  },
+  parameters: [
+    { name: 'json', type: ExpressionType.ANY, optional: false },
+    { name: 'path', type: ExpressionType.ANY, optional: false }
+  ],
+  getReturnType(args) {
+    return ExpressionType.ANY_JSON;
+  }
+};
+
+export const OPERATOR_JSON_EXTRACT_SQL: SqlFunction = {
+  debugName: 'operator->>',
+  call(json: SqliteValue, path: SqliteValue) {
+    return jsonExtract(json, path, '->>');
+  },
+  parameters: [
+    { name: 'json', type: ExpressionType.ANY, optional: false },
+    { name: 'path', type: ExpressionType.ANY, optional: false }
+  ],
+  getReturnType(_args) {
+    return ExpressionType.ANY_JSON;
+  }
+};
+
+export const OPERATOR_IS_NULL: SqlFunction = {
+  debugName: 'operator_is_null',
+  call(value: SqliteValue) {
+    return evaluateOperator('IS', value, null);
+  },
+  parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
+  getReturnType(_args) {
+    return ExpressionType.INTEGER;
+  }
+};
 
 export interface ParseDateFlags {
   /**

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -33,12 +33,14 @@ export interface FunctionParameter {
 }
 
 export interface SqlFunction {
+  readonly debugName: string;
   parameters: FunctionParameter[];
   call: (...args: SqliteValue[]) => SqliteValue;
   getReturnType(args: ExpressionType[]): ExpressionType;
 }
 
 const upper: SqlFunction = {
+  debugName: 'upper',
   call(value: SqliteValue) {
     const text = castAsText(value);
     return text?.toUpperCase() ?? null;
@@ -50,6 +52,7 @@ const upper: SqlFunction = {
 };
 
 const lower: SqlFunction = {
+  debugName: 'lower',
   call(value: SqliteValue) {
     const text = castAsText(value);
     return text?.toLowerCase() ?? null;
@@ -61,6 +64,7 @@ const lower: SqlFunction = {
 };
 
 const hex: SqlFunction = {
+  debugName: 'hex',
   call(value: SqliteValue) {
     const binary = castAsBlob(value);
     if (binary == null) {
@@ -75,6 +79,7 @@ const hex: SqlFunction = {
 };
 
 const length: SqlFunction = {
+  debugName: 'length',
   call(value: SqliteValue) {
     if (value == null) {
       return null;
@@ -92,6 +97,7 @@ const length: SqlFunction = {
 };
 
 const base64: SqlFunction = {
+  debugName: 'base64',
   call(value: SqliteValue) {
     const binary = castAsBlob(value);
     if (binary == null) {
@@ -106,6 +112,7 @@ const base64: SqlFunction = {
 };
 
 const fn_typeof: SqlFunction = {
+  debugName: 'typeof',
   call(value: SqliteValue) {
     return sqliteTypeOf(value);
   },
@@ -116,6 +123,7 @@ const fn_typeof: SqlFunction = {
 };
 
 const ifnull: SqlFunction = {
+  debugName: 'ifnull',
   call(x: SqliteValue, y: SqliteValue) {
     if (x == null) {
       return y;
@@ -139,6 +147,7 @@ const ifnull: SqlFunction = {
 };
 
 const json_extract: SqlFunction = {
+  debugName: 'json_extract',
   call(json: SqliteValue, path: SqliteValue) {
     return jsonExtract(json, path, 'json_extract');
   },
@@ -151,7 +160,36 @@ const json_extract: SqlFunction = {
   }
 };
 
+export const JSON_EXTRACT_JSON_OPERATOR: SqlFunction = {
+  debugName: '->',
+  call(json: SqliteValue, path: SqliteValue) {
+    return jsonExtract(json, path, '->');
+  },
+  parameters: [
+    { name: 'json', type: ExpressionType.ANY, optional: false },
+    { name: 'path', type: ExpressionType.ANY, optional: false }
+  ],
+  getReturnType(args) {
+    return ExpressionType.ANY_JSON;
+  }
+};
+
+export const JSON_EXTRACT_SQL_OPERATOR: SqlFunction = {
+  debugName: '->>',
+  call(json: SqliteValue, path: SqliteValue) {
+    return jsonExtract(json, path, '->>');
+  },
+  parameters: [
+    { name: 'json', type: ExpressionType.ANY, optional: false },
+    { name: 'path', type: ExpressionType.ANY, optional: false }
+  ],
+  getReturnType(args) {
+    return ExpressionType.ANY_JSON;
+  }
+};
+
 const json_array_length: SqlFunction = {
+  debugName: 'json_array_length',
   call(json: SqliteValue, path?: SqliteValue) {
     if (path != null) {
       json = json_extract.call(json, path);
@@ -177,6 +215,7 @@ const json_array_length: SqlFunction = {
 };
 
 const json_valid: SqlFunction = {
+  debugName: 'json_valid',
   call(json: SqliteValue) {
     const jsonString = castAsText(json);
     if (jsonString == null) {
@@ -196,6 +235,7 @@ const json_valid: SqlFunction = {
 };
 
 const unixepoch: SqlFunction = {
+  debugName: 'unixepoch',
   call(value?: SqliteValue, specifier?: SqliteValue, specifier2?: SqliteValue) {
     if (value == null) {
       return null;
@@ -240,6 +280,7 @@ const unixepoch: SqlFunction = {
 };
 
 const datetime: SqlFunction = {
+  debugName: 'datetime',
   call(value?: SqliteValue, specifier?: SqliteValue, specifier2?: SqliteValue) {
     if (value == null) {
       return null;
@@ -285,6 +326,7 @@ const datetime: SqlFunction = {
 };
 
 const st_asgeojson: SqlFunction = {
+  debugName: 'st_asgeojson',
   call(geometry?: SqliteValue) {
     const geo = parseGeometry(geometry);
     if (geo == null) {
@@ -299,6 +341,7 @@ const st_asgeojson: SqlFunction = {
 };
 
 const st_astext: SqlFunction = {
+  debugName: 'st_astext',
   call(geometry?: SqliteValue) {
     const geo = parseGeometry(geometry);
     if (geo == null) {
@@ -312,6 +355,7 @@ const st_astext: SqlFunction = {
   }
 };
 const st_x: SqlFunction = {
+  debugName: 'st_x',
   call(geometry?: SqliteValue) {
     const geo = parseGeometry(geometry);
     if (geo == null) {
@@ -329,6 +373,7 @@ const st_x: SqlFunction = {
 };
 
 const st_y: SqlFunction = {
+  debugName: 'st_y',
   call(geometry?: SqliteValue) {
     const geo = parseGeometry(geometry);
     if (geo == null) {

--- a/packages/sync-rules/src/sql_support.ts
+++ b/packages/sync-rules/src/sql_support.ts
@@ -236,7 +236,6 @@ export function toBooleanParameterSetClause(clause: CompiledClause): ParameterMa
   } else {
     // Equivalent to `bucket.param = true`
     const paramName = clause.bucketParameter;
-    const [table, column] = clause.bucketParameter.split('.');
 
     const inputParam: InputParameter = {
       key: paramName,
@@ -245,8 +244,8 @@ export function toBooleanParameterSetClause(clause: CompiledClause): ParameterMa
         return filterParameters[paramName];
       },
       parametersToLookupValue: (parameters) => {
-        const pt: SqliteJsonRow | undefined = (parameters as any)[table];
-        return pt?.[column] ?? null;
+        const inner = clause.lookupParameterValue(parameters);
+        return sqliteBool(inner);
       }
     };
 

--- a/packages/sync-rules/src/sql_support.ts
+++ b/packages/sync-rules/src/sql_support.ts
@@ -13,7 +13,7 @@ import {
   TrueIfParametersMatch
 } from './types.js';
 import { MATCH_CONST_FALSE, MATCH_CONST_TRUE } from './sql_filters.js';
-import { evaluateOperator, getOperatorReturnType } from './sql_functions.js';
+import { SqlFunction, evaluateOperator, getOperatorReturnType } from './sql_functions.js';
 import { SelectFromStatement } from 'pgsql-ast-parser';
 import { SqlRuleError } from './errors.js';
 import { ExpressionType } from './ExpressionType.js';
@@ -76,6 +76,22 @@ export function compileStaticOperator(
       const typeRight = right.getType(schema);
       return getOperatorReturnType(op, typeLeft, typeRight);
     }
+  };
+}
+
+export function getOperatorFunction(op: string): SqlFunction {
+  return {
+    debugName: `operator${op}`,
+    call(...args: SqliteValue[]) {
+      return evaluateOperator(op, args[0], args[1]);
+    },
+    getReturnType(args) {
+      return getOperatorReturnType(op, args[0], args[1]);
+    },
+    parameters: [
+      { name: 'left', type: ExpressionType.ANY, optional: false },
+      { name: 'right', type: ExpressionType.ANY, optional: false }
+    ]
   };
 }
 

--- a/packages/sync-rules/src/sql_support.ts
+++ b/packages/sync-rules/src/sql_support.ts
@@ -9,6 +9,7 @@ import {
   SqliteJsonRow,
   SqliteValue,
   StaticRowValueClause,
+  StaticValueClause,
   TrueIfParametersMatch
 } from './types.js';
 import { MATCH_CONST_FALSE, MATCH_CONST_TRUE } from './sql_filters.js';
@@ -23,6 +24,10 @@ export function isParameterMatchClause(clause: CompiledClause): clause is Parame
 
 export function isStaticRowValueClause(clause: CompiledClause): clause is StaticRowValueClause {
   return typeof (clause as StaticRowValueClause).evaluate == 'function';
+}
+
+export function isStaticValueClause(clause: CompiledClause): clause is StaticValueClause {
+  return isStaticRowValueClause(clause) && typeof (clause as StaticValueClause).value != 'undefined';
 }
 
 export function isParameterValueClause(clause: CompiledClause): clause is ParameterValueClause {

--- a/packages/sync-rules/src/sql_support.ts
+++ b/packages/sync-rules/src/sql_support.ts
@@ -102,7 +102,7 @@ export function andFilters(a: CompiledClause, b: CompiledClause): CompiledClause
       getType() {
         return ExpressionType.INTEGER;
       }
-    };
+    } satisfies RowValueClause;
   }
 
   const aFilter = toBooleanParameterSetClause(a);

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -155,7 +155,7 @@ export interface InputParameter {
    *
    * Only relevant for parameter queries.
    */
-  parametersToLookupValue(parameters: SyncParameters): SqliteJsonValue;
+  parametersToLookupValue(parameters: SyncParameters): SqliteValue;
 }
 
 export interface EvaluateRowOptions {
@@ -213,7 +213,7 @@ export interface ParameterValueClause {
    *
    * Only relevant for parameter queries.
    */
-  lookupParameterValue(parameters: SyncParameters): SqliteJsonValue;
+  lookupParameterValue(parameters: SyncParameters): SqliteValue;
 }
 
 export interface QuerySchema {

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -154,10 +154,13 @@ export interface ParameterMatchClause {
   /**
    * Given a data row, give a set of filter parameters that would make the filter be true.
    *
+   * For StaticSqlParameterQuery, the tables are token_parameters and user_parameters.
+   * For others, it is the table of the data or parameter query.
+   *
    * @param tables - {table => row}
    * @return The filter parameters
    */
-  filter(tables: QueryParameters): TrueIfParametersMatch;
+  filterRow(tables: QueryParameters): TrueIfParametersMatch;
 }
 
 /**

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -120,6 +120,10 @@ export type QueryParameters = { [table: string]: SqliteRow };
  * A single set of parameters that would make a WHERE filter true.
  *
  * Each parameter is prefixed with a table name, e.g. 'bucket.param'.
+ *
+ * Data queries: this is converted into a bucket id, given named bucket parameters.
+ *
+ * Parameter queries: this is converted into a lookup array.
  */
 export type FilterParameters = { [parameter: string]: SqliteJsonValue };
 

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -229,6 +229,10 @@ export interface StaticRowValueClause {
   getType(schema: QuerySchema): ExpressionType;
 }
 
+export interface StaticValueClause extends StaticRowValueClause {
+  readonly value: SqliteValue;
+}
+
 export interface ClauseError {
   error: true;
 }

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -127,6 +127,37 @@ export type QueryParameters = { [table: string]: SqliteRow };
  */
 export type FilterParameters = { [parameter: string]: SqliteJsonValue };
 
+export interface InputParameter {
+  /**
+   * An unique identifier per parameter in a query.
+   *
+   * This is used to identify the same parameters used in a query multiple times.
+   *
+   * The value itself does not necessarily have any specific meaning.
+   */
+  key: string;
+
+  /**
+   * True if the parameter expands to an array. This means parametersToLookupValue() can
+   * return a JSON array. This is different from `unbounded` on the clause.
+   */
+  expands: boolean;
+
+  /**
+   * Given FilterParameters from a data row, return the associated value.
+   *
+   * Only relevant for parameter queries.
+   */
+  filteredRowToLookupValue(filterParameters: FilterParameters): SqliteJsonValue;
+
+  /**
+   * Given SyncParamters, return the associated value to lookup.
+   *
+   * Only relevant for parameter queries.
+   */
+  parametersToLookupValue(parameters: SyncParameters): SqliteJsonValue;
+}
+
 export interface EvaluateRowOptions {
   sourceTable: SourceTableInterface;
   record: SqliteRow;
@@ -145,10 +176,11 @@ export interface ParameterMatchClause {
    *
    * These parameters are always matched by this clause, and no additional parameters are matched.
    */
-  bucketParameters: string[];
+  bucketParameters: InputParameter[];
 
   /**
-   * True if the filter depends on an unbounded array column.
+   * True if the filter depends on an unbounded array column. This means filterRow can return
+   * multiple items.
    *
    * We restrict filters to only allow a single unbounded column for bucket parameters, otherwise the number of
    * bucketParameter combinations could grow too much.
@@ -175,6 +207,13 @@ export interface ParameterValueClause {
    * The parameter fields used for this, e.g. 'bucket.region_id'
    */
   bucketParameter: string;
+
+  /**
+   * Given SyncParamters, return the associated value to lookup.
+   *
+   * Only relevant for parameter queries.
+   */
+  lookupParameterValue(parameters: SyncParameters): SqliteJsonValue;
 }
 
 export interface QuerySchema {

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest';
+import { ExpressionType, SqlDataQuery } from '../../src/index.js';
+import { BASIC_SCHEMA } from './util.js';
+
+describe('data queries', () => {
+  test('types', () => {
+    const schema = BASIC_SCHEMA;
+
+    const q1 = SqlDataQuery.fromSql('q1', ['user_id'], `SELECT * FROM assets WHERE owner_id = bucket.user_id`);
+    expect(q1.getColumnOutputs(schema)).toEqual([
+      {
+        name: 'assets',
+        columns: [
+          { name: 'id', type: ExpressionType.TEXT },
+          { name: 'name', type: ExpressionType.TEXT },
+          { name: 'count', type: ExpressionType.INTEGER },
+          { name: 'owner_id', type: ExpressionType.TEXT }
+        ]
+      }
+    ]);
+
+    const q2 = SqlDataQuery.fromSql(
+      'q1',
+      ['user_id'],
+      `
+  SELECT id :: integer as id,
+   upper(name) as name_upper,
+   hex('test') as hex,
+   count + 2 as count2,
+   count * 3.0 as count3,
+   count * '4' as count4,
+   name ->> '$.attr' as json_value,
+   ifnull(name, 2.0) as maybe_name
+  FROM assets WHERE owner_id = bucket.user_id`
+    );
+    expect(q2.getColumnOutputs(schema)).toEqual([
+      {
+        name: 'assets',
+        columns: [
+          { name: 'id', type: ExpressionType.INTEGER },
+          { name: 'name_upper', type: ExpressionType.TEXT },
+          { name: 'hex', type: ExpressionType.TEXT },
+          { name: 'count2', type: ExpressionType.INTEGER },
+          { name: 'count3', type: ExpressionType.REAL },
+          { name: 'count4', type: ExpressionType.NUMERIC },
+          { name: 'json_value', type: ExpressionType.ANY_JSON },
+          { name: 'maybe_name', type: ExpressionType.TEXT.or(ExpressionType.REAL) }
+        ]
+      }
+    ]);
+  });
+
+  test('validate columns', () => {
+    const schema = BASIC_SCHEMA;
+    const q1 = SqlDataQuery.fromSql(
+      'q1',
+      ['user_id'],
+      'SELECT id, name, count FROM assets WHERE owner_id = bucket.user_id',
+      schema
+    );
+    expect(q1.errors).toEqual([]);
+
+    const q2 = SqlDataQuery.fromSql(
+      'q2',
+      ['user_id'],
+      'SELECT id, upper(description) as d FROM assets WHERE other_id = bucket.user_id',
+      schema
+    );
+    expect(q2.errors).toMatchObject([
+      {
+        message: `Column not found: other_id`,
+        type: 'warning'
+      },
+      {
+        message: `Column not found: description`,
+        type: 'warning'
+      }
+    ]);
+
+    const q3 = SqlDataQuery.fromSql(
+      'q3',
+      ['user_id'],
+      'SELECT id, description, * FROM nope WHERE other_id = bucket.user_id',
+      schema
+    );
+    expect(q3.errors).toMatchObject([
+      {
+        message: `Table public.nope not found`,
+        type: 'warning'
+      }
+    ]);
+  });
+});

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -143,4 +143,38 @@ describe('data queries', () => {
       }
     ]);
   });
+
+  test('invalid query - invalid IN', function () {
+    const sql = 'SELECT * FROM assets WHERE assets.category IN bucket.categories';
+    const query = SqlDataQuery.fromSql('mybucket', ['categories'], sql);
+    expect(query.errors).toMatchObject([{ type: 'fatal', message: 'Unsupported usage of IN operator' }]);
+  });
+
+  test('invalid query - not all parameters used', function () {
+    const sql = 'SELECT * FROM assets WHERE 1';
+    const query = SqlDataQuery.fromSql('mybucket', ['org_id'], sql);
+    expect(query.errors).toMatchObject([
+      { type: 'fatal', message: 'Query must cover all bucket parameters. Expected: ["bucket.org_id"] Got: []' }
+    ]);
+  });
+
+  test('invalid query - parameter not defined', function () {
+    const sql = 'SELECT * FROM assets WHERE assets.org_id = bucket.org_id';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([
+      { type: 'fatal', message: 'Query must cover all bucket parameters. Expected: [] Got: ["bucket.org_id"]' }
+    ]);
+  });
+
+  test('invalid query - function on parameter (1)', function () {
+    const sql = 'SELECT * FROM assets WHERE assets.org_id = upper(bucket.org_id)';
+    const query = SqlDataQuery.fromSql('mybucket', ['org_id'], sql);
+    expect(query.errors).toMatchObject([{ type: 'fatal', message: 'Cannot use bucket parameters in expressions' }]);
+  });
+
+  test('invalid query - function on parameter (2)', function () {
+    const sql = 'SELECT * FROM assets WHERE assets.org_id = upper(bucket.org_id)';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([{ type: 'fatal', message: 'Cannot use bucket parameters in expressions' }]);
+  });
 });

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -415,4 +415,29 @@ describe('parameter queries', () => {
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/must use the same parameters/);
   });
+
+  test('invalid parameter match clause (1)', () => {
+    const sql = 'SELECT FROM users WHERE (id = token_parameters.user_id) = false';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors[0].message).toMatch(/Parameter match clauses cannot be used here/);
+  });
+
+  test('invalid parameter match clause (2)', () => {
+    const sql = 'SELECT FROM users WHERE NOT (id = token_parameters.user_id)';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors[0].message).toMatch(/Parameter match clauses cannot be used here/);
+  });
+
+  test('invalid parameter match clause (3)', () => {
+    // May be supported in the future
+    const sql = 'SELECT FROM users WHERE token_parameters.start_at < users.created_at';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors[0].message).toMatch(/Cannot use table values and parameters in the same clauses/);
+  });
+
+  test('invalid parameter match clause (4)', () => {
+    const sql = 'SELECT FROM users WHERE json_extract(users.description, token_parameters.path)';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors[0].message).toMatch(/Cannot use table values and parameters in the same clauses/);
+  });
 });

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, test } from 'vitest';
+import { SqlParameterQuery, normalizeTokenParameters } from '../../src/index.js';
+
+describe('parameter queries', () => {
+  test('token_parameters IN query', function () {
+    const sql = 'SELECT id as group_id FROM groups WHERE token_parameters.user_id IN groups.user_ids';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    query.id = '1';
+    expect(query.evaluateParameterRow({ id: 'group1', user_ids: JSON.stringify(['user1', 'user2']) })).toEqual([
+      {
+        lookup: ['mybucket', '1', 'user1'],
+        bucket_parameters: [
+          {
+            group_id: 'group1'
+          }
+        ]
+      },
+      {
+        lookup: ['mybucket', '1', 'user2'],
+        bucket_parameters: [
+          {
+            group_id: 'group1'
+          }
+        ]
+      }
+    ]);
+    expect(
+      query.getLookups(
+        normalizeTokenParameters({
+          user_id: 'user1'
+        })
+      )
+    ).toEqual([['mybucket', '1', 'user1']]);
+  });
+
+  test('IN token_parameters query', function () {
+    const sql = 'SELECT id as region_id FROM regions WHERE name IN token_parameters.region_names';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    query.id = '1';
+    expect(query.evaluateParameterRow({ id: 'region1', name: 'colorado' })).toEqual([
+      {
+        lookup: ['mybucket', '1', 'colorado'],
+        bucket_parameters: [
+          {
+            region_id: 'region1'
+          }
+        ]
+      }
+    ]);
+    expect(
+      query.getLookups(
+        normalizeTokenParameters({
+          region_names: JSON.stringify(['colorado', 'texas'])
+        })
+      )
+    ).toEqual([
+      ['mybucket', '1', 'colorado'],
+      ['mybucket', '1', 'texas']
+    ]);
+  });
+
+  test('queried numeric parameters', () => {
+    const sql =
+      'SELECT users.int1, users.float1, users.float2 FROM users WHERE users.int1 = token_parameters.int1 AND users.float1 = token_parameters.float1 AND users.float2 = token_parameters.float2';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    query.id = '1';
+    // Note: We don't need to worry about numeric vs decimal types in the lookup - JSONB handles normalization for us.
+    expect(query.evaluateParameterRow({ int1: 314n, float1: 3.14, float2: 314 })).toEqual([
+      {
+        lookup: ['mybucket', '1', 314n, 3.14, 314],
+
+        bucket_parameters: [{ int1: 314n, float1: 3.14, float2: 314 }]
+      }
+    ]);
+
+    // Similarly, we don't need to worry about the types here.
+    // This test just checks the current behavior.
+    expect(query.getLookups(normalizeTokenParameters({ int1: 314n, float1: 3.14, float2: 314 }))).toEqual([
+      ['mybucket', '1', 314n, 3.14, 314n]
+    ]);
+
+    // We _do_ need to care about the bucket string representation.
+    expect(query.resolveBucketIds([{ int1: 314, float1: 3.14, float2: 314 }], normalizeTokenParameters({}))).toEqual([
+      'mybucket[314,3.14,314]'
+    ]);
+
+    expect(query.resolveBucketIds([{ int1: 314n, float1: 3.14, float2: 314 }], normalizeTokenParameters({}))).toEqual([
+      'mybucket[314,3.14,314]'
+    ]);
+  });
+
+  test('plain token_parameter (baseline)', () => {
+    const sql = 'SELECT id from users WHERE filter_param = token_parameters.user_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+    expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 'test_param'],
+
+        bucket_parameters: [{ id: 'test_id' }]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'test' }))).toEqual([['mybucket', undefined, 'test']]);
+  });
+
+  test('function on token_parameter', () => {
+    const sql = 'SELECT id from users WHERE filter_param = upper(token_parameters.user_id)';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+    expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 'test_param'],
+
+        bucket_parameters: [{ id: 'test_id' }]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'test' }))).toEqual([['mybucket', undefined, 'TEST']]);
+  });
+
+  test('token parameter member operator', () => {
+    const sql = "SELECT id from users WHERE filter_param = token_parameters.some_param ->> 'description'";
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+    expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 'test_param'],
+
+        bucket_parameters: [{ id: 'test_id' }]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ some_param: { description: 'test_description' } }))).toEqual([
+      ['mybucket', undefined, 'test_description']
+    ]);
+  });
+
+  test('token parameter and binary operator', () => {
+    const sql = 'SELECT id from users WHERE filter_param = token_parameters.some_param + 2';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.getLookups(normalizeTokenParameters({ some_param: 3 }))).toEqual([['mybucket', undefined, 5n]]);
+  });
+
+  test('token parameter IS NULL as filter', () => {
+    const sql = 'SELECT id from users WHERE filter_param = (token_parameters.some_param IS NULL)';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.getLookups(normalizeTokenParameters({ some_param: null }))).toEqual([['mybucket', undefined, 1n]]);
+    expect(query.getLookups(normalizeTokenParameters({ some_param: 'test' }))).toEqual([['mybucket', undefined, 0n]]);
+  });
+
+  test('direct token parameter', () => {
+    const sql = 'SELECT FROM users WHERE token_parameters.some_param';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
+      ['mybucket', undefined, 0n]
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
+      ['mybucket', undefined, 1n]
+    ]);
+  });
+
+  test('token parameter IS NULL', () => {
+    const sql = 'SELECT FROM users WHERE token_parameters.some_param IS NULL';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
+      ['mybucket', undefined, 1n]
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
+      ['mybucket', undefined, 0n]
+    ]);
+  });
+
+  test('token parameter IS NOT NULL', () => {
+    const sql = 'SELECT FROM users WHERE token_parameters.some_param IS NOT NULL';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
+      ['mybucket', undefined, 0n]
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
+      ['mybucket', undefined, 1n]
+    ]);
+  });
+
+  test('token parameter NOT', () => {
+    const sql = 'SELECT FROM users WHERE NOT token_parameters.is_admin';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', is_admin: false }))).toEqual([
+      ['mybucket', undefined, 1n]
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', is_admin: 123 }))).toEqual([
+      ['mybucket', undefined, 0n]
+    ]);
+  });
+
+  test('row filter and token parameter IS NULL', () => {
+    const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.some_param IS NULL';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 'user1', 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
+      ['mybucket', undefined, 'user1', 1n]
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
+      ['mybucket', undefined, 'user1', 0n]
+    ]);
+  });
+
+  test('row filter and direct token parameter', () => {
+    const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.some_param';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 'user1', 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
+      ['mybucket', undefined, 'user1', 1n]
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
+      ['mybucket', undefined, 'user1', 0n]
+    ]);
+  });
+
+  test('cast', () => {
+    const sql = 'SELECT FROM users WHERE users.id = cast(token_parameters.user_id as text)';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
+      ['mybucket', undefined, 'user1']
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 123 }))).toEqual([['mybucket', undefined, '123']]);
+  });
+
+  test('IS NULL row filter', () => {
+    const sql = 'SELECT id FROM users WHERE role IS NULL';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1', role: null })).toEqual([
+      {
+        lookup: ['mybucket', undefined],
+        bucket_parameters: [{ id: 'user1' }]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([['mybucket', undefined]]);
+  });
+
+  test('token filter (1)', () => {
+    // Also supported: token_parameters.is_admin = true
+    // Not supported: token_parameters.is_admin != false
+    // Support could be added later.
+    const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.is_admin';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    query.id = '1';
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', '1', 'user1', 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', is_admin: true }))).toEqual([
+      ['mybucket', '1', 'user1', 1n]
+    ]);
+    // Would not match any actual lookups
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', is_admin: false }))).toEqual([
+      ['mybucket', '1', 'user1', 0n]
+    ]);
+  });
+
+  test('token filter (2)', () => {
+    const sql =
+      'SELECT users.id AS user_id, token_parameters.is_admin as is_admin FROM users WHERE users.id = token_parameters.user_id AND token_parameters.is_admin';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    query.id = '1';
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', '1', 'user1', 1n],
+
+        bucket_parameters: [{ user_id: 'user1' }]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', is_admin: true }))).toEqual([
+      ['mybucket', '1', 'user1', 1n]
+    ]);
+
+    expect(
+      query.resolveBucketIds([{ user_id: 'user1' }], normalizeTokenParameters({ user_id: 'user1', is_admin: true }))
+    ).toEqual(['mybucket["user1",1]']);
+  });
+
+  test('case-sensitive parameter queries (1)', () => {
+    const sql = 'SELECT users."userId" AS user_id FROM users WHERE users."userId" = token_parameters.user_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    query.id = '1';
+
+    expect(query.evaluateParameterRow({ userId: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', '1', 'user1'],
+
+        bucket_parameters: [{ user_id: 'user1' }]
+      }
+    ]);
+  });
+
+  test('case-sensitive parameter queries (2)', () => {
+    // Note: This documents current behavior.
+    // This may change in the future - we should check against expected behavior for
+    // Postgres and/or SQLite.
+    const sql = 'SELECT users.userId AS user_id FROM users WHERE users.userId = token_parameters.user_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    query.id = '1';
+
+    expect(query.evaluateParameterRow({ userId: 'user1' })).toEqual([]);
+    expect(query.evaluateParameterRow({ userid: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', '1', 'user1'],
+
+        bucket_parameters: [{ user_id: 'user1' }]
+      }
+    ]);
+  });
+
+  test('dynamic global parameter query', () => {
+    const sql = "SELECT workspaces.id AS workspace_id FROM workspaces WHERE visibility = 'public'";
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    query.id = '1';
+
+    expect(query.evaluateParameterRow({ id: 'workspace1', visibility: 'public' })).toEqual([
+      {
+        lookup: ['mybucket', '1'],
+
+        bucket_parameters: [{ workspace_id: 'workspace1' }]
+      }
+    ]);
+
+    expect(query.evaluateParameterRow({ id: 'workspace1', visibility: 'private' })).toEqual([]);
+  });
+
+  test('invalid OR in parameter queries', () => {
+    // Supporting this case is more tricky. We can do this by effectively denormalizing the OR clause
+    // into separate queries, but it's a significant change. For now, developers should do that manually.
+    const sql =
+      "SELECT workspaces.id AS workspace_id FROM workspaces WHERE workspaces.user_id = token_parameters.user_id OR visibility = 'public'";
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors[0].message).toMatch(/must use the same parameters/);
+  });
+});

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -6,6 +6,7 @@ describe('parameter queries', () => {
   test('token_parameters IN query', function () {
     const sql = 'SELECT id as group_id FROM groups WHERE token_parameters.user_id IN groups.user_ids';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
     query.id = '1';
     expect(query.evaluateParameterRow({ id: 'group1', user_ids: JSON.stringify(['user1', 'user2']) })).toEqual([
       {
@@ -37,6 +38,7 @@ describe('parameter queries', () => {
   test('IN token_parameters query', function () {
     const sql = 'SELECT id as region_id FROM regions WHERE name IN token_parameters.region_names';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
     query.id = '1';
     expect(query.evaluateParameterRow({ id: 'region1', name: 'colorado' })).toEqual([
       {
@@ -64,6 +66,7 @@ describe('parameter queries', () => {
     const sql =
       'SELECT users.int1, users.float1, users.float2 FROM users WHERE users.int1 = token_parameters.int1 AND users.float1 = token_parameters.float1 AND users.float2 = token_parameters.float2';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
     query.id = '1';
     // Note: We don't need to worry about numeric vs decimal types in the lookup - JSONB handles normalization for us.
     expect(query.evaluateParameterRow({ int1: 314n, float1: 3.14, float2: 314 })).toEqual([
@@ -93,8 +96,8 @@ describe('parameter queries', () => {
   test('plain token_parameter (baseline)', () => {
     const sql = 'SELECT id from users WHERE filter_param = token_parameters.user_id';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
+
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
       {
         lookup: ['mybucket', undefined, 'test_param'],
@@ -109,8 +112,8 @@ describe('parameter queries', () => {
   test('function on token_parameter', () => {
     const sql = 'SELECT id from users WHERE filter_param = upper(token_parameters.user_id)';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
+
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
       {
         lookup: ['mybucket', undefined, 'test_param'],
@@ -125,8 +128,8 @@ describe('parameter queries', () => {
   test('token parameter member operator', () => {
     const sql = "SELECT id from users WHERE filter_param = token_parameters.some_param ->> 'description'";
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
+
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
       {
         lookup: ['mybucket', undefined, 'test_param'],
@@ -143,7 +146,6 @@ describe('parameter queries', () => {
   test('token parameter and binary operator', () => {
     const sql = 'SELECT id from users WHERE filter_param = token_parameters.some_param + 2';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.getLookups(normalizeTokenParameters({ some_param: 3 }))).toEqual([['mybucket', undefined, 5n]]);
@@ -152,7 +154,6 @@ describe('parameter queries', () => {
   test('token parameter IS NULL as filter', () => {
     const sql = 'SELECT id from users WHERE filter_param = (token_parameters.some_param IS NULL)';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.getLookups(normalizeTokenParameters({ some_param: null }))).toEqual([['mybucket', undefined, 1n]]);
@@ -162,7 +163,6 @@ describe('parameter queries', () => {
   test('direct token parameter', () => {
     const sql = 'SELECT FROM users WHERE token_parameters.some_param';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
@@ -183,7 +183,6 @@ describe('parameter queries', () => {
   test('token parameter IS NULL', () => {
     const sql = 'SELECT FROM users WHERE token_parameters.some_param IS NULL';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
@@ -204,7 +203,6 @@ describe('parameter queries', () => {
   test('token parameter IS NOT NULL', () => {
     const sql = 'SELECT FROM users WHERE token_parameters.some_param IS NOT NULL';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
@@ -225,7 +223,6 @@ describe('parameter queries', () => {
   test('token parameter NOT', () => {
     const sql = 'SELECT FROM users WHERE NOT token_parameters.is_admin';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
@@ -246,7 +243,6 @@ describe('parameter queries', () => {
   test('row filter and token parameter IS NULL', () => {
     const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.some_param IS NULL';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
@@ -267,7 +263,6 @@ describe('parameter queries', () => {
   test('row filter and direct token parameter', () => {
     const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.some_param';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
@@ -288,7 +283,6 @@ describe('parameter queries', () => {
   test('cast', () => {
     const sql = 'SELECT FROM users WHERE users.id = cast(token_parameters.user_id as text)';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
@@ -300,7 +294,6 @@ describe('parameter queries', () => {
   test('IS NULL row filter', () => {
     const sql = 'SELECT id FROM users WHERE role IS NULL';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-
     expect(query.errors).toEqual([]);
 
     expect(query.evaluateParameterRow({ id: 'user1', role: null })).toEqual([
@@ -319,6 +312,7 @@ describe('parameter queries', () => {
     // Support could be added later.
     const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.is_admin';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
     query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
@@ -341,6 +335,7 @@ describe('parameter queries', () => {
     const sql =
       'SELECT users.id AS user_id, token_parameters.is_admin as is_admin FROM users WHERE users.id = token_parameters.user_id AND token_parameters.is_admin';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
     query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
@@ -363,6 +358,7 @@ describe('parameter queries', () => {
   test('case-sensitive parameter queries (1)', () => {
     const sql = 'SELECT users."userId" AS user_id FROM users WHERE users."userId" = token_parameters.user_id';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
     query.id = '1';
 
     expect(query.evaluateParameterRow({ userId: 'user1' })).toEqual([
@@ -380,6 +376,7 @@ describe('parameter queries', () => {
     // Postgres and/or SQLite.
     const sql = 'SELECT users.userId AS user_id FROM users WHERE users.userId = token_parameters.user_id';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
     query.id = '1';
 
     expect(query.evaluateParameterRow({ userId: 'user1' })).toEqual([]);
@@ -395,6 +392,7 @@ describe('parameter queries', () => {
   test('dynamic global parameter query', () => {
     const sql = "SELECT workspaces.id AS workspace_id FROM workspaces WHERE visibility = 'public'";
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
     query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'workspace1', visibility: 'public' })).toEqual([

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -488,6 +488,12 @@ describe('parameter queries', () => {
     expect(query.errors[0].message).toMatch(/Cannot use table values and parameters in the same clauses/);
   });
 
+  test('invalid function schema', () => {
+    const sql = 'SELECT FROM users WHERE something.length(users.id) = 0';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors[0].message).toMatch(/Function 'something.length' is not defined/);
+  });
+
   test('validate columns', () => {
     const schema = BASIC_SCHEMA;
 

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+import { SqlParameterQuery, normalizeTokenParameters } from '../../src/index.js';
+import { StaticSqlParameterQuery } from '../../src/StaticSqlParameterQuery.js';
+
+describe('static parameter queries', () => {
+  test('basic query', function () {
+    const sql = 'SELECT token_parameters.user_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.bucket_parameters!).toEqual(['user_id']);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1' }))).toEqual(['mybucket["user1"]']);
+  });
+
+  test('global query', function () {
+    const sql = 'SELECT';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.bucket_parameters!).toEqual([]);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1' }))).toEqual(['mybucket[]']);
+  });
+
+  test('query with filter', function () {
+    const sql = 'SELECT token_parameters.user_id WHERE token_parameters.is_admin';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1', is_admin: true }))).toEqual([
+      'mybucket["user1"]'
+    ]);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1', is_admin: false }))).toEqual([]);
+  });
+
+  test('function in select clause', function () {
+    const sql = 'SELECT upper(token_parameters.user_id) as upper_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1' }))).toEqual(['mybucket["USER1"]']);
+    expect(query.bucket_parameters!).toEqual(['upper_id']);
+  });
+
+  test('function in filter clause', function () {
+    const sql = "SELECT WHERE upper(token_parameters.role) = 'ADMIN'";
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ role: 'admin' }))).toEqual(['mybucket[]']);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ role: 'user' }))).toEqual([]);
+  });
+
+  test('comparison in filter clause', function () {
+    const sql = 'SELECT WHERE token_parameters.id1 = token_parameters.id2';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ id1: 't1', id2: 't1' }))).toEqual(['mybucket[]']);
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ id1: 't1', id2: 't2' }))).toEqual([]);
+  });
+});

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -686,6 +686,15 @@ bucket_definitions:
     ]);
   });
 
+  test('bucket with function on token_parameters (4)', () => {
+    const sql = 'SELECT id from users WHERE filter_param = token_parameters.some_param + 2';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.getLookups(normalizeTokenParameters({ some_param: 3 }))).toEqual([['mybucket', undefined, 5n]]);
+  });
+
   test('parameter query with token filter (1)', () => {
     // Also supported: token_parameters.is_admin = true
     // Not supported: token_parameters.is_admin != false

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -407,7 +407,6 @@ bucket_definitions:
       }
     ]);
 
-    // TODO: Deduplicate somewhere
     expect(
       rules.evaluateRow({ sourceTable: ASSETS, record: { id: 'asset2', description: 'test', role: 'normal' } })
     ).toEqual([

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -90,8 +90,8 @@ bucket_definitions:
     expect(bucket.bucket_parameters).toEqual([]);
     const param_query = bucket.global_parameter_queries[0];
 
-    expect(param_query.filter!.filter({ token_parameters: { is_admin: 1n } })).toEqual([{}]);
-    expect(param_query.filter!.filter({ token_parameters: { is_admin: 0n } })).toEqual([]);
+    expect(param_query.filter!.filterRow({ token_parameters: { is_admin: 1n } })).toEqual([{}]);
+    expect(param_query.filter!.filterRow({ token_parameters: { is_admin: 0n } })).toEqual([]);
     expect(rules.getStaticBucketIds(normalizeTokenParameters({ is_admin: true }))).toEqual(['mybucket[]']);
     expect(rules.getStaticBucketIds(normalizeTokenParameters({ is_admin: false }))).toEqual([]);
     expect(rules.getStaticBucketIds(normalizeTokenParameters({}))).toEqual([]);
@@ -623,6 +623,28 @@ bucket_definitions:
     expect(query.resolveBucketIds([{ int1: 314n, float1: 3.14, float2: 314 }], normalizeTokenParameters({}))).toEqual([
       'mybucket[314,3.14,314]'
     ]);
+  });
+
+  test('bucket with function on token_parameters (1)', () => {
+    const rules = SqlSyncRules.fromYaml(`
+bucket_definitions:
+  mybucket:
+    parameters: SELECT upper(token_parameters.user_id) as upper
+    data: []
+    `);
+    expect(rules.errors).toEqual([]);
+    expect(rules.getStaticBucketIds(normalizeTokenParameters({ user_id: 'test' }))).toEqual(['mybucket["TEST"]']);
+  });
+
+  test.skip('bucket with function on token_parameters (2)', () => {
+    const rules = SqlSyncRules.fromYaml(`
+bucket_definitions:
+  mybucket:
+    parameters: SELECT id from users WHERE id_upper = upper(token_parameters.user_id)
+    data: []
+    `);
+    expect(rules.errors).toEqual([]);
+    expect(rules.getStaticBucketIds(normalizeTokenParameters({ user_id: 'test' }))).toEqual(['mybucket["TEST"]']);
   });
 
   test('parameter query with token filter (1)', () => {

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -831,6 +831,18 @@ bucket_definitions:
     ]);
   });
 
+  test('parameter query with cast', () => {
+    const sql = 'SELECT FROM users WHERE users.id = cast(token_parameters.user_id as text)';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
+      ['mybucket', undefined, 'user1']
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 123 }))).toEqual([['mybucket', undefined, '123']]);
+  });
+
   test('parameter query with IS NULL row filter', () => {
     const sql = 'SELECT id FROM users WHERE role IS NULL';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -668,6 +668,24 @@ bucket_definitions:
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'test' }))).toEqual([['mybucket', undefined, 'TEST']]);
   });
 
+  test('bucket with function on token_parameters (3)', () => {
+    const sql = "SELECT id from users WHERE filter_param = token_parameters.some_param ->> 'description'";
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+    expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 'test_param'],
+
+        bucket_parameters: [{ id: 'test_id' }]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ some_param: { description: 'test_description' } }))).toEqual([
+      ['mybucket', undefined, 'test_description']
+    ]);
+  });
+
   test('parameter query with token filter (1)', () => {
     // Also supported: token_parameters.is_admin = true
     // Not supported: token_parameters.is_admin != false

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -3,10 +3,7 @@ import {
   DEFAULT_SCHEMA,
   DEFAULT_TAG,
   DartSchemaGenerator,
-  ExpressionType,
   JsSchemaGenerator,
-  SqlDataQuery,
-  SqlParameterQuery,
   SqlSyncRules,
   StaticSchema,
   normalizeTokenParameters
@@ -659,114 +656,6 @@ bucket_definitions:
           id: 'asset1'
         },
         table: 'assets'
-      }
-    ]);
-  });
-
-  test('types', () => {
-    const schema = BASIC_SCHEMA;
-
-    const q1 = SqlDataQuery.fromSql('q1', ['user_id'], `SELECT * FROM assets WHERE owner_id = bucket.user_id`);
-    expect(q1.getColumnOutputs(schema)).toEqual([
-      {
-        name: 'assets',
-        columns: [
-          { name: 'id', type: ExpressionType.TEXT },
-          { name: 'name', type: ExpressionType.TEXT },
-          { name: 'count', type: ExpressionType.INTEGER },
-          { name: 'owner_id', type: ExpressionType.TEXT }
-        ]
-      }
-    ]);
-
-    const q2 = SqlDataQuery.fromSql(
-      'q1',
-      ['user_id'],
-      `
-  SELECT id :: integer as id,
-   upper(name) as name_upper,
-   hex('test') as hex,
-   count + 2 as count2,
-   count * 3.0 as count3,
-   count * '4' as count4,
-   name ->> '$.attr' as json_value,
-   ifnull(name, 2.0) as maybe_name
-  FROM assets WHERE owner_id = bucket.user_id`
-    );
-    expect(q2.getColumnOutputs(schema)).toEqual([
-      {
-        name: 'assets',
-        columns: [
-          { name: 'id', type: ExpressionType.INTEGER },
-          { name: 'name_upper', type: ExpressionType.TEXT },
-          { name: 'hex', type: ExpressionType.TEXT },
-          { name: 'count2', type: ExpressionType.INTEGER },
-          { name: 'count3', type: ExpressionType.REAL },
-          { name: 'count4', type: ExpressionType.NUMERIC },
-          { name: 'json_value', type: ExpressionType.ANY_JSON },
-          { name: 'maybe_name', type: ExpressionType.TEXT.or(ExpressionType.REAL) }
-        ]
-      }
-    ]);
-  });
-
-  test('validate columns', () => {
-    const schema = BASIC_SCHEMA;
-    const q1 = SqlDataQuery.fromSql(
-      'q1',
-      ['user_id'],
-      'SELECT id, name, count FROM assets WHERE owner_id = bucket.user_id',
-      schema
-    );
-    expect(q1.errors).toEqual([]);
-
-    const q2 = SqlDataQuery.fromSql(
-      'q2',
-      ['user_id'],
-      'SELECT id, upper(description) as d FROM assets WHERE other_id = bucket.user_id',
-      schema
-    );
-    expect(q2.errors).toMatchObject([
-      {
-        message: `Column not found: other_id`,
-        type: 'warning'
-      },
-      {
-        message: `Column not found: description`,
-        type: 'warning'
-      }
-    ]);
-
-    const q3 = SqlDataQuery.fromSql(
-      'q3',
-      ['user_id'],
-      'SELECT id, description, * FROM nope WHERE other_id = bucket.user_id',
-      schema
-    );
-    expect(q3.errors).toMatchObject([
-      {
-        message: `Table public.nope not found`,
-        type: 'warning'
-      }
-    ]);
-
-    const q4 = SqlParameterQuery.fromSql(
-      'q4',
-      'SELECT id FROM assets WHERE owner_id = token_parameters.user_id',
-      schema
-    );
-    expect(q4.errors).toMatchObject([]);
-
-    const q5 = SqlParameterQuery.fromSql(
-      'q5',
-      'SELECT id as asset_id FROM assets WHERE other_id = token_parameters.user_id',
-      schema
-    );
-
-    expect(q5.errors).toMatchObject([
-      {
-        message: 'Column not found: other_id',
-        type: 'warning'
       }
     ]);
   });

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -721,7 +721,6 @@ bucket_definitions:
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
       ['mybucket', undefined, 0n]
     ]);
-    // Would not match any actual lookups
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
       ['mybucket', undefined, 1n]
     ]);
@@ -743,8 +742,49 @@ bucket_definitions:
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
       ['mybucket', undefined, 1n]
     ]);
-    // Would not match any actual lookups
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
+      ['mybucket', undefined, 0n]
+    ]);
+  });
+
+  test('parameter query with token parameter IS NOT NULL', () => {
+    const sql = 'SELECT FROM users WHERE token_parameters.some_param IS NOT NULL';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
+      ['mybucket', undefined, 0n]
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
+      ['mybucket', undefined, 1n]
+    ]);
+  });
+
+  test('parameter query with token parameter NOT', () => {
+    const sql = 'SELECT FROM users WHERE NOT token_parameters.is_admin';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
+      {
+        lookup: ['mybucket', undefined, 1n],
+        bucket_parameters: [{}]
+      }
+    ]);
+
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', is_admin: false }))).toEqual([
+      ['mybucket', undefined, 1n]
+    ]);
+    expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', is_admin: 123 }))).toEqual([
       ['mybucket', undefined, 0n]
     ]);
   });
@@ -765,7 +805,6 @@ bucket_definitions:
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
       ['mybucket', undefined, 'user1', 1n]
     ]);
-    // Would not match any actual lookups
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
       ['mybucket', undefined, 'user1', 0n]
     ]);
@@ -787,7 +826,6 @@ bucket_definitions:
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: 123 }))).toEqual([
       ['mybucket', undefined, 'user1', 1n]
     ]);
-    // Would not match any actual lookups
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1', some_param: null }))).toEqual([
       ['mybucket', undefined, 'user1', 0n]
     ]);

--- a/packages/sync-rules/test/src/util.ts
+++ b/packages/sync-rules/test/src/util.ts
@@ -1,0 +1,33 @@
+import { DEFAULT_SCHEMA, DEFAULT_TAG, SourceTableInterface, StaticSchema } from '../../src/index.js';
+
+export class TestSourceTable implements SourceTableInterface {
+  readonly connectionTag = DEFAULT_TAG;
+  readonly schema = DEFAULT_SCHEMA;
+
+  constructor(public readonly table: string) {}
+}
+
+export const ASSETS = new TestSourceTable('assets');
+export const USERS = new TestSourceTable('users');
+
+export const BASIC_SCHEMA = new StaticSchema([
+  {
+    tag: DEFAULT_TAG,
+    schemas: [
+      {
+        name: DEFAULT_SCHEMA,
+        tables: [
+          {
+            name: 'assets',
+            columns: [
+              { name: 'id', pg_type: 'uuid' },
+              { name: 'name', pg_type: 'text' },
+              { name: 'count', pg_type: 'int4' },
+              { name: 'owner_id', pg_type: 'uuid' }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]);


### PR DESCRIPTION
This is an initial refactoring to allow some types of expressions on token_parameters and user_parameters.

Examples that this now supports (see tests for more):

```sql
SELECT id from users WHERE filter_param = token_parameters.some_param ->> 'description'
SELECT id from users WHERE filter_param = upper(token_parameters.some_param)
SELECT id from projects WHERE page = user_parameters.index + 1
```

These expressions are only supported for parameter queries, not for bucket parameters in data queries.

Additionally this:
 * Expands test coverage for sync rules.
 * Refactors internal naming to make concepts easier to follow.
 * Adds overview documentation on the implementation.
