### PR TITLE
Add test client

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,22 @@ importers:
         specifier: ^0.34.6
         version: 0.34.6
 
+  test-client:
+    dependencies:
+      '@powersync/service-core':
+        specifier: workspace:*
+        version: link:../packages/service-core
+      '@types/node':
+        specifier: 18.11.11
+        version: 18.11.11
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
+    devDependencies:
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
+
 packages:
 
   '@babel/code-frame@7.24.6':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,13 +412,19 @@ importers:
       '@powersync/service-core':
         specifier: workspace:*
         version: link:../packages/service-core
-      '@types/node':
-        specifier: 18.11.11
-        version: 18.11.11
       commander:
         specifier: ^12.0.0
         version: 12.1.0
+      jose:
+        specifier: ^4.15.1
+        version: 4.15.5
+      yaml:
+        specifier: ^2.5.0
+        version: 2.5.0
     devDependencies:
+      '@types/node':
+        specifier: 18.11.11
+        version: 18.11.11
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -4077,6 +4083,11 @@ packages:
 
   yaml@2.4.2:
     resolution: {integrity: sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
+  yaml@2.5.0:
+    resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -8225,6 +8236,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.4.2: {}
+
+  yaml@2.5.0: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,6 @@ packages:
   - 'packages/*'
   - 'libs/*'
   - 'service'
+  - 'test-client'
   # exclude packages that are inside test directories
   - '!**/test/**'

--- a/test-client/README.md
+++ b/test-client/README.md
@@ -29,6 +29,12 @@ node dist/bin.js fetch-operations --config path/to/powersync.yaml
 node dist/bin.js fetch-operations --config path/to/powersync.yaml --sub test-user
 ```
 
-The script will normalize the data in each bucket to a single CLEAR operation, followed by the latest PUT operation for each row.
+The `fetch-operations` command downloads data for a single checkpoint, and outputs a normalized form: one CLEAR operation, followed by the latest PUT operation for each row. This normalized form is still split per bucket. The output is not affected by compacting, but can be affected by replication order.
 
-To get the raw operations instead, which may additionally include CLEAR, MOVE, REMOVE and duplicate PUT operations, use the `--raw` flag.
+To avoid normalizing the data, use the `--raw` option. This may include additional CLEAR, MOVE, REMOVE and duplicate PUT operations.
+
+To generate a token without downloading data, use the `generate-token` command:
+
+```sh
+node dist/bin.js generate-token --config path/to/powersync.yaml --sub test-user
+```

--- a/test-client/README.md
+++ b/test-client/README.md
@@ -1,0 +1,18 @@
+# Test Client
+
+This is a minimal client demonstrating direct usage of the sync api.
+
+For a full implementation, see our client SDKs.
+
+## Usage
+
+```sh
+# In project root
+pnpm install
+pnpm build:packages
+# Here
+pnpm build
+node dist/bin.js fetch-operations --token <token> --endpoint http://localhost:8080
+```
+
+The script will normalize the data in each bucket to a single CLEAR operation, followed by the latest PUT operation for each row.

--- a/test-client/README.md
+++ b/test-client/README.md
@@ -1,6 +1,6 @@
 # Test Client
 
-This is a minimal client demonstrating direct usage of the sync api.
+This is a minimal client demonstrating direct usage of the HTTP stream sync api.
 
 For a full implementation, see our client SDKs.
 
@@ -10,9 +10,25 @@ For a full implementation, see our client SDKs.
 # In project root
 pnpm install
 pnpm build:packages
-# Here
+# In this folder
 pnpm build
 node dist/bin.js fetch-operations --token <token> --endpoint http://localhost:8080
+
+# More examples:
+
+# If the endpoint is present in token aud field, it can be omitted from args:
+node dist/bin.js fetch-operations --token <token>
+
+# If a local powersync.yaml is present with a configured HS256 key, this can be used:
+node dist/bin.js fetch-operations --config path/to/powersync.yaml --endpoint http://localhost:8080
+
+# Without endpoint, it defaults to http://127.0.0.1:<port> from the config:
+node dist/bin.js fetch-operations --config path/to/powersync.yaml
+
+# Use --sub to specify a user id in the generated token:
+node dist/bin.js fetch-operations --config path/to/powersync.yaml --sub test-user
 ```
 
 The script will normalize the data in each bucket to a single CLEAR operation, followed by the latest PUT operation for each row.
+
+To get the raw operations instead, which may additionally include CLEAR, MOVE, REMOVE and duplicate PUT operations, use the `--raw` flag.

--- a/test-client/package.json
+++ b/test-client/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "test-client",
+  "repository": "https://github.com/powersync-ja/powersync-service",
+  "private": true,
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "bin": "dist/bin.js",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "fetch-operations": "tsc -b && node dist/bin.js fetch-operations",
+    "build": "tsc -b",
+    "clean": "rm -rf ./dist && tsc -b --clean"
+  },
+  "dependencies": {
+    "@powersync/service-core": "workspace:*",
+    "commander": "^12.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "@types/node": "18.11.11"
+  }
+}

