### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/packages_release.yaml
+++ b/.github/workflows/packages_release.yaml
@@ -67,8 +67,13 @@ jobs:
 
           # Use jq to check if the specific package is in the array
           # Ensure the JSON is valid by echoing it into jq
+
+          set +e  # Disable immediate exit on non-zero return
           echo "$packages" | jq -e '[.[] | select(.name == "@powersync/service-image")] | length > 0' > /dev/null
-          if [ $? -eq 0 ]; then
+          jq_exit_code=$?
+          set -e  # Re-enable immediate exit
+
+          if [ $jq_exit_code -eq 0 ]; then
             echo "release_created=true" >> $GITHUB_OUTPUT
           else
             echo "release_created=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Overview

This fixes a bug in the DockerHub release workflow. See the failed run [here](https://github.com/powersync-ja/powersync-service/actions/runs/10286203733/job/28466299830)

This action failed due to the `jq` test returning a non-zero exit code. The exit code is required in order to determine if the service image was released.

This fix allows using the return code in the following `if` block.

## Testing

This was tested locally by adding the action code into a `test.sh` file which was executed with different `$package` variables. The `echo` lines were modified for demonstrtion.

<img width="908" alt="image" src="https://github.com/user-attachments/assets/fb6fb119-b309-4526-98fa-7e7cdce4e227">
