### PR TITLE
[Chore] Automatically trigger DockerHub release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,9 @@
   "access": "restricted",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": {
+    "tag": true,
+    "version": true
+  }
 }

--- a/.github/workflows/image_release.yaml
+++ b/.github/workflows/image_release.yaml
@@ -1,7 +1,11 @@
 #  Publishes the Docker image to DockerHub
+#  This is triggered whenever the `service` is versioned and tagged
 name: Docker Image Release
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - 'powersync-open-service*'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/image_release.yaml
+++ b/.github/workflows/image_release.yaml
@@ -5,7 +5,7 @@ name: Docker Image Release
 on:
   push:
     tags:
-      - 'powersync-open-service*'
+      - '@powersync/service-image*'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:ts": "tsc -b",
     "watch:ts": "pnpm build:ts -w --preserveWatchOutput",
     "watch:service": "concurrently --passthrough-arguments \"pnpm watch:ts\" \" pnpm start:service {@}\" -- ",
-    "start:service": "pnpm --filter powersync-open-service watch",
+    "start:service": "pnpm --filter @powersync/service-image watch",
     "clean": "pnpm run -r clean",
     "release": "pnpm build:production && pnpm changeset publish",
     "test": "pnpm run -r test"

--- a/service/CHANGELOG.md
+++ b/service/CHANGELOG.md
@@ -1,4 +1,4 @@
-# powersync-open-service
+# @powersync/service-image
 
 ## 0.3.1
 

--- a/service/package.json
+++ b/service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "powersync-open-service",
+  "name": "@powersync/service-image",
   "version": "0.3.1",
   "private": true,
   "license": "FSL-1.1-Apache-2.0",


### PR DESCRIPTION
# Overview

The release process for the open edition DockerHub image is currently manually triggering the `Docker Image Release` action after the Changesets `Version` PR has been merged. It's easy to forget to trigger this action. 

The Docker image is built (and versioned) from the `powersync-open-service` private package (located in the `service` folder).
This PR configures Changesets to tag the `powersync-open-service` (private) "package" when publishing. The publish action will then run after tags have been pushed. [Refference](https://github.com/changesets/changesets/blob/main/docs/versioning-apps.md)

This will also create Github releases for `powersync-open-service` which will notify watchers of the repo about Docker image releases.

Side note: Do we want to rename `powersync-open-service` to something else? Releases will have the title `powersync-open-service@[version]`.  We could potentially name it similar to the Docker image name: `@journeyapps/powersync-service` (note: the `@` is required in `package.json`)

For example it should look like this currently:
<img width="852" alt="image" src="https://github.com/user-attachments/assets/9e9a2979-ffcb-4761-ac5a-d98f96916ac7">