--- a/test-client/package.json
+++ b/test-client/package.json
@@ -9,15 +9,18 @@
   "type": "module",
   "scripts": {
     "fetch-operations": "tsc -b && node dist/bin.js fetch-operations",
+    "generate-token": "tsc -b && node dist/bin.js generate-token",
     "build": "tsc -b",
     "clean": "rm -rf ./dist && tsc -b --clean"
   },
   "dependencies": {
     "@powersync/service-core": "workspace:*",
-    "commander": "^12.0.0"
+    "commander": "^12.0.0",
+    "jose": "^4.15.1",
+    "yaml": "^2.5.0"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
-    "@types/node": "18.11.11"
+    "@types/node": "18.11.11",
+    "typescript": "^5.2.2"
   }
 }

--- a/test-client/src/auth.ts
+++ b/test-client/src/auth.ts
@@ -1,0 +1,60 @@
+import * as jose from 'jose';
+import * as fs from 'node:fs/promises';
+import * as yaml from 'yaml';
+
+export interface CredentialsOptions {
+  token?: string;
+  endpoint?: string;
+  config?: string;
+  sub?: string;
+}
+
+export async function getCredentials(options: CredentialsOptions): Promise<{ endpoint: string; token: string }> {
+  if (options.token != null) {
+    if (options.endpoint != null) {
+      return { token: options.token, endpoint: options.endpoint };
+    } else {
+      const parsed = jose.decodeJwt(options.token);
+      const aud = Array.isArray(parsed.aud) ? parsed.aud[0] : parsed.aud;
+      if (!(aud ?? '').startsWith('http')) {
+        throw new Error(`Specify endpoint, or aud in the token`);
+      }
+      return {
+        token: options.token,
+        endpoint: aud!
+      };
+    }
+  } else if (options.config != null) {
+    const file = await fs.readFile(options.config, 'utf-8');
+    const parsed = await yaml.parse(file);
+    const keys = (parsed.client_auth?.jwks?.keys ?? []).filter((key: any) => key.alg == 'HS256');
+    if (keys.length == 0) {
+      throw new Error('No HS256 key found in the config');
+    }
+
+    let endpoint = options.endpoint;
+    if (endpoint == null) {
+      endpoint = `http://127.0.0.1:${parsed.port ?? 8080}`;
+    }
+
+    const aud = parsed.client_auth?.audience?.[0] ?? endpoint;
+
+    const rawKey = keys[0];
+    const key = await jose.importJWK(rawKey);
+
+    const sub = options.sub ?? 'test_user';
+
+    const token = await new jose.SignJWT({})
+      .setProtectedHeader({ alg: rawKey.alg, kid: rawKey.kid })
+      .setSubject(sub)
+      .setIssuedAt()
+      .setIssuer('test-client')
+      .setAudience(aud)
+      .setExpirationTime('1h')
+      .sign(key);
+
+    return { token, endpoint };
+  } else {
+    throw new Error(`Specify token or config path`);
+  }
+}

