### PR TITLE
Add TableV2 / TypeScript schema generator

### DIFF
--- a/.changeset/thirty-bikes-move.md
+++ b/.changeset/thirty-bikes-move.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Add TypeScript/TableV2 schema generator

--- a/packages/sync-rules/src/JsLegacySchemaGenerator.ts
+++ b/packages/sync-rules/src/JsLegacySchemaGenerator.ts
@@ -4,7 +4,7 @@ import { SqlSyncRules } from './SqlSyncRules.js';
 import { SourceSchema } from './types.js';
 
 export class JsLegacySchemaGenerator extends SchemaGenerator {
-  readonly key = 'js';
+  readonly key = 'jsLegacy';
   readonly label = 'JavaScript (legacy syntax)';
   readonly mediaType = 'text/javascript';
   readonly fileName = 'schema.js';

--- a/packages/sync-rules/src/JsLegacySchemaGenerator.ts
+++ b/packages/sync-rules/src/JsLegacySchemaGenerator.ts
@@ -3,10 +3,10 @@ import { SchemaGenerator } from './SchemaGenerator.js';
 import { SqlSyncRules } from './SqlSyncRules.js';
 import { SourceSchema } from './types.js';
 
-export class JsSchemaGenerator extends SchemaGenerator {
+export class JsLegacySchemaGenerator extends SchemaGenerator {
   readonly key = 'js';
-  readonly label = 'JavaScript';
-  readonly mediaType = 'application/javascript';
+  readonly label = 'JavaScript (legacy syntax)';
+  readonly mediaType = 'text/javascript';
   readonly fileName = 'schema.js';
 
   generate(source: SqlSyncRules, schema: SourceSchema): string {

--- a/packages/sync-rules/src/TsSchemaGenerator.ts
+++ b/packages/sync-rules/src/TsSchemaGenerator.ts
@@ -1,0 +1,50 @@
+import { ColumnDefinition, TYPE_INTEGER, TYPE_REAL, TYPE_TEXT } from './ExpressionType.js';
+import { SchemaGenerator } from './SchemaGenerator.js';
+import { SqlSyncRules } from './SqlSyncRules.js';
+import { SourceSchema } from './types.js';
+
+export class TsSchemaGenerator extends SchemaGenerator {
+  readonly key = 'ts';
+  readonly label = 'TypeScript';
+  readonly mediaType = 'application/typescript';
+  readonly fileName = 'schema.ts';
+
+  generate(source: SqlSyncRules, schema: SourceSchema): string {
+    const tables = super.getAllTables(source, schema);
+
+    return `import { column, Schema, TableV2 } from '@powersync/web';
+// OR: import { column, Schema, TableV2 } from '@powersync/react-native';
+
+${tables.map((table) => this.generateTable(table.name, table.columns)).join('\n\n')}
+
+export const AppSchema = new Schema({
+  ${tables.map((table) => table.name).join(',\n  ')}
+});
+
+export type Database = (typeof AppSchema)['types'];
+`;
+  }
+
+  private generateTable(name: string, columns: ColumnDefinition[]): string {
+    return `const ${name} = new TableV2(
+  {
+    // id column (text) is automatically included
+    ${columns.map((c) => this.generateColumn(c)).join(',\n    ')}
+  },
+  { indexes: {} }
+);`;
+  }
+
+  private generateColumn(column: ColumnDefinition) {
+    const t = column.type;
+    if (t.typeFlags & TYPE_TEXT) {
+      return `${column.name}: column.text`;
+    } else if (t.typeFlags & TYPE_REAL) {
+      return `${column.name}: column.real`;
+    } else if (t.typeFlags & TYPE_INTEGER) {
+      return `${column.name}: column.integer`;
+    } else {
+      return `${column.name}: column.text`;
+    }
+  }
+}

--- a/packages/sync-rules/src/TsSchemaGenerator.ts
+++ b/packages/sync-rules/src/TsSchemaGenerator.ts
@@ -4,9 +4,25 @@ import { SqlSyncRules } from './SqlSyncRules.js';
 import { SourceSchema } from './types.js';
 
 export interface TsSchemaGeneratorOptions {
-  language?: 'ts' | 'js';
-  imports?: 'web' | 'react-native' | 'auto';
+  language?: TsSchemaLanguage;
+  imports?: TsSchemaImports;
 }
+
+export enum TsSchemaLanguage {
+  ts = 'ts',
+  /** Excludes types from the generated schema. */
+  js = 'js'
+}
+
+export enum TsSchemaImports {
+  web = 'web',
+  reactNative = 'reactNative',
+  /**
+   * Emits imports for `@powersync/web`, with comments for `@powersync/react-native`.
+   */
+  auto = 'auto'
+}
+
 export class TsSchemaGenerator extends SchemaGenerator {
   readonly key = 'ts';
   readonly label = 'TypeScript';
@@ -32,8 +48,8 @@ ${this.generateTypeExports()}`;
   }
 
   private generateTypeExports() {
-    const lang = this.options.language ?? 'ts';
-    if (lang == 'ts') {
+    const lang = this.options.language ?? TsSchemaLanguage.ts;
+    if (lang == TsSchemaLanguage.ts) {
       return `export type Database = (typeof AppSchema)['types'];\n`;
     } else {
       return ``;
@@ -42,9 +58,9 @@ ${this.generateTypeExports()}`;
 
   private generateImports() {
     const importStyle = this.options.imports ?? 'auto';
-    if (importStyle == 'web') {
+    if (importStyle == TsSchemaImports.web) {
       return `import { column, Schema, TableV2 } from '@powersync/web';`;
-    } else if (importStyle == 'react-native') {
+    } else if (importStyle == TsSchemaImports.reactNative) {
       return `import { column, Schema, TableV2 } from '@powersync/react-native';`;
     } else {
       return `import { column, Schema, TableV2 } from '@powersync/web';

--- a/packages/sync-rules/src/TsSchemaGenerator.ts
+++ b/packages/sync-rules/src/TsSchemaGenerator.ts
@@ -3,17 +3,24 @@ import { SchemaGenerator } from './SchemaGenerator.js';
 import { SqlSyncRules } from './SqlSyncRules.js';
 import { SourceSchema } from './types.js';
 
+export interface TsSchemaGeneratorOptions {
+  language?: 'ts' | 'js';
+  imports?: 'web' | 'react-native' | 'auto';
+}
 export class TsSchemaGenerator extends SchemaGenerator {
   readonly key = 'ts';
   readonly label = 'TypeScript';
   readonly mediaType = 'application/typescript';
   readonly fileName = 'schema.ts';
 
+  constructor(public readonly options: TsSchemaGeneratorOptions = {}) {
+    super();
+  }
+
   generate(source: SqlSyncRules, schema: SourceSchema): string {
     const tables = super.getAllTables(source, schema);
 
-    return `import { column, Schema, TableV2 } from '@powersync/web';
-// OR: import { column, Schema, TableV2 } from '@powersync/react-native';
+    return `${this.generateImports()}
 
 ${tables.map((table) => this.generateTable(table.name, table.columns)).join('\n\n')}
 
@@ -21,8 +28,28 @@ export const AppSchema = new Schema({
   ${tables.map((table) => table.name).join(',\n  ')}
 });
 
-export type Database = (typeof AppSchema)['types'];
-`;
+${this.generateTypeExports()}`;
+  }
+
+  private generateTypeExports() {
+    const lang = this.options.language ?? 'ts';
+    if (lang == 'ts') {
+      return `export type Database = (typeof AppSchema)['types'];\n`;
+    } else {
+      return ``;
+    }
+  }
+
+  private generateImports() {
+    const importStyle = this.options.imports ?? 'auto';
+    if (importStyle == 'web') {
+      return `import { column, Schema, TableV2 } from '@powersync/web';`;
+    } else if (importStyle == 'react-native') {
+      return `import { column, Schema, TableV2 } from '@powersync/react-native';`;
+    } else {
+      return `import { column, Schema, TableV2 } from '@powersync/web';
+// OR: import { column, Schema, TableV2 } from '@powersync/react-native';`;
+    }
   }
 
   private generateTable(name: string, columns: ColumnDefinition[]): string {

--- a/packages/sync-rules/src/TsSchemaGenerator.ts
+++ b/packages/sync-rules/src/TsSchemaGenerator.ts
@@ -24,13 +24,27 @@ export enum TsSchemaImports {
 }
 
 export class TsSchemaGenerator extends SchemaGenerator {
-  readonly key = 'ts';
-  readonly label = 'TypeScript';
-  readonly mediaType = 'application/typescript';
-  readonly fileName = 'schema.ts';
+  readonly key: string;
+  readonly fileName: string;
+  readonly mediaType: string;
+  readonly label: string;
+
+  readonly language: TsSchemaLanguage;
 
   constructor(public readonly options: TsSchemaGeneratorOptions = {}) {
     super();
+
+    this.language = options.language ?? TsSchemaLanguage.ts;
+    this.key = this.language;
+    if (this.language == TsSchemaLanguage.ts) {
+      this.fileName = 'schema.ts';
+      this.mediaType = 'text/typescript';
+      this.label = 'TypeScript';
+    } else {
+      this.fileName = 'schema.js';
+      this.mediaType = 'text/javascript';
+      this.label = 'JavaScript';
+    }
   }
 
   generate(source: SqlSyncRules, schema: SourceSchema): string {
@@ -48,8 +62,7 @@ ${this.generateTypeExports()}`;
   }
 
   private generateTypeExports() {
-    const lang = this.options.language ?? TsSchemaLanguage.ts;
-    if (lang == TsSchemaLanguage.ts) {
+    if (this.language == TsSchemaLanguage.ts) {
       return `export type Database = (typeof AppSchema)['types'];\n`;
     } else {
       return ``;

--- a/packages/sync-rules/src/generators.ts
+++ b/packages/sync-rules/src/generators.ts
@@ -1,7 +1,10 @@
 import { DartSchemaGenerator } from './DartSchemaGenerator.js';
-import { JsSchemaGenerator } from './JsSchemaGenerator.js';
+import { JsLegacySchemaGenerator } from './JsLegacySchemaGenerator.js';
+import { TsSchemaGenerator, TsSchemaLanguage } from './TsSchemaGenerator.js';
 
 export const schemaGenerators = {
-  js: new JsSchemaGenerator(),
+  ts: new TsSchemaGenerator(),
+  js: new TsSchemaGenerator({ language: TsSchemaLanguage.js }),
+  jsLegacy: new JsLegacySchemaGenerator(),
   dart: new DartSchemaGenerator()
 };

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -14,6 +14,7 @@ export * from './ExpressionType.js';
 export * from './SchemaGenerator.js';
 export * from './DartSchemaGenerator.js';
 export * from './JsSchemaGenerator.js';
+export * from './TsSchemaGenerator.js';
 export * from './generators.js';
 export * from './SqlDataQuery.js';
 export * from './request_functions.js';

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -13,7 +13,7 @@ export * from './StaticSchema.js';
 export * from './ExpressionType.js';
 export * from './SchemaGenerator.js';
 export * from './DartSchemaGenerator.js';
-export * from './JsSchemaGenerator.js';
+export * from './JsLegacySchemaGenerator.js';
 export * from './TsSchemaGenerator.js';
 export * from './generators.js';
 export * from './SqlDataQuery.js';

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_SCHEMA,
   DEFAULT_TAG,
   DartSchemaGenerator,
-  JsSchemaGenerator,
+  JsLegacySchemaGenerator,
   SqlSyncRules,
   StaticSchema,
   TsSchemaGenerator
@@ -763,7 +763,7 @@ bucket_definitions:
 ]);
 `);
 
-    expect(new JsSchemaGenerator().generate(rules, schema)).toEqual(`new Schema([
+    expect(new JsLegacySchemaGenerator().generate(rules, schema)).toEqual(`new Schema([
   new Table({
     name: 'assets1',
     columns: [

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -5,8 +5,10 @@ import {
   DartSchemaGenerator,
   JsSchemaGenerator,
   SqlSyncRules,
-  StaticSchema
+  StaticSchema,
+  TsSchemaGenerator
 } from '../../src/index.js';
+
 import { ASSETS, BASIC_SCHEMA, TestSourceTable, USERS, normalizeTokenParameters } from './util.js';
 
 describe('sync rules', () => {
@@ -781,5 +783,39 @@ bucket_definitions:
   })
 ])
 `);
+
+    expect(new TsSchemaGenerator().generate(rules, schema)).toEqual(
+      `import { column, Schema, TableV2 } from '@powersync/web';
+// OR: import { column, Schema, TableV2 } from '@powersync/react-native';
+
+const assets1 = new TableV2(
+  {
+    // id column (text) is automatically included
+    name: column.text,
+    count: column.integer,
+    owner_id: column.text
+  },
+  { indexes: {} }
+);
+
+const assets2 = new TableV2(
+  {
+    // id column (text) is automatically included
+    name: column.text,
+    count: column.integer,
+    other_id: column.text,
+    foo: column.text
+  },
+  { indexes: {} }
+);
+
+export const AppSchema = new Schema({
+  assets1,
+  assets2
+});
+
+export type Database = (typeof AppSchema)['types'];
+`
+    );
   });
 });


### PR DESCRIPTION
We have been recommending this syntax for a while - the generator should use this by default.

We can still give the option of the old syntax for apps not wanting to switch.

The generator here includes the entire "schema" file, including imports and exports.