### PR TITLE
Fix concurrency limit for websockets

### DIFF
--- a/.changeset/silly-impalas-walk.md
+++ b/.changeset/silly-impalas-walk.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-rsocket-router': patch
+'@powersync/lib-services-framework': patch
+'powersync-open-service': patch
+---
+
+Fix concurrent connection limiting for websockets

--- a/libs/lib-services/src/errors/framework-errors.ts
+++ b/libs/lib-services/src/errors/framework-errors.ts
@@ -30,8 +30,16 @@ export class JourneyError extends Error {
     return input instanceof JourneyError || input?.is_journey_error == true;
   }
 
+  private static errorMessage(data: ErrorData) {
+    let message = `[${data.code}] ${data.description}`;
+    if (data.details) {
+      message += `\n  ${data.details}`;
+    }
+    return message;
+  }
+
   constructor(data: ErrorData) {
-    super(`[${data.code}] ${data.description}\n  ${data.details}`);
+    super(JourneyError.errorMessage(data));
 
     this.errorData = data;
     if (data.stack) {


### PR DESCRIPTION
#24 introduced concurrency limits for websockets, similar to what we had with http streams. However, the connection count does not always decrease when a connection is closed, leading to all clients eventually getting an error " [429] Maximum active concurrent connections limit has been reached".

This simplifies it a bit by just tracking the number of websocket clients on the websocket server, instead of attempting to track the individual streams. We could additionally limit the number of streams per client in the future.
