### PR TITLE
Fix compact action

### DIFF
--- a/.changeset/dry-walls-sleep.md
+++ b/.changeset/dry-walls-sleep.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Fix compact action

--- a/packages/service-core/src/entry/commands/compact-action.ts
+++ b/packages/service-core/src/entry/commands/compact-action.ts
@@ -29,7 +29,7 @@ export function registerCompactAction(program: Command) {
 
   return compactCommand.description('Compact storage').action(async (options) => {
     const buckets = options.buckets?.split(',');
-    if (buckets != null) {
+    if (buckets == null) {
       logger.info('Compacting storage for all buckets...');
     } else {
       logger.info(`Compacting storage for ${buckets.join(', ')}...`);


### PR DESCRIPTION
Fixes regression from #120. This caused any compact action to fail with `Fatal error Cannot read properties of undefined (reading 'join')` - both self-hosted and cloud versions.
