### PR TITLE
Compacting buckets

### DIFF
--- a/.changeset/dry-schools-rush.md
+++ b/.changeset/dry-schools-rush.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': minor
+'@powersync/service-image': minor
+---
+
+Implement a compact command

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Technical Documentation
+
+This folder contains technical documentation regarding the implementation of PowerSync.
+
+For documentation on using PowerSync, see [docs.powersync.com](https://docs.powersync.com/).

--- a/docs/bucket-properties.md
+++ b/docs/bucket-properties.md
@@ -6,9 +6,29 @@ For a more broad overview of the protocol, see [sync-protocol.md](./sync-protoco
 
 ## Buckets
 
-A bucket $B$ is defined as a set of operations $B = \\{ op_1, op_2, \ldots, op_n \\}$. Each operation is a tuple of $(opid_i, type_i, rowid_i, data_i, checksum_i)$. $opid_i \in \mathbb{N}$ is a strictly incrementing series of numbers identifying the operation within the bucket. $type_i$ is one of PUT, REMOVE, MOVE or CLEAR. $rowid_i$ is an identifier uniquely identifying a single row of data within the bucket. $checksum_i$ is a checksum over all the other fields in the tuple.
+A bucket $B$ is defined as a set of operations:
 
-We define the shorthand syntax for a sub-sequence of bucket $B$ as $B_{[a..b]} = \\{ op_i | a <= id_i <= b \\}$, and $B_{[..b]} = B_{[id_1..b]}$.
+```math
+B = \{ op_1, op_2, \ldots, op_n \}
+```
+
+Each operation $op_i$ is a tuple of:
+
+```math
+(opid_i, type_i, rowid_i, data_i, checksum_i)
+```
+
+$opid_i \in \mathbb{N}$ is a strictly incrementing series of numbers identifying the operation within the bucket. $type_i$ is one of PUT, REMOVE, MOVE or CLEAR. $rowid_i$ is an identifier uniquely identifying a single row of data within the bucket. $checksum_i$ is a checksum over all the other fields in the tuple.
+
+We define the shorthand syntax for a sub-sequence of bucket $B$ as:
+
+```math
+B_{[a..b]} = \{ op_i | a <= opid_i <= b \}
+```
+
+```math
+B_{[..b]} = B_{[opid_1..b]}
+```
 
 ## Reducing buckets
 
@@ -20,30 +40,56 @@ We define the function "reduce" on a bucket $B$, $r(B)$. This operation is run c
 
 In other words, it keeps the lastest state of each row, in addition to the checksum of other discarded operations. We define two reduced buckets as equal if they have exactly the same set of PUT operations, and the remaining checksum is equal.
 
-$r(B)$ roughly defined as follows: $r(B) = \\{ (0, CLEAR, checksum_t) \\} \cup \\{ op_i \in B | type_i = PUT \\}$ (TODO: also handle REMOVE and CLEAR operations).
+The algorithm to compute $r(B)$ is as follows:
+
+1. Start with the initial state containing a special CLEAR operation $R = \\{ (0, CLEAR, checksum_t = 0) \\}$.
+2. Iterate through the operations $op_i$ in $B$ in sequence, ordered by $opid$.
+3. If $type_i = PUT$:
+   1. Add $op_i$ to $R$.
+   2. Remove any prior operations $op_j$ from $R$ where $rowid_j = rowid_i$ and $opid_j < opid_i$ (always true since we're iterating in sequence).
+   3. Add $checksum_j$ to $checksum_t$ for any $op_j$ we removed.
+4. If $type_i = REMOVE$:
+   1. Remove any prior operations $op_j$ from $R$ where $rowid_j = rowid_i$ and $opid_j < opid_i$ (always true since we're iterating in sequence).
+   2. Add $checksum_i$ to $checksum_t$ in the first operation, as well as adding $checksum_j$ for any $op_j$ we removed.
+5. If $type_i = MOVE$:
+   1. Add $checksum_i$ to $checksum_t$ in the first operation.
+6. If $type_i = CLEAR$:
+   1. Remove ALL operations from $R$.
+   2. Set $R = \\{ (0, CLEAR, checksum_t = checksum_i) \\}$.
+7. After iterating through all operations in $B$, return $R$ as the result.
 
 $r(r(B_1) \cup B_2)$ is a common operation takes an already-reduced bucket $r(B_1)$, adds all operations from $B_2$, and reduces it again. This is the action of taking an already-download and reduced on the client bucket, downloading new operations for the bucket, and adding it to the reduced result.
 
 The function $r(B)$ must always satisfy this property:
 
-$r(B_{[..id_n]}) = r(r(B_{[..id_i]}) \cup B_{[id_{i+1}..id_n]}) \forall i \in [1..n]$
+```math
+r(B_{[..opid_n]}) = r(r(B_{[..c_i]}) \cup B_{[c_i+1..opid_n]}) \quad \textrm{for all} \quad c_i \in B
+```
 
-That is, a client must have been able to sync to any point $id_i$, persist the reduced set, then continue syncing the remainder of the data, and end up with the same result as syncing it all in one go.
+That is, a client must have been able to sync to any checkpoint $c_i$, persist the reduced set, then continue syncing the remainder of the data, and end up with the same result as syncing it all in one go. The iterative nature of the algorithm makes the above always true.
 
 ## Compacting
 
-We define a server-side compact operation, that reduces the amount of data that needs to be downloaded to clients, while keeping that same results.
+We define a server-side compact operation, that reduces the amount of data that needs to be downloaded to clients, while still getting the same results on each client.
 
-When we compact the bucket $B$ to $B'$, the following conditions must hold:
+When we compact the bucket $B$ to $B' = compact(B)$, the following conditions must hold:
 
-1. $r(B) = r(B')$.
-2. $r(B_{[..c]}) = r(B'_{[..c]})$ for any valid checkpoint $c$. Note that we can define all $opid$ less than $opid_n$ as invalid checkpoints.
-3. $r(B_{[..c]}) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}) \forall c_i \in B$.
+```math
+r(B) = r(B')
+```
 
-This easily holds when compacting operations into MOVE operations. Since move operations are not present in $r(B_{[..c]})$ apart from their checksum, and the checksum is not changed, this has zero effect.
+```math
+r(B) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..opid_n]}) \quad \textrm{for all} \quad c_i \in B
+```
 
-TODO: Proof for CLEAR operations.
+Note that this is the same as the standard equation for buckets above, but with $B$ replaced by the compacted bucket $B'$ in one place, representing newer data downloaded by clients.
+
+The compact operation is defined in [compacting-operations.md](./compacting-operations.md), a formal description is pending.
+
+The above easily holds when compacting operations into MOVE operations. Since move operations are not present in $r(B)$ apart from their checksum, and the checksum is not changed with $B'$, this has no effect on the outcome.
+
+A proof of compacting into CLEAR operations is pending.
 
 ### Consistency during sync
 
-Suppose a client starts downloading at checkpoint $c_1$, operations $B_{[..c_1]}$. Right after, operations are added - checkpoint $c_2$, operations $B_{[c_1+1..c_2]}$. Right after, the bucket is compacted to $B'\_{[..c_2]}$. While we have a guaranteed $r(B_{[..c_2]}) = r(B'\_{[..c_2]})$, there is no guarantee that $r(B_{[..c_1]}) = r(B'\_{[..c_1]})$. In fact it's very possible that MOVE operations can cause $r(B_{[..c_1]}) \neq r(B'_{[..c_1]})$. Therefore, we invalidate the checkpoint $c_1$ - the client will only have consistent data once it has fully synced up to $c_2$.
+Suppose a client starts downloading at checkpoint $c_1$, operations $B_{[..c_1]}$. Right after, operations are added - checkpoint $c_2$, operations $B_{[c_1+1..c_2]}$. Then, the bucket is compacted to $B'\_{[..c_2]}$. While we have a guaranteed $r(B_{[..c_2]}) = r(B'\_{[..c_2]})$, there is no guarantee that $r(B_{[..c_1]}) = r(B'\_{[..c_1]})$. In fact it's very possible that MOVE operations can cause $r(B_{[..c_1]}) \neq r(B'\_{[..c_1]})$. Therefore, we invalidate the checkpoint $c_1$ - the client will only have consistent data once it has fully synced up to $c_2$.

--- a/docs/bucket-properties.md
+++ b/docs/bucket-properties.md
@@ -1,0 +1,49 @@
+# Formal Bucket Properties
+
+This document describes buckets as a set of operations, along with the properties we guarantee for the sync protocol. These are the properties used to ensure that each client ends up with the same bucket state when the same bucket has been downloaded.
+
+For a more broad overview of the protocol, see [sync-protocol.md](./sync-protocol.md). For a high-level description of the compact implementation, see [compacting-operations.md](./compacting-operations.md).
+
+## Buckets
+
+A bucket $B$ is defined as a set of operations $B = \{ op_1, op_2, \ldots, op_n \}$. Each operation is a tuple of $(opid_i, type_i, rowid_i, data_i, checksum_i)$. $opid_i \in \N$ is a strictly incrementing series of numbers identifying the operation within the bucket. $type_i$ is one of PUT, REMOVE, MOVE or CLEAR. $rowid_i$ is an identifier uniquely identifying a single row of data within the bucket. $checksum_i$ is a checksum over all the other fields in the tuple.
+
+We define the shorthand syntax for a sub-sequence of bucket $B$ as $B_{[a..b]} = \{ op_i \;|\; a <= id_i <= b \}$, and $B_{[..b]} = B_{[id_1..b]}$.
+
+## Reducing buckets
+
+We define the function "reduce" on a bucket $B$, $r(B)$. This operation is run client-side, after downloading data for a bucket, to get the final state for each unique row. The reduced state:
+
+1. Discards MOVE operations, only keeping track of their checksum.
+2. Discards superseded operations, only keeping the last operation for each unique row (but keeps track of the checksum of prior operations).
+3. Discards REMOVE operations (keeping their checkums), only after all prior operations for those rows have been superseded.
+
+In other words, it keeps the lastest state of each row, in addition to the checksum of other discarded operations. We define two reduced buckets as equal if they have exactly the same set of PUT operations, and the remaining checksum is equal.
+
+$r(B)$ roughly defined as follows: $r(B) = \{ (0, CLEAR, checksum_t) \} \cup \{ op_i \in B \;|\; type_i = PUT \}$ (TODO: also handle REMOVE and CLEAR operations).
+
+$r(r(B_1) \cup B_2)$ is a common operation takes an already-reduced bucket $r(B_1)$, adds all operations from $B_2$, and reduces it again. This is the action of taking an already-download and reduced on the client bucket, downloading new operations for the bucket, and adding it to the reduced result.
+
+The function $r(B)$ must always satisfy this property:
+
+$r(B_{[..id_n]}) = r(r(B_{[..id_i]}) \cup B_{[id_{i+1}..id_n]}) \;\forall\; i \in [1..n]$
+
+That is, a client must have been able to sync to any point $id_i$, persist the reduced set, then continue syncing the remainder of the data, and end up with the same result as syncing it all in one go.
+
+## Compacting
+
+We define a server-side compact operation, that reduces the amount of data that needs to be downloaded to clients, while keeping that same results.
+
+When we compact the bucket $B$ to $B'$, the following conditions must hold:
+
+1. $r(B) = r(B')$.
+2. $r(B_{[..c]}) = r(B'_{[..c]})$ for any valid checkpoint $c$. Note that we can define all $opid$ less than $opid_n$ as invalid checkpoints.
+3. $r(B_{[..c]}) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}) \;\forall\; c_i \in B$.
+
+This easily holds when compacting operations into MOVE operations. Since move operations are not present in $r(B_{[..c]})$ apart from their checksum, and the checksum is not changed, this has zero effect.
+
+TODO: Proof for CLEAR operations.
+
+### Consistency during sync
+
+Suppose a client starts downloading at checkpoint $c_1$, operations $B_{[..c_1]}$. Right after, operations are added - checkpoint $c_2$, operations $B_{[c_1+1..c_2]}$. Right after, the bucket is compacted to $B'_{[..c_2]}$. While we have a guaranteed $r(B_{[..c_2]}) = r(B'_{[..c_2]})$, there is no guarantee that $r(B_{[..c_1]}) = r(B'_{[..c_1]})$. In fact it's very possible that MOVE operations can cause $r(B_{[..c_1]}) \neq r(B'_{[..c_1]})$. Therefore, we invalidate the checkpoint $c_1$ - the client will only have consistent data once it has fully synced up to $c_2$.

--- a/docs/bucket-properties.md
+++ b/docs/bucket-properties.md
@@ -6,9 +6,9 @@ For a more broad overview of the protocol, see [sync-protocol.md](./sync-protoco
 
 ## Buckets
 
-A bucket $B$ is defined as a set of operations $B = \{ op_1, op_2, \ldots, op_n \}$. Each operation is a tuple of $(opid_i, type_i, rowid_i, data_i, checksum_i)$. $opid_i \in \N$ is a strictly incrementing series of numbers identifying the operation within the bucket. $type_i$ is one of PUT, REMOVE, MOVE or CLEAR. $rowid_i$ is an identifier uniquely identifying a single row of data within the bucket. $checksum_i$ is a checksum over all the other fields in the tuple.
+A bucket $B$ is defined as a set of operations $B = \\{ op_1, op_2, \ldots, op_n \\}$. Each operation is a tuple of $(opid_i, type_i, rowid_i, data_i, checksum_i)$. $opid_i \in \mathbb{N}$ is a strictly incrementing series of numbers identifying the operation within the bucket. $type_i$ is one of PUT, REMOVE, MOVE or CLEAR. $rowid_i$ is an identifier uniquely identifying a single row of data within the bucket. $checksum_i$ is a checksum over all the other fields in the tuple.
 
-We define the shorthand syntax for a sub-sequence of bucket $B$ as $B_{[a..b]} = \{ op_i \;|\; a <= id_i <= b \}$, and $B_{[..b]} = B_{[id_1..b]}$.
+We define the shorthand syntax for a sub-sequence of bucket $B$ as $B_{[a..b]} = \\{ op_i | a <= id_i <= b \\}$, and $B_{[..b]} = B_{[id_1..b]}$.
 
 ## Reducing buckets
 
@@ -20,13 +20,13 @@ We define the function "reduce" on a bucket $B$, $r(B)$. This operation is run c
 
 In other words, it keeps the lastest state of each row, in addition to the checksum of other discarded operations. We define two reduced buckets as equal if they have exactly the same set of PUT operations, and the remaining checksum is equal.
 
-$r(B)$ roughly defined as follows: $r(B) = \{ (0, CLEAR, checksum_t) \} \cup \{ op_i \in B \;|\; type_i = PUT \}$ (TODO: also handle REMOVE and CLEAR operations).
+$r(B)$ roughly defined as follows: $r(B) = \\{ (0, CLEAR, checksum_t) \\} \cup \\{ op_i \in B | type_i = PUT \\}$ (TODO: also handle REMOVE and CLEAR operations).
 
 $r(r(B_1) \cup B_2)$ is a common operation takes an already-reduced bucket $r(B_1)$, adds all operations from $B_2$, and reduces it again. This is the action of taking an already-download and reduced on the client bucket, downloading new operations for the bucket, and adding it to the reduced result.
 
 The function $r(B)$ must always satisfy this property:
 
-$r(B_{[..id_n]}) = r(r(B_{[..id_i]}) \cup B_{[id_{i+1}..id_n]}) \;\forall\; i \in [1..n]$
+$r(B_{[..id_n]}) = r(r(B_{[..id_i]}) \cup B_{[id_{i+1}..id_n]}) \forall i \in [1..n]$
 
 That is, a client must have been able to sync to any point $id_i$, persist the reduced set, then continue syncing the remainder of the data, and end up with the same result as syncing it all in one go.
 
@@ -38,7 +38,7 @@ When we compact the bucket $B$ to $B'$, the following conditions must hold:
 
 1. $r(B) = r(B')$.
 2. $r(B_{[..c]}) = r(B'_{[..c]})$ for any valid checkpoint $c$. Note that we can define all $opid$ less than $opid_n$ as invalid checkpoints.
-3. $r(B_{[..c]}) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}) \;\forall\; c_i \in B$.
+3. $r(B_{[..c]}) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}) \forall c_i \in B$.
 
 This easily holds when compacting operations into MOVE operations. Since move operations are not present in $r(B_{[..c]})$ apart from their checksum, and the checksum is not changed, this has zero effect.
 
@@ -46,4 +46,4 @@ TODO: Proof for CLEAR operations.
 
 ### Consistency during sync
 
-Suppose a client starts downloading at checkpoint $c_1$, operations $B_{[..c_1]}$. Right after, operations are added - checkpoint $c_2$, operations $B_{[c_1+1..c_2]}$. Right after, the bucket is compacted to $B'_{[..c_2]}$. While we have a guaranteed $r(B_{[..c_2]}) = r(B'_{[..c_2]})$, there is no guarantee that $r(B_{[..c_1]}) = r(B'_{[..c_1]})$. In fact it's very possible that MOVE operations can cause $r(B_{[..c_1]}) \neq r(B'_{[..c_1]})$. Therefore, we invalidate the checkpoint $c_1$ - the client will only have consistent data once it has fully synced up to $c_2$.
+Suppose a client starts downloading at checkpoint $c_1$, operations $B_{[..c_1]}$. Right after, operations are added - checkpoint $c_2$, operations $B_{[c_1+1..c_2]}$. Right after, the bucket is compacted to $B'\_{[..c_2]}$. While we have a guaranteed $r(B_{[..c_2]}) = r(B'\_{[..c_2]})$, there is no guarantee that $r(B_{[..c_1]}) = r(B'\_{[..c_1]})$. In fact it's very possible that MOVE operations can cause $r(B_{[..c_1]}) \neq r(B'_{[..c_1]})$. Therefore, we invalidate the checkpoint $c_1$ - the client will only have consistent data once it has fully synced up to $c_2$.

--- a/docs/compacting-operations.md
+++ b/docs/compacting-operations.md
@@ -22,9 +22,9 @@ Any operation on a row may be converted into a MOVE operation if there is anothe
 
 Two rows are considered the same if the combination of `(object_type, object_id, subkey)` is the same.
 
-A MOVE operation may contain data of `{target: '<op_id>'}`. This indicates that the operation was "moved" to the target, and no checksum before that op_id will be valid. This is optional - the server may omit this data if the checkpoint being synced is greater than or equal to the target op_id.
+A MOVE operation may contain internal metadata of `{target_op: op_id}`. This indicates that the operation was "moved" to the target, and no checkpoint before that op_id will be valid. A previous protocol revision included this in the operation data, and let clients invalidate the checkpoint. Now, this is used purely server-side, and the server omits the `CheckpointComplete` message if the current checkpoint has been invalidated by such an operation. The same applies to CLEAR operations below.
 
-When converting an operation to a MOVE operation, the bucket, op_id and checksum remain the same. The data, object_type, object_id and subkey fields may be cleared, reducing the size of the operation.
+When converting an operation to a MOVE operation, the bucket, op_id and checksum remain the same. The data, object_type, object_id and subkey fields must be cleared, reducing the size of the operation.
 
 By itself, converting operations into MOVE operations does not reduce the number of operations synced, but may reduce the total size of the operations synced. It has no effect on clients that are already up-to-date.
 

--- a/docs/compacting-operations.md
+++ b/docs/compacting-operations.md
@@ -66,7 +66,7 @@ The process iterates through all operations in reverse order. This effectively p
 
 We track each row we've seen in a bucket, along with the last PUT/REMOVE operation we've seen for the row. Whenever we see the same row again, we replace that operation with a MOVE operation, using the PUT/REMOVE op_id as the target.
 
-To avoid indefinite memory growth for this process, we place a limit on the memory usage for the set of rows we're tracking. Once we reach this limit, we avoid adding tracking any additional rows for the bucket. We should be able to effectively compact buckets in the order of 10M rows using 1GB of memory, and only lose some compacting gains for larger buckets.
+To avoid indefinite memory growth for this process, we place a limit on the memory usage for the set of rows we're tracking. Once we reach this limit, we avoid adding tracking any additional rows for the bucket. We should be able to effectively compact buckets in the order of 4M unique rows using 1GB of memory, and only lose some compacting gains for larger buckets.
 
 The second part is compacting to CLEAR operations. For each bucket, we keep track of the last PUT operation we've seen (last meaning the smallest op_id since we're iterating in reverse). We then replace all the operations before that with a single CLEAR operation.
 

--- a/docs/compacting-operations.md
+++ b/docs/compacting-operations.md
@@ -1,0 +1,102 @@
+# Compacting Operations
+
+This document describes the internal process of compacting operations. This describes what happens behind the scenes when running the `compact` CLI command.
+
+By default, each change in the source database becomes a new operation in the ever-growing bucket history. To avoid this history from growing indefinitely, we "compact" the buckets.
+
+## Previous Workaround
+
+A workaround is to deploy a sync rules change, which re-creates all buckets from scratch, containing only the latest version of each row. This reduces the size of buckets for new clients performing a sync from scratch, but requires existing clients to completely re-sync the buckets.
+
+# Compacting Processes
+
+The compacting process can be split into three distinct processes.
+
+1. Convert operations into MOVE operations.
+2. Convert operations into CLEAR operations.
+3. Defragment buckets.
+
+## 1. MOVE operations
+
+Any operation on a row may be converted into a MOVE operation if there is another PUT or REMOVE operation later in the bucket for the same row.
+
+Two rows are considered the same if the combination of `(object_type, object_id, subkey)` is the same.
+
+A MOVE operation may contain data of `{target: '<op_id>'}`. This indicates that the operation was "moved" to the target, and no checksum before that op_id will be valid. This is optional - the server may omit this data if the checkpoint being synced is greater than or equal to the target op_id.
+
+When converting an operation to a MOVE operation, the bucket, op_id and checksum remain the same. The data, object_type, object_id and subkey fields may be cleared, reducing the size of the operation.
+
+By itself, converting operations into MOVE operations does not reduce the number of operations synced, but may reduce the total size of the operations synced. It has no effect on clients that are already up-to-date.
+
+## 2. CLEAR operations
+
+A CLEAR operation in a bucket indicates that all preceeding operations in the bucket must be deleted. It is typically the first operation in a bucket, but the client may receive it at any later point.
+
+The the client has active PUT options before the CLEAR operation, those are effectively converted into REMOVE operations. This will remove the data unless there is another PUT operation for the relevant rows later in the bucket.
+
+The compact process involves:
+
+1. Find the largest sequence of REMOVE, MOVE and/or CLEAR operations of at the start of the bucket.
+2. Replace all of those with the single CLEAR operation.
+
+The op_id of the CLEAR operation is the latest op_id of the operations being replaced, and the checksum is the combination of those operations' checksums.
+
+Compacting to CLEAR operations can reduce the number of operations in a bucket. However,
+it is not effective if there is a PUT operation near the start of the bucket. This compacting step has no effect on clients that are already up-to-date.
+
+The MOVE compact step above should typically be run before the CLEAR compact step, to ensure maximum effectiveness.
+
+## 3. Defragmentation
+
+Even after doing the MOVE and CLEAR compact processes, there is still a possibility of a bucket being fragmented with many MOVE and REMOVE operations. In the worst case, a bucket may start with a single PUT operation, followed by thousands of MOVE and REMOVE operations. Only a single row (the PUT operation) still exists, but new clients must sync all the MOVE and CLEAR operations.
+
+To handle these cases, we can "defragment" the data.
+
+Defragmentation does not involve any new operations. Instead, it just moves PUT operations for active rows from the start of the bucket to the end of the bucket, to allow the above MOVE and COMPACT processes to efficiently compact the bucket.
+
+The disadvantage here is that these rows will be re-synced by existing clients.
+
+# Implementation
+
+## MOVE + CLEAR
+
+This is a process that compacts all buckets, by iterating through all operations. This process can be run periodically, for example once a day, or after bulk data modifications.
+
+The process iterates through all operations in reverse order. This effectively processes one bucket at a time, in reverse order of operatoins.
+
+We track each row we've seen in a bucket, along with the last PUT/REMOVE operation we've seen for the row. Whenever we see the same row again, we replace that operation with a MOVE operation, using the PUT/REMOVE op_id as the target.
+
+To avoid indefinite memory growth for this process, we place a limit on the memory usage for the set of rows we're tracking. Once we reach this limit, we avoid adding tracking any additional rows for the bucket. We should be able to effectively compact buckets in the order of 10M rows using 1GB of memory, and only lose some compacting gains for larger buckets.
+
+The second part is compacting to CLEAR operations. For each bucket, we keep track of the last PUT operation we've seen (last meaning the smallest op_id since we're iterating in reverse). We then replace all the operations before that with a single CLEAR operation.
+
+## Defragmentation
+
+For an initial workaround, defragmenting can be performed outside powersync by touching all rows in a bucket:
+
+```sql
+update mytable set id = id
+-- Repeat the above for other tables in the same bucket if relevant
+```
+
+After this, the normal MOVE + CLEAR compacting will compact the bucket to only have a single operation per active row.
+
+This would cause existing clients to re-sync every row, while reducing the number of operations for new clients.
+
+If an updated_at column or similar is present, we can use this to defragment more incrementally:
+
+```sql
+update mytable set id = id where updated_at < now() - interval '1 week'
+```
+
+This version avoids unnecessary defragmentation of rows modified recently.
+
+In the future, we can implement defragmentation inside PowerSync, using heuristics around the spread of operations within a bucket.
+
+# Future additions
+
+Improvements may be implemented in the future:
+
+1. Keeping track of buckets that need compacting would allow us to compact those as soon as needed, without the overhead of compacting buckets where it won't have an effect.
+2. Together with the above, we can implement a lightweight compacting process inside the replication worker, to compact operations as soon as modifications come in. This can help to quickly compact in cases where multiple modifications are made to the same rows in a short time span.
+3. Implement automatic defragmentation inside PowerSync as described above.

--- a/docs/compacting-operations.md
+++ b/docs/compacting-operations.md
@@ -62,7 +62,7 @@ The disadvantage here is that these rows will be re-synced by existing clients.
 
 This is a process that compacts all buckets, by iterating through all operations. This process can be run periodically, for example once a day, or after bulk data modifications.
 
-The process iterates through all operations in reverse order. This effectively processes one bucket at a time, in reverse order of operatoins.
+The process iterates through all operations in reverse order. This effectively processes one bucket at a time, in reverse order of operations.
 
 We track each row we've seen in a bucket, along with the last PUT/REMOVE operation we've seen for the row. Whenever we see the same row again, we replace that operation with a MOVE operation, using the PUT/REMOVE op_id as the target.
 

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -151,6 +151,8 @@ Format:
 }
 ```
 
+A previous iteration of the protocol included an optional `data: '{"target": OpId}'` field. This was to indicate a checkpoint is not valid unless its op_id is greater than or equal to the target. Now, the server is responsible for invalidating checkpoints in those cases, by not sending a `CheckpointComplete` in that case.
+
 ## CLEAR
 
 Indicates a "reset point" of a bucket. All operations prior to this bucket must be removed.

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -1,0 +1,170 @@
+# Sync Protocol
+
+This document is a work in progress - more details to be added over time.
+
+# Sync stream
+
+A sync stream contains 5 possible messages:
+
+## StreamingSyncCheckpoint
+
+Format:
+
+```ts
+{
+  checkpoint: {
+    last_op_id: OpId;
+    write_checkpoint?: OpId;
+    buckets: BucketChecksum[];
+  }
+}
+```
+
+This indicates a new checkpoint is available, along with checksums for each bucket in the checkpoint.
+
+This is typically (but not necessarily) be the first message in the response, and is often followed by StreamingSyncData and StreamingSyncCheckpointComplete (both optional).
+
+## StreamingSyncCheckpointDiff
+
+This has the same conceptual meaning as a StreamingSyncCheckpoint. It is an optimization to only sent details for buckets that changed, instead of sending the entire checkpoint over.
+
+Format:
+
+```ts
+{
+  checkpoint_diff: {
+    last_op_id: OpId;
+    write_checkpoint?: OpId;
+    updated_buckets: BucketChecksum[];
+    removed_buckets: string[];
+  }
+}
+```
+
+Typically a sync stream would contain a single StreamingSyncCheckpoint, and then after that only StreamingSyncCheckpointDiff messages. However, the server may send any number of StreamingSyncCheckpoint messags after that, each time "resetting" the checkpoint state.
+
+## StreamingSyncData
+
+This message contains data for a single bucket.
+
+Format:
+
+```ts
+{
+  data: SyncBucketData;
+}
+```
+
+While this data is typically associated with the last checkpoint sent, it may be sent at any other time, and may contain data outside the last checkpoint boundaries.
+
+## StreamingSyncCheckpointComplete
+
+This message indicates that all data has been sent for the last checkpoint.
+
+Format:
+
+```ts
+{
+  checkpoint_complete: {
+    last_op_id: OpId;
+  }
+}
+```
+
+`last_op_id` here _must_ match the `last_op_id` of the last `StreamingSyncCheckpoint` or `StreamingSyncCheckpointDiff` message sent.
+
+It is not required to have one `StreamingSyncCheckpointComplete` message for every `StreamingSyncCheckpoint` or `StreamingSyncCheckpointDiff`. In some cases, a checkpoint may be invalidated while data were being sent, in which case no matching `StreamingSyncCheckpointComplete` will be sent. Instead, another `StreamingSyncCheckpoint` or `StreamingSyncCheckpointDiff` will be sent with a new checkpoint.
+
+## StreamingSyncKeepalive
+
+Serves as both a general keepalive message to keep the stream open, and an indication of how long before the current token expires.
+
+Format:
+
+```ts
+{
+  token_expires_in: number;
+}
+```
+
+# Bucket operations
+
+## PUT
+
+Includes contents for an entire row.
+
+The row is uniquely identified using the combination of (object_type, object_id, subkey).
+
+Another PUT or REMOVE operation with the same `(object_type, object_id, subkey)` _replaces_
+this operation.
+
+Another PUT or REMOVE operation with the same `(object_type, object_id, subkey)` but a different `subkey` _does not_ directly replace this one, and may exist concurrently.
+
+Format:
+
+```ts
+{
+  op_id: OpId;
+  op: 'PUT';
+  object_type: string;
+  object_id: string;
+  data: string;
+  checksum: number;
+  subkey?: string;
+}
+```
+
+## REMOVE
+
+Indicates that a row is removed from a bucket.
+
+The row is uniquely identified using the combination of (object_type, object_id, subkey).
+
+Another PUT or REMOVE operation with the same `(object_type, object_id, subkey)` _replaces_
+this operation.
+
+Format:
+
+```ts
+{
+  op_id: OpId;
+  op: 'REMOVE';
+  object_type: string;
+  object_id: string;
+  checksum: number;
+  subkey?: string;
+}
+```
+
+## MOVE
+
+Indicates a "tombstone" operation - an operation that has been replaced by another one.
+The checksum of the operation is unchanged.
+
+Format:
+
+```ts
+{
+  op_id: OpId;
+  op: 'MOVE';
+  checksum: number;
+}
+```
+
+## CLEAR
+
+Indicates a "reset point" of a bucket. All operations prior to this bucket must be removed.
+
+If the client has any active PUT operations prior to a CLEAR operation, those should effectively be converted into REMOVE operations.
+
+The checksum of this operation is equal to the combined checksum of all prior operations it replaced.
+
+Format:
+
+```ts
+{
+  op_id: OpId;
+  op: 'CLEAR';
+  checksum: number;
+}
+```

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -26,7 +26,7 @@ This is typically (but not necessarily) be the first message in the response, an
 
 ## StreamingSyncCheckpointDiff
 
-This has the same conceptual meaning as a StreamingSyncCheckpoint. It is an optimization to only sent details for buckets that changed, instead of sending the entire checkpoint over.
+This has the same conceptual meaning as a StreamingSyncCheckpoint. It is an optimization to only send details for buckets that changed, instead of sending the entire checkpoint over.
 
 Format:
 

--- a/packages/service-core/src/entry/cli-entry.ts
+++ b/packages/service-core/src/entry/cli-entry.ts
@@ -3,7 +3,7 @@ import { Command } from 'commander';
 import * as utils from '../util/util-index.js';
 import { registerMigrationAction } from './commands/migrate-action.js';
 import { registerTearDownAction } from './commands/teardown-action.js';
-import { registerStartAction } from './entry-index.js';
+import { registerCompactAction, registerStartAction } from './entry-index.js';
 import { logger } from '@powersync/lib-services-framework';
 
 /**
@@ -18,6 +18,7 @@ export function generateEntryProgram(startHandlers?: Record<utils.ServiceRunner,
 
   registerTearDownAction(entryProgram);
   registerMigrationAction(entryProgram);
+  registerCompactAction(entryProgram);
 
   if (startHandlers) {
     registerStartAction(entryProgram, startHandlers);

--- a/packages/service-core/src/entry/commands/compact-action.ts
+++ b/packages/service-core/src/entry/commands/compact-action.ts
@@ -1,0 +1,38 @@
+import { Command } from 'commander';
+
+import { extractRunnerOptions, wrapConfigCommand } from './config-command.js';
+import { logger } from '@powersync/lib-services-framework';
+import { loadConfig } from '../../util/config.js';
+import { mongo } from '../../db/db-index.js';
+import { MongoBucketStorage, MongoSyncBucketStorage, PowerSyncMongo } from '../../storage/storage-index.js';
+
+const COMMAND_NAME = 'compact';
+
+export function registerCompactAction(program: Command) {
+  const compactCommand = program.command(COMMAND_NAME);
+
+  wrapConfigCommand(compactCommand);
+
+  return compactCommand.description('Compact storage').action(async (options) => {
+    const runnerConfig = extractRunnerOptions(options);
+
+    const config = await loadConfig(runnerConfig);
+    const { storage } = config;
+    const client = mongo.createMongoClient(storage);
+    await client.connect();
+    try {
+      const psdb = new PowerSyncMongo(client);
+      const bucketStorage = new MongoBucketStorage(psdb, { slot_name_prefix: config.slot_name_prefix });
+      const active = await bucketStorage.getActiveSyncRules();
+      if (active == null) {
+        logger.info('No active instance to compact');
+        return;
+      }
+      const p = bucketStorage.getInstance(active);
+      await p.compact({});
+      logger.info('done');
+    } finally {
+      await client.close();
+    }
+  });
+}

--- a/packages/service-core/src/entry/commands/compact-action.ts
+++ b/packages/service-core/src/entry/commands/compact-action.ts
@@ -1,12 +1,25 @@
 import { Command } from 'commander';
 
-import { extractRunnerOptions, wrapConfigCommand } from './config-command.js';
 import { logger } from '@powersync/lib-services-framework';
-import { loadConfig } from '../../util/config.js';
+import * as v8 from 'v8';
 import { mongo } from '../../db/db-index.js';
-import { MongoBucketStorage, MongoSyncBucketStorage, PowerSyncMongo } from '../../storage/storage-index.js';
+import { MongoBucketStorage, PowerSyncMongo } from '../../storage/storage-index.js';
+import { loadConfig } from '../../util/config.js';
+import { extractRunnerOptions, wrapConfigCommand } from './config-command.js';
 
 const COMMAND_NAME = 'compact';
+
+/**
+ * Approximately max-old-space-size + 64MB.
+ */
+const HEAP_LIMIT = v8.getHeapStatistics().heap_size_limit;
+
+/**
+ * Subtract 128MB for process overhead.
+ *
+ * Limit to 1024MB overall.
+ */
+const COMPACT_MEMORY_LIMIT_MB = Math.min(HEAP_LIMIT / 1024 / 1024 - 128, 1024);
 
 export function registerCompactAction(program: Command) {
   const compactCommand = program.command(COMMAND_NAME);
@@ -29,10 +42,14 @@ export function registerCompactAction(program: Command) {
         return;
       }
       const p = bucketStorage.getInstance(active);
-      await p.compact({});
+      await p.compact({ memoryLimitMB: COMPACT_MEMORY_LIMIT_MB });
       logger.info('done');
+    } catch (e) {
+      logger.error(`Failed to compact: ${e.toString()}`);
+      process.exit(1);
     } finally {
       await client.close();
+      process.exit(0);
     }
   });
 }

--- a/packages/service-core/src/entry/entry-index.ts
+++ b/packages/service-core/src/entry/entry-index.ts
@@ -3,3 +3,4 @@ export * from './commands/config-command.js';
 export * from './commands/migrate-action.js';
 export * from './commands/start-action.js';
 export * from './commands/teardown-action.js';
+export * from './commands/compact-action.js';

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -228,7 +228,7 @@ export interface SyncRulesBucketStorage {
     checkpoint: util.OpId,
     dataBuckets: Map<string, string>,
     options?: BucketDataBatchOptions
-  ): AsyncIterable<util.SyncBucketData>;
+  ): AsyncIterable<SyncBucketDataBatch>;
 
   /**
    * Compute checksums for a given list of buckets.
@@ -386,6 +386,10 @@ export interface SaveDelete {
   sourceTable: SourceTable;
   before: SqliteRow;
   after?: undefined;
+}
+
+export interface SyncBucketDataBatch extends util.SyncBucketData {
+  targetOp: bigint | null;
 }
 
 export function mergeToast(record: ToastableSqliteRow, persisted: ToastableSqliteRow): ToastableSqliteRow {

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -266,6 +266,8 @@ export interface SyncRulesBucketStorage {
    * Errors are cleared on commit.
    */
   reportError(e: any): Promise<void>;
+
+  compact(options: CompactOptions): Promise<void>;
 }
 
 export interface SyncRuleStatus {
@@ -403,4 +405,14 @@ export function mergeToast(record: ToastableSqliteRow, persisted: ToastableSqlit
     }
   }
   return newRecord;
+}
+
+export interface CompactOptions {
+  /**
+   * Heap memory limit for the compact process.
+   *
+   * Add around 64MB to this to determine the "--max-old-space-size" argument.
+   * Add another 80MB to get RSS usage / memory limits.
+   */
+  memoryLimitMB: number;
 }

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -388,7 +388,8 @@ export interface SaveDelete {
   after?: undefined;
 }
 
-export interface SyncBucketDataBatch extends util.SyncBucketData {
+export interface SyncBucketDataBatch {
+  batch: util.SyncBucketData;
   targetOp: bigint | null;
 }
 

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -415,4 +415,15 @@ export interface CompactOptions {
    * Add another 80MB to get RSS usage / memory limits.
    */
   memoryLimitMB?: number;
+
+  /**
+   * If specified, ignore any operations newer than this when compacting.
+   *
+   * This is primarily for tests, where we want to test compacting at a specific
+   * point.
+   *
+   * This can also be used to create a "safe buffer" of recent operations that should
+   * not be compacted, to avoid invalidating checkpoints in use.
+   */
+  maxOpId?: bigint;
 }

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -267,7 +267,7 @@ export interface SyncRulesBucketStorage {
    */
   reportError(e: any): Promise<void>;
 
-  compact(options: CompactOptions): Promise<void>;
+  compact(options?: CompactOptions): Promise<void>;
 }
 
 export interface SyncRuleStatus {
@@ -414,5 +414,5 @@ export interface CompactOptions {
    * Add around 64MB to this to determine the "--max-old-space-size" argument.
    * Add another 80MB to get RSS usage / memory limits.
    */
-  memoryLimitMB: number;
+  memoryLimitMB?: number;
 }

--- a/packages/service-core/src/storage/mongo/MongoCompactor.ts
+++ b/packages/service-core/src/storage/mongo/MongoCompactor.ts
@@ -1,125 +1,202 @@
-import { AnyBulkWriteOperation, MinKey } from 'mongodb';
+import { logger } from '@powersync/lib-services-framework';
+import { AnyBulkWriteOperation, MaxKey, MinKey } from 'mongodb';
+import { addChecksums } from '../../util/utils.js';
 import { PowerSyncMongo } from './db.js';
 import { BucketDataDocument, BucketDataKey } from './models.js';
-import { idPrefixFilter } from './util.js';
-import { logger } from '@powersync/lib-services-framework';
-import { addChecksums } from '../../util/utils.js';
 
 export interface CompactOptions {
-  memoryLimitMB?: number;
+  /**
+   * Heap memory limit for the compact process.
+   *
+   * Add around 64MB to this to determine the "--max-old-space-size" argument.
+   * Add another 80MB to get RSS usage / memory limits.
+   */
+  memoryLimitMB: number;
+}
+
+interface CurrentBucketState {
+  /** Bucket name */
+  bucket: string;
+  /**
+   * Rows seen in the bucket, with the last op_id of each.
+   */
+  seen: Map<string, bigint>;
+  /**
+   * Estimated memory usage of the seen Map.
+   */
+  trackingSize: number;
+
+  /**
+   * Last (lowest) seen op_id that is not a PUT.
+   */
+  lastNotPut: bigint | null;
+
+  /**
+   * Number of REMOVE/MOVE operations seen since lastNotPut.
+   */
+  opsSincePut: number;
 }
 
 const CLEAR_BATCH_LIMIT = 5000;
+const MOVE_BATCH_LIMIT = 2000;
+const MOVE_BATCH_QUERY_LIMIT = 10_000;
 
 export class MongoCompactor {
   private updates: AnyBulkWriteOperation<BucketDataDocument>[] = [];
 
   constructor(private db: PowerSyncMongo, private group_id: number) {}
 
+  /**
+   * Compact buckets by converting operatoins into MOVE and/or CLEAR operations.
+   *
+   * See /docs/compacting-operations.md for details.
+   */
   async compact(options: CompactOptions) {
-    if (options.memoryLimitMB ?? 512 < 256) {
-      throw new Error('Minimum of 256MB memory required');
-    }
-    const idLimitBytes = ((options.memoryLimitMB ?? 512) - 128) * 1024 * 1024;
+    const idLimitBytes = options.memoryLimitMB * 1024 * 1024;
 
-    const stream = this.db.bucket_data
-      .find(
-        {
-          _id: idPrefixFilter<BucketDataKey>({ g: this.group_id }, ['b', 'o'])
-        },
-        {
-          projection: {
-            _id: 1,
-            op: 1,
-            table: 1,
-            row_id: 1,
-            source_table: 1,
-            source_key: 1
+    let currentState: CurrentBucketState | null = null;
+
+    const lowerBound: BucketDataKey = {
+      g: this.group_id,
+      b: new MinKey() as any,
+      o: new MinKey() as any
+    };
+
+    let upperBound: BucketDataKey = {
+      g: this.group_id,
+      b: new MaxKey() as any,
+      o: new MaxKey() as any
+    };
+
+    while (true) {
+      // Query one batch at a time, to avoid cursor timeouts
+      const batch = await this.db.bucket_data
+        .find(
+          {
+            _id: {
+              $gte: lowerBound,
+              $lt: upperBound
+            }
+          },
+          {
+            projection: {
+              _id: 1,
+              op: 1,
+              table: 1,
+              row_id: 1,
+              source_table: 1,
+              source_key: 1
+            },
+            limit: MOVE_BATCH_QUERY_LIMIT,
+            sort: { _id: -1 },
+            singleBatch: true
           }
-        }
-      )
-      .sort({ _id: -1 })
-      .stream();
+        )
+        .toArray();
 
-    let currentBucket: string | null = null;
-    let seen = new Map<string, bigint>();
-    let trackingSize = 0;
-    let lastNotPut: bigint | null = null;
-    let opsSincePut = 0;
-
-    for await (let doc of stream) {
-      if (doc._id.b != currentBucket) {
-        if (currentBucket != null && lastNotPut != null && opsSincePut >= 1) {
-          await this.flush();
-          logger.info(
-            `Inserting CLEAR at ${this.group_id}:${currentBucket}:${lastNotPut} to remove ${opsSincePut} operations`
-          );
-          await this.clearBucket(currentBucket, lastNotPut);
-        }
-        currentBucket = doc._id.b;
-        seen = new Map();
-        trackingSize = 0;
-
-        lastNotPut = null;
-        opsSincePut = 0;
+      if (batch.length == 0) {
+        // We've reached the end
+        break;
       }
+      // Set upperBound for the next batch
+      upperBound = batch[batch.length - 1]._id;
 
-      let isPersistentPut = doc.op == 'PUT';
+      for (let doc of batch) {
+        if (currentState == null || doc._id.b != currentState.bucket) {
+          if (currentState != null && currentState.lastNotPut != null && currentState.opsSincePut >= 1) {
+            // Important to flush before clearBucket()
+            await this.flush();
+            logger.info(
+              `Inserting CLEAR at ${this.group_id}:${currentState.bucket}:${currentState.lastNotPut} to remove ${currentState.opsSincePut} operations`
+            );
 
-      if (doc.op == 'REMOVE' || doc.op == 'PUT') {
-        const key = `${doc.table}/${doc.row_id}/${doc.source_table}/${doc.source_key?.toHexString()}`;
-        const targetOp = seen.get(key);
-        if (targetOp) {
-          isPersistentPut = false;
-          this.updates.push({
-            updateOne: {
-              filter: {
-                _id: doc._id
-              },
-              update: {
-                $set: {
-                  op: 'MOVE',
-                  data: JSON.stringify({ target: `${targetOp}` })
+            const bucket = currentState.bucket;
+            const clearOp = currentState.lastNotPut;
+            // Free memory before clearing bucket
+            currentState = null;
+            await this.clearBucket(bucket, clearOp);
+          }
+          currentState = {
+            bucket: doc._id.b,
+            seen: new Map(),
+            trackingSize: 0,
+            lastNotPut: null,
+            opsSincePut: 0
+          };
+        }
+
+        let isPersistentPut = doc.op == 'PUT';
+
+        if (doc.op == 'REMOVE' || doc.op == 'PUT') {
+          const key = `${doc.table}/${doc.row_id}/${doc.source_table}/${doc.source_key?.toHexString()}`;
+          const targetOp = currentState.seen.get(key);
+          if (targetOp) {
+            // Will convert to MOVE, so don't count as PUT
+            isPersistentPut = false;
+
+            this.updates.push({
+              updateOne: {
+                filter: {
+                  _id: doc._id
                 },
-                $unset: {
-                  source_table: 1,
-                  source_key: 1,
-                  table: 1,
-                  row_id: 1
+                update: {
+                  $set: {
+                    op: 'MOVE',
+                    data: JSON.stringify({ target: `${targetOp}` })
+                  },
+                  $unset: {
+                    source_table: 1,
+                    source_key: 1,
+                    table: 1,
+                    row_id: 1
+                  }
                 }
               }
+            });
+          } else {
+            if (currentState.trackingSize > idLimitBytes) {
+              // Reached memory limit.
+              // Keep the highest seen values in this case.
+            } else {
+              // flatstr reduces the memory usage by flattening the string
+              currentState.seen.set(flatstr(key), doc._id.o);
+              // length + 16 for the string
+              // 24 for the bigint
+              // 50 for map overhead
+              // 50 for additional overhead
+              currentState.trackingSize += key.length + 140;
             }
-          });
-        } else {
-          if (trackingSize > idLimitBytes) {
-            seen = new Map();
-            trackingSize = 0;
           }
-          seen.set(key, doc._id.o);
-          trackingSize += key.length + 16;
         }
-      }
 
-      if (isPersistentPut) {
-        lastNotPut = null;
-        opsSincePut = 0;
-      } else if (doc.op != 'CLEAR') {
-        if (lastNotPut == null) {
-          lastNotPut = doc._id.o;
+        if (isPersistentPut) {
+          currentState.lastNotPut = null;
+          currentState.opsSincePut = 0;
+        } else if (doc.op != 'CLEAR') {
+          if (currentState.lastNotPut == null) {
+            currentState.lastNotPut = doc._id.o;
+          }
+          currentState.opsSincePut += 1;
         }
-        opsSincePut += 1;
-      }
 
-      if (this.updates.length >= 1000) {
-        await this.flush();
+        if (this.updates.length >= MOVE_BATCH_LIMIT) {
+          await this.flush();
+        }
       }
     }
+
+    console.log('size', currentState?.trackingSize, idLimitBytes, currentState?.seen.size);
     await this.flush();
-    if (currentBucket != null && lastNotPut != null && opsSincePut >= 1) {
+    currentState?.seen.clear();
+    if (currentState?.lastNotPut != null && currentState?.opsSincePut > 1) {
       logger.info(
-        `Inserting CLEAR at ${this.group_id}:${currentBucket}:${lastNotPut} to remove ${opsSincePut} operations`
+        `Inserting CLEAR at ${this.group_id}:${currentState.bucket}:${currentState.lastNotPut} to remove ${currentState.opsSincePut} operations`
       );
-      await this.clearBucket(currentBucket, lastNotPut);
+      const bucket = currentState.bucket;
+      const clearOp = currentState.lastNotPut;
+      // Free memory before clearing bucket
+      currentState = null;
+      await this.clearBucket(bucket, clearOp);
     }
   }
 
@@ -128,7 +205,7 @@ export class MongoCompactor {
       logger.info(`Compacting ${this.updates.length} ops`);
       await this.db.bucket_data.bulkWrite(this.updates, {
         // Order is not important.
-        // These operations can happen in any order,
+        // Since checksums are not affected, these operations can happen in any order,
         // and it's fine if the operations are partially applied.
         ordered: false
       });
@@ -136,6 +213,12 @@ export class MongoCompactor {
     }
   }
 
+  /**
+   * Perform a CLEAR compact for a bucket.
+   *
+   * @param bucket bucket name
+   * @param op op_id of the last non-PUT operation, which will be converted to CLEAR.
+   */
   private async clearBucket(bucket: string, op: bigint) {
     const opFilter = {
       _id: {
@@ -158,6 +241,7 @@ export class MongoCompactor {
       while (!done) {
         // Do the CLEAR operation in batches, with each batch a separate transaction.
         // The state after each batch is fully consistent.
+        // We need a transaction per batch to make sure checksums stay consistent.
         await session.withTransaction(
           async () => {
             const query = this.db.bucket_data.find(opFilter, {
@@ -224,4 +308,15 @@ export class MongoCompactor {
       await session.endSession();
     }
   }
+}
+
+/**
+ * Flattens string to reduce memory usage (around 320 bytes -> 120 bytes),
+ * at the cost of some upfront CPU usage.
+ *
+ * From: https://github.com/davidmarkclements/flatstr/issues/8
+ */
+function flatstr(s: string) {
+  s.match(/\n/g);
+  return s;
 }

--- a/packages/service-core/src/storage/mongo/MongoCompactor.ts
+++ b/packages/service-core/src/storage/mongo/MongoCompactor.ts
@@ -65,7 +65,7 @@ export class MongoCompactor {
   }
 
   /**
-   * Compact buckets by converting operatoins into MOVE and/or CLEAR operations.
+   * Compact buckets by converting operations into MOVE and/or CLEAR operations.
    *
    * See /docs/compacting-operations.md for details.
    */

--- a/packages/service-core/src/storage/mongo/MongoCompactor.ts
+++ b/packages/service-core/src/storage/mongo/MongoCompactor.ts
@@ -3,16 +3,7 @@ import { AnyBulkWriteOperation, MaxKey, MinKey } from 'mongodb';
 import { addChecksums } from '../../util/utils.js';
 import { PowerSyncMongo } from './db.js';
 import { BucketDataDocument, BucketDataKey } from './models.js';
-
-export interface CompactOptions {
-  /**
-   * Heap memory limit for the compact process.
-   *
-   * Add around 64MB to this to determine the "--max-old-space-size" argument.
-   * Add another 80MB to get RSS usage / memory limits.
-   */
-  memoryLimitMB: number;
-}
+import { CompactOptions } from '../BucketStorage.js';
 
 interface CurrentBucketState {
   /** Bucket name */
@@ -253,7 +244,8 @@ export class MongoCompactor {
               projection: {
                 _id: 1,
                 op: 1,
-                checksum: 1
+                checksum: 1,
+                target_op: 1
               },
               limit: CLEAR_BATCH_LIMIT
             });

--- a/packages/service-core/src/storage/mongo/MongoCompactor.ts
+++ b/packages/service-core/src/storage/mongo/MongoCompactor.ts
@@ -54,12 +54,14 @@ export class MongoCompactor {
   private moveBatchLimit: number;
   private moveBatchQueryLimit: number;
   private clearBatchLimit: number;
+  private maxOpId: bigint | undefined;
 
   constructor(private db: PowerSyncMongo, private group_id: number, options?: MongoCompactOptions) {
     this.idLimitBytes = (options?.memoryLimitMB ?? DEFAULT_MEMORY_LIMIT_MB) * 1024 * 1024;
     this.moveBatchLimit = options?.moveBatchLimit ?? DEFAULT_MOVE_BATCH_LIMIT;
     this.moveBatchQueryLimit = options?.moveBatchQueryLimit ?? DEFAULT_MOVE_BATCH_QUERY_LIMIT;
     this.clearBatchLimit = options?.clearBatchLimit ?? DEFAULT_CLEAR_BATCH_LIMIT;
+    this.maxOpId = options?.maxOpId;
   }
 
   /**
@@ -142,6 +144,10 @@ export class MongoCompactor {
             lastNotPut: null,
             opsSincePut: 0
           };
+        }
+
+        if (this.maxOpId != null && doc._id.o > this.maxOpId) {
+          continue;
         }
 
         let isPersistentPut = doc.op == 'PUT';

--- a/packages/service-core/src/storage/mongo/MongoCompactor.ts
+++ b/packages/service-core/src/storage/mongo/MongoCompactor.ts
@@ -32,6 +32,9 @@ const CLEAR_BATCH_LIMIT = 5000;
 const MOVE_BATCH_LIMIT = 2000;
 const MOVE_BATCH_QUERY_LIMIT = 10_000;
 
+/** This default is primarily for tests. */
+const DEFAULT_MEMORY_LIMIT_MB = 64;
+
 export class MongoCompactor {
   private updates: AnyBulkWriteOperation<BucketDataDocument>[] = [];
 
@@ -42,8 +45,8 @@ export class MongoCompactor {
    *
    * See /docs/compacting-operations.md for details.
    */
-  async compact(options: CompactOptions) {
-    const idLimitBytes = options.memoryLimitMB * 1024 * 1024;
+  async compact(options?: CompactOptions) {
+    const idLimitBytes = (options?.memoryLimitMB ?? DEFAULT_MEMORY_LIMIT_MB) * 1024 * 1024;
 
     let currentState: CurrentBucketState | null = null;
 

--- a/packages/service-core/src/storage/mongo/MongoCompactor.ts
+++ b/packages/service-core/src/storage/mongo/MongoCompactor.ts
@@ -1,0 +1,94 @@
+import { AnyBulkWriteOperation } from 'mongodb';
+import { PowerSyncMongo } from './db.js';
+import { BucketDataDocument, BucketDataKey } from './models.js';
+import { idPrefixFilter } from './util.js';
+
+export interface CompactOptions {
+  memoryLimitMB?: number;
+}
+
+export class MongoCompactor {
+  private updates: AnyBulkWriteOperation<BucketDataDocument>[] = [];
+
+  constructor(private db: PowerSyncMongo, private group_id: number) {}
+
+  async compact(options: CompactOptions) {
+    if (options.memoryLimitMB ?? 512 < 256) {
+      throw new Error('Minimum of 256MB memory required');
+    }
+    const idLimitBytes = ((options.memoryLimitMB ?? 512) - 128) * 1024 * 1024;
+
+    const stream = this.db.bucket_data
+      .find(
+        {
+          _id: idPrefixFilter<BucketDataKey>({ g: this.group_id }, ['b', 'o'])
+        },
+        {
+          projection: {
+            _id: 1,
+            op: 1,
+            table: 1,
+            row_id: 1,
+            source_table: 1,
+            source_key: 1
+          }
+        }
+      )
+      .sort({ _id: -1 })
+      .stream();
+
+    let currentBucket: string | null = null;
+    let seen = new Set<string>();
+    let trackingSize = 0;
+
+    for await (let doc of stream) {
+      if (doc._id.b != currentBucket) {
+        currentBucket = doc._id.b;
+        seen = new Set();
+        trackingSize = 0;
+      }
+
+      if (doc.op == 'REMOVE' || doc.op == 'PUT') {
+        const key = `${doc.table}/${doc.row_id}/${doc.source_table}/${doc.source_key.toHexString()}`;
+        if (seen.has(key)) {
+          this.updates.push({
+            updateOne: {
+              filter: {
+                _id: doc._id
+              },
+              update: {
+                $set: {
+                  op: 'MOVE',
+                  data: JSON.stringify({ target: `${doc._id.o}` })
+                }
+              }
+            }
+          });
+
+          if (this.updates.length >= 1000) {
+            await this.flush();
+          }
+        } else {
+          if (trackingSize > idLimitBytes) {
+            seen = new Set();
+            trackingSize = 0;
+          }
+          seen.add(key);
+          trackingSize += key.length + 10;
+        }
+      }
+    }
+  }
+
+  private async flush() {
+    if (this.updates.length > 0) {
+      await this.db.bucket_data.bulkWrite(this.updates, {
+        // Order is not important.
+        // These operations can happen in any order,
+        // and it's fine if the operations are partially applied.
+        ordered: false
+      });
+      this.updates = [];
+    }
+  }
+}

--- a/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
+++ b/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
@@ -8,6 +8,7 @@ import * as util from '../../util/util-index.js';
 import {
   BucketDataBatchOptions,
   BucketStorageBatch,
+  CompactOptions,
   DEFAULT_DOCUMENT_BATCH_LIMIT,
   DEFAULT_DOCUMENT_CHUNK_LIMIT_BYTES,
   FlushedResult,
@@ -17,14 +18,14 @@ import {
   SyncRulesBucketStorage,
   SyncRuleStatus
 } from '../BucketStorage.js';
+import { ChecksumCache, FetchPartialBucketChecksum } from '../ChecksumCache.js';
 import { MongoBucketStorage } from '../MongoBucketStorage.js';
 import { SourceTable } from '../SourceTable.js';
 import { PowerSyncMongo } from './db.js';
 import { BucketDataDocument, BucketDataKey, SourceKey, SyncRuleState } from './models.js';
 import { MongoBucketBatch } from './MongoBucketBatch.js';
+import { MongoCompactor } from './MongoCompactor.js';
 import { BSON_DESERIALIZE_OPTIONS, idPrefixFilter, readSingleBatch, serializeLookup } from './util.js';
-import { ChecksumCache, FetchPartialBucketChecksum } from '../ChecksumCache.js';
-import { CompactOptions, MongoCompactor } from './MongoCompactor.js';
 
 export class MongoSyncBucketStorage implements SyncRulesBucketStorage {
   private readonly db: PowerSyncMongo;
@@ -340,7 +341,7 @@ export class MongoSyncBucketStorage implements SyncRulesBucketStorage {
     if (currentBatch != null) {
       const yieldBatch = currentBatch;
       currentBatch = null;
-      yield { batch: yieldBatch, targetOp: null };
+      yield { batch: yieldBatch, targetOp: targetOp };
       targetOp = null;
     }
   }

--- a/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
+++ b/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
@@ -555,7 +555,7 @@ export class MongoSyncBucketStorage implements SyncRulesBucketStorage {
     );
   }
 
-  async compact(options: CompactOptions) {
-    return new MongoCompactor(this.db, this.group_id).compact(options);
+  async compact(options?: CompactOptions) {
+    return new MongoCompactor(this.db, this.group_id, options).compact();
   }
 }

--- a/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
+++ b/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
@@ -301,15 +301,27 @@ export class MongoSyncBucketStorage implements SyncRulesBucketStorage {
         };
       }
 
-      const entry: util.OplogEntry = {
-        op_id: util.timestampToOpId(row._id.o),
-        op: row.op,
-        object_type: row.table,
-        object_id: row.row_id,
-        checksum: Number(row.checksum),
-        subkey: `${row.source_table}/${row.source_key.toHexString()}`,
-        data: row.data
-      };
+      let entry: util.OplogEntry;
+
+      if (row.op == 'PUT' || row.op == 'REMOVE') {
+        entry = {
+          op_id: util.timestampToOpId(row._id.o),
+          op: row.op,
+          object_type: row.table,
+          object_id: row.row_id,
+          checksum: Number(row.checksum),
+          subkey: `${row.source_table}/${row.source_key!.toHexString()}`,
+          data: row.data
+        };
+      } else {
+        // MOVE, CLEAR
+        entry = {
+          op_id: util.timestampToOpId(row._id.o),
+          op: row.op,
+          checksum: Number(row.checksum),
+          data: row.data
+        };
+      }
       currentBatch.data.push(entry);
       currentBatch.next_after = entry.op_id;
 

--- a/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
+++ b/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
@@ -23,6 +23,7 @@ import { BucketDataDocument, BucketDataKey, SourceKey, SyncRuleState } from './m
 import { MongoBucketBatch } from './MongoBucketBatch.js';
 import { BSON_DESERIALIZE_OPTIONS, idPrefixFilter, readSingleBatch, serializeLookup } from './util.js';
 import { ChecksumCache, FetchPartialBucketChecksum } from '../ChecksumCache.js';
+import { CompactOptions, MongoCompactor } from './MongoCompactor.js';
 
 export class MongoSyncBucketStorage implements SyncRulesBucketStorage {
   private readonly db: PowerSyncMongo;
@@ -532,80 +533,6 @@ export class MongoSyncBucketStorage implements SyncRulesBucketStorage {
   }
 
   async compact(options: CompactOptions) {
-    if (options.memoryLimitMB ?? 512 < 256) {
-      throw new Error('Minimum of 256MB memory required');
-    }
-    const idLimitBytes = ((options.memoryLimitMB ?? 512) - 128) * 1024 * 1024;
-
-    const stream = this.db.bucket_data
-      .find(
-        {
-          _id: idPrefixFilter<BucketDataKey>({ g: this.group_id }, ['b', 'o'])
-        },
-        {
-          projection: {
-            _id: 1,
-            op: 1,
-            table: 1,
-            row_id: 1,
-            source_table: 1,
-            source_key: 1
-          }
-        }
-      )
-      .sort({ _id: -1 })
-      .stream();
-
-    let currentBucket: string | null = null;
-    let seen = new Set<string>();
-    let trackingSize = 0;
-
-    let updates: mongo.AnyBulkWriteOperation<BucketDataDocument>[] = [];
-    for await (let doc of stream) {
-      if (doc._id.b != currentBucket) {
-        currentBucket = doc._id.b;
-        seen = new Set();
-        trackingSize = 0;
-      }
-
-      if (doc.op == 'REMOVE' || doc.op == 'PUT') {
-        const key = `${doc.table}/${doc.row_id}/${doc.source_table}/${doc.source_key.toHexString()}`;
-        if (seen.has(key)) {
-          updates.push({
-            updateOne: {
-              filter: {
-                _id: doc._id
-              },
-              update: {
-                $set: {
-                  op: 'MOVE',
-                  data: JSON.stringify({ target: `${doc._id.o}` })
-                }
-              }
-            }
-          });
-
-          if (updates.length >= 1000) {
-            await this.db.bucket_data.bulkWrite(updates);
-            updates = [];
-          }
-        } else {
-          if (trackingSize > idLimitBytes) {
-            seen = new Set();
-            trackingSize = 0;
-          }
-          seen.add(key);
-          trackingSize += key.length + 10;
-        }
-      }
-    }
-    if (updates.length > 0) {
-      await this.db.bucket_data.bulkWrite(updates);
-      updates = [];
-    }
+    return new MongoCompactor(this.db, this.group_id).compact(options);
   }
-}
-
-export interface CompactOptions {
-  memoryLimitMB?: number;
 }

--- a/packages/service-core/src/storage/mongo/models.ts
+++ b/packages/service-core/src/storage/mongo/models.ts
@@ -48,6 +48,7 @@ export interface BucketDataDocument {
   row_id?: string;
   checksum: number;
   data: string | null;
+  target_op?: bigint | null;
 }
 
 export type OpType = 'PUT' | 'REMOVE' | 'MOVE' | 'CLEAR';

--- a/packages/service-core/src/storage/mongo/models.ts
+++ b/packages/service-core/src/storage/mongo/models.ts
@@ -42,10 +42,10 @@ export interface BucketParameterDocument {
 export interface BucketDataDocument {
   _id: BucketDataKey;
   op: OpType;
-  source_table: bson.ObjectId;
-  source_key: bson.UUID;
-  table: string;
-  row_id: string;
+  source_table?: bson.ObjectId;
+  source_key?: bson.UUID;
+  table?: string;
+  row_id?: string;
   checksum: number;
   data: string | null;
 }

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -239,14 +239,14 @@ async function* bucketDataBatch(request: BucketDataRequest) {
 
     let has_more = false;
 
-    for await (let r of data) {
+    for await (let { batch: r, targetOp } of data) {
       if (signal.aborted) {
         return;
       }
       if (r.has_more) {
         has_more = true;
       }
-      if (r.targetOp != null && r.targetOp > checkpointOp) {
+      if (targetOp != null && targetOp > checkpointOp) {
         checkpointInvalidated = true;
       }
       if (r.data.length == 0) {

--- a/packages/service-core/test/src/__snapshots__/sync.test.ts.snap
+++ b/packages/service-core/test/src/__snapshots__/sync.test.ts.snap
@@ -1,5 +1,90 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`sync - mongodb > compacting data - invalidate checkpoint 1`] = `
+[
+  {
+    "checkpoint": {
+      "buckets": [
+        {
+          "bucket": "mybucket[]",
+          "checksum": -93886621,
+          "count": 2,
+        },
+      ],
+      "last_op_id": "2",
+      "write_checkpoint": undefined,
+    },
+  },
+]
+`;
+
+exports[`sync - mongodb > compacting data - invalidate checkpoint 2`] = `
+[
+  {
+    "data": {
+      "after": "0",
+      "bucket": "mybucket[]",
+      "data": [
+        {
+          "checksum": -93886621n,
+          "op": "CLEAR",
+          "op_id": "2",
+        },
+      ],
+      "has_more": false,
+      "next_after": "2",
+    },
+  },
+  {
+    "checkpoint_diff": {
+      "last_op_id": "4",
+      "removed_buckets": [],
+      "updated_buckets": [
+        {
+          "bucket": "mybucket[]",
+          "checksum": 499012468,
+          "count": 4,
+        },
+      ],
+      "write_checkpoint": undefined,
+    },
+  },
+  {
+    "data": {
+      "after": "2",
+      "bucket": "mybucket[]",
+      "data": [
+        {
+          "checksum": 1859363232n,
+          "data": "{\\"id\\":\\"t1\\",\\"description\\":\\"Test 1b\\"}",
+          "object_id": "t1",
+          "object_type": "test",
+          "op": "PUT",
+          "op_id": "3",
+          "subkey": "6544e3899293153fa7b38331/117ab485-4b42-58a2-ab32-0053a22c3423",
+        },
+        {
+          "checksum": 3028503153n,
+          "data": "{\\"id\\":\\"t2\\",\\"description\\":\\"Test 2b\\"}",
+          "object_id": "t2",
+          "object_type": "test",
+          "op": "PUT",
+          "op_id": "4",
+          "subkey": "6544e3899293153fa7b38331/ec27c691-b47a-5d92-927a-9944feb89eee",
+        },
+      ],
+      "has_more": false,
+      "next_after": "4",
+    },
+  },
+  {
+    "checkpoint_complete": {
+      "last_op_id": "4",
+    },
+  },
+]
+`;
+
 exports[`sync - mongodb > expired token 1`] = `
 [
   {

--- a/packages/service-core/test/src/bucket_validation.test.ts
+++ b/packages/service-core/test/src/bucket_validation.test.ts
@@ -1,0 +1,142 @@
+import { OplogEntry } from '@/util/protocol-types.js';
+import { describe, expect, test } from 'vitest';
+import { reduceBucket, validateBucket } from './bucket_validation.js';
+
+// This tests the reduceBucket function.
+// While this function is not used directly in the service implementation,
+// it is an important part of validating consistency in other tests.
+describe('bucket validation', () => {
+  const ops1: OplogEntry[] = [
+    {
+      op_id: '1',
+      op: 'PUT',
+      object_type: 'test',
+      object_id: 't1',
+      checksum: 2634521662,
+      subkey: '6544e3899293153fa7b38331/117ab485-4b42-58a2-ab32-0053a22c3423',
+      data: '{"id":"t1"}'
+    },
+    {
+      op_id: '2',
+      op: 'PUT',
+      object_type: 'test',
+      object_id: 't2',
+      checksum: 4243212114,
+      subkey: '6544e3899293153fa7b38331/ec27c691-b47a-5d92-927a-9944feb89eee',
+      data: '{"id":"t2"}'
+    },
+    {
+      op_id: '3',
+      op: 'REMOVE',
+      object_type: 'test',
+      object_id: 't1',
+      checksum: 4228978084,
+      subkey: '6544e3899293153fa7b38331/117ab485-4b42-58a2-ab32-0053a22c3423',
+      data: null
+    },
+    {
+      op_id: '4',
+      op: 'PUT',
+      object_type: 'test',
+      object_id: 't2',
+      checksum: 4243212114,
+      subkey: '6544e3899293153fa7b38331/ec27c691-b47a-5d92-927a-9944feb89eee',
+      data: '{"id":"t2"}'
+    }
+  ];
+
+  test('reduce 1', () => {
+    expect(reduceBucket(ops1)).toEqual([
+      {
+        checksum: -1778190028,
+        op: 'CLEAR',
+        op_id: '0'
+      },
+      {
+        checksum: 4243212114,
+        data: '{"id":"t2"}',
+        object_id: 't2',
+        object_type: 'test',
+        op: 'PUT',
+        op_id: '4',
+        subkey: '6544e3899293153fa7b38331/ec27c691-b47a-5d92-927a-9944feb89eee'
+      }
+    ]);
+
+    expect(reduceBucket(reduceBucket(ops1))).toEqual([
+      {
+        checksum: -1778190028,
+        op: 'CLEAR',
+        op_id: '0'
+      },
+      {
+        checksum: 4243212114,
+        data: '{"id":"t2"}',
+        object_id: 't2',
+        object_type: 'test',
+        op: 'PUT',
+        op_id: '4',
+        subkey: '6544e3899293153fa7b38331/ec27c691-b47a-5d92-927a-9944feb89eee'
+      }
+    ]);
+
+    validateBucket(ops1);
+  });
+
+  test('reduce 2', () => {
+    const bucket: OplogEntry[] = [
+      ...ops1,
+
+      {
+        checksum: 93784613,
+        op: 'CLEAR',
+        op_id: '5'
+      },
+      {
+        checksum: 5133378,
+        data: '{"id":"t3"}',
+        object_id: 't3',
+        object_type: 'test',
+        op: 'PUT',
+        op_id: '11',
+        subkey: '6544e3899293153fa7b38333/ec27c691-b47a-5d92-927a-9944feb89eee'
+      }
+    ];
+
+    expect(reduceBucket(bucket)).toEqual([
+      {
+        checksum: 93784613,
+        op: 'CLEAR',
+        op_id: '0'
+      },
+      {
+        checksum: 5133378,
+        data: '{"id":"t3"}',
+        object_id: 't3',
+        object_type: 'test',
+        op: 'PUT',
+        op_id: '11',
+        subkey: '6544e3899293153fa7b38333/ec27c691-b47a-5d92-927a-9944feb89eee'
+      }
+    ]);
+
+    expect(reduceBucket(reduceBucket(bucket))).toEqual([
+      {
+        checksum: 93784613,
+        op: 'CLEAR',
+        op_id: '0'
+      },
+      {
+        checksum: 5133378,
+        data: '{"id":"t3"}',
+        object_id: 't3',
+        object_type: 'test',
+        op: 'PUT',
+        op_id: '11',
+        subkey: '6544e3899293153fa7b38333/ec27c691-b47a-5d92-927a-9944feb89eee'
+      }
+    ]);
+
+    validateBucket(bucket);
+  });
+});

--- a/packages/service-core/test/src/bucket_validation.ts
+++ b/packages/service-core/test/src/bucket_validation.ts
@@ -1,0 +1,93 @@
+import { OplogEntry } from '@/util/protocol-types.js';
+import { addChecksums } from '@/util/utils.js';
+import { expect } from 'vitest';
+
+/**
+ * Reduce a bucket to the final state as stored on the client.
+ */
+export function reduceBucket(operations: OplogEntry[]) {
+  let rowState = new Map<string, OplogEntry>();
+  let otherChecksum = 0;
+
+  for (let op of operations) {
+    const key = rowKey(op);
+    if (op.op == 'PUT') {
+      const existing = rowState.get(key);
+      if (existing) {
+        otherChecksum = addChecksums(otherChecksum, existing.checksum as number);
+      }
+      rowState.set(key, op);
+    } else if (op.op == 'REMOVE') {
+      const existing = rowState.get(key);
+      if (existing) {
+        otherChecksum = addChecksums(otherChecksum, existing.checksum as number);
+      }
+      rowState.delete(key);
+      otherChecksum = addChecksums(otherChecksum, op.checksum as number);
+    } else if (op.op == 'CLEAR') {
+      rowState.clear();
+      otherChecksum = op.checksum as number;
+    } else if (op.op == 'MOVE') {
+      otherChecksum = addChecksums(otherChecksum, op.checksum as number);
+    } else {
+      throw new Error(`Unknown operation ${op.op}`);
+    }
+  }
+
+  const puts = [...rowState.values()].sort((a, b) => {
+    return Number(BigInt(a.op_id) - BigInt(b.op_id));
+  });
+
+  let finalState: OplogEntry[] = [
+    // Special operation to indiciate the checksum remainder
+    { op_id: '0', op: 'CLEAR', checksum: otherChecksum },
+    ...puts
+  ];
+
+  return finalState;
+}
+
+function rowKey(entry: OplogEntry) {
+  return `${entry.object_type}/${entry.object_id}/${entry.subkey}`;
+}
+
+/**
+ * Validate this property:
+ *
+ * $r(B_{[..id_n]}) = r(r(B_{[..id_i]}) \cup B_{[id_{i+1}..id_n]}) \;\forall\; i \in [1..n]$
+ */
+export function validateReducedSets(bucket: OplogEntry[]) {
+  const r1 = reduceBucket(bucket);
+  for (let i = 0; i <= bucket.length; i++) {
+    const r2 = reduceBucket(bucket.slice(0, i + 1));
+    const b3 = bucket.slice(i + 1);
+    const r3 = r2.concat(b3);
+    const r4 = reduceBucket(r3);
+    expect(r4).toEqual(r1);
+  }
+
+  // This is the same check, just implemented differently
+  validateCompactedBucket(bucket, bucket);
+}
+
+/**
+ * Validate this property:
+ *
+ * $r(B_{[..c]}) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}) \;\forall\; c_i \in B$
+ */
+export function validateCompactedBucket(bucket: OplogEntry[], compacted: OplogEntry[]) {
+  // r(B_{[..c]})
+  const r1 = reduceBucket(bucket);
+  for (let i = 0; i < bucket.length; i++) {
+    // r(B_{[..c_i]})
+    const r2 = reduceBucket(bucket.slice(0, i + 1));
+    const c_i = bucket[i].op_id;
+    // B'_{[c_i+1..c]}
+    const b3 = compacted.filter((op) => op.op_id > c_i);
+    // r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}
+    const r3 = r2.concat(b3);
+    // r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]})
+    const r4 = reduceBucket(r3);
+    expect(r4).toEqual(r1);
+  }
+}

--- a/packages/service-core/test/src/bucket_validation.ts
+++ b/packages/service-core/test/src/bucket_validation.ts
@@ -10,7 +10,7 @@ import { expect } from 'vitest';
  * All other operations are replaced with a single CLEAR operation,
  * summing their checksums, and using a 0 as an op_id.
  *
- * This is the function $r(B)$.
+ * This is the function $r(B)$, as described in /docs/bucket-properties.md.
  */
 export function reduceBucket(operations: OplogEntry[]) {
   let rowState = new Map<string, OplogEntry>();
@@ -59,7 +59,7 @@ function rowKey(entry: OplogEntry) {
 }
 
 /**
- * Validate this property:
+ * Validate this property, as described in /docs/bucket-properties.md:
  *
  * $r(B_{[..id_n]}) = r(r(B_{[..id_i]}) \cup B_{[id_{i+1}..id_n]}) \;\forall\; i \in [1..n]$
  *
@@ -82,7 +82,8 @@ export function validateBucket(bucket: OplogEntry[]) {
 }
 
 /**
- * Validate these properties for a bucket $B$ and its compacted version $B'$:
+ * Validate these properties for a bucket $B$ and its compacted version $B'$,:
+ * as described in /docs/bucket-properties.md:
  *
  * 1. $r(B) = r(B')$
  * 2. $r(B_{[..c]}) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}) \;\forall\; c_i \in B$
@@ -97,7 +98,7 @@ export function validateBucket(bucket: OplogEntry[]) {
 export function validateCompactedBucket(bucket: OplogEntry[], compacted: OplogEntry[]) {
   // r(B_{[..c]})
   const r1 = reduceBucket(bucket);
-  // $r(B) = r(B')$
+  // r(B) = r(B')
   expect(reduceBucket(compacted)).toEqual(r1);
 
   for (let i = 0; i < bucket.length; i++) {

--- a/packages/service-core/test/src/bucket_validation.ts
+++ b/packages/service-core/test/src/bucket_validation.ts
@@ -81,9 +81,9 @@ export function validateCompactedBucket(bucket: OplogEntry[], compacted: OplogEn
   for (let i = 0; i < bucket.length; i++) {
     // r(B_{[..c_i]})
     const r2 = reduceBucket(bucket.slice(0, i + 1));
-    const c_i = bucket[i].op_id;
+    const c_i = BigInt(bucket[i].op_id);
     // B'_{[c_i+1..c]}
-    const b3 = compacted.filter((op) => op.op_id > c_i);
+    const b3 = compacted.filter((op) => BigInt(op.op_id) > c_i);
     // r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}
     const r3 = r2.concat(b3);
     // r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]})

--- a/packages/service-core/test/src/bucket_validation.ts
+++ b/packages/service-core/test/src/bucket_validation.ts
@@ -4,6 +4,13 @@ import { expect } from 'vitest';
 
 /**
  * Reduce a bucket to the final state as stored on the client.
+ *
+ * This keeps the final state for each row as a PUT operation.
+ *
+ * All other operations are replaced with a single CLEAR operation,
+ * summing their checksums, and using a 0 as an op_id.
+ *
+ * This is the function $r(B)$.
  */
 export function reduceBucket(operations: OplogEntry[]) {
   let rowState = new Map<string, OplogEntry>();
@@ -55,8 +62,12 @@ function rowKey(entry: OplogEntry) {
  * Validate this property:
  *
  * $r(B_{[..id_n]}) = r(r(B_{[..id_i]}) \cup B_{[id_{i+1}..id_n]}) \;\forall\; i \in [1..n]$
+ *
+ * We test that a client syncing the entire bucket in one go (left side of the equation),
+ * ends up with the same result as another client syncing up to operation id_i, then sync
+ * the rest.
  */
-export function validateReducedSets(bucket: OplogEntry[]) {
+export function validateBucket(bucket: OplogEntry[]) {
   const r1 = reduceBucket(bucket);
   for (let i = 0; i <= bucket.length; i++) {
     const r2 = reduceBucket(bucket.slice(0, i + 1));
@@ -71,13 +82,24 @@ export function validateReducedSets(bucket: OplogEntry[]) {
 }
 
 /**
- * Validate this property:
+ * Validate these properties for a bucket $B$ and its compacted version $B'$:
  *
- * $r(B_{[..c]}) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}) \;\forall\; c_i \in B$
+ * 1. $r(B) = r(B')$
+ * 2. $r(B_{[..c]}) = r(r(B_{[..c_i]}) \cup B'_{[c_i+1..c]}) \;\forall\; c_i \in B$
+ *
+ * The first one is that the result of syncing the original bucket is the same as
+ * syncing the compacted bucket.
+ *
+ * The second property is that result of syncing the entire original bucket, is the same
+ * as syncing any partial version of that (up to op $c_i$), and then continue syncing
+ * using the compacted bucket.
  */
 export function validateCompactedBucket(bucket: OplogEntry[], compacted: OplogEntry[]) {
   // r(B_{[..c]})
   const r1 = reduceBucket(bucket);
+  // $r(B) = r(B')$
+  expect(reduceBucket(compacted)).toEqual(r1);
+
   for (let i = 0; i < bucket.length; i++) {
     // r(B_{[..c_i]})
     const r2 = reduceBucket(bucket.slice(0, i + 1));

--- a/packages/service-core/test/src/compacting.test.ts
+++ b/packages/service-core/test/src/compacting.test.ts
@@ -1,0 +1,194 @@
+import { SqlSyncRules } from '@powersync/service-sync-rules';
+import { describe, expect, test } from 'vitest';
+import { makeTestTable, MONGO_STORAGE_FACTORY } from './util.js';
+import { oneFromAsync } from './wal_stream_utils.js';
+
+const TEST_TABLE = makeTestTable('test', ['id']);
+
+describe('compacting buckets', function () {
+  const factory = MONGO_STORAGE_FACTORY;
+
+  test('compacting (1)', async () => {
+    const sync_rules = SqlSyncRules.fromYaml(`
+bucket_definitions:
+  global:
+    data: [select * from test]
+    `);
+
+    const storage = (await factory()).getInstance({ id: 1, sync_rules, slot_name: 'test' });
+
+    const result = await storage.startBatch({}, async (batch) => {
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'insert',
+        after: {
+          id: 't1'
+        }
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'insert',
+        after: {
+          id: 't2'
+        }
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'update',
+        after: {
+          id: 't2'
+        }
+      });
+    });
+
+    const checkpoint = result!.flushed_op;
+
+    const batchBefore = await oneFromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
+    const dataBefore = batchBefore.batch.data;
+
+    expect(dataBefore).toMatchObject([
+      {
+        checksum: 2634521662,
+        object_id: 't1',
+        op: 'PUT',
+        op_id: '1'
+      },
+      {
+        checksum: 4243212114,
+        object_id: 't2',
+        op: 'PUT',
+        op_id: '2'
+      },
+      {
+        checksum: 4243212114,
+        object_id: 't2',
+        op: 'PUT',
+        op_id: '3'
+      }
+    ]);
+
+    await storage.compact({ memoryLimitMB: 100 });
+
+    const batchAfter = await oneFromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
+    const dataAfter = batchAfter.batch.data;
+
+    expect(batchAfter.targetOp).toEqual(3n);
+    expect(dataAfter).toMatchObject([
+      {
+        checksum: 2634521662,
+        object_id: 't1',
+        op: 'PUT',
+        op_id: '1'
+      },
+      {
+        checksum: 4243212114,
+        op: 'MOVE',
+        op_id: '2'
+      },
+      {
+        checksum: 4243212114,
+        object_id: 't2',
+        op: 'PUT',
+        op_id: '3'
+      }
+    ]);
+  });
+
+  test('compacting (2)', async () => {
+    const sync_rules = SqlSyncRules.fromYaml(`
+bucket_definitions:
+  global:
+    data: [select * from test]
+    `);
+
+    const storage = (await factory()).getInstance({ id: 1, sync_rules, slot_name: 'test' });
+
+    const result = await storage.startBatch({}, async (batch) => {
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'insert',
+        after: {
+          id: 't1'
+        }
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'insert',
+        after: {
+          id: 't2'
+        }
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'delete',
+        before: {
+          id: 't1'
+        }
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'update',
+        after: {
+          id: 't2'
+        }
+      });
+    });
+
+    const checkpoint = result!.flushed_op;
+
+    const batchBefore = await oneFromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
+    const dataBefore = batchBefore.batch.data;
+
+    expect(dataBefore).toMatchObject([
+      {
+        checksum: 2634521662,
+        object_id: 't1',
+        op: 'PUT',
+        op_id: '1'
+      },
+      {
+        checksum: 4243212114,
+        object_id: 't2',
+        op: 'PUT',
+        op_id: '2'
+      },
+      {
+        checksum: 4228978084,
+        object_id: 't1',
+        op: 'REMOVE',
+        op_id: '3'
+      },
+      {
+        checksum: 4243212114,
+        object_id: 't2',
+        op: 'PUT',
+        op_id: '4'
+      }
+    ]);
+
+    await storage.compact({ memoryLimitMB: 100 });
+
+    const batchAfter = await oneFromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
+    const dataAfter = batchAfter.batch.data;
+
+    expect(batchAfter.targetOp).toEqual(4n);
+    expect(dataAfter).toMatchObject([
+      {
+        checksum: -1778190028,
+        op: 'CLEAR',
+        op_id: '3'
+      },
+      {
+        checksum: 4243212114,
+        object_id: 't2',
+        op: 'PUT',
+        op_id: '4'
+      }
+    ]);
+  });
+});

--- a/packages/service-core/test/src/compacting.test.ts
+++ b/packages/service-core/test/src/compacting.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { makeTestTable, MONGO_STORAGE_FACTORY } from './util.js';
 import { oneFromAsync } from './wal_stream_utils.js';
 import { MongoCompactOptions } from '@/storage/mongo/MongoCompactor.js';
+import { reduceBucket, validateCompactedBucket, validateReducedSets } from './bucket_validation.js';
 
 const TEST_TABLE = makeTestTable('test', ['id']);
 
@@ -102,6 +103,11 @@ bucket_definitions:
         op_id: '3'
       }
     ]);
+
+    expect(reduceBucket(dataBefore)).toEqual(reduceBucket(dataAfter));
+    validateReducedSets(dataBefore);
+    validateReducedSets(dataAfter);
+    validateCompactedBucket(dataBefore, dataAfter);
   });
 
   test('compacting (2)', async () => {
@@ -198,5 +204,10 @@ bucket_definitions:
         op_id: '4'
       }
     ]);
+
+    expect(reduceBucket(dataBefore)).toEqual(reduceBucket(dataAfter));
+    validateReducedSets(dataBefore);
+    validateReducedSets(dataAfter);
+    validateCompactedBucket(dataBefore, dataAfter);
   });
 }

--- a/packages/service-core/test/src/compacting.test.ts
+++ b/packages/service-core/test/src/compacting.test.ts
@@ -69,7 +69,7 @@ bucket_definitions:
       }
     ]);
 