--- a/test-client/src/bin.ts
+++ b/test-client/src/bin.ts
@@ -1,14 +1,32 @@
 import { program } from 'commander';
 import { getCheckpointData } from './client.js';
+import { getCredentials } from './auth.js';
+import * as jose from 'jose';
 
 program
   .command('fetch-operations')
-  .option('-t, --token [token]')
-  .option('-e, --endpoint [endpoint]')
-  .option('--raw')
+  .option('-t, --token [token]', 'JWT to use for authentication')
+  .option('-e, --endpoint [endpoint]', 'endpoint URI')
+  .option('-c, --config [config]', 'path to powersync.yaml, to auto-generate a token from a HS256 key')
+  .option('-u, --sub [sub]', 'sub field for auto-generated token')
+  .option('--raw', 'output operations as received, without normalizing')
   .action(async (options) => {
-    const data = await getCheckpointData({ endpoint: options.endpoint, token: options.token, raw: options.raw });
+    const credentials = await getCredentials(options);
+    const data = await getCheckpointData({ ...credentials, raw: options.raw });
     console.log(JSON.stringify(data, null, 2));
+  });
+
+program
+  .command('generate-token')
+  .description('Generate a JWT from for a given powersync.yaml config file')
+  .option('-c, --config [config]', 'path to powersync.yaml')
+  .option('-u, --sub [sub]', 'sub field for auto-generated token')
+  .action(async (options) => {
+    const credentials = await getCredentials(options);
+    const decoded = await jose.decodeJwt(credentials.token);
+
+    console.error(`Payload:\n${JSON.stringify(decoded, null, 2)}\nToken:`);
+    console.log(credentials.token);
   });
 
 await program.parseAsync();

--- a/test-client/src/bin.ts
+++ b/test-client/src/bin.ts
@@ -1,0 +1,14 @@
+import { program } from 'commander';
+import { getCheckpointData } from './client.js';
+
+program
+  .command('fetch-operations')
+  .option('-t, --token [token]')
+  .option('-e, --endpoint [endpoint]')
+  .option('--raw')
+  .action(async (options) => {
+    const data = await getCheckpointData({ endpoint: options.endpoint, token: options.token, raw: options.raw });
+    console.log(JSON.stringify(data, null, 2));
+  });
+
+await program.parseAsync();

--- a/test-client/src/client.ts
+++ b/test-client/src/client.ts
@@ -18,6 +18,7 @@ export async function getCheckpointData(options: GetCheckpointOptions) {
     body: JSON.stringify({
       raw_data: true,
       include_checksum: true,
+      // Client parameters can be specified here
       parameters: {}
     } satisfies types.StreamingSyncRequest)
   });
