### PR TITLE
Log sync lock

### DIFF
--- a/.changeset/tricky-phones-tell.md
+++ b/.changeset/tricky-phones-tell.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Log stats on sync lock when reaching concurrency limit


### PR DESCRIPTION
Lock sync lock stats when get close to the concurrency limit. This should give us an indication if/when this lock is the cause of sync issues.

