### PR TITLE
Fix hanging streams

### DIFF
--- a/.changeset/dull-foxes-explode.md
+++ b/.changeset/dull-foxes-explode.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-rsocket-router': patch
+'@powersync/service-core': patch
+---
+
+Fix hanging streams

--- a/packages/rsocket-router/src/router/SocketRouterListener.ts
+++ b/packages/rsocket-router/src/router/SocketRouterListener.ts
@@ -1,16 +1,11 @@
 import { BaseObserver } from '../utils/BaseObserver.js';
 
 export interface SocketRouterListener {
-  cancel: () => void;
   onExtension: () => void;
   request: (n: number) => void;
 }
 
 export class SocketRouterObserver extends BaseObserver<SocketRouterListener> {
-  triggerCancel() {
-    this.iterateListeners((l) => l.cancel?.());
-  }
-
   triggerExtension() {
     this.iterateListeners((l) => l.onExtension?.());
   }

--- a/packages/rsocket-router/src/router/types.ts
+++ b/packages/rsocket-router/src/router/types.ts
@@ -25,6 +25,7 @@ export type SocketResponder = OnTerminalSubscriber & OnNextSubscriber & OnExtens
 export type CommonStreamPayload = {
   observer: SocketRouterObserver;
   responder: SocketResponder;
+  signal: AbortSignal;
 };
 
 export type ReactiveStreamPayload<O> = CommonStreamPayload & {

--- a/packages/rsocket-router/tests/src/requests.test.ts
+++ b/packages/rsocket-router/tests/src/requests.test.ts
@@ -23,6 +23,7 @@ async function handleRoute(path: string, endpoints: ReactiveEndpoint[], responde
       responder
     },
     createMockObserver(),
+    new AbortController(),
     {
       contextProvider: async () => ({}),
       endpoints,


### PR DESCRIPTION
A race conditions with websocket handling could cause the route handler to "hang" indefinitely, after the underlying connection is closed. This surfaces in two ways:
1. The "concurrent connections" metric reports these as connections, giving a slow increase in connection count over time.
2. The `syncSemaphore` could permanently hold on to a lock for these, eventually leading to no locks being available, and no users able to sync.

While the race condition is rare, it does build up over time.

In tests I could trigger the race condition in two places:
1. Closing a connection before `observer.registerListener()` is called, by setting `lifetime: 0` on the client. I'm not sure whether this ever happened in practice.
2. Close the connection after next batch of data is retrieved, but before the `if (requestedN <= 0)` check. This caused the handler to indefinitely wait for the next `request()` or `cancel()` to be triggered.

The fix here is to:
1. Use an `AbortController` instead of the observer to handle stream cancellation.
2. Check `if (signal.aborted)` to see whether the stream is already cancelled, wherever we listen for cancellation.
3. Throw an error when unable to acquire the `syncSemaphore` within 30 seconds, instead of just waiting silently.