### PR TITLE
Fix storageStats error

### DIFF
--- a/.changeset/green-books-shout.md
+++ b/.changeset/green-books-shout.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix storageStats error in metrics endpoint when collections don't exist.

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -253,8 +253,6 @@ export interface SyncRulesBucketStorage {
    */
   clear(): Promise<void>;
 
-  setSnapshotDone(lsn: string): Promise<void>;
-
   autoActivate(): Promise<void>;
 
   /**

--- a/packages/service-core/src/storage/MongoBucketStorage.ts
+++ b/packages/service-core/src/storage/MongoBucketStorage.ts
@@ -294,22 +294,15 @@ export class MongoBucketStorage implements BucketStorageFactory {
   }
 
   async getStorageMetrics(): Promise<StorageMetrics> {
-    try {
-      return await this.getStorageMetricsInner();
-    } catch (e: unknown) {
-      // This can happen when migrations weren't run
+    const ignoreNotExiting = (e: unknown) => {
       if (e instanceof mongo.MongoServerError && e.codeName == 'NamespaceNotFound') {
-        return {
-          operations_size_bytes: 0,
-          parameters_size_bytes: 0,
-          replication_size_bytes: 0
-        };
+        // Collection doesn't exist - return 0
+        return [{ storageStats: { size: 0 } }];
+      } else {
+        return Promise.reject(e);
       }
-      throw e;
-    }
-  }
+    };
 
-  private async getStorageMetricsInner(): Promise<StorageMetrics> {
     const active_sync_rules = await this.getActiveSyncRules();
     if (active_sync_rules == null) {
       return {
@@ -323,34 +316,34 @@ export class MongoBucketStorage implements BucketStorageFactory {
       .aggregate([
         {
           $collStats: {
-            storageStats: {},
-            count: {}
+            storageStats: {}
           }
         }
       ])
-      .toArray();
+      .toArray()
+      .catch(ignoreNotExiting);
 
     const parameters_aggregate = await this.db.bucket_parameters
       .aggregate([
         {
           $collStats: {
-            storageStats: {},
-            count: {}
+            storageStats: {}
           }
         }
       ])
-      .toArray();
+      .toArray()
+      .catch(ignoreNotExiting);
 
     const replication_aggregate = await this.db.current_data
       .aggregate([
         {
           $collStats: {
-            storageStats: {},
-            count: {}
+            storageStats: {}
           }
         }
       ])
-      .toArray();
+      .toArray()
+      .catch(ignoreNotExiting);
 
     return {
       operations_size_bytes: operations_aggregate[0].storageStats.size,

--- a/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
+++ b/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
@@ -505,21 +505,6 @@ export class MongoSyncBucketStorage implements SyncRulesBucketStorage {
     );
   }
 
-  async setSnapshotDone(lsn: string): Promise<void> {
-    await this.db.sync_rules.updateOne(
-      {
-        _id: this.group_id
-      },
-      {
-        $set: {
-          snapshot_done: true,
-          persisted_lsn: lsn,
-          last_checkpoint_ts: new Date()
-        }
-      }
-    );
-  }
-
   async autoActivate(): Promise<void> {
     await this.db.client.withSession(async (session) => {
       await session.withTransaction(async () => {

--- a/packages/service-core/src/storage/mongo/db.ts
+++ b/packages/service-core/src/storage/mongo/db.ts
@@ -59,6 +59,9 @@ export class PowerSyncMongo {
     this.locks = this.db.collection('locks');
   }
 
+  /**
+   * Clear all collections.
+   */
   async clear() {
     await this.current_data.deleteMany({});
     await this.bucket_data.deleteMany({});
@@ -69,5 +72,22 @@ export class PowerSyncMongo {
     await this.write_checkpoints.deleteMany({});
     await this.instance.deleteOne({});
     await this.locks.deleteMany({});
+  }
+
+  /**
+   * Drop all collections.
+   *
+   * Primarily for tests.
+   */
+  async drop() {
+    await this.current_data.drop();
+    await this.bucket_data.drop();
+    await this.bucket_parameters.drop();
+    await this.op_id_sequence.drop();
+    await this.sync_rules.drop();
+    await this.source_tables.drop();
+    await this.write_checkpoints.drop();
+    await this.instance.drop();
+    await this.locks.drop();
   }
 }

--- a/packages/service-core/src/storage/mongo/db.ts
+++ b/packages/service-core/src/storage/mongo/db.ts
@@ -75,19 +75,11 @@ export class PowerSyncMongo {
   }
 
   /**
-   * Drop all collections.
+   * Drop the entire database.
    *
    * Primarily for tests.
    */
   async drop() {
-    await this.current_data.drop();
-    await this.bucket_data.drop();
-    await this.bucket_parameters.drop();
-    await this.op_id_sequence.drop();
-    await this.sync_rules.drop();
-    await this.source_tables.drop();
-    await this.write_checkpoints.drop();
-    await this.instance.drop();
-    await this.locks.drop();
+    await this.db.dropDatabase();
   }
 }

