### PR TITLE
Use standard function composition for IN operator

### DIFF
--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -117,7 +117,7 @@ export class StaticSqlParameterQuery {
 
   get usesUnauthenticatedRequestParameters(): boolean {
     // select where request.parameters() ->> 'include_comments'
-    const unauthenticatedFilter = this.filter!.usesUnauthenticatedRequestParameters;
+    const unauthenticatedFilter = this.filter?.usesUnauthenticatedRequestParameters;
 
     // select request.parameters() ->> 'project_id'
     const unauthenticatedExtractor =

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -36,11 +36,6 @@ export interface SqlFunction {
   readonly debugName: string;
   call: (...args: SqliteValue[]) => SqliteValue;
   getReturnType(args: ExpressionType[]): ExpressionType;
-  /**
-   * For error messages such as "Cannot use bucket parameters [debugDescription]"
-   * Default: 'in expressions'
-   */
-  debugDescription?: string;
 }
 
 export interface DocumentedSqlFunction extends SqlFunction {

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -1,5 +1,5 @@
 import { JSONBig } from '@powersync/service-jsonbig';
-import { SQLITE_FALSE, SQLITE_TRUE, sqliteBool, sqliteNot } from './sql_support.js';
+import { getOperatorFunction, SQLITE_FALSE, SQLITE_TRUE, sqliteBool, sqliteNot } from './sql_support.js';
 import { SqliteValue } from './types.js';
 import { jsonValueToSqlite } from './utils.js';
 // Declares @syncpoint/wkx module
@@ -36,6 +36,11 @@ export interface SqlFunction {
   readonly debugName: string;
   call: (...args: SqliteValue[]) => SqliteValue;
   getReturnType(args: ExpressionType[]): ExpressionType;
+  /**
+   * For error messages such as "Cannot use bucket parameters [debugDescription]"
+   * Default: 'in expressions'
+   */
+  debugDescription?: string;
 }
 
 export interface DocumentedSqlFunction extends SqlFunction {
@@ -786,6 +791,8 @@ export const OPERATOR_NOT: SqlFunction = {
     return ExpressionType.INTEGER;
   }
 };
+
+export const OPERATOR_IN = getOperatorFunction('IN');
 
 export function castOperator(castTo: string | undefined): SqlFunction | null {
   if (castTo == null || !CAST_TYPES.has(castTo)) {

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -41,6 +41,38 @@ describe('data queries', () => {
     expect(query.evaluateRow(ASSETS, { id: 'asset1', org_id: null })).toEqual([]);
   });
 
+  test('static IN data query', function () {
+    const sql = `SELECT * FROM assets WHERE 'green' IN assets.categories`;
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateRow(ASSETS, { id: 'asset1', categories: JSON.stringify(['red', 'green']) })).toMatchObject([
+      {
+        bucket: 'mybucket[]',
+        table: 'assets',
+        id: 'asset1'
+      }
+    ]);
+
+    expect(query.evaluateRow(ASSETS, { id: 'asset1', categories: JSON.stringify(['red', 'blue']) })).toEqual([]);
+  });
+
+  test('data IN static query', function () {
+    const sql = `SELECT * FROM assets WHERE assets.condition IN '["good","great"]'`;
+    const query = SqlDataQuery.fromSql('mybucket', [], sql);
+    expect(query.errors).toEqual([]);
+
+    expect(query.evaluateRow(ASSETS, { id: 'asset1', condition: 'good' })).toMatchObject([
+      {
+        bucket: 'mybucket[]',
+        table: 'assets',
+        id: 'asset1'
+      }
+    ]);
+
+    expect(query.evaluateRow(ASSETS, { id: 'asset1', condition: 'bad' })).toEqual([]);
+  });
+
   test('table alias', function () {
     const sql = 'SELECT * FROM assets as others WHERE others.org_id = bucket.org_id';
     const query = SqlDataQuery.fromSql('mybucket', ['org_id'], sql);

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -158,7 +158,9 @@ describe('data queries', () => {
   test('invalid query - invalid IN', function () {
     const sql = 'SELECT * FROM assets WHERE assets.category IN bucket.categories';
     const query = SqlDataQuery.fromSql('mybucket', ['categories'], sql);
-    expect(query.errors).toMatchObject([{ type: 'fatal', message: 'Unsupported usage of IN operator' }]);
+    expect(query.errors).toMatchObject([
+      { type: 'fatal', message: 'Cannot use bucket parameters on the right side of IN operators' }
+    ]);
   });
 
   test('invalid query - not all parameters used', function () {


### PR DESCRIPTION
This allows some additional variations of the IN operator previously not supported:

```sql
-- parameter queries
SELECT WHERE request.jwt() ->> 'role' IN '["admin", "superuser"]'`
SELECT WHERE 'read:users' IN (request.jwt() ->> 'permissions')
SELECT WHERE 'test' IN '["test"]'

-- data queries
SELECT * FROM assets WHERE assets.condition IN '["good","great"]'
SELECT * FROM assets WHERE 'green' IN assets.categories
```

