### PR TITLE
[Fix] Missing router error logs

### DIFF
--- a/.changeset/stale-hounds-tell.md
+++ b/.changeset/stale-hounds-tell.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fixed missing route error logs

--- a/packages/service-core/src/routes/route-register.ts
+++ b/packages/service-core/src/routes/route-register.ts
@@ -63,6 +63,7 @@ export function registerFastifyRoutes(
             }
           } catch (ex) {
             const journeyError = errors.JourneyError.isJourneyError(ex) ? ex : new errors.InternalServerError(ex);
+            logger.error(`Request failed`, journeyError);
 
             response = new router.RouterResponse({
               status: journeyError.errorData.status || 500,


### PR DESCRIPTION
# Overview

This fixes an omission from https://github.com/powersync-ja/powersync-service/pull/24. 

Errors thrown in Router endpoints should be logged.

A sample production log is included below

```json
{
  "errorData": {
    "code": "AUTHORIZATION",
    "description": "Authorization failed",
    "details": [
      "Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID"
    ],
    "name": "AuthorizationError",
    "status": 401
  },
  "is_journey_error": true,
  "level": "error",
  "message": "Request failed [AUTHORIZATION] Authorization failed\n  Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID",
  "name": "AuthorizationError",
  "stack": "AuthorizationError: [AUTHORIZATION] Authorization failed\n  Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID\n    at Module.executeEndpoint (file:///Users/stevenontong/Documents/platform_code/powersync/service/powersync-service/libs/lib-services/dist/router/endpoint.js:14:15)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Object.handler (file:///Users/stevenontong/Documents/platform_code/powersync/service/powersync-service/packages/service-core/dist/routes/route-register.js:32:50)",
  "timestamp": "2024-07-10T09:17:10.941Z"
}

```