### PR TITLE
[MongoDB] Schema Endpoint Fix

### DIFF
--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -260,7 +260,8 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
         name: key,
         type: internal_type,
         sqlite_type: value.sqliteType.typeFlags,
-        internal_type
+        internal_type,
+        pg_type: internal_type
       };
     });
   }

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -255,10 +255,12 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
       }
     }
     return [...columns.entries()].map(([key, value]) => {
+      const internal_type = value.bsonTypes.size == 0 ? '' : [...value.bsonTypes].join(' | ');
       return {
         name: key,
+        type: internal_type,
         sqlite_type: value.sqliteType.typeFlags,
-        internal_type: value.bsonTypes.size == 0 ? '' : [...value.bsonTypes].join(' | ')
+        internal_type
       };
     });
   }

--- a/packages/types/src/definitions.ts
+++ b/packages/types/src/definitions.ts
@@ -132,7 +132,7 @@ export const TableSchema = t.object({
        * Internal postgres type, e.g. "varchar[]".
        * @deprecated - use internal_type instead
        */
-      pg_type: t.string.optional()
+      pg_type: t.string
     })
   )
 });

--- a/packages/types/src/definitions.ts
+++ b/packages/types/src/definitions.ts
@@ -126,7 +126,7 @@ export const TableSchema = t.object({
        * Full type name, e.g. "character varying(255)[]"
        * @deprecated - use internal_type
        */
-      type: t.string.optional(),
+      type: t.string,
 
       /**
        * Internal postgres type, e.g. "varchar[]".


### PR DESCRIPTION
# Overview

This reverts sone API facing type changes from [here](https://github.com/powersync-ja/powersync-service/pull/90/files#diff-01ef33ad4cd133d7161fe4d3ffd0dbf5acd29cd8480ea9f25fcb954f62376087). The deprecated `type` and `pg_type` are expected in upstream consumers of the service routes. This PR sets the values explicitly to the recommended alternative, `internal_type`. 

This fixes schema querying in the PowerSync dashboard.
