### PR TITLE
[MongoDB] More types fixes

### DIFF
--- a/modules/module-mongodb/src/replication/MongoRelation.ts
+++ b/modules/module-mongodb/src/replication/MongoRelation.ts
@@ -121,9 +121,9 @@ function filterJsonData(data: any, depth = 0): any {
   } else if (data instanceof mongo.Decimal128) {
     return data.toString();
   } else if (data instanceof mongo.MinKey || data instanceof mongo.MaxKey) {
-    return data._bsontype;
-  } else if (data instanceof mongo.BSONRegExp) {
-    return JSON.stringify({ pattern: data.pattern, options: data.options });
+    return null;
+  } else if (data instanceof RegExp) {
+    return { pattern: data.source, options: data.flags };
   } else if (Array.isArray(data)) {
     return data.map((element) => filterJsonData(element, depth + 1));
   } else if (ArrayBuffer.isView(data)) {

--- a/modules/module-mongodb/test/src/mongo_test.test.ts
+++ b/modules/module-mongodb/test/src/mongo_test.test.ts
@@ -34,7 +34,18 @@ describe('mongo data types', () => {
         objectId: mongo.ObjectId.createFromHexString('66e834cc91d805df11fa0ecb'),
         regexp: new mongo.BSONRegExp('test', 'i'),
         minKey: new mongo.MinKey(),
-        maxKey: new mongo.MaxKey()
+        maxKey: new mongo.MaxKey(),
+        symbol: new mongo.BSONSymbol('test'),
+        js: new mongo.Code('testcode'),
+        js2: new mongo.Code('testcode', { foo: 'bar' }),
+        pointer: new mongo.DBRef('mycollection', mongo.ObjectId.createFromHexString('66e834cc91d805df11fa0ecb')),
+        pointer2: new mongo.DBRef(
+          'mycollection',
+          mongo.ObjectId.createFromHexString('66e834cc91d805df11fa0ecb'),
+          'mydb',
+          { foo: 'bar' }
+        ),
+        undefined: undefined
       }
     ]);
   }
@@ -62,7 +73,11 @@ describe('mongo data types', () => {
         objectId: [mongo.ObjectId.createFromHexString('66e834cc91d805df11fa0ecb')],
         regexp: [new mongo.BSONRegExp('test', 'i')],
         minKey: [new mongo.MinKey()],
-        maxKey: [new mongo.MaxKey()]
+        maxKey: [new mongo.MaxKey()],
+        symbol: [new mongo.BSONSymbol('test')],
+        js: [new mongo.Code('testcode')],
+        pointer: [new mongo.DBRef('mycollection', mongo.ObjectId.createFromHexString('66e834cc91d805df11fa0ecb'))],
+        undefined: [undefined]
       }
     ]);
   }
@@ -97,7 +112,13 @@ describe('mongo data types', () => {
       timestamp: 1958505087099n,
       regexp: '{"pattern":"test","options":"i"}',
       minKey: null,
-      maxKey: null
+      maxKey: null,
+      symbol: 'test',
+      js: '{"code":"testcode","scope":null}',
+      js2: '{"code":"testcode","scope":{"foo":"bar"}}',
+      pointer: '{"collection":"mycollection","oid":"66e834cc91d805df11fa0ecb","fields":{}}',
+      pointer2: '{"collection":"mycollection","oid":"66e834cc91d805df11fa0ecb","db":"mydb","fields":{"foo":"bar"}}',
+      undefined: null
     });
   }
 
@@ -130,7 +151,14 @@ describe('mongo data types', () => {
     expect(transformed[3]).toMatchObject({
       _id: 10n,
       objectId: '["66e834cc91d805df11fa0ecb"]',
-      timestamp: '[1958505087099]'
+      timestamp: '[1958505087099]',
+      regexp: '[{"pattern":"test","options":"i"}]',
+      symbol: '["test"]',
+      js: '[{"code":"testcode","scope":null}]',
+      pointer: '[{"collection":"mycollection","oid":"66e834cc91d805df11fa0ecb","fields":{}}]',
+      minKey: '[null]',
+      maxKey: '[null]',
+      undefined: '[null]'
     });
   }
 
@@ -245,14 +273,23 @@ describe('mongo data types', () => {
             { name: 'int2', sqlite_type: 4, internal_type: 'Integer' },
             { name: 'int4', sqlite_type: 4, internal_type: 'Integer' },
             { name: 'int8', sqlite_type: 4, internal_type: 'Long' },
+            // We can fix these later
+            { name: 'js', sqlite_type: 2, internal_type: 'Object' },
+            { name: 'js2', sqlite_type: 2, internal_type: 'Object' },
             { name: 'maxKey', sqlite_type: 0, internal_type: 'MaxKey' },
             { name: 'minKey', sqlite_type: 0, internal_type: 'MinKey' },
             { name: 'nested', sqlite_type: 2, internal_type: 'Object' },
             { name: 'null', sqlite_type: 0, internal_type: 'Null' },
             { name: 'objectId', sqlite_type: 2, internal_type: 'ObjectId' },
+            // We can fix these later
+            { name: 'pointer', sqlite_type: 2, internal_type: 'Object' },
+            { name: 'pointer2', sqlite_type: 2, internal_type: 'Object' },
             { name: 'regexp', sqlite_type: 2, internal_type: 'RegExp' },
+            // Can fix this later
+            { name: 'symbol', sqlite_type: 2, internal_type: 'String' },
             { name: 'text', sqlite_type: 2, internal_type: 'String' },
             { name: 'timestamp', sqlite_type: 4, internal_type: 'Timestamp' },
+            { name: 'undefined', sqlite_type: 0, internal_type: 'Null' },
             { name: 'uuid', sqlite_type: 2, internal_type: 'UUID' }
           ]
         }


### PR DESCRIPTION
Minor fixes to how RegExp, MinKey and MaxKey are handled inside nested arrays or objects. Also adds more tests for the remaining BSON types.

With this, we should now support the full set of BSON types, as documented here: https://github.com/powersync-ja/mintlify-docs/pull/26


