### PR TITLE
[test-client] Include endpoint as additional audience

### DIFF
--- a/test-client/src/auth.ts
+++ b/test-client/src/auth.ts
@@ -37,7 +37,7 @@ export async function getCredentials(options: CredentialsOptions): Promise<{ end
       endpoint = `http://127.0.0.1:${parsed.port ?? 8080}`;
     }
 
-    const aud = parsed.client_auth?.audience?.[0] ?? endpoint;
+    const aud = [parsed.client_auth?.audience?.[0], endpoint].filter((a) => a != null);
 
     const rawKey = keys[0];
     const key = await jose.importJWK(rawKey);
@@ -50,7 +50,7 @@ export async function getCredentials(options: CredentialsOptions): Promise<{ end
       .setIssuedAt()
       .setIssuer('test-client')
       .setAudience(aud)
-      .setExpirationTime('1h')
+      .setExpirationTime('24h')
       .sign(key);
 
     return { token, endpoint };

--- a/test-client/src/bin.ts
+++ b/test-client/src/bin.ts
@@ -20,7 +20,8 @@ program
   .command('generate-token')
   .description('Generate a JWT from for a given powersync.yaml config file')
   .option('-c, --config [config]', 'path to powersync.yaml')
-  .option('-u, --sub [sub]', 'sub field for auto-generated token')
+  .option('-u, --sub [sub]', 'payload sub')
+  .option('-e, --endpoint [endpoint]', 'additional payload aud')
   .action(async (options) => {
     const credentials = await getCredentials(options);
     const decoded = await jose.decodeJwt(credentials.token);


### PR DESCRIPTION
A self-hosted setup often uses `powersync-dev` as the audience, instead of the endpoint URL. This updates the generate-token script to include the endpoint URL as an additional audience. This defaults to `http://127.0.0.1:<port>`. but can be customized.

This also increases the token expiry from 1h to 24h.

Combined with https://github.com/powersync-ja/powersync-js/pull/264, this helps streamline usage of the diagnostics app for local development.

Sample:

```
pnpm generate-token -c ../service/powersync.yaml 

> test-client@0.1.0 generate-token /home/ralf/src/powersync-service/test-client
> tsc -b && node dist/bin.js generate-token "-c" "../service/powersync.yaml"

Payload:
{
  "sub": "test_user",
  "iat": 1723548362,
  "iss": "test-client",
  "aud": [
    "powersync-dev",
    "http://127.0.0.1:8080"
  ],
  "exp": 1723634762
}
Token:
eyJhbGciOiJIUzI1NiIsImtpZCI6InBvd2Vyc3luYy1kZXYifQ.e...
```