### PR TITLE
[MongoDB] Fix initial snapshot / Better error recovery

### DIFF
--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -564,7 +564,10 @@ export class ChangeStream {
         stream.close();
       });
 
-      let waitForCheckpointLsn: string | null = null;
+      // Always start with a checkpoint.
+      // This helps us to clear erorrs when restarting, even if there is
+      // no data to replicate.
+      let waitForCheckpointLsn: string | null = await createCheckpoint(this.client, this.defaultDb);
 
       while (true) {
         if (this.abort_signal.aborted) {

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -214,9 +214,7 @@ export class ChangeStream {
           if (snapshotTime != null) {
             const lsn = getMongoLsn(snapshotTime);
             logger.info(`Snapshot commit at ${snapshotTime.inspect()} / ${lsn}`);
-            // keepalive() does an auto-commit if there is data
-            await batch.flush();
-            await batch.keepalive(lsn);
+            await batch.commit(lsn);
           } else {
             throw new Error(`No snapshot clusterTime available.`);
           }
@@ -597,8 +595,7 @@ export class ChangeStream {
           if (waitForCheckpointLsn != null && lsn >= waitForCheckpointLsn) {
             waitForCheckpointLsn = null;
           }
-          await batch.flush();
-          await batch.keepalive(lsn);
+          await batch.commit(lsn);
         } else if (
           changeDocument.operationType == 'insert' ||
           changeDocument.operationType == 'update' ||

--- a/modules/module-mongodb/test/src/slow_tests.test.ts
+++ b/modules/module-mongodb/test/src/slow_tests.test.ts
@@ -1,0 +1,109 @@
+import { MONGO_STORAGE_FACTORY } from '@core-tests/util.js';
+import { BucketStorageFactory } from '@powersync/service-core';
+import * as mongo from 'mongodb';
+import { setTimeout } from 'node:timers/promises';
+import { describe, expect, test } from 'vitest';
+import { ChangeStreamTestContext, setSnapshotHistorySeconds } from './change_stream_utils.js';
+import { env } from './env.js';
+
+type StorageFactory = () => Promise<BucketStorageFactory>;
+
+const BASIC_SYNC_RULES = `
+bucket_definitions:
+  global:
+    data:
+      - SELECT _id as id, description FROM "test_data"
+`;
+
+describe('change stream slow tests - mongodb', { timeout: 60_000 }, function () {
+  if (env.CI || env.SLOW_TESTS) {
+    defineSlowTests(MONGO_STORAGE_FACTORY);
+  } else {
+    // Need something in this file.
+    test('no-op', () => {});
+  }
+});
+
+function defineSlowTests(factory: StorageFactory) {
+  test('replicating snapshot with lots of data', async () => {
+    await using context = await ChangeStreamTestContext.open(factory);
+    // Test with low minSnapshotHistoryWindowInSeconds, to trigger:
+    // > Read timestamp .. is older than the oldest available timestamp.
+    // This happened when we had {snapshot: true} in the initial
+    // snapshot session.
+    await using _ = await setSnapshotHistorySeconds(context.client, 1);
+    const { db } = context;
+    await context.updateSyncRules(`
+bucket_definitions:
+  global:
+    data:
+      - SELECT _id as id, description, num FROM "test_data1"
+      - SELECT _id as id, description, num FROM "test_data2"
+      `);
+
+    const collection1 = db.collection('test_data1');
+    const collection2 = db.collection('test_data2');
+
+    let operations: mongo.AnyBulkWriteOperation[] = [];
+    for (let i = 0; i < 10_000; i++) {
+      operations.push({ insertOne: { document: { description: `pre${i}`, num: i } } });
+    }
+    await collection1.bulkWrite(operations);
+    await collection2.bulkWrite(operations);
+
+    await context.replicateSnapshot();
+    context.startStreaming();
+    const checksum = await context.getChecksum('global[]');
+    expect(checksum).toMatchObject({
+      count: 20_000
+    });
+  });
+
+  test('writes concurrently with snapshot', async () => {
+    // If there is an issue with snapshotTime (the start LSN for the
+    // changestream), we may miss updates, which this test would
+    // hopefully catch.
+
+    await using context = await ChangeStreamTestContext.open(factory);
+    const { db } = context;
+    await context.updateSyncRules(`
+bucket_definitions:
+  global:
+    data:
+      - SELECT _id as id, description, num FROM "test_data"
+      `);
+
+    const collection = db.collection('test_data');
+
+    let operations: mongo.AnyBulkWriteOperation[] = [];
+    for (let i = 0; i < 5_000; i++) {
+      operations.push({ insertOne: { document: { description: `pre${i}`, num: i } } });
+    }
+    await collection.bulkWrite(operations);
+
+    const snapshotPromise = context.replicateSnapshot();
+
+    for (let i = 49; i >= 0; i--) {
+      await collection.updateMany(
+        { num: { $gte: i * 100, $lt: i * 100 + 100 } },
+        { $set: { description: 'updated' + i } }
+      );
+      await setTimeout(20);
+    }
+
+    await snapshotPromise;
+    context.startStreaming();
+
+    const data = await context.getBucketData('global[]', undefined, { limit: 50_000, chunkLimitBytes: 60_000_000 });
+
+    const preDocuments = data.filter((d) => JSON.parse(d.data! as string).description.startsWith('pre')).length;
+    const updatedDocuments = data.filter((d) => JSON.parse(d.data! as string).description.startsWith('updated')).length;
+
+    // If the test works properly, preDocuments should be around 2000-3000.
+    // The total should be around 9000-9900.
+    // However, it is very sensitive to timing, so we allow a wide range.
+    // updatedDocuments must be strictly >= 5000, otherwise something broke.
+    expect(updatedDocuments).toBeGreaterThanOrEqual(5_000);
+    expect(preDocuments).toBeLessThanOrEqual(5_000);
+  });
+}


### PR DESCRIPTION
Builds on #121.

## 1. Initial snapshot

Previously, we used `{snapshot: true}` to replicate an initial snapshot. That gives nice consistency guarantees, but cannot run longer than 5 minutes (configurable using [minSnapshotHistoryWindowInSeconds](https://www.mongodb.com/docs/manual/reference/parameters/#mongodb-parameter-param.minSnapshotHistoryWindowInSeconds)). So this caused replication of larger amounts of data to fail.

This fixes it to not use the snapshot mode anymore, but rather just make sure we replicate all incremental changes since the start of the snapshot. This means data modified during the snapshot may be replicated twice, but that should not cause any consistency issues.

## 2. Error recovery

Replication errors are only cleared once we successfully replicate some data (when `.commit(lsn)` is called). Development instances are often mostly idle, which meant that if some transient error ever occurred, it could take a long time before the error is cleared from the dashboard.

This fixes it to create an internal checkpoint whenever we start replication, which will trigger at least one `commit()` (as long as replication is working), clearing the error.



