### PR TITLE
Ignore Unauthorized errors on collections for MongoDB schema

### DIFF
--- a/.changeset/cold-items-explain.md
+++ b/.changeset/cold-items-explain.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': patch
+---
+
+Fix diagnostics schema authorization issues for MongoDB

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -210,6 +210,9 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
             // https://www.mongodb.com/docs/manual/reference/system-collections/
             continue;
           }
+          if (collection.type == 'view') {
+            continue;
+          }
           try {
             const sampleDocuments = await this.db
               .collection(collection.name)


### PR DESCRIPTION
On an Atlas M10 instance with views, `listCollections()` lists `system.views`, but we're not authorized to query it.

This fixes the issue on two levels:
1. Filter out system collections.
2. Ignore `Unauthorized` errors when sampling data.