### PR TITLE
Write checkpoint workaround for Aurora Postgres

### DIFF
--- a/.changeset/tender-lions-hope.md
+++ b/.changeset/tender-lions-hope.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Workaround for Aurora Postgres write checkpoint bug

--- a/modules/module-postgres/src/module/PostgresModule.ts
+++ b/modules/module-postgres/src/module/PostgresModule.ts
@@ -47,7 +47,7 @@ export class PostgresModule extends replication.ReplicationModule<types.Postgres
   }
 
   protected createRouteAPIAdapter(): api.RouteAPI {
-    return new PostgresRouteAPIAdapter(this.resolveConfig(this.decodedConfig!));
+    return PostgresRouteAPIAdapter.withConfig(this.resolveConfig(this.decodedConfig!));
   }
 
   protected createReplicator(context: system.ServiceContext): replication.AbstractReplicator {

--- a/modules/module-postgres/test/src/util.ts
+++ b/modules/module-postgres/test/src/util.ts
@@ -6,6 +6,7 @@ import { BucketStorageFactory, Metrics, MongoBucketStorage, OpId } from '@powers
 import * as pgwire from '@powersync/service-jpgwire';
 import { pgwireRows } from '@powersync/service-jpgwire';
 import { env } from './env.js';
+import { PostgresRouteAPIAdapter } from '@module/api/PostgresRouteAPIAdapter.js';
 
 // The metrics need to be initialized before they can be used
 await Metrics.initialise({
@@ -82,7 +83,8 @@ export async function getClientCheckpoint(
 ): Promise<OpId> {
   const start = Date.now();
 
-  const [{ lsn }] = pgwireRows(await db.query(`SELECT pg_logical_emit_message(false, 'powersync', 'ping') as lsn`));
+  const api = new PostgresRouteAPIAdapter(db);
+  const lsn = await api.getReplicationHead();
 
   // This old API needs a persisted checkpoint id.
   // Since we don't use LSNs anymore, the only way to get that is to wait.

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -206,9 +206,7 @@ const uuid_blob: DocumentedSqlFunction = {
 
     return uuid.parse(uuidText);
   },
-  parameters: [
-    { name: 'uuid', type: ExpressionType.TEXT, optional: false }
-  ],
+  parameters: [{ name: 'uuid', type: ExpressionType.TEXT, optional: false }],
   getReturnType(args) {
     return ExpressionType.BLOB;
   },

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -102,19 +102,19 @@ describe('SQL functions', () => {
     expect(fn.base64(123.4)).toEqual('MTIzLjQ=');
   });
 
-
   test('uuid_blob', () => {
     expect(fn.uuid_blob(null)).toEqual(null);
     expect(fn.uuid_blob('550e8400-e29b-41d4-a716-446655440000')).toEqual(
-      new Uint8Array([85, 14, 132, 0, 226, 155, 65, 212, 167, 22, 68, 102, 85, 68, 0, 0]));
+      new Uint8Array([85, 14, 132, 0, 226, 155, 65, 212, 167, 22, 68, 102, 85, 68, 0, 0])
+    );
     expect(fn.uuid_blob('877b8be2-5a63-48e9-8ece-5e45b1d4f4ae')).toEqual(
       new Uint8Array([135, 123, 139, 226, 90, 99, 72, 233, 142, 206, 94, 69, 177, 212, 244, 174])
     );
-    expect(() => fn.uuid_blob("non-uuid")).toThrowError();
+    expect(() => fn.uuid_blob('non-uuid')).toThrowError();
 
     // Combine with base64
     const blob = fn.uuid_blob('550e8400-e29b-41d4-a716-446655440000');
-    expect(fn.base64(blob)).toEqual("VQ6EAOKbQdSnFkRmVUQAAA==");
+    expect(fn.base64(blob)).toEqual('VQ6EAOKbQdSnFkRmVUQAAA==');
   });
 
   test('ifnull', () => {


### PR DESCRIPTION
On most Postgres versions, `pg_logical_emit_message()` returns the correct current LSN. However, on Aurora (Postgres compatible), it can return an entirely different LSN in some (but not all) cases, causing the write checkpoints to never be replicated back to the client. To cater for those cases, we now use `pg_current_wal_lsn()` to get the correct LSN.

Both queries are done in a single pgwire query call, so it is still a single round-trip with minimal overhead.