### PR TITLE
Validate id column for "select *"

### DIFF
--- a/.changeset/brown-horses-whisper.md
+++ b/.changeset/brown-horses-whisper.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Warn when id column is not present in "select \* from ..."

--- a/packages/sync-rules/src/ExpressionType.ts
+++ b/packages/sync-rules/src/ExpressionType.ts
@@ -67,4 +67,8 @@ export class ExpressionType {
   isNumericOnly() {
     return this.typeFlags != TYPE_NONE && (this.typeFlags & (TYPE_INTEGER | TYPE_REAL)) == this.typeFlags;
   }
+
+  isNone() {
+    return this.typeFlags == TYPE_NONE;
+  }
 }

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -142,6 +142,17 @@ describe('data queries', () => {
         type: 'warning'
       }
     ]);
+
+    const q4 = SqlDataQuery.fromSql('q4', [], 'SELECT * FROM other', schema);
+    expect(q4.errors).toMatchObject([
+      {
+        message: `Query must return an "id" column`,
+        type: 'warning'
+      }
+    ]);
+
+    const q5 = SqlDataQuery.fromSql('q5', [], 'SELECT other_id as id, * FROM other', schema);
+    expect(q5.errors).toMatchObject([]);
   });
 
   test('invalid query - invalid IN', function () {

--- a/packages/sync-rules/test/src/util.ts
+++ b/packages/sync-rules/test/src/util.ts
@@ -32,6 +32,10 @@ export const BASIC_SCHEMA = new StaticSchema([
               { name: 'count', pg_type: 'int4' },
               { name: 'owner_id', pg_type: 'uuid' }
             ]
+          },
+          {
+            name: 'other',
+            columns: [{ name: 'other_id', pg_type: 'uuid' }]
           }
         ]
       }


### PR DESCRIPTION
Previously, this data query would report an error `Query must return an "id" column`:

```
select name from mytable
```

However, this would not:

```
select * from mytable
```

Now, the above would give a warning if `mytable` does not have an id column defined.
