### PR TITLE
feat: add http probes for health checks

### DIFF
--- a/.changeset/witty-maps-heal.md
+++ b/.changeset/witty-maps-heal.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Add probe endpoints which can be used for system health checks.

--- a/packages/service-core/src/routes/configure-fastify.ts
+++ b/packages/service-core/src/routes/configure-fastify.ts
@@ -5,6 +5,7 @@ import * as system from '../system/system-index.js';
 
 import { ADMIN_ROUTES } from './endpoints/admin.js';
 import { CHECKPOINT_ROUTES } from './endpoints/checkpointing.js';
+import { PROBES_ROUTES } from './endpoints/probes.js';
 import { SYNC_RULES_ROUTES } from './endpoints/sync-rules.js';
 import { SYNC_STREAM_ROUTES } from './endpoints/sync-stream.js';
 import { createRequestQueueHook, CreateRequestQueueParams } from './hooks.js';
@@ -35,7 +36,7 @@ export type FastifyServerConfig = {
 
 export const DEFAULT_ROUTE_OPTIONS = {
   api: {
-    routes: [...ADMIN_ROUTES, ...CHECKPOINT_ROUTES, ...SYNC_RULES_ROUTES],
+    routes: [...ADMIN_ROUTES, ...CHECKPOINT_ROUTES, ...SYNC_RULES_ROUTES, ...PROBES_ROUTES],
     queueOptions: {
       concurrency: 10,
       max_queue_depth: 20

--- a/packages/service-core/src/routes/endpoints/probes.ts
+++ b/packages/service-core/src/routes/endpoints/probes.ts
@@ -11,7 +11,6 @@ export enum ProbeRoutes {
 export const startupCheck = routeDefinition({
   path: ProbeRoutes.STARTUP,
   method: router.HTTPMethod.GET,
-  authorize: authUser,
   handler: async () => {
     const state = container.probes.state();
 
@@ -27,12 +26,15 @@ export const startupCheck = routeDefinition({
 export const livenessCheck = routeDefinition({
   path: ProbeRoutes.LIVENESS,
   method: router.HTTPMethod.GET,
-  authorize: authUser,
   handler: async () => {
     const state = container.probes.state();
 
+    const timeDifference = Date.now() - state.touched_at.getTime()
+    const status = timeDifference > 10000 ? 400 : 200;
+    console.log(status)
+
     return new router.RouterResponse({
-      status: Date.now() - state.touched_at.getTime() > 10000 ? 200 : 400,
+      status,
       data: {
         ...state,
       }
@@ -43,7 +45,6 @@ export const livenessCheck = routeDefinition({
 export const readinessCheck = routeDefinition({
   path: ProbeRoutes.READINESS,
   method: router.HTTPMethod.GET,
-  authorize: authUser,
   handler: async () => {
     const state = container.probes.state();
 

--- a/packages/service-core/src/routes/endpoints/probes.ts
+++ b/packages/service-core/src/routes/endpoints/probes.ts
@@ -1,0 +1,59 @@
+import { container, router } from "@powersync/lib-services-framework";
+import { routeDefinition } from "../router.js";
+import { authUser } from "../auth.js";
+
+export enum ProbeRoutes {
+  STARTUP = '/probes/startup',
+  LIVENESS = '/probes/liveness',
+  READINESS = '/probes/readiness'
+}
+
+export const startupCheck = routeDefinition({
+  path: ProbeRoutes.STARTUP,
+  method: router.HTTPMethod.GET,
+  authorize: authUser,
+  handler: async () => {
+    const state = container.probes.state();
+
+    return new router.RouterResponse({
+      status: state.started ? 200 : 400,
+      data: {
+        ...state,
+      }
+    });
+  }
+});
+
+export const livenessCheck = routeDefinition({
+  path: ProbeRoutes.LIVENESS,
+  method: router.HTTPMethod.GET,
+  authorize: authUser,
+  handler: async () => {
+    const state = container.probes.state();
+
+    return new router.RouterResponse({
+      status: Date.now() - state.touched_at.getTime() > 10000 ? 200 : 400,
+      data: {
+        ...state,
+      }
+    });
+  }
+});
+
+export const readinessCheck = routeDefinition({
+  path: ProbeRoutes.READINESS,
+  method: router.HTTPMethod.GET,
+  authorize: authUser,
+  handler: async () => {
+    const state = container.probes.state();
+
+    return new router.RouterResponse({
+      status: state.ready ? 200 : 400,
+      data: {
+        ...state,
+      }
+    });
+  }
+});
+
+export const PROBES_ROUTES = [startupCheck, livenessCheck, readinessCheck];

--- a/packages/service-core/src/routes/endpoints/probes.ts
+++ b/packages/service-core/src/routes/endpoints/probes.ts
@@ -1,6 +1,5 @@
 import { container, router } from "@powersync/lib-services-framework";
 import { routeDefinition } from "../router.js";
-import { authUser } from "../auth.js";
 
 export enum ProbeRoutes {
   STARTUP = '/probes/startup',
@@ -30,8 +29,7 @@ export const livenessCheck = routeDefinition({
     const state = container.probes.state();
 
     const timeDifference = Date.now() - state.touched_at.getTime()
-    const status = timeDifference > 10000 ? 400 : 200;
-    console.log(status)
+    const status = timeDifference < 10000 ? 200 : 400;
 
     return new router.RouterResponse({
       status,

--- a/packages/service-core/src/routes/router.ts
+++ b/packages/service-core/src/routes/router.ts
@@ -1,6 +1,6 @@
 import { router } from '@powersync/lib-services-framework';
-import * as auth from '../auth/auth-index.js';
-import { CorePowerSyncSystem } from '../system/CorePowerSyncSystem.js';
+import type { JwtPayload } from '../auth/auth-index.js';
+import type { CorePowerSyncSystem } from '../system/CorePowerSyncSystem.js';
 
 /**
  * Common context for routes
@@ -9,7 +9,7 @@ export type Context = {
   user_id?: string;
   system: CorePowerSyncSystem;
 
-  token_payload?: auth.JwtPayload;
+  token_payload?: JwtPayload;
   token_errors?: string[];
   /**
    * Only on websocket endpoints.

--- a/packages/service-core/test/src/routes/probes.integration.test.ts
+++ b/packages/service-core/test/src/routes/probes.integration.test.ts
@@ -15,7 +15,7 @@ vi.mock("@powersync/lib-services-framework", async () => {
       probes: {
         state: vi.fn()
       }
-    }
+    },
   }
 })
 
@@ -34,17 +34,14 @@ describe('Probe Routes Integration', () => {
     await app.close();
   });
 
-  describe.only('Startup Probe', () => {
+  describe('Startup Probe', () => {
     it('returns 200 when system is started', async () => {
       const mockState = {
         started: true,
         ready: true,
         touched_at: new Date()
       };
-      vi.spyOn(auth, 'authorizeUser').mockResolvedValue({ authorized: true });
-      vi.spyOn(auth, 'authApi').mockResolvedValue({ authorized: true });
       vi.spyOn(auth, 'authUser').mockResolvedValue({ authorized: true });
-      vi.spyOn(auth, 'authDevUser').mockResolvedValue({ authorized: true });
       vi.mocked(container.probes.state).mockReturnValue(mockState);
 
       const response = await app.inject({
@@ -53,7 +50,10 @@ describe('Probe Routes Integration', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(JSON.parse(response.payload)).toEqual(mockState);
+      expect(JSON.parse(response.payload)).toEqual({
+        ...mockState,
+        touched_at: mockState.touched_at.toISOString()
+      });
     });
 
     it('returns 400 when system is not started', async () => {
@@ -71,7 +71,10 @@ describe('Probe Routes Integration', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.payload)).toEqual(mockState);
+      expect(JSON.parse(response.payload)).toEqual({
+        ...mockState,
+        touched_at: mockState.touched_at.toISOString()
+      });
     });
   });
 
@@ -91,7 +94,10 @@ describe('Probe Routes Integration', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(JSON.parse(response.payload)).toEqual(mockState);
+      expect(JSON.parse(response.payload)).toEqual({
+        ...mockState,
+        touched_at: mockState.touched_at.toISOString()
+      });
     });
 
     it('returns 400 when system has not been touched recently', async () => {
@@ -109,7 +115,10 @@ describe('Probe Routes Integration', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.payload)).toEqual(mockState);
+      expect(JSON.parse(response.payload)).toEqual({
+        ...mockState,
+        touched_at: mockState.touched_at.toISOString()
+      });
     });
   });
 
@@ -129,7 +138,10 @@ describe('Probe Routes Integration', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      expect(JSON.parse(response.payload)).toEqual(mockState);
+      expect(JSON.parse(response.payload)).toEqual({
+        ...mockState,
+        touched_at: mockState.touched_at.toISOString()
+      });
     });
 
     it('returns 400 when system is not ready', async () => {
@@ -147,7 +159,10 @@ describe('Probe Routes Integration', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      expect(JSON.parse(response.payload)).toEqual(mockState);
+      expect(JSON.parse(response.payload)).toEqual({
+        ...mockState,
+        touched_at: mockState.touched_at.toISOString()
+      });
     });
   });
 
@@ -169,7 +184,10 @@ describe('Probe Routes Integration', () => {
       // All requests should complete successfully
       responses.forEach(response => {
         expect(response.statusCode).toBe(200);
-        expect(JSON.parse(response.payload)).toEqual(mockState);
+        expect(JSON.parse(response.payload)).toEqual({
+          ...mockState,
+          touched_at: mockState.touched_at.toISOString()
+        });
       });
     });
 

--- a/packages/service-core/test/src/routes/probes.integration.test.ts
+++ b/packages/service-core/test/src/routes/probes.integration.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Fastify, { FastifyInstance } from 'fastify';
+import { container } from '@powersync/lib-services-framework';
+import * as auth from '../../../src/routes/auth.js';
+import * as system from '../../../src/system/system-index.js';
+import { configureFastifyServer } from '../../../src/index.js';
+import { ProbeRoutes } from '../../../src/routes/endpoints/probes.js';
+
+vi.mock("@powersync/lib-services-framework", async () => {
+  const actual = await vi.importActual("@powersync/lib-services-framework") as any;
+  return {
+    ...actual,
+    container: {
+      ...actual.container,
+      probes: {
+        state: vi.fn()
+      }
+    }
+  }
+})
+
+describe('Probe Routes Integration', () => {
+  let app: FastifyInstance;
+  let mockSystem: system.CorePowerSyncSystem;
+
+  beforeEach(async () => {
+    app = Fastify();
+    mockSystem = {} as system.CorePowerSyncSystem;
+    await configureFastifyServer(app, { system: mockSystem });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe.only('Startup Probe', () => {
+    it('returns 200 when system is started', async () => {
+      const mockState = {
+        started: true,
+        ready: true,
+        touched_at: new Date()
+      };
+      vi.spyOn(auth, 'authorizeUser').mockResolvedValue({ authorized: true });
+      vi.spyOn(auth, 'authApi').mockResolvedValue({ authorized: true });
+      vi.spyOn(auth, 'authUser').mockResolvedValue({ authorized: true });
+      vi.spyOn(auth, 'authDevUser').mockResolvedValue({ authorized: true });
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: ProbeRoutes.STARTUP,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.payload)).toEqual(mockState);
+    });
+
+    it('returns 400 when system is not started', async () => {
+      const mockState = {
+        started: false,
+        ready: false,
+        touched_at: new Date()
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: ProbeRoutes.STARTUP,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload)).toEqual(mockState);
+    });
+  });
+
+  describe('Liveness Probe', () => {
+    it('returns 200 when system was touched recently', async () => {
+      const mockState = {
+        started: true,
+        ready: true,
+        touched_at: new Date()
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: ProbeRoutes.LIVENESS,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.payload)).toEqual(mockState);
+    });
+
+    it('returns 400 when system has not been touched recently', async () => {
+      const mockState = {
+        started: true,
+        ready: true,
+        touched_at: new Date(Date.now() - 15000) // 15 seconds ago
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: ProbeRoutes.LIVENESS,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload)).toEqual(mockState);
+    });
+  });
+
+  describe('Readiness Probe', () => {
+    it('returns 200 when system is ready', async () => {
+      const mockState = {
+        started: true,
+        ready: true,
+        touched_at: new Date()
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: ProbeRoutes.READINESS,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.payload)).toEqual(mockState);
+    });
+
+    it('returns 400 when system is not ready', async () => {
+      const mockState = {
+        started: true,
+        ready: false,
+        touched_at: new Date()
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: ProbeRoutes.READINESS,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(JSON.parse(response.payload)).toEqual(mockState);
+    });
+  });
+
+  describe('Request Queue Behavior', () => {
+    it('handles concurrent requests within limits', async () => {
+      const mockState = { started: true, ready: true, touched_at: new Date() };
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      // Create array of 15 concurrent requests (default concurrency is 10)
+      const requests = Array(15).fill(null).map(() =>
+        app.inject({
+          method: 'GET',
+          url: ProbeRoutes.STARTUP,
+        })
+      );
+
+      const responses = await Promise.all(requests);
+
+      // All requests should complete successfully
+      responses.forEach(response => {
+        expect(response.statusCode).toBe(200);
+        expect(JSON.parse(response.payload)).toEqual(mockState);
+      });
+    });
+
+    it('respects max queue depth', async () => {
+      const mockState = { started: true, ready: true, touched_at: new Date() };
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      // Create array of 35 concurrent requests (default max_queue_depth is 20)
+      const requests = Array(35).fill(null).map(() =>
+        app.inject({
+          method: 'GET',
+          url: ProbeRoutes.STARTUP,
+        })
+      );
+
+      const responses = await Promise.all(requests);
+
+      // Some requests should succeed and some should fail with 429
+      const successCount = responses.filter(r => r.statusCode === 200).length;
+      const queueFullCount = responses.filter(r => r.statusCode === 429).length;
+
+      expect(successCount).toBeGreaterThan(0);
+      expect(queueFullCount).toBeGreaterThan(0);
+      expect(successCount + queueFullCount).toBe(35);
+    });
+  });
+
+  describe('Content Types', () => {
+    it('returns correct content type headers', async () => {
+      const mockState = { started: true, ready: true, touched_at: new Date() };
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await app.inject({
+        method: 'GET',
+        url: ProbeRoutes.STARTUP,
+      });
+
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+    });
+  });
+});

--- a/packages/service-core/test/src/routes/probes.test.ts
+++ b/packages/service-core/test/src/routes/probes.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { container } from '@powersync/lib-services-framework';
+import { startupCheck, livenessCheck, readinessCheck } from '../../../src/routes/endpoints/probes.js';
+
+// Mock the container
+vi.mock('@powersync/lib-services-framework', () => ({
+  container: {
+    probes: {
+      state: vi.fn()
+    }
+  },
+  router: {
+    HTTPMethod: {
+      GET: 'GET'
+    },
+    RouterResponse: class RouterResponse {
+      status: number;
+      data: any;
+      headers: Record<string, string>;
+      afterSend: () => Promise<void>;
+      __micro_router_response = true;
+
+      constructor({ status, data, headers, afterSend }: {
+        status?: number;
+        data: any;
+        headers?: Record<string, string>;
+        afterSend?: () => Promise<void>;
+      }) {
+        this.status = status || 200;
+        this.data = data;
+        this.headers = headers || { 'Content-Type': 'application/json' };
+        this.afterSend = afterSend ?? (() => Promise.resolve());
+      }
+    }
+  }
+}));
+
+describe('Probe Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('startupCheck', () => {
+    it('has the correct route definitions', () => {
+      expect(startupCheck.path).toBe('/probes/startup');
+      expect(startupCheck.method).toBe('GET');
+    });
+
+    it('returns 200 when started is true', async () => {
+      const mockState = {
+        started: true,
+        ready: true,
+        touched_at: new Date()
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await startupCheck.handler();
+
+      expect(response.status).toEqual(200);
+      expect(response.data).toEqual(mockState);
+    });
+
+    it('returns 400 when started is false', async () => {
+      const mockState = {
+        started: false,
+        ready: false,
+        touched_at: new Date()
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await startupCheck.handler();
+
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual(mockState);
+    });
+  });
+
+  describe('livenessCheck', () => {
+    it('has the correct route definitions', () => {
+      expect(livenessCheck.path).toBe('/probes/liveness');
+      expect(livenessCheck.method).toBe('GET');
+    });
+
+    it('returns 200 when last touch was more than 10 seconds ago', async () => {
+      const mockState = {
+        started: true,
+        ready: true,
+        touched_at: new Date(Date.now() - 11000) // 11 seconds ago
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await livenessCheck.handler();
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual(mockState);
+    });
+
+    it('returns 400 when last touch was less than 10 seconds ago', async () => {
+      const mockState = {
+        started: true,
+        ready: true,
+        touched_at: new Date(Date.now() - 5000)
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await livenessCheck.handler();
+
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual(mockState);
+    });
+  });
+
+  describe('readinessCheck', () => {
+    it('has the correct route definitions', () => {
+      expect(readinessCheck.path).toBe('/probes/readiness');
+      expect(readinessCheck.method).toBe('GET');
+    });
+
+    it('returns 200 when ready is true', async () => {
+      const mockState = {
+        started: true,
+        ready: true,
+        touched_at: new Date()
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await readinessCheck.handler();
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual(mockState);
+    });
+
+    it('returns 400 when ready is false', async () => {
+      const mockState = {
+        started: true,
+        ready: false,
+        touched_at: new Date()
+      };
+
+      vi.mocked(container.probes.state).mockReturnValue(mockState);
+
+      const response = await readinessCheck.handler();
+
+      expect(response.status).toBe(400);
+      expect(response.data).toEqual(mockState);
+    });
+  });
+});

--- a/packages/service-core/test/src/routes/probes.test.ts
+++ b/packages/service-core/test/src/routes/probes.test.ts
@@ -83,11 +83,11 @@ describe('Probe Routes', () => {
       expect(livenessCheck.method).toBe('GET');
     });
 
-    it('returns 200 when last touch was more than 10 seconds ago', async () => {
+    it('returns 200 when last touch was less than 10 seconds ago', async () => {
       const mockState = {
         started: true,
         ready: true,
-        touched_at: new Date(Date.now() - 11000) // 11 seconds ago
+        touched_at: new Date(Date.now() - 9000) // 11 seconds ago
       };
 
       vi.mocked(container.probes.state).mockReturnValue(mockState);
@@ -98,11 +98,11 @@ describe('Probe Routes', () => {
       expect(response.data).toEqual(mockState);
     });
 
-    it('returns 400 when last touch was less than 10 seconds ago', async () => {
+    it('returns 400 when last touch was more than 10 seconds ago', async () => {
       const mockState = {
         started: true,
         ready: true,
-        touched_at: new Date(Date.now() - 5000)
+        touched_at: new Date(Date.now() - 11000)
       };
 
       vi.mocked(container.probes.state).mockReturnValue(mockState);


### PR DESCRIPTION
## Description
Added probe endpoints which can be used for healthchecks by users. Startup to show the system has started up, liveness to show if the system is alive and readiness to show the system is ready.

## Work Done
* Added readiness, liveness, and startup endpoints

## Testing
Added unit and integration testing for probes endpoint. 

Not sure if there is any other testing I should do?