### PR TITLE
[Fix] Add missing changeset

### DIFF
--- a/.changeset/plenty-ads-matter.md
+++ b/.changeset/plenty-ads-matter.md
@@ -2,4 +2,4 @@
 '@powersync/service-rsocket-router': patch
 ---
 
-Added a log for current count of connected WebSocket connections.
+Added a tog for current count of connected WebSocket connections.

--- a/.changeset/plenty-ads-matter.md
+++ b/.changeset/plenty-ads-matter.md
@@ -2,4 +2,4 @@
 '@powersync/service-rsocket-router': patch
 ---
 
-Added a tog for current count of connected WebSocket connections.
+Added a log for current count of connected WebSocket connections.

--- a/.changeset/plenty-ads-matter.md
+++ b/.changeset/plenty-ads-matter.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-rsocket-router': patch
+---
+
+Added a log for current count of connected WebSocket connections.


### PR DESCRIPTION
# Overview

https://github.com/powersync-ja/powersync-service/pull/49/files added a log entry for the number of currently connected WebSockets. This change is useful for debugging, but since no Changeset was added for this - no package version bump was done and the changes are not present downstream. The open edition has the change due to the Docker image copying the package from the repo source.

