### PR TITLE
[MongoDB] Skip current_data storage

### DIFF
--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -260,7 +260,7 @@ AND table_type = 'BASE TABLE';`,
       await promiseConnection.query<mysqlPromise.RowDataPacket[]>('START TRANSACTION');
       const sourceTables = this.syncRules.getSourceTables();
       await this.storage.startBatch(
-        { zeroLSN: ReplicatedGTID.ZERO.comparable, defaultSchema: this.defaultSchema },
+        { zeroLSN: ReplicatedGTID.ZERO.comparable, defaultSchema: this.defaultSchema, storeCurrentData: true },
         async (batch) => {
           for (let tablePattern of sourceTables) {
             const tables = await this.getQualifiedTableNames(batch, tablePattern);
@@ -383,7 +383,7 @@ AND table_type = 'BASE TABLE';`,
 
     if (!this.stopped) {
       await this.storage.startBatch(
-        { zeroLSN: ReplicatedGTID.ZERO.comparable, defaultSchema: this.defaultSchema },
+        { zeroLSN: ReplicatedGTID.ZERO.comparable, defaultSchema: this.defaultSchema, storeCurrentData: true },
         async (batch) => {
           const zongji = this.connections.createBinlogListener();
 

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -201,6 +201,16 @@ export interface BucketDataBatchOptions {
 
 export interface StartBatchOptions extends ParseSyncRulesOptions {
   zeroLSN: string;
+  /**
+   * Whether or not to store a copy of the current data.
+   *
+   * This is needed if we need to apply partial updates, for example
+   * when we get TOAST values from Postgres.
+   *
+   * This is not needed when we get the full document from the source
+   * database, for example from MongoDB.
+   */
+  storeCurrentData: boolean;
 }
 
 export interface SyncRulesBucketStorageListener extends DisposableListener {

--- a/packages/service-core/src/storage/mongo/OperationBatch.ts
+++ b/packages/service-core/src/storage/mongo/OperationBatch.ts
@@ -43,7 +43,16 @@ export class OperationBatch {
     return this.batch.length >= MAX_BATCH_COUNT || this.currentSize > MAX_RECORD_BATCH_SIZE;
   }
 
-  *batched(sizes: Map<string, number>): Generator<RecordOperation[]> {
+  /**
+   *
+   * @param sizes Map of source key to estimated size of the current_data document, or undefined if current_data is not persisted.
+   *
+   */
+  *batched(sizes: Map<string, number> | undefined): Generator<RecordOperation[]> {
+    if (sizes == null) {
+      yield this.batch;
+      return;
+    }
     let currentBatch: RecordOperation[] = [];
     let currentBatchSize = 0;
     for (let op of this.batch) {

--- a/packages/service-core/test/src/util.ts
+++ b/packages/service-core/test/src/util.ts
@@ -51,7 +51,8 @@ export const PARSE_OPTIONS: ParseSyncRulesOptions = {
 
 export const BATCH_OPTIONS: StartBatchOptions = {
   ...PARSE_OPTIONS,
-  zeroLSN: ZERO_LSN
+  zeroLSN: ZERO_LSN,
+  storeCurrentData: true
 };
 
 export function testRules(content: string): PersistedSyncRulesContent {


### PR DESCRIPTION
Builds on #121.

The current_data bucket storage collection stores the following data:

 * `buckets`: The current set of buckets for each replicated row
 * `lookups`: Current parameter query lookups for each replicated row
 * `data`: A copy of the current data

Buckets and lookups are used to be able to do REMOVE operations (need to know in which buckets a row was before, so we know from which buckets we need to remove it from after an update).

The `data` bit is to support partial updates. For Postgres, this could be when we receive an update with unchanged TOAST columns. However, for MongoDB we get the full document on each update, so never need that. This adds an optimization for MongoDB to skip that persistence.
