### PR TITLE
Support for `request.parameters()`

### DIFF
--- a/.changeset/cuddly-numbers-hope.md
+++ b/.changeset/cuddly-numbers-hope.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': minor
+---
+
+Expose basic documentation for functions

--- a/.changeset/tame-planes-argue.md
+++ b/.changeset/tame-planes-argue.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-core': minor
+'@powersync/service-sync-rules': minor
+'powersync-open-service': minor
+---
+
+Support `request.parameters()`, `request.jwt()` and `request.user_id()`.
+Warn on potentially dangerous queries using request parameters.

--- a/packages/service-core/src/auth/JwtPayload.ts
+++ b/packages/service-core/src/auth/JwtPayload.ts
@@ -1,9 +1,13 @@
+/**
+ * Payload from a JWT, always signed.
+ *
+ * May have arbitrary additional parameters.
+ */
 export interface JwtPayload {
   /**
-   * user_id
+   * token_parameters.user_id
    */
   sub: string;
-  parameters: Record<string, any>;
 
   iss?: string | undefined;
   exp: number;

--- a/packages/service-core/src/auth/KeyStore.ts
+++ b/packages/service-core/src/auth/KeyStore.ts
@@ -83,13 +83,7 @@ export class KeyStore {
       throw new jose.errors.JWTInvalid('parameters must be an object');
     }
 
-    return {
-      ...(tokenPayload as any),
-      parameters: {
-        user_id: tokenPayload.sub,
-        ...parameters
-      }
-    };
+    return tokenPayload as JwtPayload;
   }
 
   private async verifyInternal(token: string, options: jose.JWTVerifyOptions) {

--- a/packages/service-core/src/routes/endpoints/socket-route.ts
+++ b/packages/service-core/src/routes/endpoints/socket-route.ts
@@ -1,12 +1,12 @@
-import { serialize } from 'bson';
-import { SyncParameters, normalizeTokenParameters } from '@powersync/service-sync-rules';
 import { errors, logger, schema } from '@powersync/lib-services-framework';
+import { RequestParameters } from '@powersync/service-sync-rules';
+import { serialize } from 'bson';
 
-import * as util from '../../util/util-index.js';
-import { streamResponse } from '../../sync/sync.js';
-import { SyncRoutes } from './sync-stream.js';
-import { SocketRouteGenerator } from '../router-socket.js';
 import { Metrics } from '../../metrics/Metrics.js';
+import { streamResponse } from '../../sync/sync.js';
+import * as util from '../../util/util-index.js';
+import { SocketRouteGenerator } from '../router-socket.js';
+import { SyncRoutes } from './sync-stream.js';
 
 export const syncStreamReactive: SocketRouteGenerator = (router) =>
   router.reactiveStream<util.StreamingSyncRequest, any>(SyncRoutes.STREAM, {
@@ -34,10 +34,7 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
 
       const controller = new AbortController();
 
-      const syncParams: SyncParameters = normalizeTokenParameters(
-        context.token_payload?.parameters ?? {},
-        params.parameters ?? {}
-      );
+      const syncParams = new RequestParameters(context.token_payload!, params.parameters ?? {});
 
       const storage = system.storage;
       // Sanity check before we start the stream

--- a/packages/service-core/src/routes/endpoints/sync-stream.ts
+++ b/packages/service-core/src/routes/endpoints/sync-stream.ts
@@ -1,13 +1,13 @@
-import { Readable } from 'stream';
-import { SyncParameters, normalizeTokenParameters } from '@powersync/service-sync-rules';
 import { errors, logger, router, schema } from '@powersync/lib-services-framework';
+import { RequestParameters } from '@powersync/service-sync-rules';
+import { Readable } from 'stream';
 
 import * as sync from '../../sync/sync-index.js';
 import * as util from '../../util/util-index.js';
 
+import { Metrics } from '../../metrics/Metrics.js';
 import { authUser } from '../auth.js';
 import { routeDefinition } from '../router.js';
-import { Metrics } from '../../metrics/Metrics.js';
 
 export enum SyncRoutes {
   STREAM = '/sync/stream'
@@ -30,10 +30,7 @@ export const syncStreamed = routeDefinition({
     }
 
     const params: util.StreamingSyncRequest = payload.params;
-    const syncParams: SyncParameters = normalizeTokenParameters(
-      payload.context.token_payload!.parameters ?? {},
-      payload.params.parameters ?? {}
-    );
+    const syncParams = new RequestParameters(payload.context.token_payload!, payload.params.parameters ?? {});
 
     const storage = system.storage;
     // Sanity check before we start the stream

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -1,5 +1,5 @@
 import { JSONBig, JsonContainer } from '@powersync/service-jsonbig';
-import { SyncParameters } from '@powersync/service-sync-rules';
+import { RequestParameters } from '@powersync/service-sync-rules';
 import { Semaphore } from 'async-mutex';
 import { AbortError } from 'ix/aborterror.js';
 
@@ -7,10 +7,10 @@ import * as auth from '../auth/auth-index.js';
 import * as storage from '../storage/storage-index.js';
 import * as util from '../util/util-index.js';
 
+import { logger } from '@powersync/lib-services-framework';
+import { Metrics } from '../metrics/Metrics.js';
 import { mergeAsyncIterables } from './merge.js';
 import { TokenStreamOptions, tokenStream } from './util.js';
-import { Metrics } from '../metrics/Metrics.js';
-import { logger } from '@powersync/lib-services-framework';
 
 /**
  * Maximum number of connections actively fetching data.
@@ -21,7 +21,7 @@ const syncSemaphore = new Semaphore(MAX_ACTIVE_CONNECTIONS);
 export interface SyncStreamParameters {
   storage: storage.BucketStorageFactory;
   params: util.StreamingSyncRequest;
-  syncParams: SyncParameters;
+  syncParams: RequestParameters;
   token: auth.JwtPayload;
   /**
    * If this signal is aborted, the stream response ends as soon as possible, without error.
@@ -71,7 +71,7 @@ export async function* streamResponse(
 async function* streamResponseInner(
   storage: storage.BucketStorageFactory,
   params: util.StreamingSyncRequest,
-  syncParams: SyncParameters,
+  syncParams: RequestParameters,
   signal: AbortSignal
 ): AsyncGenerator<util.StreamingSyncLine | string | null> {
   // Bucket state of bucket id -> op_id.

--- a/packages/service-core/test/src/data_storage.test.ts
+++ b/packages/service-core/test/src/data_storage.test.ts
@@ -1,4 +1,4 @@
-import { SqlSyncRules } from '@powersync/service-sync-rules';
+import { RequestParameters, SqlSyncRules } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { describe, expect, test } from 'vitest';
 import { SourceTable } from '../../src/storage/SourceTable.js';
@@ -289,12 +289,7 @@ bucket_definitions:
 
     const checkpoint = result!.flushed_op;
 
-    const parameters = {
-      token_parameters: {
-        user_id: 'u1'
-      },
-      user_parameters: {}
-    };
+    const parameters = new RequestParameters({ sub: 'u1' }, {});
 
     const q1 = sync_rules.bucket_descriptors[0].parameter_queries[0];
 
@@ -358,12 +353,7 @@ bucket_definitions:
 
     const checkpoint = result!.flushed_op;
 
-    const parameters = {
-      token_parameters: {
-        user_id: 'unknown'
-      },
-      user_parameters: {}
-    };
+    const parameters = new RequestParameters({ sub: 'unknown' }, {});
 
     const q1 = sync_rules.bucket_descriptors[0].parameter_queries[0];
 
@@ -442,12 +432,7 @@ bucket_definitions:
 
     const checkpoint = result!.flushed_op;
 
-    const parameters = {
-      token_parameters: {
-        user_id: 'u1'
-      },
-      user_parameters: {}
-    };
+    const parameters = new RequestParameters({ sub: 'u1' }, {});
 
     // Test intermediate values - could be moved to sync_rules.test.ts
     const q1 = sync_rules.bucket_descriptors[0].parameter_queries[0];

--- a/packages/service-core/test/src/sync.test.ts
+++ b/packages/service-core/test/src/sync.test.ts
@@ -8,6 +8,7 @@ import { JSONBig } from '@powersync/service-jsonbig';
 import { streamResponse } from '../../src/sync/sync.js';
 import * as timers from 'timers/promises';
 import { lsnMakeComparable } from '@powersync/service-jpgwire';
+import { RequestParameters } from '@powersync/service-sync-rules';
 
 describe('sync - mongodb', function () {
   defineTests(MONGO_STORAGE_FACTORY);
@@ -77,7 +78,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: true
       },
-      syncParams: { token_parameters: {}, user_parameters: {} },
+      syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: Date.now() / 1000 + 10 } as any
     });
 
@@ -117,7 +118,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: false
       },
-      syncParams: { token_parameters: {}, user_parameters: {} },
+      syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: Date.now() / 1000 + 10 } as any
     });
 
@@ -145,7 +146,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: true
       },
-      syncParams: { token_parameters: {}, user_parameters: {} },
+      syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: 0 } as any
     });
 
@@ -171,7 +172,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: true
       },
-      syncParams: { token_parameters: {}, user_parameters: {} },
+      syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: Date.now() / 1000 + 10 } as any
     });
     const iter = stream[Symbol.asyncIterator]();
@@ -231,7 +232,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: true
       },
-      syncParams: { token_parameters: {}, user_parameters: {} },
+      syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: exp } as any
     });
     const iter = stream[Symbol.asyncIterator]();

--- a/packages/sync-rules/README.md
+++ b/packages/sync-rules/README.md
@@ -78,18 +78,17 @@ There are two types of parameter queries:
 
 These are effecitively just a function of `(request) => Array[{bucket}]`. These queries can select values from request parameters, and apply filters from request parameters.
 
-The WHERE filter is a ParameterMatchClause that operates on the request parameters.
-The bucket parameters are each a RowValueClause that operates on the request parameters.
+The WHERE filter is a ParameterValueClause that operates on the request parameters.
+The bucket parameters are each a ParameterValueClause that operates on the request parameters.
 
 Compiled expression clauses are structured as follows:
 
 ```SQL
 'literal' -- StaticValueClause
-token_parameters.param -- RowValueClause
-fn(token_parameters.param) -- RowValueClause. This includes most operators.
+token_parameters.param -- ParameterValueClause
+request.parameters() -- ParameterValueClause
+fn(token_parameters.param) -- ParameterValueClause. This includes most operators.
 ```
-
-The implementation may be refactored to be more consistent with `SqlParameterQuery` in the future - using `RowValueClause` for request parameters is not ideal.
 
 ### SqlParameterQuery
 
@@ -107,7 +106,7 @@ The compiled query is based on the following:
 
 1. WHERE clause compiled into a `ParameterMatchClause`. This computes the lookup index.
 2. `lookup_extractors`: Set of `RowValueClause`. Each of these represent a SELECT clause based on a row value, e.g. `SELECT users.org_id`. These are evaluated during the `evaluateParameterRow` call.
-3. `static_extractors`. Set of `RowValueClause`. Each of these represent a SELECT clause based on a request parameter, e.g. `SELECT token_parameters.user_id`. These are evaluated during the `queryBucketIds` call.
+3. `parameter_extractors`. Set of `ParameterValueClause`. Each of these represent a SELECT clause based on a request parameter, e.g. `SELECT token_parameters.user_id`. These are evaluated during the `queryBucketIds` call.
 
 Compiled expression clauses are structured as follows:
 
@@ -116,6 +115,7 @@ Compiled expression clauses are structured as follows:
 mytable.column -- RowValueClause
 fn(mytable.column) -- RowValueClause. This includes most operators.
 token_parameters.param -- ParameterValueClause
+request.parameters() -- ParameterValueClause
 fn(token_parameters.param) -- ParameterValueClause
 fn(mytable.column, token_parameters.param) -- Error: not allowed
 

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -10,6 +10,7 @@ import {
   EvaluatedParametersResult,
   EvaluationResult,
   QueryBucketIdOptions,
+  QueryParseOptions,
   RequestParameters,
   SourceSchema,
   SqliteRow
@@ -57,8 +58,8 @@ export class SqlBucketDescriptor {
     };
   }
 
-  addParameterQuery(sql: string, schema: SourceSchema | undefined): QueryParseResult {
-    const parameterQuery = SqlParameterQuery.fromSql(this.name, sql, schema);
+  addParameterQuery(sql: string, schema: SourceSchema | undefined, options: QueryParseOptions): QueryParseResult {
+    const parameterQuery = SqlParameterQuery.fromSql(this.name, sql, schema, options);
     if (this.bucket_parameters == null) {
       this.bucket_parameters = parameterQuery.bucket_parameters;
     } else {

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -6,13 +6,13 @@ import { StaticSqlParameterQuery } from './StaticSqlParameterQuery.js';
 import { TablePattern } from './TablePattern.js';
 import { SqlRuleError } from './errors.js';
 import {
-  EvaluatedParametersResult,
   EvaluateRowOptions,
+  EvaluatedParametersResult,
   EvaluationResult,
   QueryBucketIdOptions,
+  RequestParameters,
   SourceSchema,
-  SqliteRow,
-  SyncParameters
+  SqliteRow
 } from './types.js';
 
 export interface QueryParseResult {
@@ -103,7 +103,7 @@ export class SqlBucketDescriptor {
     return results;
   }
 
-  getStaticBucketIds(parameters: SyncParameters) {
+  getStaticBucketIds(parameters: RequestParameters) {
     let results: string[] = [];
     for (let query of this.global_parameter_queries) {
       results.push(...query.getStaticBucketIds(parameters));

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -109,7 +109,7 @@ export class SqlDataQuery {
     for (let column of q.columns ?? []) {
       const name = tools.getOutputName(column);
       if (name != '*') {
-        const clause = tools.compileStaticExtractor(column.expr);
+        const clause = tools.compileRowValueExtractor(column.expr);
         if (isClauseError(clause)) {
           // Error logged already
           continue;

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -1,28 +1,27 @@
 import { parse, SelectedColumn } from 'pgsql-ast-parser';
+import { SqlRuleError } from './errors.js';
+import { SourceTableInterface } from './SourceTableInterface.js';
+import { SqlTools } from './sql_filters.js';
+import { checkUnsupportedFeatures, isClauseError } from './sql_support.js';
+import { StaticSqlParameterQuery } from './StaticSqlParameterQuery.js';
+import { TablePattern } from './TablePattern.js';
+import { TableQuerySchema } from './TableQuerySchema.js';
 import {
   EvaluatedParameters,
   EvaluatedParametersResult,
-  FilterParameters,
   InputParameter,
   ParameterMatchClause,
+  ParameterValueClause,
   QueryBucketIdOptions,
   QuerySchema,
+  RequestParameters,
+  RowValueClause,
   SourceSchema,
   SqliteJsonRow,
   SqliteJsonValue,
-  SqliteRow,
-  RowValueClause,
-  SyncParameters,
-  ParameterValueClause
+  SqliteRow
 } from './types.js';
-import { SqlRuleError } from './errors.js';
-import { SqlTools } from './sql_filters.js';
-import { StaticSqlParameterQuery } from './StaticSqlParameterQuery.js';
 import { filterJsonRow, getBucketId, isJsonValue, isSelectStatement } from './utils.js';
-import { TablePattern } from './TablePattern.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
-import { checkUnsupportedFeatures, isClauseError } from './sql_support.js';
-import { TableQuerySchema } from './TableQuerySchema.js';
 
 /**
  * Represents a parameter query, such as:
@@ -226,7 +225,7 @@ export class SqlParameterQuery {
   /**
    * Given partial parameter rows, turn into bucket ids.
    */
-  resolveBucketIds(bucketParameters: SqliteJsonRow[], parameters: SyncParameters): string[] {
+  resolveBucketIds(bucketParameters: SqliteJsonRow[], parameters: RequestParameters): string[] {
     // Filters have already been applied and gotten us the set of bucketParameters - don't attempt to filter again.
     // We _do_ need to evaluate the output columns here, using a combination of precomputed bucketParameters,
     // and values from token parameters.
@@ -259,7 +258,7 @@ export class SqlParameterQuery {
    *
    * Each lookup is [bucket definition name, parameter query index, ...lookup values]
    */
-  getLookups(parameters: SyncParameters): SqliteJsonValue[][] {
+  getLookups(parameters: RequestParameters): SqliteJsonValue[][] {
     if (!this.expanded_input_parameter) {
       let lookup: SqliteJsonValue[] = [this.descriptor_name!, this.id!];
 

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -136,6 +136,10 @@ export class SqlParameterQuery {
     }
     rows.tools = tools;
     rows.errors.push(...tools.errors);
+
+    if (rows.usesDangerousRequestParameters) {
+      rows.errors.push(new SqlRuleError('Pontially dangerous query based on unauthenticated client parameters', sql));
+    }
     return rows;
   }
 

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -126,7 +126,7 @@ export class SqlParameterQuery {
       const name = tools.getSpecificOutputName(column);
       if (tools.isTableRef(column.expr)) {
         rows.lookup_columns.push(column);
-        const extractor = tools.compileStaticExtractor(column.expr);
+        const extractor = tools.compileRowValueExtractor(column.expr);
         if (isClauseError(extractor)) {
           // Error logged already
           continue;
@@ -134,7 +134,7 @@ export class SqlParameterQuery {
         rows.lookup_extractors[name] = extractor;
       } else {
         rows.static_columns.push(column);
-        const extractor = rows.static_tools.compileStaticExtractor(column.expr);
+        const extractor = rows.static_tools.compileRowValueExtractor(column.expr);
         if (isClauseError(extractor)) {
           // Error logged already
           continue;

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -140,7 +140,10 @@ export class SqlParameterQuery {
     rows.errors.push(...tools.errors);
 
     if (rows.usesDangerousRequestParameters && !options?.accept_potentially_dangerous_queries) {
-      let err = new SqlRuleError('Pontially dangerous query based on unauthenticated client parameters', sql);
+      let err = new SqlRuleError(
+        "Potentially dangerous query based on parameters set by the client. The client can send any value for these parameters so it's not a good place to do authorization.",
+        sql
+      );
       err.type = 'warning';
       rows.errors.push(err);
     }

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -16,9 +16,9 @@ import {
   isEvaluatedRow,
   isEvaluationError,
   QueryBucketIdOptions,
+  RequestParameters,
   SourceSchema,
   SqliteRow,
-  SyncParameters,
   SyncRules
 } from './types.js';
 
@@ -237,7 +237,7 @@ export class SqlSyncRules implements SyncRules {
   /**
    * @deprecated For testing only.
    */
-  getStaticBucketIds(parameters: SyncParameters) {
+  getStaticBucketIds(parameters: RequestParameters) {
     let results: string[] = [];
     for (let bucket of this.bucket_descriptors) {
       results.push(...bucket.getStaticBucketIds(parameters));

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -16,11 +16,14 @@ import {
   isEvaluatedRow,
   isEvaluationError,
   QueryBucketIdOptions,
+  QueryParseOptions,
   RequestParameters,
   SourceSchema,
   SqliteRow,
   SyncRules
 } from './types.js';
+
+const ACCEPT_POTENTIALLY_DANGEROUS_QUERIES = Symbol('ACCEPT_POTENTIALLY_DANGEROUS_QUERIES');
 
 export class SqlSyncRules implements SyncRules {
   bucket_descriptors: SqlBucketDescriptor[] = [];
@@ -50,7 +53,19 @@ export class SqlSyncRules implements SyncRules {
     const schema = options?.schema;
 
     const lineCounter = new LineCounter();
-    const parsed = parseDocument(yaml, { schema: 'core', keepSourceTokens: true, lineCounter });
+    const parsed = parseDocument(yaml, {
+      schema: 'core',
+      keepSourceTokens: true,
+      lineCounter,
+      customTags: [
+        {
+          tag: '!accept_potentially_dangerous_queries',
+          resolve(_text: string, _onError: (error: string) => void) {
+            return ACCEPT_POTENTIALLY_DANGEROUS_QUERIES;
+          }
+        }
+      ]
+    });
 
     const rules = new SqlSyncRules(yaml);
 
@@ -81,6 +96,11 @@ export class SqlSyncRules implements SyncRules {
       const { key: keyScalar, value } = entry as { key: Scalar; value: YAMLMap };
       const key = keyScalar.toString();
 
+      const accept_potentially_dangerous_queries =
+        value.get('accept_potentially_dangerous_queries', true)?.value == true;
+      const options: QueryParseOptions = {
+        accept_potentially_dangerous_queries
+      };
       const parameters = value.get('parameters', true) as unknown;
       const dataQueries = value.get('data', true) as unknown;
 
@@ -88,16 +108,16 @@ export class SqlSyncRules implements SyncRules {
 
       if (parameters instanceof Scalar) {
         rules.withScalar(parameters, (q) => {
-          return descriptor.addParameterQuery(q, schema);
+          return descriptor.addParameterQuery(q, schema, options);
         });
       } else if (parameters instanceof YAMLSeq) {
         for (let item of parameters.items) {
           rules.withScalar(item, (q) => {
-            return descriptor.addParameterQuery(q, schema);
+            return descriptor.addParameterQuery(q, schema, options);
           });
         }
       } else {
-        descriptor.addParameterQuery('SELECT', schema);
+        descriptor.addParameterQuery('SELECT', schema, options);
       }
 
       if (!(dataQueries instanceof YAMLSeq)) {

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -1,16 +1,9 @@
 import { SelectedColumn, SelectFromStatement } from 'pgsql-ast-parser';
-import {
-  ParameterMatchClause,
-  SqliteJsonValue,
-  RowValueClause,
-  SyncParameters,
-  ParameterValueClause,
-  StaticValueClause
-} from './types.js';
-import { SqlTools } from './sql_filters.js';
-import { getBucketId, isJsonValue } from './utils.js';
 import { SqlRuleError } from './errors.js';
-import { checkUnsupportedFeatures, isClauseError, isStaticValueClause, sqliteBool } from './sql_support.js';
+import { SqlTools } from './sql_filters.js';
+import { checkUnsupportedFeatures, isClauseError, sqliteBool } from './sql_support.js';
+import { ParameterValueClause, RequestParameters, SqliteJsonValue } from './types.js';
+import { getBucketId, isJsonValue } from './utils.js';
 
 /**
  * Represents a bucket parameter query without any tables, e.g.:
@@ -72,8 +65,7 @@ export class StaticSqlParameterQuery {
 
   errors: SqlRuleError[] = [];
 
-  getStaticBucketIds(parameters: SyncParameters): string[] {
-    const tables = { token_parameters: parameters.token_parameters, user_parameters: parameters.user_parameters };
+  getStaticBucketIds(parameters: RequestParameters): string[] {
     if (this.filter == null) {
       // Error in filter clause
       return [];

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -49,6 +49,10 @@ export class StaticSqlParameterQuery {
     }
 
     query.errors.push(...tools.errors);
+
+    if (query.usesDangerousRequestParameters) {
+      query.errors.push(new SqlRuleError('Pontially dangerous query based on unauthenticated client parameters', sql));
+    }
     return query;
   }
 

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -1,9 +1,16 @@
 import { SelectedColumn, SelectFromStatement } from 'pgsql-ast-parser';
-import { ParameterMatchClause, SqliteJsonValue, RowValueClause, SyncParameters } from './types.js';
+import {
+  ParameterMatchClause,
+  SqliteJsonValue,
+  RowValueClause,
+  SyncParameters,
+  ParameterValueClause,
+  StaticValueClause
+} from './types.js';
 import { SqlTools } from './sql_filters.js';
 import { getBucketId, isJsonValue } from './utils.js';
 import { SqlRuleError } from './errors.js';
-import { checkUnsupportedFeatures, isClauseError } from './sql_support.js';
+import { checkUnsupportedFeatures, isClauseError, isStaticValueClause, sqliteBool } from './sql_support.js';
 
 /**
  * Represents a bucket parameter query without any tables, e.g.:
@@ -19,12 +26,13 @@ export class StaticSqlParameterQuery {
 
     const tools = new SqlTools({
       table: undefined,
-      value_tables: ['token_parameters', 'user_parameters'],
+      parameter_tables: ['token_parameters', 'user_parameters'],
+      supports_parameter_expressions: true,
       sql
     });
     const where = q.where;
-    const filter = tools.compileWhereClause(where);
 
+    const filter = tools.compileParameterValueExtractor(where);
     const columns = q.columns ?? [];
     const bucket_parameters = columns.map((column) => tools.getOutputName(column));
 
@@ -33,16 +41,18 @@ export class StaticSqlParameterQuery {
     query.bucket_parameters = bucket_parameters;
     query.columns = columns;
     query.tools = tools;
-    query.filter = filter;
+    if (!isClauseError(filter)) {
+      query.filter = filter;
+    }
 
     for (let column of columns) {
       const name = tools.getSpecificOutputName(column);
-      const extractor = tools.compileStaticExtractor(column.expr);
+      const extractor = tools.compileParameterValueExtractor(column.expr);
       if (isClauseError(extractor)) {
         // Error logged already
         continue;
       }
-      query.static_extractors[name] = extractor;
+      query.parameter_extractors[name] = extractor;
     }
 
     query.errors.push(...tools.errors);
@@ -51,27 +61,31 @@ export class StaticSqlParameterQuery {
 
   sql?: string;
   columns?: SelectedColumn[];
-  static_extractors: Record<string, RowValueClause> = {};
+  parameter_extractors: Record<string, ParameterValueClause> = {};
   descriptor_name?: string;
   /** _Output_ bucket parameters */
   bucket_parameters?: string[];
   id?: string;
   tools?: SqlTools;
 
-  filter?: ParameterMatchClause;
+  filter?: ParameterValueClause;
 
   errors: SqlRuleError[] = [];
 
   getStaticBucketIds(parameters: SyncParameters): string[] {
     const tables = { token_parameters: parameters.token_parameters, user_parameters: parameters.user_parameters };
-    const filtered = this.filter!.filterRow(tables);
-    if (filtered.length == 0) {
+    if (this.filter == null) {
+      // Error in filter clause
+      return [];
+    }
+    const filterValue = this.filter.lookupParameterValue(parameters);
+    if (sqliteBool(filterValue) === 0n) {
       return [];
     }
 
     let result: Record<string, SqliteJsonValue> = {};
     for (let name of this.bucket_parameters!) {
-      const value = this.static_extractors[name].evaluate(tables);
+      const value = this.parameter_extractors[name].lookupParameterValue(parameters);
       if (isJsonValue(value)) {
         result[`bucket.${name}`] = value;
       } else {

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -51,7 +51,10 @@ export class StaticSqlParameterQuery {
     query.errors.push(...tools.errors);
 
     if (query.usesDangerousRequestParameters && !options?.accept_potentially_dangerous_queries) {
-      let err = new SqlRuleError('Pontially dangerous query based on unauthenticated client parameters', sql);
+      let err = new SqlRuleError(
+        "Potentially dangerous query based on parameters set by the client. The client can send any value for these parameters so it's not a good place to do authorization.",
+        sql
+      );
       err.type = 'warning';
       query.errors.push(err);
     }

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -16,3 +16,4 @@ export * from './DartSchemaGenerator.js';
 export * from './JsSchemaGenerator.js';
 export * from './generators.js';
 export * from './SqlDataQuery.js';
+export * from './request_functions.js';

--- a/packages/sync-rules/src/json_schema.ts
+++ b/packages/sync-rules/src/json_schema.ts
@@ -16,6 +16,10 @@ export const syncRulesSchema: ajvModule.Schema = {
           required: ['data'],
           examples: [{ data: ['select * from mytable'] }],
           properties: {
+            accept_potentially_dangerous_queries: {
+              description: 'If true, disables warnings on potentially dangerous queries',
+              type: 'boolean'
+            },
             parameters: {
               description: 'Parameter query(ies)',
               anyOf: [

--- a/packages/sync-rules/src/request_functions.ts
+++ b/packages/sync-rules/src/request_functions.ts
@@ -5,6 +5,10 @@ export interface SqlParameterFunction {
   readonly debugName: string;
   call: (parameters: RequestParameters) => SqliteValue;
   getReturnType(): ExpressionType;
+  /** request.user_id(), request.jwt(), token_parameters.* */
+  usesAuthenticatedRequestParameters: boolean;
+  /** request.parameters(), user_parameters.* */
+  usesUnauthenticatedRequestParameters: boolean;
 }
 
 const request_parameters: SqlParameterFunction = {
@@ -14,7 +18,9 @@ const request_parameters: SqlParameterFunction = {
   },
   getReturnType() {
     return ExpressionType.TEXT;
-  }
+  },
+  usesAuthenticatedRequestParameters: false,
+  usesUnauthenticatedRequestParameters: true
 };
 
 const request_jwt: SqlParameterFunction = {
@@ -24,7 +30,9 @@ const request_jwt: SqlParameterFunction = {
   },
   getReturnType() {
     return ExpressionType.TEXT;
-  }
+  },
+  usesAuthenticatedRequestParameters: true,
+  usesUnauthenticatedRequestParameters: false
 };
 
 const request_user_id: SqlParameterFunction = {
@@ -34,7 +42,9 @@ const request_user_id: SqlParameterFunction = {
   },
   getReturnType() {
     return ExpressionType.TEXT;
-  }
+  },
+  usesAuthenticatedRequestParameters: true,
+  usesUnauthenticatedRequestParameters: false
 };
 
 export const REQUEST_FUNCTIONS_NAMED = {

--- a/packages/sync-rules/src/request_functions.ts
+++ b/packages/sync-rules/src/request_functions.ts
@@ -1,0 +1,46 @@
+import { ExpressionType } from './ExpressionType.js';
+import { RequestParameters, SqliteValue } from './types.js';
+
+export interface SqlParameterFunction {
+  readonly debugName: string;
+  call: (parameters: RequestParameters) => SqliteValue;
+  getReturnType(): ExpressionType;
+}
+
+const request_parameters: SqlParameterFunction = {
+  debugName: 'request.parameters',
+  call(parameters: RequestParameters) {
+    return parameters.raw_user_parameters;
+  },
+  getReturnType() {
+    return ExpressionType.TEXT;
+  }
+};
+
+const request_jwt: SqlParameterFunction = {
+  debugName: 'request.jwt',
+  call(parameters: RequestParameters) {
+    return parameters.raw_token_payload;
+  },
+  getReturnType() {
+    return ExpressionType.TEXT;
+  }
+};
+
+const request_user_id: SqlParameterFunction = {
+  debugName: 'request.user_id',
+  call(parameters: RequestParameters) {
+    return parameters.user_id;
+  },
+  getReturnType() {
+    return ExpressionType.TEXT;
+  }
+};
+
+export const REQUEST_FUNCTIONS_NAMED = {
+  parameters: request_parameters,
+  jwt: request_jwt,
+  user_id: request_user_id
+};
+
+export const REQUEST_FUNCTIONS: Record<string, SqlParameterFunction> = REQUEST_FUNCTIONS_NAMED;

--- a/packages/sync-rules/src/request_functions.ts
+++ b/packages/sync-rules/src/request_functions.ts
@@ -9,6 +9,8 @@ export interface SqlParameterFunction {
   usesAuthenticatedRequestParameters: boolean;
   /** request.parameters(), user_parameters.* */
   usesUnauthenticatedRequestParameters: boolean;
+  detail: string;
+  documentation: string;
 }
 
 const request_parameters: SqlParameterFunction = {
@@ -19,6 +21,9 @@ const request_parameters: SqlParameterFunction = {
   getReturnType() {
     return ExpressionType.TEXT;
   },
+  detail: 'Unauthenticated request parameters as JSON',
+  documentation:
+    'Returns parameters passed by the client as a JSON string. These parameters are not authenticated - any value can be passed in by the client.',
   usesAuthenticatedRequestParameters: false,
   usesUnauthenticatedRequestParameters: true
 };
@@ -31,6 +36,8 @@ const request_jwt: SqlParameterFunction = {
   getReturnType() {
     return ExpressionType.TEXT;
   },
+  detail: 'JWT payload as JSON',
+  documentation: 'The JWT payload as a JSON string. This is always validated against trusted keys.',
   usesAuthenticatedRequestParameters: true,
   usesUnauthenticatedRequestParameters: false
 };
@@ -43,6 +50,8 @@ const request_user_id: SqlParameterFunction = {
   getReturnType() {
     return ExpressionType.TEXT;
   },
+  detail: 'Authenticated user id',
+  documentation: "The id of the authenticated user.\nSame as `request.jwt() ->> 'sub'`.",
   usesAuthenticatedRequestParameters: true,
   usesUnauthenticatedRequestParameters: false
 };

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -413,6 +413,22 @@ export class SqlTools {
             return parameters.raw_user_parameters;
           }
         } satisfies ParameterValueClause;
+      } else if (schema == 'request' && fn == 'jwt') {
+        // Special function
+        if (!this.supports_parameter_expressions) {
+          return this.error(`Function '${schema}.${fn}' is not available in data queries`, expr);
+        }
+
+        if (expr.args.length > 0) {
+          return this.error(`Function '${schema}.${fn}' does not take arguments`, expr);
+        }
+
+        return {
+          key: 'request.jwt()',
+          lookupParameterValue(parameters) {
+            return parameters.raw_token_payload;
+          }
+        } satisfies ParameterValueClause;
       } else {
         // Unknown function with schema
         return this.error(`Function '${schema}.${fn}' is not defined`, expr);

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -156,7 +156,7 @@ export class SqlTools {
   compileRowValueExtractor(expr: Expr | nil): RowValueClause | ClauseError {
     const clause = this.compileClause(expr);
     if (!isRowValueClause(clause) && !isClauseError(clause)) {
-      throw new SqlRuleError('Bucket parameters are not allowed here', this.sql, expr ?? undefined);
+      return this.error('Parameter match expression is not allowed here', expr ?? undefined);
     }
     return clause;
   }
@@ -168,8 +168,7 @@ export class SqlTools {
       return clause;
     }
 
-    // TODO: better message?
-    throw new SqlRuleError('This expression not allowed here', this.sql, expr ?? undefined);
+    return this.error('Parameter match expression is not allowed here', expr ?? undefined);
   }
 
   /**

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -34,12 +34,17 @@ export interface FunctionParameter {
 
 export interface SqlFunction {
   readonly debugName: string;
-  parameters: FunctionParameter[];
   call: (...args: SqliteValue[]) => SqliteValue;
   getReturnType(args: ExpressionType[]): ExpressionType;
 }
 
-const upper: SqlFunction = {
+export interface DocumentedSqlFunction extends SqlFunction {
+  parameters: FunctionParameter[];
+  detail: string;
+  documentation?: string;
+}
+
+const upper: DocumentedSqlFunction = {
   debugName: 'upper',
   call(value: SqliteValue) {
     const text = castAsText(value);
@@ -48,10 +53,11 @@ const upper: SqlFunction = {
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
-  }
+  },
+  detail: 'Convert text to upper case'
 };
 
-const lower: SqlFunction = {
+const lower: DocumentedSqlFunction = {
   debugName: 'lower',
   call(value: SqliteValue) {
     const text = castAsText(value);
@@ -60,10 +66,11 @@ const lower: SqlFunction = {
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
-  }
+  },
+  detail: 'Convert text to lower case'
 };
 
-const hex: SqlFunction = {
+const hex: DocumentedSqlFunction = {
   debugName: 'hex',
   call(value: SqliteValue) {
     const binary = castAsBlob(value);
@@ -75,10 +82,11 @@ const hex: SqlFunction = {
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
-  }
+  },
+  detail: 'Convert a blob to hex text'
 };
 
-const length: SqlFunction = {
+const length: DocumentedSqlFunction = {
   debugName: 'length',
   call(value: SqliteValue) {
     if (value == null) {
@@ -93,10 +101,11 @@ const length: SqlFunction = {
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.INTEGER;
-  }
+  },
+  detail: 'Returns the length of a text or blob value'
 };
 
-const base64: SqlFunction = {
+const base64: DocumentedSqlFunction = {
   debugName: 'base64',
   call(value: SqliteValue) {
     const binary = castAsBlob(value);
@@ -108,10 +117,11 @@ const base64: SqlFunction = {
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
-  }
+  },
+  detail: 'Convert a blob to base64 text'
 };
 
-const fn_typeof: SqlFunction = {
+const fn_typeof: DocumentedSqlFunction = {
   debugName: 'typeof',
   call(value: SqliteValue) {
     return sqliteTypeOf(value);
@@ -119,10 +129,12 @@ const fn_typeof: SqlFunction = {
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
-  }
+  },
+  detail: 'Returns the SQLite type of a value',
+  documentation: `Returns 'null', 'text', 'integer', 'real' or 'blob'.`
 };
 
-const ifnull: SqlFunction = {
+const ifnull: DocumentedSqlFunction = {
   debugName: 'ifnull',
   call(x: SqliteValue, y: SqliteValue) {
     if (x == null) {
@@ -143,10 +155,11 @@ const ifnull: SqlFunction = {
     } else {
       return args[0].or(args[1]);
     }
-  }
+  },
+  detail: 'Returns the first non-null parameter'
 };
 
-const json_extract: SqlFunction = {
+const json_extract: DocumentedSqlFunction = {
   debugName: 'json_extract',
   call(json: SqliteValue, path: SqliteValue) {
     return jsonExtract(json, path, 'json_extract');
@@ -157,10 +170,11 @@ const json_extract: SqlFunction = {
   ],
   getReturnType(args) {
     return ExpressionType.ANY_JSON;
-  }
+  },
+  detail: 'Extract a JSON property'
 };
 
-const json_array_length: SqlFunction = {
+const json_array_length: DocumentedSqlFunction = {
   debugName: 'json_array_length',
   call(json: SqliteValue, path?: SqliteValue) {
     if (path != null) {
@@ -183,10 +197,11 @@ const json_array_length: SqlFunction = {
   ],
   getReturnType(args) {
     return ExpressionType.INTEGER;
-  }
+  },
+  detail: 'Returns the length of a JSON array'
 };
 
-const json_valid: SqlFunction = {
+const json_valid: DocumentedSqlFunction = {
   debugName: 'json_valid',
   call(json: SqliteValue) {
     const jsonString = castAsText(json);
@@ -203,10 +218,12 @@ const json_valid: SqlFunction = {
   parameters: [{ name: 'json', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.INTEGER;
-  }
+  },
+  detail: 'Checks whether JSON text is valid',
+  documentation: 'Returns 1 if valid, 0 if invalid'
 };
 
-const unixepoch: SqlFunction = {
+const unixepoch: DocumentedSqlFunction = {
   debugName: 'unixepoch',
   call(value?: SqliteValue, specifier?: SqliteValue, specifier2?: SqliteValue) {
     if (value == null) {
@@ -248,10 +265,11 @@ const unixepoch: SqlFunction = {
   ],
   getReturnType(args) {
     return ExpressionType.INTEGER.or(ExpressionType.REAL);
-  }
+  },
+  detail: 'Convert a date to unix epoch'
 };
 
-const datetime: SqlFunction = {
+const datetime: DocumentedSqlFunction = {
   debugName: 'datetime',
   call(value?: SqliteValue, specifier?: SqliteValue, specifier2?: SqliteValue) {
     if (value == null) {
@@ -294,10 +312,11 @@ const datetime: SqlFunction = {
   ],
   getReturnType(args) {
     return ExpressionType.TEXT;
-  }
+  },
+  detail: 'Convert a date string or unix epoch to a consistent date string'
 };
 
-const st_asgeojson: SqlFunction = {
+const st_asgeojson: DocumentedSqlFunction = {
   debugName: 'st_asgeojson',
   call(geometry?: SqliteValue) {
     const geo = parseGeometry(geometry);
@@ -309,10 +328,11 @@ const st_asgeojson: SqlFunction = {
   parameters: [{ name: 'geometry', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
-  }
+  },
+  detail: 'Covert PostGIS geometry to GeoJSON text'
 };
 
-const st_astext: SqlFunction = {
+const st_astext: DocumentedSqlFunction = {
   debugName: 'st_astext',
   call(geometry?: SqliteValue) {
     const geo = parseGeometry(geometry);
@@ -324,9 +344,11 @@ const st_astext: SqlFunction = {
   parameters: [{ name: 'geometry', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
-  }
+  },
+  detail: 'Covert PostGIS geometry to WKT text'
 };
-const st_x: SqlFunction = {
+
+const st_x: DocumentedSqlFunction = {
   debugName: 'st_x',
   call(geometry?: SqliteValue) {
     const geo = parseGeometry(geometry);
@@ -341,10 +363,11 @@ const st_x: SqlFunction = {
   parameters: [{ name: 'geometry', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.REAL;
-  }
+  },
+  detail: 'Get the X value of a PostGIS point'
 };
 
-const st_y: SqlFunction = {
+const st_y: DocumentedSqlFunction = {
   debugName: 'st_y',
   call(geometry?: SqliteValue) {
     const geo = parseGeometry(geometry);
@@ -359,7 +382,8 @@ const st_y: SqlFunction = {
   parameters: [{ name: 'geometry', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.REAL;
-  }
+  },
+  detail: 'Get the Y value of a PostGIS point'
 };
 
 export const SQL_FUNCTIONS_NAMED = {
@@ -387,7 +411,7 @@ export const SQL_FUNCTIONS_CALL = Object.fromEntries(
   Object.entries(SQL_FUNCTIONS_NAMED).map(([name, fn]) => [name, fn.call])
 ) as Record<FunctionName, SqlFunction['call']>;
 
-export const SQL_FUNCTIONS: Record<string, SqlFunction> = SQL_FUNCTIONS_NAMED;
+export const SQL_FUNCTIONS: Record<string, DocumentedSqlFunction> = SQL_FUNCTIONS_NAMED;
 
 export const CAST_TYPES = new Set<String>(['text', 'numeric', 'integer', 'real', 'blob']);
 
@@ -718,10 +742,6 @@ export const OPERATOR_JSON_EXTRACT_JSON: SqlFunction = {
   call(json: SqliteValue, path: SqliteValue) {
     return jsonExtract(json, path, '->');
   },
-  parameters: [
-    { name: 'json', type: ExpressionType.ANY, optional: false },
-    { name: 'path', type: ExpressionType.ANY, optional: false }
-  ],
   getReturnType(args) {
     return ExpressionType.ANY_JSON;
   }
@@ -732,10 +752,6 @@ export const OPERATOR_JSON_EXTRACT_SQL: SqlFunction = {
   call(json: SqliteValue, path: SqliteValue) {
     return jsonExtract(json, path, '->>');
   },
-  parameters: [
-    { name: 'json', type: ExpressionType.ANY, optional: false },
-    { name: 'path', type: ExpressionType.ANY, optional: false }
-  ],
   getReturnType(_args) {
     return ExpressionType.ANY_JSON;
   }
@@ -746,7 +762,6 @@ export const OPERATOR_IS_NULL: SqlFunction = {
   call(value: SqliteValue) {
     return evaluateOperator('IS', value, null);
   },
-  parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(_args) {
     return ExpressionType.INTEGER;
   }
@@ -757,7 +772,6 @@ export const OPERATOR_IS_NOT_NULL: SqlFunction = {
   call(value: SqliteValue) {
     return evaluateOperator('IS NOT', value, null);
   },
-  parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(_args) {
     return ExpressionType.INTEGER;
   }
@@ -768,7 +782,6 @@ export const OPERATOR_NOT: SqlFunction = {
   call(value: SqliteValue) {
     return sqliteNot(value);
   },
-  parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(_args) {
     return ExpressionType.INTEGER;
   }
@@ -786,7 +799,6 @@ export function castOperator(castTo: string | undefined): SqlFunction | null {
       }
       return cast(value, castTo!);
     },
-    parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
     getReturnType(_args) {
       return ExpressionType.fromTypeText(castTo as SqliteType);
     }

--- a/packages/sync-rules/src/sql_support.ts
+++ b/packages/sync-rules/src/sql_support.ts
@@ -82,11 +82,7 @@ export function getOperatorFunction(op: string): SqlFunction {
     },
     getReturnType(args) {
       return getOperatorReturnType(op, args[0], args[1]);
-    },
-    parameters: [
-      { name: 'left', type: ExpressionType.ANY, optional: false },
-      { name: 'right', type: ExpressionType.ANY, optional: false }
-    ]
+    }
   };
 }
 

--- a/packages/sync-rules/src/sql_support.ts
+++ b/packages/sync-rules/src/sql_support.ts
@@ -143,7 +143,11 @@ export function andFilters(a: CompiledClause, b: CompiledClause): CompiledClause
         }
       }
       return results;
-    }
+    },
+    usesAuthenticatedRequestParameters:
+      aFilter.usesAuthenticatedRequestParameters || bFilter.usesAuthenticatedRequestParameters,
+    usesUnauthenticatedRequestParameters:
+      aFilter.usesUnauthenticatedRequestParameters || bFilter.usesUnauthenticatedRequestParameters
   } satisfies ParameterMatchClause;
 }
 
@@ -197,7 +201,12 @@ export function orParameterSetClauses(a: ParameterMatchClause, b: ParameterMatch
 
       let results: FilterParameters[] = [...aResult, ...bResult];
       return results;
-    }
+    },
+    // Pessimistic check
+    usesAuthenticatedRequestParameters: a.usesAuthenticatedRequestParameters && b.usesAuthenticatedRequestParameters,
+    // Optimistic check
+    usesUnauthenticatedRequestParameters:
+      a.usesUnauthenticatedRequestParameters || b.usesUnauthenticatedRequestParameters
   } satisfies ParameterMatchClause;
 }
 
@@ -217,7 +226,9 @@ export function toBooleanParameterSetClause(clause: CompiledClause): ParameterMa
       filterRow(tables: QueryParameters): TrueIfParametersMatch {
         const value = sqliteBool(clause.evaluate(tables));
         return value ? MATCH_CONST_TRUE : MATCH_CONST_FALSE;
-      }
+      },
+      usesAuthenticatedRequestParameters: false,
+      usesUnauthenticatedRequestParameters: false
     } satisfies ParameterMatchClause;
   } else if (isClauseError(clause)) {
     return {
@@ -226,7 +237,9 @@ export function toBooleanParameterSetClause(clause: CompiledClause): ParameterMa
       unbounded: false,
       filterRow(tables: QueryParameters): TrueIfParametersMatch {
         throw new Error('invalid clause');
-      }
+      },
+      usesAuthenticatedRequestParameters: false,
+      usesUnauthenticatedRequestParameters: false
     } satisfies ParameterMatchClause;
   } else {
     // Equivalent to `bucket.param = true`
@@ -250,7 +263,9 @@ export function toBooleanParameterSetClause(clause: CompiledClause): ParameterMa
       unbounded: false,
       filterRow(tables: QueryParameters): TrueIfParametersMatch {
         return [{ [key]: SQLITE_TRUE }];
-      }
+      },
+      usesAuthenticatedRequestParameters: clause.usesAuthenticatedRequestParameters,
+      usesUnauthenticatedRequestParameters: clause.usesUnauthenticatedRequestParameters
     } satisfies ParameterMatchClause;
   }
 }

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -244,9 +244,9 @@ export interface RowValueClause {
 /**
  * Completely static value.
  *
- * Extends RowValueClause to simplify code in some places.
+ * Extends RowValueClause and ParameterValueClause to simplify code in some places.
  */
-export interface StaticValueClause extends RowValueClause {
+export interface StaticValueClause extends RowValueClause, ParameterValueClause {
   readonly value: SqliteValue;
 }
 

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -61,6 +61,7 @@ export type EvaluationResult = EvaluatedRow | EvaluationError;
 export interface SyncParameters {
   token_parameters: SqliteJsonRow;
   user_parameters: SqliteJsonRow;
+  raw_user_parameters: string;
 }
 
 /**

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -242,12 +242,22 @@ export interface ParameterMatchClause {
    * @return The filter parameters
    */
   filterRow(tables: QueryParameters): TrueIfParametersMatch;
+
+  /** request.user_id(), request.jwt(), token_parameters.* */
+  usesAuthenticatedRequestParameters: boolean;
+  /** request.parameters(), user_parameters.* */
+  usesUnauthenticatedRequestParameters: boolean;
 }
 
 /**
  * This is a clause that operates on request or bucket parameters.
  */
 export interface ParameterValueClause {
+  /** request.user_id(), request.jwt(), token_parameters.* */
+  usesAuthenticatedRequestParameters: boolean;
+  /** request.parameters(), user_parameters.* */
+  usesUnauthenticatedRequestParameters: boolean;
+
   /**
    * An unique key for the clause.
    *

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -80,7 +80,7 @@ export class RequestParameters {
   /**
    * JSON string of raw request parameters.
    */
-  token_payload: string;
+  raw_token_payload: string;
 
   user_id: string;
 
@@ -96,7 +96,7 @@ export class RequestParameters {
 
     this.token_parameters = toSyncRulesParameters(token_parameters);
     this.user_id = tokenPayload.sub;
-    this.token_payload = JSONBig.stringify(tokenPayload);
+    this.raw_token_payload = JSONBig.stringify(tokenPayload);
 
     this.raw_user_parameters = JSONBig.stringify(clientParameters);
     this.user_parameters = toSyncRulesParameters(clientParameters);

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -10,6 +10,10 @@ export interface SyncRules {
   evaluateParameterRow(table: SourceTableInterface, row: SqliteRow): EvaluatedParametersResult[];
 }
 
+export interface QueryParseOptions {
+  accept_potentially_dangerous_queries?: boolean;
+}
+
 export interface EvaluatedParameters {
   lookup: SqliteJsonValue[];
 

--- a/packages/sync-rules/src/utils.ts
+++ b/packages/sync-rules/src/utils.ts
@@ -1,5 +1,13 @@
 import { Statement, SelectFromStatement } from 'pgsql-ast-parser';
-import { DatabaseInputRow, SqliteRow, SqliteJsonRow, SqliteJsonValue, SqliteValue, SyncParameters } from './types.js';
+import {
+  DatabaseInputRow,
+  SqliteRow,
+  SqliteJsonRow,
+  SqliteJsonValue,
+  SqliteValue,
+  RequestParameters,
+  RequestJwtPayload
+} from './types.js';
 import { SQLITE_FALSE, SQLITE_TRUE } from './sql_support.js';
 import { JsonContainer } from '@powersync/service-jsonbig';
 import { JSONBig, stringifyRaw, Replacer } from '@powersync/service-jsonbig';
@@ -150,18 +158,6 @@ export function toSyncRulesValue(data: any, autoBigNum?: boolean, keepUndefined?
   } else {
     return null;
   }
-}
-
-export function normalizeTokenParameters(
-  token_parameters: Record<string, any>,
-  user_parameters?: Record<string, any>
-): SyncParameters {
-  const raw_user_parameters = JSONBig.stringify(user_parameters ?? {});
-  return {
-    token_parameters: toSyncRulesParameters(token_parameters),
-    user_parameters: toSyncRulesParameters(user_parameters ?? {}),
-    raw_user_parameters
-  };
 }
 
 /**

--- a/packages/sync-rules/src/utils.ts
+++ b/packages/sync-rules/src/utils.ts
@@ -156,9 +156,11 @@ export function normalizeTokenParameters(
   token_parameters: Record<string, any>,
   user_parameters?: Record<string, any>
 ): SyncParameters {
+  const raw_user_parameters = JSONBig.stringify(user_parameters ?? {});
   return {
     token_parameters: toSyncRulesParameters(token_parameters),
-    user_parameters: toSyncRulesParameters(user_parameters ?? {})
+    user_parameters: toSyncRulesParameters(user_parameters ?? {}),
+    raw_user_parameters
   };
 }
 

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -177,4 +177,10 @@ describe('data queries', () => {
     const query = SqlDataQuery.fromSql('mybucket', [], sql);
     expect(query.errors).toMatchObject([{ type: 'fatal', message: 'Cannot use bucket parameters in expressions' }]);
   });
+
+  test('invalid query - match clause in select', () => {
+    const sql = 'SELECT id, (bucket.org_id = assets.org_id) as org_matches FROM assets where org_id = bucket.org_id';
+    const query = SqlDataQuery.fromSql('mybucket', ['org_id'], sql);
+    expect(query.errors[0].message).toMatch(/Parameter match expression is not allowed here/);
+  });
 });

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -543,6 +543,15 @@ describe('parameter queries', () => {
     expect(query.getLookups(requestParams)).toEqual([['mybucket', '1', 'user1']]);
   });
 
+  test('request.jwt()', function () {
+    const sql = "SELECT FROM users WHERE id = request.jwt() ->> 'sub'";
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
+
+    const requestParams = normalizeTokenParameters({ user_id: 'user1' });
+    expect(query.getLookups(requestParams)).toEqual([['mybucket', undefined, 'user1']]);
+  });
+
   test('invalid OR in parameter queries', () => {
     // Supporting this case is more tricky. We can do this by effectively denormalizing the OR clause
     // into separate queries, but it's a significant change. For now, developers should do that manually.

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -652,7 +652,8 @@ describe('parameter queries', () => {
         const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
         expect(query.errors).toMatchObject([
           {
-            message: 'Pontially dangerous query based on unauthenticated client parameters'
+            message:
+              "Potentially dangerous query based on parameters set by the client. The client can send any value for these parameters so it's not a good place to do authorization."
           }
         ]);
         expect(query.usesDangerousRequestParameters).toEqual(true);

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -449,7 +449,9 @@ describe('parameter queries', () => {
 
   test('request.parameters()', function () {
     const sql = "SELECT FROM posts WHERE category = request.parameters() ->> 'category_id'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, undefined, {
+      accept_potentially_dangerous_queries: true
+    }) as SqlParameterQuery;
     expect(query.errors).toEqual([]);
     query.id = '1';
     expect(query.evaluateParameterRow({ id: 'group1', category: 'red' })).toEqual([
@@ -463,7 +465,9 @@ describe('parameter queries', () => {
 
   test('nested request.parameters() (1)', function () {
     const sql = "SELECT FROM posts WHERE category = request.parameters() -> 'details' ->> 'category'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, undefined, {
+      accept_potentially_dangerous_queries: true
+    }) as SqlParameterQuery;
     expect(query.errors).toEqual([]);
     query.id = '1';
     expect(query.getLookups(normalizeTokenParameters({}, { details: { category: 'red' } }))).toEqual([
@@ -473,7 +477,9 @@ describe('parameter queries', () => {
 
   test('nested request.parameters() (2)', function () {
     const sql = "SELECT FROM posts WHERE category = request.parameters() ->> 'details.category'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, undefined, {
+      accept_potentially_dangerous_queries: true
+    }) as SqlParameterQuery;
     expect(query.errors).toEqual([]);
     query.id = '1';
     expect(query.getLookups(normalizeTokenParameters({}, { details: { category: 'red' } }))).toEqual([
@@ -484,7 +490,9 @@ describe('parameter queries', () => {
   test('IN request.parameters()', function () {
     // Can use -> or ->> here
     const sql = "SELECT id as region_id FROM regions WHERE name IN request.parameters() -> 'region_names'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, undefined, {
+      accept_potentially_dangerous_queries: true
+    }) as SqlParameterQuery;
     expect(query.errors).toEqual([]);
     query.id = '1';
     expect(query.evaluateParameterRow({ id: 'region1', name: 'colorado' })).toEqual([

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -642,7 +642,11 @@ describe('parameter queries', () => {
     function testDangerousQuery(sql: string) {
       test(sql, function () {
         const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-        expect(query.errors).toEqual([]);
+        expect(query.errors).toMatchObject([
+          {
+            message: 'Pontially dangerous query based on unauthenticated client parameters'
+          }
+        ]);
         expect(query.usesDangerousRequestParameters).toEqual(true);
       });
     }

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { SqlParameterQuery, normalizeTokenParameters } from '../../src/index.js';
-import { BASIC_SCHEMA } from './util.js';
+import { SqlParameterQuery } from '../../src/index.js';
+import { BASIC_SCHEMA, normalizeTokenParameters } from './util.js';
 
 describe('parameter queries', () => {
   test('token_parameters IN query', function () {

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -552,6 +552,15 @@ describe('parameter queries', () => {
     expect(query.getLookups(requestParams)).toEqual([['mybucket', undefined, 'user1']]);
   });
 
+  test('request.user_id()', function () {
+    const sql = 'SELECT FROM users WHERE id = request.user_id()';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toEqual([]);
+
+    const requestParams = normalizeTokenParameters({ user_id: 'user1' });
+    expect(query.getLookups(requestParams)).toEqual([['mybucket', undefined, 'user1']]);
+  });
+
   test('invalid OR in parameter queries', () => {
     // Supporting this case is more tricky. We can do this by effectively denormalizing the OR clause
     // into separate queries, but it's a significant change. For now, developers should do that manually.

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -56,7 +56,9 @@ describe('static parameter queries', () => {
 
   test('request.parameters()', function () {
     const sql = "SELECT request.parameters() ->> 'org_id' as org_id";
-    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, undefined, {
+      accept_potentially_dangerous_queries: true
+    }) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
 
     expect(query.getStaticBucketIds(normalizeTokenParameters({}, { org_id: 'test' }))).toEqual(['mybucket["test"]']);

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -52,4 +52,13 @@ describe('static parameter queries', () => {
     expect(query.getStaticBucketIds(normalizeTokenParameters({ id1: 't1', id2: 't1' }))).toEqual(['mybucket[]']);
     expect(query.getStaticBucketIds(normalizeTokenParameters({ id1: 't1', id2: 't2' }))).toEqual([]);
   });
+
+  test.skip('request.parameters()', function () {
+    // Not implemented in StaticSqlParameterQuery yet
+    const sql = "SELECT request.parameters() ->> 'org_id' as org_id";
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+
+    expect(query.getStaticBucketIds(normalizeTokenParameters({}, { org_id: 'test' }))).toEqual(['mybucket["test"]']);
+  });
 });

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -70,4 +70,13 @@ describe('static parameter queries', () => {
 
     expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1' }))).toEqual(['mybucket["user1"]']);
   });
+
+  test('request.user_id()', function () {
+    const sql = 'SELECT request.user_id() as user_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.bucket_parameters).toEqual(['user_id']);
+
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1' }))).toEqual(['mybucket["user1"]']);
+  });
 });

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import { SqlParameterQuery, normalizeTokenParameters } from '../../src/index.js';
+import { SqlParameterQuery } from '../../src/index.js';
 import { StaticSqlParameterQuery } from '../../src/StaticSqlParameterQuery.js';
+import { normalizeTokenParameters } from './util.js';
 
 describe('static parameter queries', () => {
   test('basic query', function () {

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -88,7 +88,8 @@ describe('static parameter queries', () => {
         const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
         expect(query.errors).toMatchObject([
           {
-            message: 'Pontially dangerous query based on unauthenticated client parameters'
+            message:
+              "Potentially dangerous query based on parameters set by the client. The client can send any value for these parameters so it's not a good place to do authorization."
           }
         ]);
         expect(query.usesDangerousRequestParameters).toEqual(true);

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -53,7 +53,7 @@ describe('static parameter queries', () => {
     expect(query.getStaticBucketIds(normalizeTokenParameters({ id1: 't1', id2: 't2' }))).toEqual([]);
   });
 
-  test.skip('request.parameters()', function () {
+  test('request.parameters()', function () {
     // Not implemented in StaticSqlParameterQuery yet
     const sql = "SELECT request.parameters() ->> 'org_id' as org_id";
     const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -55,11 +55,19 @@ describe('static parameter queries', () => {
   });
 
   test('request.parameters()', function () {
-    // Not implemented in StaticSqlParameterQuery yet
     const sql = "SELECT request.parameters() ->> 'org_id' as org_id";
     const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
 
     expect(query.getStaticBucketIds(normalizeTokenParameters({}, { org_id: 'test' }))).toEqual(['mybucket["test"]']);
+  });
+
+  test('request.jwt()', function () {
+    const sql = "SELECT request.jwt() ->> 'sub' as user_id";
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.bucket_parameters).toEqual(['user_id']);
+
+    expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1' }))).toEqual(['mybucket["user1"]']);
   });
 });

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -692,7 +692,8 @@ bucket_definitions:
 
     expect(rules.errors).toMatchObject([
       {
-        message: 'Pontially dangerous query based on unauthenticated client parameters',
+        message:
+          "Potentially dangerous query based on parameters set by the client. The client can send any value for these parameters so it's not a good place to do authorization.",
         type: 'warning'
       }
     ]);

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -41,7 +41,7 @@ bucket_definitions:
         bucket: 'mybucket[]'
       }
     ]);
-    expect(rules.getStaticBucketIds({ token_parameters: {}, user_parameters: {} })).toEqual(['mybucket[]']);
+    expect(rules.getStaticBucketIds(normalizeTokenParameters({}))).toEqual(['mybucket[]']);
   });
 
   test('parse global sync rules with filter', () => {
@@ -55,8 +55,10 @@ bucket_definitions:
     expect(bucket.bucket_parameters).toEqual([]);
     const param_query = bucket.global_parameter_queries[0];
 
-    expect(param_query.filter!.filterRow({ token_parameters: { is_admin: 1n } })).toEqual([{}]);
-    expect(param_query.filter!.filterRow({ token_parameters: { is_admin: 0n } })).toEqual([]);
+    // Internal API, subject to change
+    expect(param_query.filter!.lookupParameterValue(normalizeTokenParameters({ is_admin: 1n }))).toEqual(1n);
+    expect(param_query.filter!.lookupParameterValue(normalizeTokenParameters({ is_admin: 0n }))).toEqual(0n);
+
     expect(rules.getStaticBucketIds(normalizeTokenParameters({ is_admin: true }))).toEqual(['mybucket[]']);
     expect(rules.getStaticBucketIds(normalizeTokenParameters({ is_admin: false }))).toEqual([]);
     expect(rules.getStaticBucketIds(normalizeTokenParameters({}))).toEqual([]);

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -679,6 +679,40 @@ bucket_definitions:
     ]);
   });
 
+  test('dangerous query errors', () => {
+    const rules = SqlSyncRules.fromYaml(
+      `
+bucket_definitions:
+  mybucket:
+    parameters: SELECT request.parameters() ->> 'project_id' as project_id
+    data: []
+    `,
+      { schema: BASIC_SCHEMA }
+    );
+
+    expect(rules.errors).toMatchObject([
+      {
+        message: 'Pontially dangerous query based on unauthenticated client parameters',
+        type: 'warning'
+      }
+    ]);
+  });
+
+  test('dangerous query errors - ignored', () => {
+    const rules = SqlSyncRules.fromYaml(
+      `
+bucket_definitions:
+  mybucket:
+    accept_potentially_dangerous_queries: true
+    parameters: SELECT request.parameters() ->> 'project_id' as project_id
+    data: []
+    `,
+      { schema: BASIC_SCHEMA }
+    );
+
+    expect(rules.errors).toEqual([]);
+  });
+
   test('schema generation', () => {
     const schema = new StaticSchema([
       {

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -5,10 +5,9 @@ import {
   DartSchemaGenerator,
   JsSchemaGenerator,
   SqlSyncRules,
-  StaticSchema,
-  normalizeTokenParameters
+  StaticSchema
 } from '../../src/index.js';
-import { ASSETS, BASIC_SCHEMA, TestSourceTable, USERS } from './util.js';
+import { ASSETS, BASIC_SCHEMA, TestSourceTable, USERS, normalizeTokenParameters } from './util.js';
 
 describe('sync rules', () => {
   test('parse empty sync rules', () => {

--- a/packages/sync-rules/test/src/util.ts
+++ b/packages/sync-rules/test/src/util.ts
@@ -1,4 +1,11 @@
-import { DEFAULT_SCHEMA, DEFAULT_TAG, SourceTableInterface, StaticSchema } from '../../src/index.js';
+import {
+  DEFAULT_SCHEMA,
+  DEFAULT_TAG,
+  RequestJwtPayload,
+  RequestParameters,
+  SourceTableInterface,
+  StaticSchema
+} from '../../src/index.js';
 
 export class TestSourceTable implements SourceTableInterface {
   readonly connectionTag = DEFAULT_TAG;
@@ -31,3 +38,18 @@ export const BASIC_SCHEMA = new StaticSchema([
     ]
   }
 ]);
+
+/**
+ * For backwards-compatiblity in tests only.
+ */
+export function normalizeTokenParameters(
+  token_parameters: Record<string, any>,
+  user_parameters?: Record<string, any>
+): RequestParameters {
+  const tokenPayload = {
+    sub: token_parameters.user_id ?? '',
+    parameters: { ...token_parameters }
+  } satisfies RequestJwtPayload;
+  delete tokenPayload.parameters.user_id;
+  return new RequestParameters(tokenPayload, user_parameters ?? {});
+}


### PR DESCRIPTION
Adds new functions, for use in parameter queries only:
 1. `request.jwt()`: Returns the entire (signed) JWT payload as a JSON string.
 2. `request.parameters()`: Returns the client parameters (unauthenticated) as a JSON string.
 3. `request.user_id()`: Returns the token subject, same as `token_parameters.user_id()`.

These are similar to the current `token_parameters` and `user_parameters` (added in #7) respectively. The major differences are that the entire payloads are preserved as-is, which can make usage a little more intuitive. It also includes JWT payload fields not previously accessible.

Examples:
```sql
request.jwt() ->> 'sub' -- Same as token_parameters.user_id. Makes it clear which JWT field is used.
request.user_id() -- Same as `request.jwt() ->> 'sub'` and `token_parameters.user_id`
request.parameters() ->> 'param' -- Similar to as user_parameters.param.

-- Some supabase-specific examples below. These can be used with standard Supabase tokens, for use cases which previously required custom tokens
request.jwt() ->> 'role' -- 'authenticated' or 'anonymous'
request.jwt() ->> 'email' -- automatic email field
request.jwt() ->> 'user_metadata.custom_field' -- custom field added on the client (not authenticated)
request.jwt() ->> 'app_metadata.custom_field' -- custom field added by a service account (authenticated)

-- Complete examples:

-- Sync archived projects only when specifically requested in client parameters, authenticated by org_id
SELECT id as project_id FROM projects WHERE org_id IN request.jwt() ->> 'app_metadata.org_id' AND archived = true AND request.parameters() ->> 'include_archived'

-- Only sync selected projects, authenticated by org_id
SELECT id as project_id FROM projects WHERE org_id IN request.jwt() ->> 'app_metadata.org_id' AND id IN request.parameters() -> 'selected_projects'
```

## Implementation

This builds on the refactor in #30.

The biggest change here is to make static parameter queries behave the same as other parameter queries. Previously, static parameter queries treated `token_parameters` and `user_parameters` as row data, while other queries treated it as parameter data. Now, both treat it as parameter data.

From there it's just implementing two special-case functions as `ParameterValueClause`s.

`SyncParameters` was also refactored to get access to the raw payloads in sync rules.

## Naming things

 * [x] Should the jwt function be `request.jwt()` to match `request.parameters()`, ~or `auth.jwt()` to match Supabase RLS~?
 * [x] Should we add `request.user_id()`, ~or `auth.uid()` to match Supabase RLS~?
 * [x] Should we make it more explicit that parameters are not authenticated, e.g. `request.unauthenticated_parameters()`?

## Warning on potentially dangerous queries

To identify potentially dangerous queries, this checks for queries that:
1. Use `request.parameters()` (or `user_parameters`).
2. Does not use `request.jwt()` (or `token_parameters`).

There are some special cases deviating from those, but that's the general principle. These warnings can be disabled by specifying `accept_potentially_dangerous_queries: true` in the bucket definition.

Message updated since screenshot:
> Potentially dangerous query based on parameters set by the client. The client can send any value for these parameters so it's not a good place to do authorization.

![image](https://github.com/powersync-ja/powersync-service/assets/94081/73757b46-bc3b-495e-a6e6-79f0daf840d1)

Accepting the warning:
![image](https://github.com/powersync-ja/powersync-service/assets/94081/064ed638-384d-477b-80d8-3bc800caf8dd)

## Function documentation

This adds basic documentation for each function definition, for use in the sync rules editor.

![image](https://github.com/powersync-ja/powersync-service/assets/94081/312ecaf5-edbf-4e17-b661-d5ebefcc273a)

