### PR TITLE
Fix uninitialized tag

### DIFF
--- a/.changeset/olive-spoons-stare.md
+++ b/.changeset/olive-spoons-stare.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Moved tag variable initialization in diagnostics route to ensure it is initialized before usage

--- a/packages/service-core/src/api/diagnostics.ts
+++ b/packages/service-core/src/api/diagnostics.ts
@@ -54,6 +54,10 @@ export async function getSyncRulesStatus(
   }
 
   const sourceConfig = await apiHandler.getSourceConfig();
+  // This is a bit weird.
+  // This method can run under some situations if no connection is configured.
+  // It will return a default tag if no connection is available. This default tag
+  // is not module specific.
   const tag = sourceConfig.tag ?? DEFAULT_TAG;
   const systemStorage = live_status ? bucketStorage.getInstance(sync_rules) : undefined;
   const status = await systemStorage?.getStatus();

--- a/packages/service-core/src/api/diagnostics.ts
+++ b/packages/service-core/src/api/diagnostics.ts
@@ -54,10 +54,8 @@ export async function getSyncRulesStatus(
   }
 
   const sourceConfig = await apiHandler.getSourceConfig();
-  // This is a bit weird.
-  // This method can run under some situations if no connection is configured.
-  // It will return a default tag if no connection is available. This default tag
-  // is not module specific.
+  // This method can run under some situations if no connection is configured yet.
+  // It will return a default tag in such a case. This default tag is not module specific.
   const tag = sourceConfig.tag ?? DEFAULT_TAG;
   const systemStorage = live_status ? bucketStorage.getInstance(sync_rules) : undefined;
   const status = await systemStorage?.getStatus();

--- a/packages/service-core/src/api/diagnostics.ts
+++ b/packages/service-core/src/api/diagnostics.ts
@@ -53,6 +53,8 @@ export async function getSyncRulesStatus(
     };
   }
 
+  const sourceConfig = await apiHandler.getSourceConfig();
+  const tag = sourceConfig.tag ?? DEFAULT_TAG;
   const systemStorage = live_status ? bucketStorage.getInstance(sync_rules) : undefined;
   const status = await systemStorage?.getStatus();
   let replication_lag_bytes: number | undefined = undefined;
@@ -128,15 +130,12 @@ export async function getSyncRulesStatus(
     })
   );
 
-  const sourceConfig = await apiHandler.getSourceConfig();
-  const tag = sourceConfig.tag ?? DEFAULT_TAG;
-
   return {
     content: include_content ? sync_rules.sync_rules_content : undefined,
     connections: [
       {
         id: sourceConfig.id ?? DEFAULT_DATASOURCE_ID,
-        tag: sourceConfig.tag ?? DEFAULT_TAG,
+        tag: tag,
         slot_name: sync_rules.slot_name,
         initial_replication_done: status?.snapshot_done ?? false,
         // TODO: Rename?


### PR DESCRIPTION
Picked up this issue while testing the diagnostics api call. The way the function was structured meant that the tag variable was accessed before being initialized. 