### PR TITLE
Require authentication on websocket connection level

### DIFF
--- a/.changeset/popular-rivers-smell.md
+++ b/.changeset/popular-rivers-smell.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-image': patch
+---
+
+Fix websockets not being closed on authentication error


### PR DESCRIPTION
For websocket connections, the authentication token is provided on the connection setup (RSocket SETUP frame).

The current implementation parsed the token in the connection setup via the `contextProvider`, but only checked that it was valid in the RSocket stream. It would then close the RSocket stream if authentication failed, while the websocket itself stayed open.

This now adds the same validation on the connection level via the `contextProvider`. This causes the entire websocket to be closed when authentication fails.

We have no websocket routes using anonymous authentication, so proper per-route auth is not a consideration now.

There is probably a bug on journey-js as well. It appears to currently re-create the entire connection if a RSocket stream errors, without closing the previous connection.


