### PR TITLE
feat: Postgres connection port (de)restrictions

### DIFF
--- a/.changeset/eighty-coins-jog.md
+++ b/.changeset/eighty-coins-jog.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Improved Postgres connection port restrictions. Connections are now supported on ports >= 1024.

--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -13,7 +13,7 @@
     "build": "tsc -b",
     "build:tests": "tsc -b test/tsconfig.json",
     "test": "vitest --no-threads",
-    "clean": "rm -rf ./lib && tsc -b --clean"
+    "clean": "rm -rf ./dist && tsc -b --clean"
   },
   "dependencies": {
     "@js-sdsl/ordered-set": "^4.4.2",

--- a/packages/types/src/config/normalize.ts
+++ b/packages/types/src/config/normalize.ts
@@ -1,5 +1,5 @@
-import { PostgresConnection } from './PowerSyncConfig.js';
 import * as urijs from 'uri-js';
+import { PostgresConnection } from './PowerSyncConfig.js';
 
 /**
  * Validate and normalize connection options.
@@ -97,11 +97,10 @@ export function validatePort(port: string | number): number {
   if (typeof port == 'string') {
     port = parseInt(port);
   }
-  if (port >= 1024 && port <= 49151) {
-    return port;
-  } else {
+  if (port < 1024) {
     throw new Error(`Port ${port} not supported`);
   }
+  return port;
 }
 
 /**


### PR DESCRIPTION
# Overview

The currently restrict Postgres connections to ports in the range of [1024, 49151]. 

Certain local Postgres services, such as Supabase expose Postgres on port `54322` by default. This PR removes the restriction for connecting to "Ephemeral" [ports](https://en.wikipedia.org/wiki/Ephemeral_port) (ports > 49151). This allows for easier local development with Supabase and potentially other databases.

The check for "Privileged" [ports](https://www.w3.org/Daemon/User/Installation/PrivilegedPorts.html) is still maintained.