### PR TITLE
fix: Cached Parsed Sync Rules

### DIFF
--- a/.changeset/heavy-shirts-chew.md
+++ b/.changeset/heavy-shirts-chew.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Improved sync rules storage cached parsed sync rules, accommodating different parsing options where necessary.

--- a/packages/service-core/test/src/data_storage.test.ts
+++ b/packages/service-core/test/src/data_storage.test.ts
@@ -1462,8 +1462,6 @@ bucket_definitions:
   });
 
   test('invalidate cached parsed sync rules', async () => {
-    const WORKSPACE_TABLE = makeTestTable('workspace', ['id']);
-
     const sync_rules_content = testRules(
       `
 bucket_definitions:

--- a/packages/service-core/test/src/util.ts
+++ b/packages/service-core/test/src/util.ts
@@ -62,7 +62,7 @@ export function testRules(content: string): PersistedSyncRulesContent {
     parsed(options) {
       return {
         id: 1,
-        sync_rules: SqlSyncRules.fromYaml(content, PARSE_OPTIONS),
+        sync_rules: SqlSyncRules.fromYaml(content, options),
         slot_name: 'test'
       };
     },


### PR DESCRIPTION
# Overview

The `MongoSyncBucketStorage`'s `getParsedSyncRules` method currently caches the parsed sync rules with the assumption that the previously cached Sync rules were generated with the same `options`. This assumption is not always true. 

In some cases an external module could request parsed Sync rules without knowing the exact `defaultSchema`. This external request should not affect subsequent requests for parsed Sync rules. Currently this behaviour breaks syncing for schemas which are different from the cached schema. 