-    await storage.compact({ memoryLimitMB: 100 });
+    await storage.compact();
 
     const batchAfter = await oneFromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
     const dataAfter = batchAfter.batch.data;
@@ -171,7 +171,7 @@ bucket_definitions:
       }
     ]);
 
-    await storage.compact({ memoryLimitMB: 100 });
+    await storage.compact();
 
     const batchAfter = await oneFromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
     const dataAfter = batchAfter.batch.data;

--- a/packages/service-core/test/src/compacting.test.ts
+++ b/packages/service-core/test/src/compacting.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { makeTestTable, MONGO_STORAGE_FACTORY } from './util.js';
 import { oneFromAsync } from './wal_stream_utils.js';
 import { MongoCompactOptions } from '@/storage/mongo/MongoCompactor.js';
-import { reduceBucket, validateCompactedBucket, validateReducedSets } from './bucket_validation.js';
+import { reduceBucket, validateCompactedBucket, validateBucket } from './bucket_validation.js';
 
 const TEST_TABLE = makeTestTable('test', ['id']);
 
@@ -104,9 +104,6 @@ bucket_definitions:
       }
     ]);
 
-    expect(reduceBucket(dataBefore)).toEqual(reduceBucket(dataAfter));
-    validateReducedSets(dataBefore);
-    validateReducedSets(dataAfter);
     validateCompactedBucket(dataBefore, dataAfter);
   });
 
