### PR TITLE
Add browser user agent to logs for websocket connections

### DIFF
--- a/packages/rsocket-router/src/router/ReactiveSocketRouter.ts
+++ b/packages/rsocket-router/src/router/ReactiveSocketRouter.ts
@@ -54,7 +54,9 @@ export class ReactiveSocketRouter<C> {
     const rSocketServer = new RSocketServer({
       transport,
       acceptor: {
-        accept: async (payload) => {
+        accept: async (payload, peer) => {
+          const userAgent = (peer as any).connection.userAgent;
+
           const { max_concurrent_connections } = this.options ?? {};
           logger.info(`Currently have ${wss.clients.size} active WebSocket connection(s)`);
           // wss.clients.size includes this connection, so we check for greater than
@@ -75,7 +77,7 @@ export class ReactiveSocketRouter<C> {
             throw new errors.AuthorizationError('No context meta data provided');
           }
 
-          const context = await params.contextProvider(payload.metadata!);
+          const context = await params.contextProvider(payload.metadata!, { userAgent: userAgent });
 
           return {
             // RequestStream is currently the only supported connection type

--- a/packages/rsocket-router/src/router/transport/WebsocketDuplexConnection.ts
+++ b/packages/rsocket-router/src/router/transport/WebsocketDuplexConnection.ts
@@ -16,6 +16,7 @@
  */
 
 import { logger } from '@powersync/lib-services-framework';
+import { IncomingMessage } from 'http';
 import {
   Closeable,
   Deferred,
@@ -33,6 +34,8 @@ import WebSocket from 'ws';
 
 export class WebsocketDuplexConnection extends Deferred implements DuplexConnection, Outbound {
   readonly multiplexerDemultiplexer: Multiplexer & Demultiplexer & FrameHandler;
+
+  userAgent?: string;
 
   constructor(
     private websocketDuplex: Duplex,
@@ -119,7 +122,8 @@ export class WebsocketDuplexConnection extends Deferred implements DuplexConnect
       frame: Frame,
       outbound: Outbound & Closeable
     ) => Multiplexer & Demultiplexer & FrameHandler,
-    rawSocket: WebSocket.WebSocket
+    rawSocket: WebSocket.WebSocket,
+    request?: IncomingMessage
   ): void {
     socket.once('data', async (buffer) => {
       let frame: Frame | undefined = undefined;
@@ -135,6 +139,7 @@ export class WebsocketDuplexConnection extends Deferred implements DuplexConnect
       }
 
       const connection = new WebsocketDuplexConnection(socket, frame, multiplexerDemultiplexerFactory, rawSocket);
+      connection.userAgent = request?.headers['user-agent'];
       if (connection.done) {
         return;
       }

--- a/packages/rsocket-router/src/router/types.ts
+++ b/packages/rsocket-router/src/router/types.ts
@@ -53,9 +53,13 @@ export type IReactiveStreamInput<I, O, C> = Omit<IReactiveStream<I, O, C>, 'path
 
 export type ReactiveEndpoint = IReactiveStream;
 
+export interface RequestData {
+  userAgent?: string;
+}
+
 export type CommonParams<C> = {
   endpoints: Array<ReactiveEndpoint>;
-  contextProvider: (metaData: Buffer) => Promise<C>;
+  contextProvider: (metaData: Buffer, request: RequestData) => Promise<C>;
   metaDecoder: (meta: Buffer) => Promise<RequestMeta>;
   payloadDecoder: (rawData?: Buffer) => Promise<any>;
 };

--- a/packages/service-core/src/routes/endpoints/sync-stream.ts
+++ b/packages/service-core/src/routes/endpoints/sync-stream.ts
@@ -22,7 +22,10 @@ export const syncStreamed = routeDefinition({
   handler: async (payload) => {
     const system = payload.context.system;
     const headers = payload.request.headers;
-    const userAgent = headers['x-user-agent'] ?? headers['user-agent'];
+
+    const userAgentCustom = headers['x-user-agent'];
+    const userAgentbase = headers['user-agent'];
+    const userAgent = [userAgentCustom, userAgentbase].filter((ua) => ua != null).join(' ');
     const clientId = payload.params.client_id;
 
     if (system.closed) {


### PR DESCRIPTION
The user agent is in the websocket request headers, but needs to be added in a couple of places to make it into the request context.