@@ -30,10 +31,12 @@ export async function getCheckpointData(options: GetCheckpointOptions) {
 
   for await (let chunk of ndjsonStream<types.StreamingSyncLine>(response.body!)) {
     if (isStreamingSyncData(chunk)) {
+      // Collect data
       data.push(chunk);
     } else if (isCheckpoint(chunk)) {
       checkpoint = chunk;
     } else if (isCheckpointComplete(chunk)) {
+      // Stop on the first checkpoint_complete message.
       break;
     }
   }

--- a/test-client/src/client.ts
+++ b/test-client/src/client.ts
@@ -1,0 +1,42 @@
+import { ndjsonStream } from './ndjson.js';
+import type * as types from '@powersync/service-core';
+import { isCheckpoint, isCheckpointComplete, isStreamingSyncData, normalizeData } from './util.js';
+
+export interface GetCheckpointOptions {
+  endpoint: string;
+  token: string;
+  raw?: boolean;
+}
+
+export async function getCheckpointData(options: GetCheckpointOptions) {
+  const response = await fetch(`${options.endpoint}/sync/stream`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Token ${options.token}`
+    },
+    body: JSON.stringify({
+      raw_data: true,
+      include_checksum: true,
+      parameters: {}
+    } satisfies types.StreamingSyncRequest)
+  });
+  if (!response.ok) {
+    throw new Error(response.statusText + '\n' + (await response.text()));
+  }
+
+  let data: types.StreamingSyncData[] = [];
+  let checkpoint: types.StreamingSyncCheckpoint;
+
+  for await (let chunk of ndjsonStream<types.StreamingSyncLine>(response.body!)) {
+    if (isStreamingSyncData(chunk)) {
+      data.push(chunk);
+    } else if (isCheckpoint(chunk)) {
+      checkpoint = chunk;
+    } else if (isCheckpointComplete(chunk)) {
+      break;
+    }
+  }
+
+  return normalizeData(checkpoint!, data, { raw: options.raw ?? false });
+}

--- a/test-client/src/index.ts
+++ b/test-client/src/index.ts
@@ -1,0 +1,3 @@
+export * from './client.js';
+export * from './ndjson.js';
+export * from './util.js';

--- a/test-client/src/ndjson.ts
+++ b/test-client/src/ndjson.ts
@@ -1,7 +1,4 @@
-// import { ReadableStream } from 'node:stream/web';
-
 export function ndjsonStream<T>(response: ReadableStream<Uint8Array>): ReadableStream<T> & AsyncIterable<T> {
-  // For cancellation
   var is_reader: any,
     cancellationRequest = false;
   return new ReadableStream<T>({

--- a/test-client/src/ndjson.ts
+++ b/test-client/src/ndjson.ts
@@ -1,0 +1,62 @@
+// import { ReadableStream } from 'node:stream/web';
+
+export function ndjsonStream<T>(response: ReadableStream<Uint8Array>): ReadableStream<T> & AsyncIterable<T> {
+  // For cancellation
+  var is_reader: any,
+    cancellationRequest = false;
+  return new ReadableStream<T>({
+    start: function (controller) {
+      var reader = response.getReader();
+      is_reader = reader;
+      var decoder = new TextDecoder();
+      var data_buf = '';
+
+      reader.read().then(function processResult(result): void | Promise<any> {
+        if (result.done) {
+          if (cancellationRequest) {
+            // Immediately exit
+            return;
+          }
+
+          data_buf = data_buf.trim();
+          if (data_buf.length !== 0) {
+            try {
+              var data_l = JSON.parse(data_buf);
+              controller.enqueue(data_l);
+            } catch (e) {
+              controller.error(e);
+              return;
+            }
+          }
+          controller.close();
+          return;
+        }
+
+        var data = decoder.decode(result.value, { stream: true });
+        data_buf += data;
+        var lines = data_buf.split('\n');
+        for (var i = 0; i < lines.length - 1; ++i) {
+          var l = lines[i].trim();
+          if (l.length > 0) {
+            try {
+              var data_line = JSON.parse(l);
+              controller.enqueue(data_line);
+            } catch (e) {
+              controller.error(e);
+              cancellationRequest = true;
+              reader.cancel();
+              return;
+            }
+          }
+        }
+        data_buf = lines[lines.length - 1];
+
+        return reader.read().then(processResult);
+      });
+    },
+    cancel: function (reason) {
+      cancellationRequest = true;
+      is_reader.cancel();
+    }
+  }) as any;
+}

--- a/test-client/src/util.ts
+++ b/test-client/src/util.ts
@@ -1,0 +1,104 @@
+import type * as types from '@powersync/service-core';
+
+export type BucketData = Record<string, types.OplogEntry[]>;
+
+export function normalizeData(
+  checkpoint: types.StreamingSyncCheckpoint,
+  chunks: types.StreamingSyncData[],
+  options: { raw: boolean }
+) {
+  const lastOpId = BigInt(checkpoint.checkpoint.last_op_id);
+  let buckets: BucketData = {};
+  for (let {
+    data: { bucket, data }
+  } of chunks) {
+    buckets[bucket] ??= [];
+    for (let entry of data) {
+      if (BigInt(entry.op_id) > lastOpId) {
+        continue;
+      }
+      buckets[bucket].push(entry);
+    }
+  }
+
+  if (options.raw) {
+    return buckets;
+  }
+
+  return Object.fromEntries(
+    Object.entries(buckets).map(([bucket, entries]) => {
+      return [bucket, reduceBucket(entries)];
+    })
+  );
+}
+
+export function isStreamingSyncData(line: types.StreamingSyncLine): line is types.StreamingSyncData {
+  return (line as types.StreamingSyncData).data != null;
+}
+
+export function isCheckpointComplete(line: types.StreamingSyncLine): line is types.StreamingSyncCheckpointComplete {
+  return (line as types.StreamingSyncCheckpointComplete).checkpoint_complete != null;
+}
+export function isCheckpoint(line: types.StreamingSyncLine): line is types.StreamingSyncCheckpoint {
+  return (line as types.StreamingSyncCheckpoint).checkpoint != null;
+}
+
+/**
+ * Reduce a bucket to the final state as stored on the client.
+ *
+ * This keeps the final state for each row as a PUT operation.
+ *
+ * All other operations are replaced with a single CLEAR operation,
+ * summing their checksums, and using a 0 as an op_id.
+ *
+ * This is the function $r(B)$, as described in /docs/bucket-properties.md.
+ */
+export function reduceBucket(operations: types.OplogEntry[]) {
+  let rowState = new Map<string, types.OplogEntry>();
+  let otherChecksum = 0;
+
+  for (let op of operations) {
+    const key = rowKey(op);
+    if (op.op == 'PUT') {
+      const existing = rowState.get(key);
+      if (existing) {
+        otherChecksum = addChecksums(otherChecksum, existing.checksum as number);
+      }
+      rowState.set(key, op);
+    } else if (op.op == 'REMOVE') {
+      const existing = rowState.get(key);
+      if (existing) {
+        otherChecksum = addChecksums(otherChecksum, existing.checksum as number);
+      }
+      rowState.delete(key);
+      otherChecksum = addChecksums(otherChecksum, op.checksum as number);
+    } else if (op.op == 'CLEAR') {
+      rowState.clear();
+      otherChecksum = op.checksum as number;
+    } else if (op.op == 'MOVE') {
+      otherChecksum = addChecksums(otherChecksum, op.checksum as number);
+    } else {
+      throw new Error(`Unknown operation ${op.op}`);
+    }
+  }
+
+  const puts = [...rowState.values()].sort((a, b) => {
+    return Number(BigInt(a.op_id) - BigInt(b.op_id));
+  });
+
+  let finalState: types.OplogEntry[] = [
+    // Special operation to indiciate the checksum remainder
+    { op_id: '0', op: 'CLEAR', checksum: otherChecksum },
+    ...puts
+  ];
+
+  return finalState;
+}
+
+function rowKey(entry: types.OplogEntry) {
+  return `${entry.object_type}/${entry.object_id}/${entry.subkey}`;
+}
+
+export function addChecksums(a: number, b: number) {
+  return (a + b) & 0xffffffff;
+}

--- a/test-client/src/util.ts
+++ b/test-client/src/util.ts
@@ -2,6 +2,9 @@ import type * as types from '@powersync/service-core';
 
 export type BucketData = Record<string, types.OplogEntry[]>;
 
+/**
+ * Combine all chunks of received data, excluding any data after the checkpoint.
+ */
 export function normalizeData(
   checkpoint: types.StreamingSyncCheckpoint,
   chunks: types.StreamingSyncData[],
@@ -39,6 +42,7 @@ export function isStreamingSyncData(line: types.StreamingSyncLine): line is type
 export function isCheckpointComplete(line: types.StreamingSyncLine): line is types.StreamingSyncCheckpointComplete {
   return (line as types.StreamingSyncCheckpointComplete).checkpoint_complete != null;
 }
+
 export function isCheckpoint(line: types.StreamingSyncLine): line is types.StreamingSyncCheckpoint {
   return (line as types.StreamingSyncCheckpoint).checkpoint != null;
 }

--- a/test-client/tsconfig.json
+++ b/test-client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "references": []
+}


### PR DESCRIPTION
Add an example NodeJS client that retrieves the raw operation data.

Apart from type definitions, the client uses minimal powersync dependencies, to attempt to be a standalone example.

See the readme for details.