@@ -205,9 +202,6 @@ bucket_definitions:
       }
     ]);
 
-    expect(reduceBucket(dataBefore)).toEqual(reduceBucket(dataAfter));
-    validateReducedSets(dataBefore);
-    validateReducedSets(dataAfter);
     validateCompactedBucket(dataBefore, dataAfter);
   });
 }

--- a/packages/service-core/test/src/data_storage.test.ts
+++ b/packages/service-core/test/src/data_storage.test.ts
@@ -5,7 +5,7 @@ import { SourceTable } from '../../src/storage/SourceTable.js';
 import { hashData } from '../../src/util/utils.js';
 import { MONGO_STORAGE_FACTORY, StorageFactory } from './util.js';
 import { SyncBucketData } from '../../src/util/protocol-types.js';
-import { BucketDataBatchOptions } from '../../src/storage/BucketStorage.js';
+import { BucketDataBatchOptions, SyncBucketDataBatch } from '../../src/storage/BucketStorage.js';
 import { fromAsync } from './wal_stream_utils.js';
 
 function makeTestTable(name: string, columns?: string[] | undefined) {
@@ -236,7 +236,7 @@ bucket_definitions:
     const checkpoint = result!.flushed_op;
 
     const batch = await fromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
-    const data = batch[0].data.map((d) => {
+    const data = batch[0].batch.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -504,7 +504,7 @@ bucket_definitions:
     });
     const checkpoint = result!.flushed_op;
     const batch = await fromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
-    const data = batch[0].data.map((d) => {
+    const data = batch[0].batch.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id
@@ -568,7 +568,7 @@ bucket_definitions:
     const checkpoint = result!.flushed_op;
 
     const batch = await fromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
-    const data = batch[0].data.map((d) => {
+    const data = batch[0].batch.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -680,7 +680,7 @@ bucket_definitions:
 
     const batch = await fromAsync(storage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']])));
 
-    const data = batch[0].data.map((d) => {
+    const data = batch[0].batch.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -855,7 +855,7 @@ bucket_definitions:
     const checkpoint2 = result2!.flushed_op;
 
     const batch = await fromAsync(storage.getBucketDataBatch(checkpoint2, new Map([['global[]', checkpoint1]])));
-    const data = batch[0].data.map((d) => {
+    const data = batch[0].batch.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -939,7 +939,7 @@ bucket_definitions:
     const checkpoint3 = result3!.flushed_op;
 
     const batch = await fromAsync(storage.getBucketDataBatch(checkpoint3, new Map([['global[]', checkpoint1]])));
-    const data = batch[0].data.map((d) => {
+    const data = batch[0].batch.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -1031,7 +1031,7 @@ bucket_definitions:
     const checkpoint3 = result3!.flushed_op;
 
     const batch = await fromAsync(storage.getBucketDataBatch(checkpoint3, new Map([['global[]', checkpoint1]])));
-    const data = batch[0].data.map((d) => {
+    const data = batch[0].batch.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -1133,7 +1133,7 @@ bucket_definitions:
     });
 
     const batch2 = await fromAsync(
-      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch1[0].next_after]]), options)
+      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch1[0].batch.next_after]]), options)
     );
     expect(getBatchData(batch2)).toEqual([
       { op_id: '3', op: 'PUT', object_id: 'large2', checksum: 1795508474 },
@@ -1146,7 +1146,7 @@ bucket_definitions:
     });
 
     const batch3 = await fromAsync(
-      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch2[0].next_after]]), options)
+      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch2[0].batch.next_after]]), options)
     );
     expect(getBatchData(batch3)).toEqual([]);
     expect(getBatchMeta(batch3)).toEqual(null);
