### PR TITLE
Reduce memory usage of slot health check

### DIFF
--- a/.changeset/young-rockets-behave.md
+++ b/.changeset/young-rockets-behave.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix "JavaScript heap out of memory" on startup (slot health check)

--- a/packages/service-core/src/replication/WalStream.ts
+++ b/packages/service-core/src/replication/WalStream.ts
@@ -209,15 +209,22 @@ export class WalStream {
           // We peek a large number of changes here, to make it more likely to pick up replication slot errors.
           // For example, "publication does not exist" only occurs here if the peek actually includes changes related
           // to the slot.
-          await this.connections.pool.query({
-            statement: `SELECT *
-                    FROM pg_catalog.pg_logical_slot_peek_binary_changes($1, NULL, 1000, 'proto_version', '1',
-                                                                        'publication_names', $2)`,
+          logger.info(`Checking ${slotName}`);
+
+          // The actual results can be quite large, so we don't actually return everything
+          // due to memory and processing overhead that would create.
+          const cursor = await this.connections.pool.stream({
+            statement: `SELECT 1 FROM pg_catalog.pg_logical_slot_peek_binary_changes($1, NULL, 1000, 'proto_version', '1', 'publication_names', $2)`,
             params: [
               { type: 'varchar', value: slotName },
               { type: 'varchar', value: this.publication_name }
             ]
           });
+
+          for await (let _chunk of cursor) {
+            // No-op, just exhaust the cursor
+          }
+
           // Success
           logger.info(`Slot ${slotName} appears healthy`);
           return { needsInitialSync: false };


### PR DESCRIPTION
Fixes #86.

We use `pg_logical_slot_peek_binary_changes` to peak up to 1000 changes to check slot health on startup.

If the peaked changes are large, this can add significant processing and memory overhead, potentially leading to out-of-memory errors such as #86.

This changes to streaming results, as well as removing the large binary data from the results, to avoid that issue.