### PR TITLE
New sync rule functions: json_keys and substring

### DIFF
--- a/.changeset/thirty-llamas-carry.md
+++ b/.changeset/thirty-llamas-carry.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': minor
+---
+
+Support substring and json_keys functions in sync rules

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -223,6 +223,32 @@ const json_valid: DocumentedSqlFunction = {
   documentation: 'Returns 1 if valid, 0 if invalid'
 };
 
+const json_keys: DocumentedSqlFunction = {
+  debugName: 'json_keys',
+  call(json: SqliteValue) {
+    const jsonString = castAsText(json);
+    if (jsonString == null) {
+      return null;
+    }
+
+    const jsonParsed = JSONBig.parse(jsonString);
+    if (typeof jsonParsed != 'object') {
+      throw new Error(`Cannot call json_keys on a scalar`);
+    } else if (Array.isArray(jsonParsed)) {
+      throw new Error(`Cannot call json_keys on an array`);
+    }
+    const keys = Object.keys(jsonParsed as {});
+    // Keys are always strings, safe to use plain JSON.
+    return JSON.stringify(keys);
+  },
+  parameters: [{ name: 'json', type: ExpressionType.ANY, optional: false }],
+  getReturnType(args) {
+    // TODO: proper nullable types
+    return ExpressionType.TEXT;
+  },
+  detail: 'Returns the keys of a JSON object as a JSON array'
+};
+
 const unixepoch: DocumentedSqlFunction = {
   debugName: 'unixepoch',
   call(value?: SqliteValue, specifier?: SqliteValue, specifier2?: SqliteValue) {
@@ -397,6 +423,7 @@ export const SQL_FUNCTIONS_NAMED = {
   json_extract,
   json_array_length,
   json_valid,
+  json_keys,
   unixepoch,
   datetime,
   st_asgeojson,

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -44,6 +44,30 @@ describe('SQL functions', () => {
     expect(fn.json_array_length(`{"a":[1,2,3,4]}`)).toEqual(0n);
   });
 
+  test('json_keys', () => {
+    expect(fn.json_keys(`{"a": 1, "b": "2", "0": "test", "c": {"d": "e"}}`)).toEqual(`["0","a","b","c"]`);
+    expect(fn.json_keys(`{}`)).toEqual(`[]`);
+    expect(fn.json_keys(null)).toEqual(null);
+    expect(fn.json_keys()).toEqual(null);
+    expect(() => fn.json_keys(`{"a": 1, "a": 2}`)).toThrow();
+    expect(() => fn.json_keys(`[1,2,3]`)).toThrow();
+    expect(() => fn.json_keys(3)).toThrow();
+  });
+
+  test('json_valid', () => {
+    expect(fn.json_valid(`{"a": 1, "b": "2", "0": "test", "c": {"d": "e"}}`)).toEqual(1n);
+    expect(fn.json_valid(`{}`)).toEqual(1n);
+    expect(fn.json_valid(null)).toEqual(0n);
+    expect(fn.json_valid()).toEqual(0n);
+    expect(fn.json_valid(`{"a": 1, "a": 2}`)).toEqual(0n);
+    expect(fn.json_valid(`[1,2,3]`)).toEqual(1n);
+    expect(fn.json_valid(3)).toEqual(1n);
+    expect(fn.json_valid('test')).toEqual(0n);
+    expect(fn.json_valid('"test"')).toEqual(1n);
+    expect(fn.json_valid('true')).toEqual(1n);
+    expect(fn.json_valid('TRUE')).toEqual(0n);
+  });
+
   test('typeof', () => {
     expect(fn.typeof(null)).toEqual('null');
     expect(fn.typeof('test')).toEqual('text');

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -125,6 +125,22 @@ describe('SQL functions', () => {
     expect(fn.lower(Uint8Array.of(0x61, 0x62, 0x43))).toEqual('abc');
   });
 
+  test('substring', () => {
+    expect(fn.substring(null)).toEqual(null);
+    expect(fn.substring('abc')).toEqual(null);
+    expect(fn.substring('abcde', 2, 3)).toEqual('bcd');
+    expect(fn.substring('abcde', 2)).toEqual('bcde');
+    expect(fn.substring('abcde', 2, null)).toEqual(null);
+    expect(fn.substring('abcde', 0, 1)).toEqual('');
+    expect(fn.substring('abcde', 0, 2)).toEqual('a');
+    expect(fn.substring('abcde', 1, 2)).toEqual('ab');
+    expect(fn.substring('abcde', -2)).toEqual('de');
+    expect(fn.substring('abcde', -2, 1)).toEqual('d');
+    expect(fn.substring('abcde', 6, -5)).toEqual('abcde');
+    expect(fn.substring('abcde', 5, -2)).toEqual('cd');
+    expect(fn.substring('2023-06-28 14:12:00.999Z', 1, 10)).toEqual('2023-06-28');
+  });
+
   test('cast', () => {
     expect(cast(null, 'text')).toEqual(null);
     expect(cast(null, 'integer')).toEqual(null);


### PR DESCRIPTION
The `substring` function roughly matches the [SQLite substring function](https://sqlite.org/lang_corefunc.html#substr) (notably different from the JavaScript equivalent). It is also similar to the Postgres substring function, but different when a negative `start` or `length` is specified.

The `json_keys` function has no direct equivalent in Postgres or SQLite. Postgres has a similar `json_object_keys`, but that returns each key as a separate row, while we return the keys as a JSON array.

Use cases:

substring:

```sql
-- Parameter query - filter by date value
-- substring(created_at, 1, 10) returns the date portion of the timestamp
select id as post_id from posts where substring(created_at, 1, 10) in request.jwt() -> 'sync_dates'
```

json_keys:
```sql
-- Data query - permissions_json: {[user_id]: 'read' | 'write' | 'admin'}
-- This is still limited - we can only operate on the keys, and not the values
select * from items where bucket.user_id in json_keys(permissions_json)

-- even better would be something like this, but that is significantly more complex to implement:
select * from items where (permissions_json ->> bucket.user_id) = 'read'
select * from items where 'read' in (permissions_json ->> bucket.user_id)
```

