### PR TITLE
Immediately retry clear operations on timeout

### DIFF
--- a/.changeset/funny-pianos-allow.md
+++ b/.changeset/funny-pianos-allow.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix "operation exceeded time limit" error

--- a/packages/service-core/src/db/mongo.ts
+++ b/packages/service-core/src/db/mongo.ts
@@ -22,6 +22,13 @@ export const MONGO_SOCKET_TIMEOUT_MS = 60_000;
  */
 export const MONGO_OPERATION_TIMEOUT_MS = 30_000;
 
+/**
+ * Same as above, but specifically for clear operations.
+ *
+ * These are retried when reaching the timeout.
+ */
+export const MONGO_CLEAR_OPERATION_TIMEOUT_MS = 5_000;
+
 export function createMongoClient(config: configFile.PowerSyncConfig['storage']) {
   return new mongo.MongoClient(config.uri, {
     auth: {


### PR DESCRIPTION
Fixes "operation exceeded time limit" error displayed when clearing large amounts of bucket data after a sync rule update.

The error resolved automatically, but often caused confusion.