### PR TITLE
Add logging and hard exit to migration script

### DIFF
--- a/packages/service-core/src/entry/commands/migrate-action.ts
+++ b/packages/service-core/src/entry/commands/migrate-action.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { extractRunnerOptions, wrapConfigCommand } from './config-command.js';
 import { migrate } from '../../migrations/migrations.js';
 import { Direction } from '../../migrations/definitions.js';
+import { logger } from '@powersync/lib-services-framework';
 
 const COMMAND_NAME = 'migrate';
 
@@ -17,9 +18,16 @@ export function registerMigrationAction(program: Command) {
     .action(async (direction: Direction, options) => {
       const runnerConfig = extractRunnerOptions(options);
 
-      await migrate({
-        direction,
-        runner_config: runnerConfig
-      });
+      try {
+        await migrate({
+          direction,
+          runner_config: runnerConfig
+        });
+
+        process.exit(0);
+      } catch (e) {
+        logger.error(`Migration failure`, e);
+        process.exit(1);
+      }
     });
 }


### PR DESCRIPTION
Similar to #19.

We're getting some migration jobs timing out after 10 minutes, with no meaningful log output to indicate what's happening.

This makes sure that the migration process exits properly after the migrations are done, and adds logging to help debug issues if the migration process does hang in the middle of the migrations.