### PR TITLE
[beta] Fix managed write checkpoint filtering

### DIFF
--- a/packages/service-core/src/storage/mongo/MongoWriteCheckpointAPI.ts
+++ b/packages/service-core/src/storage/mongo/MongoWriteCheckpointAPI.ts
@@ -111,9 +111,16 @@ export class MongoWriteCheckpointAPI implements WriteCheckpointAPI {
   }
 
   protected async lastManagedWriteCheckpoint(filters: ManagedWriteCheckpointFilters) {
-    const { user_id } = filters;
+    const { user_id, heads } = filters;
+    // TODO: support multiple heads when we need to support multiple connections
+    const lsn = heads['1'];
+    if (lsn == null) {
+      // Can happen if we haven't replicated anything yet.
+      return null;
+    }
     const lastWriteCheckpoint = await this.db.write_checkpoints.findOne({
-      user_id: user_id
+      user_id: user_id,
+      'lsns.1': { $lte: lsn }
     });
     return lastWriteCheckpoint?.client_id ?? null;
   }


### PR DESCRIPTION
With #105, write checkpoint filtering was broken during the refactoring. This fixes it again.

The effect of the bug is that write checkpoints could be reported to the client sooner than it should be, which could result in "flickering" of data. This may not be noticeable in many cases, but would be more common if there is replication lag due to high write volumes.

Note: The test does pass on the current `main` branch (although it has to be refactored a bit to run).