@@ -1223,7 +1223,7 @@ bucket_definitions:
     });
 
     const batch2 = await fromAsync(
-      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch1[0].next_after]]), options)
+      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch1[0].batch.next_after]]), options)
     );
     expect(getBatchData(batch2)).toEqual([{ op_id: '3', op: 'PUT', object_id: 'large2', checksum: 1607205872 }]);
     expect(getBatchMeta(batch2)).toEqual({
@@ -1233,7 +1233,7 @@ bucket_definitions:
     });
 
     const batch3 = await fromAsync(
-      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch2[0].next_after]]), options)
+      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch2[0].batch.next_after]]), options)
     );
     expect(getBatchData(batch3)).toEqual([{ op_id: '4', op: 'PUT', object_id: 'test3', checksum: 1359888332 }]);
     expect(getBatchMeta(batch3)).toEqual({
@@ -1286,7 +1286,7 @@ bucket_definitions:
     });
 
     const batch2 = await fromAsync(
-      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch1[0].next_after]]), {
+      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch1[0].batch.next_after]]), {
         limit: 4
       })
     );
@@ -1302,7 +1302,7 @@ bucket_definitions:
     });
 
     const batch3 = await fromAsync(
-      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch2[0].next_after]]), {
+      storage.getBucketDataBatch(checkpoint, new Map([['global[]', batch2[0].batch.next_after]]), {
         limit: 4
       })
     );
