### PR TITLE
[Fix] Add log to WebSocket Endpoint

### DIFF
--- a/.changeset/stale-llamas-shave.md
+++ b/.changeset/stale-llamas-shave.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Added `client_id` log to WebSocket `sync/stream` endpoint.

--- a/packages/service-core/src/routes/endpoints/socket-route.ts
+++ b/packages/service-core/src/routes/endpoints/socket-route.ts
@@ -124,6 +124,7 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
         disposer();
         logger.info(`Sync stream complete`, {
           user_id: syncParams.user_id,
+          client_id: params.client_id,
           user_agent: context.user_agent,
           operations_synced: tracker.operationsSynced,
           data_synced_bytes: tracker.dataSyncedBytes


### PR DESCRIPTION
# Overview

This adds the `client_id` from https://github.com/powersync-ja/powersync-service/pull/64  to the logs for WebSocket sync endpoints.