### PR TITLE
Log user_id and sync stats for each connection

### DIFF
--- a/.changeset/plenty-dryers-look.md
+++ b/.changeset/plenty-dryers-look.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Log user_id and sync stats for each connection

--- a/packages/service-core/src/routes/endpoints/sync-stream.ts
+++ b/packages/service-core/src/routes/endpoints/sync-stream.ts
@@ -8,6 +8,7 @@ import * as util from '../../util/util-index.js';
 import { Metrics } from '../../metrics/Metrics.js';
 import { authUser } from '../auth.js';
 import { routeDefinition } from '../router.js';
+import { RequestTracker } from '../../sync/RequestTracker.js';
 
 export enum SyncRoutes {
   STREAM = '/sync/stream'
@@ -43,6 +44,7 @@ export const syncStreamed = routeDefinition({
       });
     }
     const controller = new AbortController();
+    const tracker = new RequestTracker();
     try {
       Metrics.getInstance().concurrent_connections.add(1);
       const stream = Readable.from(
@@ -53,9 +55,11 @@ export const syncStreamed = routeDefinition({
               params,
               syncParams,
               token: payload.context.token_payload!,
+              tracker,
               signal: controller.signal
             })
-          )
+          ),
+          tracker
         ),
         { objectMode: false, highWaterMark: 16 * 1024 }
       );
@@ -86,6 +90,11 @@ export const syncStreamed = routeDefinition({
         afterSend: async () => {
           controller.abort();
           Metrics.getInstance().concurrent_connections.add(-1);
+          logger.info(`Sync stream complete`, {
+            user_id: syncParams.user_id,
+            operations_synced: tracker.operationsSynced,
+            data_synced_bytes: tracker.dataSyncedBytes
+          });
         }
       });
     } catch (ex) {

--- a/packages/service-core/src/sync/RequestTracker.ts
+++ b/packages/service-core/src/sync/RequestTracker.ts
@@ -1,0 +1,21 @@
+import { Metrics } from '../metrics/Metrics.js';
+
+/**
+ * Record sync stats per request stream.
+ */
+export class RequestTracker {
+  operationsSynced = 0;
+  dataSyncedBytes = 0;
+
+  addOperationsSynced(operations: number) {
+    this.operationsSynced += operations;
+
+    Metrics.getInstance().operations_synced_total.add(operations);
+  }
+
+  addDataSynced(bytes: number) {
+    this.dataSyncedBytes += bytes;
+
+    Metrics.getInstance().data_synced_bytes.add(bytes);
+  }
+}

--- a/packages/service-core/src/sync/util.ts
+++ b/packages/service-core/src/sync/util.ts
@@ -2,6 +2,7 @@ import * as timers from 'timers/promises';
 
 import * as util from '../util/util-index.js';
 import { Metrics } from '../metrics/Metrics.js';
+import { RequestTracker } from './RequestTracker.js';
 
 export type TokenStreamOptions = {
   /**
@@ -89,10 +90,13 @@ export async function* ndjson(iterator: AsyncIterable<string | null | Record<str
   }
 }
 
-export async function* transformToBytesTracked(iterator: AsyncIterable<string>): AsyncGenerator<Buffer> {
+export async function* transformToBytesTracked(
+  iterator: AsyncIterable<string>,
+  tracker: RequestTracker
+): AsyncGenerator<Buffer> {
   for await (let data of iterator) {
     const encoded = Buffer.from(data, 'utf8');
-    Metrics.getInstance().data_synced_bytes.add(encoded.length);
+    tracker.addDataSynced(encoded.length);
     yield encoded;
   }
 }

--- a/packages/service-core/test/src/sync.test.ts
+++ b/packages/service-core/test/src/sync.test.ts
@@ -9,6 +9,7 @@ import { streamResponse } from '../../src/sync/sync.js';
 import * as timers from 'timers/promises';
 import { lsnMakeComparable } from '@powersync/service-jpgwire';
 import { RequestParameters } from '@powersync/service-sync-rules';
+import { RequestTracker } from '@/sync/RequestTracker.js';
 
 describe('sync - mongodb', function () {
   defineTests(MONGO_STORAGE_FACTORY);
@@ -38,6 +39,8 @@ bucket_definitions:
     `;
 
 function defineTests(factory: StorageFactory) {
+  const tracker = new RequestTracker();
+
   test('sync global data', async () => {
     const f = await factory();
 
@@ -78,6 +81,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: true
       },
+      tracker,
       syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: Date.now() / 1000 + 10 } as any
     });
@@ -118,6 +122,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: false
       },
+      tracker,
       syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: Date.now() / 1000 + 10 } as any
     });
@@ -146,6 +151,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: true
       },
+      tracker,
       syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: 0 } as any
     });
@@ -172,6 +178,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: true
       },
+      tracker,
       syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: Date.now() / 1000 + 10 } as any
     });
@@ -232,6 +239,7 @@ function defineTests(factory: StorageFactory) {
         include_checksum: true,
         raw_data: true
       },
+      tracker,
       syncParams: new RequestParameters({ sub: '' }, {}),
       token: { exp: exp } as any
     });


### PR DESCRIPTION
This additionally adds some additional fields to structured logs, for easier processing if desired.

Sample log output for a single HTTP request:

```
info: New checkpoint: 2686394 | write: null | buckets: 2 ["global[]","by_user[\"test\"]"] {"buckets":2,"checkpoint":"2686394","user_id":"test"}
info: Sync stream complete {"data_synced_bytes":14291587,"operations_synced":2402,"user_id":"test"}
info: POST /sync/stream {"duration_ms":181,"method":"POST","path":"/sync/stream","route":"/sync/stream","status":200}
```

JSON log format:
```json
{"buckets":2,"checkpoint":"2686394","level":"info","message":"New checkpoint: 2686394 | write: null | buckets: 2 [\"global[]\",\"by_user[\\\"test\\\"]\"]","timestamp":"2024-07-17T09:05:33.532Z","user_id":"test"}
{"data_synced_bytes":14291587,"level":"info","message":"Sync stream complete","operations_synced":2402,"timestamp":"2024-07-17T09:05:33.780Z","user_id":"test"}
{"duration_ms":252,"level":"info","message":"POST /sync/stream","method":"POST","path":"/sync/stream","route":"/sync/stream","status":200,"timestamp":"2024-07-17T09:05:33.780Z"}
```