@@ -1312,11 +1312,12 @@ bucket_definitions:
   });
 }
 
-function getBatchData(batch: SyncBucketData[]) {
-  if (batch.length == 0) {
+function getBatchData(batch: SyncBucketData[] | SyncBucketDataBatch[]) {
+  const first = getFirst(batch);
+  if (first == null) {
     return [];
   }
-  return batch[0].data.map((d) => {
+  return first.data.map((d) => {
     return {
       op_id: d.op_id,
       op: d.op,
@@ -1326,13 +1327,26 @@ function getBatchData(batch: SyncBucketData[]) {
   });
 }
 
-function getBatchMeta(batch: SyncBucketData[]) {
-  if (batch.length == 0) {
+function getBatchMeta(batch: SyncBucketData[] | SyncBucketDataBatch[]) {
+  const first = getFirst(batch);
+  if (first == null) {
     return null;
   }
   return {
-    has_more: batch[0].has_more,
-    after: batch[0].after,
-    next_after: batch[0].next_after
+    has_more: first.has_more,
+    after: first.after,
+    next_after: first.next_after
   };
+}
+
+function getFirst(batch: SyncBucketData[] | SyncBucketDataBatch[]): SyncBucketData | null {
+  if (batch.length == 0) {
+    return null;
+  }
+  let first = batch[0];
+  if ((first as SyncBucketDataBatch).batch != null) {
+    return (first as SyncBucketDataBatch).batch;
+  } else {
+    return first as SyncBucketData;
+  }
 }

--- a/packages/service-core/test/src/slow_tests.test.ts
+++ b/packages/service-core/test/src/slow_tests.test.ts
@@ -158,11 +158,11 @@ bucket_definitions:
         const ops = await f.db.bucket_data.find().sort({ _id: 1 }).toArray();
         let active = new Set<string>();
         for (let op of ops) {
-          const key = op.source_key.toHexString();
+          const key = op.source_key?.toHexString();
           if (op.op == 'PUT') {
-            active.add(key);
+            active.add(key!);
           } else if (op.op == 'REMOVE') {
-            active.delete(key);
+            active.delete(key!);
           }
         }
         if (active.size > 0) {

--- a/packages/service-core/test/src/slow_tests.test.ts
+++ b/packages/service-core/test/src/slow_tests.test.ts
@@ -11,7 +11,7 @@ import { SqliteRow } from '@powersync/service-sync-rules';
 import { MongoBucketStorage } from '../../src/storage/MongoBucketStorage.js';
 import { PgManager } from '../../src/util/PgManager.js';
 import { mapOpEntry } from '@/storage/storage-index.js';
-import { reduceBucket, validateCompactedBucket, validateReducedSets } from './bucket_validation.js';
+import { reduceBucket, validateCompactedBucket, validateBucket } from './bucket_validation.js';
 import * as timers from 'node:timers/promises';
 
 describe('slow tests - mongodb', function () {

--- a/packages/service-core/test/src/sync.test.ts
+++ b/packages/service-core/test/src/sync.test.ts
@@ -3,30 +3,17 @@ import { describe, expect, test } from 'vitest';
 import { ZERO_LSN } from '../../src/replication/WalStream.js';
 import { SourceTable } from '../../src/storage/SourceTable.js';
 import { hashData } from '../../src/util/utils.js';
-import { MONGO_STORAGE_FACTORY, StorageFactory } from './util.js';
+import { makeTestTable, MONGO_STORAGE_FACTORY, StorageFactory } from './util.js';
 import { JSONBig } from '@powersync/service-jsonbig';
 import { streamResponse } from '../../src/sync/sync.js';
 import * as timers from 'timers/promises';
 import { lsnMakeComparable } from '@powersync/service-jpgwire';
 import { RequestParameters } from '@powersync/service-sync-rules';
+import { StreamingSyncCheckpoint, StreamingSyncLine } from '@/util/protocol-types.js';
 
 describe('sync - mongodb', function () {
   defineTests(MONGO_STORAGE_FACTORY);
 });
-
-function makeTestTable(name: string, columns?: string[] | undefined) {
-  const relId = hashData('table', name, (columns ?? ['id']).join(','));
-  const id = new bson.ObjectId('6544e3899293153fa7b38331');
-  return new SourceTable(
-    id,
-    SourceTable.DEFAULT_TAG,
-    relId,
-    SourceTable.DEFAULT_SCHEMA,
-    name,
-    (columns ?? ['id']).map((column) => ({ name: column, typeOid: 25 })),
-    true
-  );
-}
 
 const TEST_TABLE = makeTestTable('test', ['id']);
 
@@ -243,15 +230,155 @@ function defineTests(factory: StorageFactory) {
     const expLines = await getCheckpointLines(iter);
     expect(expLines).toMatchSnapshot();
   });
+
+  test('compacting data - invalidate checkpoint', async () => {
+    // This tests a case of a compact operation invalidating a checkpoint in the
+    // middle of syncing data.
+    // This is expected to be rare in practice, but it is important to handle
+    // this case correctly to maintain consistency on the client.
+
+    const f = await factory();
+
+    const syncRules = await f.updateSyncRules({
+      content: BASIC_SYNC_RULES
+    });
+
+    const storage = await f.getInstance(syncRules.parsed());
+    await storage.setSnapshotDone(ZERO_LSN);
+    await storage.autoActivate();
+
+    await storage.startBatch({}, async (batch) => {
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'insert',
+        after: {
+          id: 't1',
+          description: 'Test 1'
+        }
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'insert',
+        after: {
+          id: 't2',
+          description: 'Test 2'
+        }
+      });
+
+      await batch.commit(lsnMakeComparable('0/1'));
+    });
+
+    const stream = streamResponse({
+      storage: f,
+      params: {
+        buckets: [],
+        include_checksum: true,
+        raw_data: true
+      },
+      syncParams: new RequestParameters({ sub: '' }, {}),
+      token: { exp: Date.now() / 1000 + 10 } as any
+    });
+
+    const iter = stream[Symbol.asyncIterator]();
+
+    // Only consume the first "checkpoint" message, and pause before receiving data.
+    const lines = await consumeIterator(iter, { consume: false, isDone: (line) => (line as any)?.checkpoint != null });
+    expect(lines).toMatchSnapshot();
+    expect(lines[0]).toEqual({
+      checkpoint: expect.objectContaining({
+        last_op_id: '2'
+      })
+    });
+
+    // Now we save additional data AND compact before continuing.
+    // This invalidates the checkpoint we've received above.
+
+    await storage.startBatch({}, async (batch) => {
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'update',
+        after: {
+          id: 't1',
+          description: 'Test 1b'
+        }
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: 'update',
+        after: {
+          id: 't2',
+          description: 'Test 2b'
+        }
+      });
+
+      await batch.commit(lsnMakeComparable('0/2'));
+    });
+
+    await storage.compact();
+
+    const lines2 = await getCheckpointLines(iter, { consume: true });
+
+    // Snapshot test checks for changes in general.
+    // The tests after that documents the specific things we're looking for
+    // in this test.
+    expect(lines2).toMatchSnapshot();
+
+    expect(lines2[0]).toEqual({
+      data: expect.objectContaining({
+        has_more: false,
+        data: [
+          // The first two ops have been replaced by a single CLEAR op
+          expect.objectContaining({
+            op: 'CLEAR'
+          })
+        ]
+      })
+    });
+
+    // Note: No checkpoint_complete here, since the checkpoint has been
+    // invalidated by the CLEAR op.
+
+    expect(lines2[1]).toEqual({
+      checkpoint_diff: expect.objectContaining({
+        last_op_id: '4'
+      })
+    });
+
+    expect(lines2[2]).toEqual({
+      data: expect.objectContaining({
+        has_more: false,
+        data: [
+          expect.objectContaining({
+            op: 'PUT'
+          }),
+          expect.objectContaining({
+            op: 'PUT'
+          })
+        ]
+      })
+    });
+
+    // Now we get a checkpoint_complete
+    expect(lines2[3]).toEqual({
+      checkpoint_complete: expect.objectContaining({
+        last_op_id: '4'
+      })
+    });
+  });
 }
 
 /**
- * Get lines on an iterator until the next checkpoint_complete.
+ * Get lines on an iterator until isDone(line) == true.
  *
- * Does not stop the iterator.
+ * Does not stop the iterator unless options.consume is true.
  */
-async function getCheckpointLines(iter: AsyncIterator<any>, options?: { consume?: boolean }): Promise<any[]> {
-  let lines: any[] = [];
+async function consumeIterator<T>(
+  iter: AsyncIterator<T>,
+  options: { isDone: (line: T) => boolean; consume?: boolean }
+) {
+  let lines: T[] = [];
   try {
     const controller = new AbortController();
     const timeout = timers.setTimeout(1500, { value: null, done: 'timeout' }, { signal: controller.signal });
@@ -266,7 +393,7 @@ async function getCheckpointLines(iter: AsyncIterator<any>, options?: { consume?
       if (value) {
         lines.push(value);
       }
-      if (done || value.checkpoint_complete) {
+      if (done || options.isDone(value)) {
         break;
       }
     }
@@ -287,8 +414,23 @@ async function getCheckpointLines(iter: AsyncIterator<any>, options?: { consume?
 /**
  * Get lines on an iterator until the next checkpoint_complete.
  *
+ * Does not stop the iterator unless options.consume is true.
+ */
+async function getCheckpointLines(
+  iter: AsyncIterator<StreamingSyncLine | string | null>,
+  options?: { consume?: boolean }
+) {
+  return consumeIterator(iter, {
+    consume: options?.consume,
+    isDone: (line) => (line as any)?.checkpoint_complete
+  });
+}
+
+/**
+ * Get lines on an iterator until the next checkpoint_complete.
+ *
  * Stops the iterator afterwards.
  */
-async function consumeCheckpointLines(iterable: AsyncIterable<any>): Promise<any[]> {
+async function consumeCheckpointLines(iterable: AsyncIterable<StreamingSyncLine | string | null>): Promise<any[]> {
   return getCheckpointLines(iterable[Symbol.asyncIterator](), { consume: true });
 }

--- a/packages/service-core/test/src/util.ts
+++ b/packages/service-core/test/src/util.ts
@@ -31,6 +31,10 @@ export const MONGO_STORAGE_FACTORY: StorageFactory = async () => {
 };
 
 export async function clearTestDb(db: pgwire.PgClient) {
+  await db.query(
+    "select pg_drop_replication_slot(slot_name) from pg_replication_slots where active = false and slot_name like 'test_%'"
+  );
+
   await db.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
   try {
     await db.query(`DROP PUBLICATION powersync`);

--- a/packages/service-core/test/src/util.ts
+++ b/packages/service-core/test/src/util.ts
@@ -1,12 +1,16 @@
 import * as pgwire from '@powersync/service-jpgwire';
 import { normalizeConnection } from '@powersync/service-types';
 import * as mongo from 'mongodb';
-import { BucketStorageFactory } from '../../src/storage/BucketStorage.js';
+import { BucketStorageFactory, SyncBucketDataBatch } from '../../src/storage/BucketStorage.js';
 import { MongoBucketStorage } from '../../src/storage/MongoBucketStorage.js';
 import { PowerSyncMongo } from '../../src/storage/mongo/db.js';
 import { escapeIdentifier } from '../../src/util/pgwire_utils.js';
 import { env } from './env.js';
 import { Metrics } from '@/metrics/Metrics.js';
+import { hashData } from '@/util/utils.js';
+import { SourceTable } from '@/storage/SourceTable.js';
+import * as bson from 'bson';
+import { SyncBucketData } from '@/util/protocol-types.js';
 
 // The metrics need to be initialised before they can be used
 await Metrics.initialise({
@@ -73,4 +77,60 @@ export async function connectMongo() {
   });
   const db = new PowerSyncMongo(client);
   return db;
+}
+
+export function makeTestTable(name: string, columns?: string[] | undefined) {
+  const relId = hashData('table', name, (columns ?? ['id']).join(','));
+  const id = new bson.ObjectId('6544e3899293153fa7b38331');
+  return new SourceTable(
+    id,
+    SourceTable.DEFAULT_TAG,
+    relId,
+    SourceTable.DEFAULT_SCHEMA,
+    name,
+    (columns ?? ['id']).map((column) => ({ name: column, typeOid: 25 })),
+    true
+  );
+}
+
+export function getBatchData(batch: SyncBucketData[] | SyncBucketDataBatch[] | SyncBucketDataBatch) {
+  const first = getFirst(batch);
+  if (first == null) {
+    return [];
+  }
+  return first.data.map((d) => {
+    return {
+      op_id: d.op_id,
+      op: d.op,
+      object_id: d.object_id,
+      checksum: d.checksum
+    };
+  });
+}
+
+export function getBatchMeta(batch: SyncBucketData[] | SyncBucketDataBatch[] | SyncBucketDataBatch) {
+  const first = getFirst(batch);
+  if (first == null) {
+    return null;
+  }
+  return {
+    has_more: first.has_more,
+    after: first.after,
+    next_after: first.next_after
+  };
+}
+
+function getFirst(batch: SyncBucketData[] | SyncBucketDataBatch[] | SyncBucketDataBatch): SyncBucketData | null {
+  if (!Array.isArray(batch)) {
+    return batch.batch;
+  }
+  if (batch.length == 0) {
+    return null;
+  }
+  let first = batch[0];
+  if ((first as SyncBucketDataBatch).batch != null) {
+    return (first as SyncBucketDataBatch).batch;
+  } else {
+    return first as SyncBucketData;
+  }
 }

--- a/packages/service-core/test/src/wal_stream_utils.ts
+++ b/packages/service-core/test/src/wal_stream_utils.ts
@@ -145,3 +145,14 @@ export async function fromAsync<T>(source: Iterable<T> | AsyncIterable<T>): Prom
   }
   return items;
 }
+
+export async function oneFromAsync<T>(source: Iterable<T> | AsyncIterable<T>): Promise<T> {
+  const items: T[] = [];
+  for await (const item of source) {
+    items.push(item);
+  }
+  if (items.length != 1) {
+    throw new Error(`One item expected, got: ${items.length}`);
+  }
+  return items[0];
+}

--- a/packages/service-core/test/src/wal_stream_utils.ts
+++ b/packages/service-core/test/src/wal_stream_utils.ts
@@ -113,7 +113,7 @@ export class WalStreamTestContext {
     const map = new Map<string, string>([[bucket, start]]);
     const batch = await this.storage!.getBucketDataBatch(checkpoint, map);
     const batches = await fromAsync(batch);
-    return batches[0]?.data ?? [];
+    return batches[0]?.batch.data ?? [];
   }
 }
 

--- a/packages/service-core/test/src/wal_stream_utils.ts
+++ b/packages/service-core/test/src/wal_stream_utils.ts
@@ -20,9 +20,7 @@ export function walStreamTest(
   return async () => {
     const f = await factory();
     const connections = new PgManager(TEST_CONNECTION_OPTIONS, {});
-    await connections.pool.query(
-      'select pg_drop_replication_slot(slot_name) from pg_replication_slots where active = false'
-    );
+
     await clearTestDb(connections.pool);
     const context = new WalStreamTestContext(f, connections);
     try {


### PR DESCRIPTION
Implement a `compact` command that compacts all buckets in the instance. See the new documentation for what exactly it does.

This is currently a separate manual command, and not run automatically. It can be run manually or on a schedule.

This does not implement defragmentation yet. For some use cases it may be beneficial to trigger defragmentation from the postgres side using a periodic query such as `update mytable set id = id where updated_at < now() - interval '1 week'`, after which the compact command will be able to efficiently compact historical operations.

The memory used by the command can be controlled using the `--max-old-space-size` config for NodeJS. 256MB should be enough for up to 1M unique rows per bucket.

This is the first implementation using MOVE and CLEAR operations. These operations have been defined in the protocol and implemented in all clients since the start, but we'll need proper integration testing for consistency.

This also adds:
1. Overview documentation for the protocol.
2. Documentation on formal bucket properties guaranteed by the protocol.
3. Tests validating the above properties for buckets and compacted buckets.
