### PR TITLE
[Fix] WebSocket Close

### DIFF
--- a/.changeset/nasty-mugs-battle.md
+++ b/.changeset/nasty-mugs-battle.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-rsocket-router': patch
+---
+
+Fix issue where WebSocket close events would not immediately propagate to router handlers.

--- a/packages/rsocket-router/src/router/transport/WebSocketServerTransport.ts
+++ b/packages/rsocket-router/src/router/transport/WebSocketServerTransport.ts
@@ -74,6 +74,9 @@ export class WebsocketServerTransport implements ServerTransport {
       try {
         websocket.binaryType = 'nodebuffer';
         const duplex = WebSocket.createWebSocketStream(websocket);
+        websocket.on('close', (e) => {
+          duplex.emit('close', e);
+        });
         WebsocketDuplexConnection.create(duplex, connectionAcceptor, multiplexerDemultiplexerFactory, websocket);
       } catch (ex) {
         logger.error(`Could not create duplex connection`, ex);


### PR DESCRIPTION
# Overview

When closing a WebSocket connection, e.g. by closing a web tab, the router did not immediately detect that the connection has been closed.

The connection would close when the keep-alive ping-pong check failed, but the delay could cause the number of concurrent connections and active streams to accumulate for short periods. 

This bubbles the WebSocket `close` event through the WebSocket Duplex connection and router endpoint handlers.

Thanks @rkistner for finding the issue and providing a fix.

## Testing

This was tested locally with web and React Native. See screenshots below where the `STREAM` log duration is below the keep-alive period of 30_000ms.

<img width="808" alt="Screenshot 2024-07-18 at 14 09 30" src="https://github.com/user-attachments/assets/98c20eac-042e-4437-9492-5be4498f26b7">
<img width="1062" alt="Screenshot 2024-07-18 at 14 14 27" src="https://github.com/user-attachments/assets/7e69d8c5-5321-4671-9a2e-47f4ff0d585b">


The close unit test was updated to ensure that the cancel event is called correctly. Oddly enough this extended test actually would pass with the previous code - the bug is only reproducible with an actual connection. 