### PR TITLE
Compact fixes

### DIFF
--- a/.changeset/purple-moles-shave.md
+++ b/.changeset/purple-moles-shave.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Fix compact command to use the correct database

--- a/packages/service-core/src/entry/commands/compact-action.ts
+++ b/packages/service-core/src/entry/commands/compact-action.ts
@@ -34,7 +34,7 @@ export function registerCompactAction(program: Command) {
     const client = mongo.createMongoClient(storage);
     await client.connect();
     try {
-      const psdb = new PowerSyncMongo(client);
+      const psdb = new PowerSyncMongo(client, { database: storage.database });
       const bucketStorage = new MongoBucketStorage(psdb, { slot_name_prefix: config.slot_name_prefix });
       const active = await bucketStorage.getActiveSyncRules();
       if (active == null) {

--- a/packages/service-core/src/entry/commands/compact-action.ts
+++ b/packages/service-core/src/entry/commands/compact-action.ts
@@ -2,8 +2,7 @@ import { Command } from 'commander';
 
 import { logger } from '@powersync/lib-services-framework';
 import * as v8 from 'v8';
-import { mongo } from '../../db/db-index.js';
-import { MongoBucketStorage, PowerSyncMongo } from '../../storage/storage-index.js';
+import { createPowerSyncMongo, MongoBucketStorage } from '../../storage/storage-index.js';
 import { loadConfig } from '../../util/config.js';
 import { extractRunnerOptions, wrapConfigCommand } from './config-command.js';
 
@@ -31,10 +30,10 @@ export function registerCompactAction(program: Command) {
 
     const config = await loadConfig(runnerConfig);
     const { storage } = config;
-    const client = mongo.createMongoClient(storage);
+    const psdb = createPowerSyncMongo(storage);
+    const client = psdb.client;
     await client.connect();
     try {
-      const psdb = new PowerSyncMongo(client, { database: storage.database });
       const bucketStorage = new MongoBucketStorage(psdb, { slot_name_prefix: config.slot_name_prefix });
       const active = await bucketStorage.getActiveSyncRules();
       if (active == null) {

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -426,4 +426,11 @@ export interface CompactOptions {
    * not be compacted, to avoid invalidating checkpoints in use.
    */
   maxOpId?: bigint;
+
+  /**
+   * If specified, compact only the specific buckets.
+   *
+   * If not specified, compacts all buckets.
+   */
+  compactBuckets?: string[];
 }


### PR DESCRIPTION
Follows on #37.

1. Use the correct storage database for the compact action. Previously it would only work if the database was specified in the URI.
2. Add an API to compact specific buckets instead of all buckets.


