### PR TITLE
[MongoDB] Reduce permissions required

### DIFF
--- a/.changeset/fifty-dogs-reply.md
+++ b/.changeset/fifty-dogs-reply.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': minor
+---
+
+Reduce permissions required for replicating a single mongodb database


### PR DESCRIPTION
Currently, we always use a global changestream, which needs the `readAnyDatabase` permission on Atlas.

This is needed when sync rules reference multiple databases in the same cluster. We want to use a single changestream for the entire replication process, so having `read` permissions for each individual database is not sufficient when using multiple databases. Replicating multiple databses is not a common use case though, and the permissions needed is a problem for some users.

This now changes to opening a changestream on the specific database if only the default database is used. This effectively reduces the required permissions to just `read@mydb`.

So overall the current permissions required for Atlas are:

```
readWrite@mydb._powersync_checkpoints
readAnyDatabase@admin
```

And after the change it would be:
```
readWrite@mydb._powersync_checkpoints
read@mydb
```

Note that for the beta, we'd likely use document pre/post-images for each replicated collection, which requires the `collMod` permission if we set it up automatically. This would require the `dbAdmin@mydb` permission on Atlas. However, users will still have the option to instead configure that manually and just use `read@mydb`.