--- a/packages/service-core/test/src/data_storage.test.ts
+++ b/packages/service-core/test/src/data_storage.test.ts
@@ -1294,4 +1294,26 @@ bucket_definitions:
 
     expect(getBatchMeta(batch3)).toEqual(null);
   });
+
+  test('empty storage metrics', async () => {
+    const f = await factory({ dropAll: true });
+
+    const metrics = await f.getStorageMetrics();
+    expect(metrics).toEqual({
+      operations_size_bytes: 0,
+      parameters_size_bytes: 0,
+      replication_size_bytes: 0
+    });
+
+    const r = await f.configureSyncRules('bucket_definitions: {}');
+    const storage = f.getInstance(r.persisted_sync_rules!.parsed());
+    await storage.autoActivate();
+
+    const metrics2 = await f.getStorageMetrics();
+    expect(metrics2).toEqual({
+      operations_size_bytes: 0,
+      parameters_size_bytes: 0,
+      replication_size_bytes: 0
+    });
+  });
 }

--- a/packages/service-core/test/src/sync.test.ts
+++ b/packages/service-core/test/src/sync.test.ts
@@ -5,7 +5,6 @@ import { JSONBig } from '@powersync/service-jsonbig';
 import { RequestParameters } from '@powersync/service-sync-rules';
 import * as timers from 'timers/promises';
 import { describe, expect, test } from 'vitest';
-import { ZERO_LSN } from '../../src/replication/WalStream.js';
 import { streamResponse } from '../../src/sync/sync.js';
 import { makeTestTable, MONGO_STORAGE_FACTORY, StorageFactory } from './util.js';
 
@@ -33,7 +32,6 @@ function defineTests(factory: StorageFactory) {
     });
 
     const storage = await f.getInstance(syncRules.parsed());
-    await storage.setSnapshotDone(ZERO_LSN);
     await storage.autoActivate();
 
     const result = await storage.startBatch({}, async (batch) => {
@@ -82,7 +80,6 @@ function defineTests(factory: StorageFactory) {
     });
 
     const storage = await f.getInstance(syncRules.parsed());
-    await storage.setSnapshotDone(ZERO_LSN);
     await storage.autoActivate();
 
     const result = await storage.startBatch({}, async (batch) => {
@@ -125,7 +122,6 @@ function defineTests(factory: StorageFactory) {
     });
 
     const storage = await f.getInstance(syncRules.parsed());
-    await storage.setSnapshotDone(ZERO_LSN);
     await storage.autoActivate();
 
     const stream = streamResponse({
@@ -152,7 +148,6 @@ function defineTests(factory: StorageFactory) {
     });
 
     const storage = await f.getInstance(syncRules.parsed());
-    await storage.setSnapshotDone(ZERO_LSN);
     await storage.autoActivate();
 
     const stream = streamResponse({
@@ -211,7 +206,6 @@ function defineTests(factory: StorageFactory) {
     });
 
     const storage = await f.getInstance(syncRules.parsed());
-    await storage.setSnapshotDone(ZERO_LSN);
     await storage.autoActivate();
 
     const exp = Date.now() / 1000 + 0.1;
@@ -249,7 +243,6 @@ function defineTests(factory: StorageFactory) {
     });
 
     const storage = await f.getInstance(syncRules.parsed());
-    await storage.setSnapshotDone(ZERO_LSN);
     await storage.autoActivate();
 
     await storage.startBatch({}, async (batch) => {

--- a/packages/service-core/test/src/util.ts
+++ b/packages/service-core/test/src/util.ts
@@ -22,11 +22,22 @@ Metrics.getInstance().resetCounters();
 
 export const TEST_URI = env.PG_TEST_URL;
 
-export type StorageFactory = () => Promise<BucketStorageFactory>;
+export interface StorageOptions {
+  /**
+   * By default, collections are only cleared/
+   * Setting this to true will drop the collections completely.
+   */
+  dropAll?: boolean;
+}
+export type StorageFactory = (options?: StorageOptions) => Promise<BucketStorageFactory>;
 
-export const MONGO_STORAGE_FACTORY: StorageFactory = async () => {
+export const MONGO_STORAGE_FACTORY: StorageFactory = async (options?: StorageOptions) => {
   const db = await connectMongo();
-  await db.clear();
+  if (options?.dropAll) {
+    await db.drop();
+  } else {
+    await db.clear();
+  }
   return new MongoBucketStorage(db, { slot_name_prefix: 'test_' });
 };
 


### PR DESCRIPTION
Fix storageStats error in metrics endpoint when the collections don't exist.

Fixes #81.

Also removes the unused `setSnapshotDone()` function.