### PR TITLE
[Feature] Enable additional metrics endpoints

### DIFF
--- a/packages/service-core/src/util/config/compound-config-collector.ts
+++ b/packages/service-core/src/util/config/compound-config-collector.ts
@@ -122,7 +122,8 @@ export class CompoundConfigCollector {
       telemetry: {
         disable_telemetry_sharing: baseConfig.telemetry?.disable_telemetry_sharing ?? false,
         internal_service_endpoint:
-          baseConfig.telemetry?.internal_service_endpoint ?? 'https://pulse.journeyapps.com/v1/metrics'
+          baseConfig.telemetry?.internal_service_endpoint ?? 'https://pulse.journeyapps.com/v1/metrics',
+        additional_endpoints: baseConfig?.telemetry?.additional_endpoints
       },
       slot_name_prefix: connections[0]?.slot_name_prefix ?? 'powersync_'
     };

--- a/packages/service-core/src/util/config/types.ts
+++ b/packages/service-core/src/util/config/types.ts
@@ -59,6 +59,7 @@ export type ResolvedPowerSyncConfig = {
   telemetry: {
     disable_telemetry_sharing: boolean;
     internal_service_endpoint: string;
+    additional_endpoints?: configFile.AdditionalMetricEndpoint[];
   };
 
   /** Prefix for postgres replication slot names. May eventually be connection-specific. */

--- a/packages/types/src/config/PowerSyncConfig.ts
+++ b/packages/types/src/config/PowerSyncConfig.ts
@@ -92,6 +92,16 @@ export const storageConfig = t.object({
 
 export type StorageConfig = t.Decoded<typeof storageConfig>;
 
+/**
+ * An additional OTLP metrics endpoint
+ */
+export const AdditionalMetricEndpoint = t.object({
+  url: t.string,
+  export_interval_ms: t.number.optional()
+});
+
+export type AdditionalMetricEndpoint = t.Decoded<typeof AdditionalMetricEndpoint>;
+
 export const powerSyncConfig = t.object({
   replication: t
     .object({
@@ -145,7 +155,8 @@ export const powerSyncConfig = t.object({
   telemetry: t
     .object({
       disable_telemetry_sharing: t.boolean,
-      internal_service_endpoint: t.string.optional()
+      internal_service_endpoint: t.string.optional(),
+      additional_endpoints: t.array(AdditionalMetricEndpoint).optional()
     })
     .optional()
 });

--- a/service/src/system/PowerSyncSystem.ts
+++ b/service/src/system/PowerSyncSystem.ts
@@ -44,7 +44,8 @@ export class PowerSyncSystem extends system.CorePowerSyncSystem {
         await Metrics.initialise({
           powersync_instance_id: instanceId,
           disable_telemetry_sharing: config.telemetry.disable_telemetry_sharing,
-          internal_metrics_endpoint: config.telemetry.internal_service_endpoint
+          internal_metrics_endpoint: config.telemetry.internal_service_endpoint,
+          additional_endpoints: config.telemetry.additional_endpoints
         });
       },
       async stop() {


### PR DESCRIPTION
# Overview

We currently have the functionality to capture various metrics throughout the service. These metrics are anonymously pushed to our OLTP service if configured. 

This PR allows users to specify additional OLTP endpoints for metrics to be exported to. 

Additional endpoints can be specified in the config YAML file, e.g.:

```yaml
telemetry:
  # Opt out of reporting anonymized usage metrics to PowerSync telemetry service
  disable_telemetry_sharing: true
  additional_endpoints:
    - url: http://localhost:4318/v1/metrics
    # Optionally configure the export interval - defaults to 5 minutes
      export_interval_ms: 10000 # 10 seconds
```
