### PR TITLE
Warn on table/column identifier case issues

### DIFF
--- a/.changeset/short-bats-sin.md
+++ b/.changeset/short-bats-sin.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': minor
+---
+
+Warn when identifiers are automatically convererted to lower case.

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -76,6 +76,7 @@ export class SqlDataQuery {
       sql,
       schema: querySchema
     });
+    tools.checkSpecificNameCase(tableRef);
     const filter = tools.compileWhereClause(where);
 
     const inputParameterNames = filter.inputParameters!.map((p) => p.key);

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -96,6 +96,7 @@ export class SqlParameterQuery {
       supports_parameter_expressions: true,
       schema: querySchema
     });
+    tools.checkSpecificNameCase(tableRef);
     const where = q.where;
     const filter = tools.compileWhereClause(where);
 
@@ -118,6 +119,9 @@ export class SqlParameterQuery {
 
     for (let column of q.columns ?? []) {
       const name = tools.getSpecificOutputName(column);
+      if (column.alias != null) {
+        tools.checkSpecificNameCase(column.alias);
+      }
       if (tools.isTableRef(column.expr)) {
         rows.lookup_columns.push(column);
         const extractor = tools.compileRowValueExtractor(column.expr);

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -39,6 +39,9 @@ export class StaticSqlParameterQuery {
     }
 
     for (let column of columns) {
+      if (column.alias != null) {
+        tools.checkSpecificNameCase(column.alias);
+      }
       const name = tools.getSpecificOutputName(column);
       const extractor = tools.compileParameterValueExtractor(column.expr);
       if (isClauseError(extractor)) {

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -194,4 +194,64 @@ describe('data queries', () => {
     const query = SqlDataQuery.fromSql('mybucket', ['org_id'], sql);
     expect(query.errors[0].message).toMatch(/Parameter match expression is not allowed here/);
   });
+
+  test('case-sensitive queries (1)', () => {
+    const sql = 'SELECT * FROM Assets';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "Assets" instead.` }
+    ]);
+  });
+
+  test('case-sensitive queries (2)', () => {
+    const sql = 'SELECT *, Name FROM assets';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "Name" instead.` }
+    ]);
+  });
+
+  test('case-sensitive queries (3)', () => {
+    const sql = 'SELECT * FROM assets WHERE Archived = False';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "Archived" instead.` }
+    ]);
+  });
+
+  test.skip('case-sensitive queries (4)', () => {
+    // Cannot validate table alias yet
+    const sql = 'SELECT * FROM assets as myAssets';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "myAssets" instead.` }
+    ]);
+  });
+
+  test.skip('case-sensitive queries (5)', () => {
+    // Cannot validate table alias yet
+    const sql = 'SELECT * FROM assets myAssets';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "myAssets" instead.` }
+    ]);
+  });
+
+  test.skip('case-sensitive queries (6)', () => {
+    // Cannot validate anything with a schema yet
+    const sql = 'SELECT * FROM public.ASSETS';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "ASSETS" instead.` }
+    ]);
+  });
+
+  test.skip('case-sensitive queries (7)', () => {
+    // Cannot validate schema yet
+    const sql = 'SELECT * FROM PUBLIC.assets';
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "PUBLIC" instead.` }
+    ]);
+  });
 });

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -376,7 +376,10 @@ describe('parameter queries', () => {
     // Postgres and/or SQLite.
     const sql = 'SELECT users.userId AS user_id FROM users WHERE users.userId = token_parameters.user_id';
     const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
-    expect(query.errors).toEqual([]);
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "userId" instead.` },
+      { message: `Unquoted identifiers are converted to lower-case. Use "userId" instead.` }
+    ]);
     query.id = '1';
 
     expect(query.evaluateParameterRow({ userId: 'user1' })).toEqual([]);
@@ -386,6 +389,46 @@ describe('parameter queries', () => {
 
         bucket_parameters: [{ user_id: 'user1' }]
       }
+    ]);
+  });
+
+  test('case-sensitive parameter queries (3)', () => {
+    const sql = 'SELECT user_id FROM users WHERE Users.user_id = token_parameters.user_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "Users" instead.` }
+    ]);
+  });
+
+  test('case-sensitive parameter queries (4)', () => {
+    const sql = 'SELECT Users.user_id FROM users WHERE user_id = token_parameters.user_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "Users" instead.` }
+    ]);
+  });
+
+  test('case-sensitive parameter queries (5)', () => {
+    const sql = 'SELECT user_id FROM Users WHERE user_id = token_parameters.user_id';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "Users" instead.` }
+    ]);
+  });
+
+  test('case-sensitive parameter queries (6)', () => {
+    const sql = 'SELECT userId FROM users';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "userId" instead.` }
+    ]);
+  });
+
+  test('case-sensitive parameter queries (7)', () => {
+    const sql = 'SELECT user_id as userId FROM users';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "userId" instead.` }
     ]);
   });
 

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -82,6 +82,14 @@ describe('static parameter queries', () => {
     expect(query.getStaticBucketIds(normalizeTokenParameters({ user_id: 'user1' }))).toEqual(['mybucket["user1"]']);
   });
 
+  test('case-sensitive queries (1)', () => {
+    const sql = 'SELECT request.user_id() as USER_ID';
+    const query = SqlParameterQuery.fromSql('mybucket', sql) as SqlParameterQuery;
+    expect(query.errors).toMatchObject([
+      { message: `Unquoted identifiers are converted to lower-case. Use "USER_ID" instead.` }
+    ]);
+  });
+
   describe('dangerous queries', function () {
     function testDangerousQuery(sql: string) {
       test(sql, function () {


### PR DESCRIPTION
For queries such as `SELECT * FROM assets WHERE userId = bucket.userId`, both instances of `userId` are converted to a lower-case `userid`. This is standard behavior in Postgres SQL, and common in other SQL variations as well. However, it is often unexpected for developers, causing difficult-to-debug issues.

This adds a warning when an unquoted identifier is used that is not all lower-case. We don't get enough info to properly split schema name, table name and table alias, so the check does nothing for now if a schema name or table alias is encountered.

The check is especially relevant when schema information is not available for validations.

![image](https://github.com/user-attachments/assets/a44413e2-75fe-4cfa-8b04-2e8a40dbf6a0)
