### PR TITLE
Supabase static keys - simplified config

### DIFF
--- a/.changeset/green-forks-approve.md
+++ b/.changeset/green-forks-approve.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-core': minor
+'@powersync/service-types': minor
+'@powersync/service-image': minor
+---
+
+Add "supabase_jwt_secret" config option to simplify static Supabase auth.

--- a/modules/module-postgres/src/auth/SupabaseKeyCollector.ts
+++ b/modules/module-postgres/src/auth/SupabaseKeyCollector.ts
@@ -10,6 +10,8 @@ import * as pgwire_utils from '../utils/pgwire_utils.js';
  *
  * Unfortunately, despite the JWTs containing a kid, we have no way to lookup that kid
  * before receiving a valid token.
+ *
+ * @deprecated Supabase is removing support for "app.settings.jwt_secret".
  */
 export class SupabaseKeyCollector implements auth.KeyCollector {
   private pool: pgwire.PgClient;

--- a/packages/service-core/src/auth/KeySpec.ts
+++ b/packages/service-core/src/auth/KeySpec.ts
@@ -24,8 +24,13 @@ export class KeySpec {
   options: KeyOptions;
 
   static async importKey(key: jose.JWK, options?: KeyOptions): Promise<KeySpec> {
-    const parsed = (await jose.importJWK(key)) as jose.KeyLike;
-    return new KeySpec(key, parsed, options);
+    let normalizedKey: jose.JWK = {
+      ...key,
+      // treat '' as wildcard kid
+      kid: key.kid == '' ? undefined : key.kid
+    };
+    const parsed = (await jose.importJWK(normalizedKey)) as jose.KeyLike;
+    return new KeySpec(normalizedKey, parsed, options);
   }
 
   constructor(source: jose.JWK, key: jose.KeyLike, options?: KeyOptions) {

--- a/packages/service-core/src/auth/KeySpec.ts
+++ b/packages/service-core/src/auth/KeySpec.ts
@@ -24,13 +24,8 @@ export class KeySpec {
   options: KeyOptions;
 
   static async importKey(key: jose.JWK, options?: KeyOptions): Promise<KeySpec> {
-    let normalizedKey: jose.JWK = {
-      ...key,
-      // treat '' as wildcard kid
-      kid: key.kid == '' ? undefined : key.kid
-    };
-    const parsed = (await jose.importJWK(normalizedKey)) as jose.KeyLike;
-    return new KeySpec(normalizedKey, parsed, options);
+    const parsed = (await jose.importJWK(key)) as jose.KeyLike;
+    return new KeySpec(key, parsed, options);
   }
 
   constructor(source: jose.JWK, key: jose.KeyLike, options?: KeyOptions) {

--- a/packages/service-core/src/auth/StaticSupabaseKeyCollector.ts
+++ b/packages/service-core/src/auth/StaticSupabaseKeyCollector.ts
@@ -1,0 +1,31 @@
+import * as jose from 'jose';
+import { KeySpec, KeyOptions } from './KeySpec.js';
+import { KeyCollector, KeyResult } from './KeyCollector.js';
+
+const SUPABASE_KEY_OPTIONS: KeyOptions = {
+  requiresAudience: ['authenticated'],
+  maxLifetimeSeconds: 86400 * 7 + 1200 // 1 week + 20 minutes margin
+};
+
+/**
+ * Set of static keys for Supabase.
+ *
+ * Same as StaticKeyCollector, but with some configuration tweaks for Supabase.
+ *
+ * Similar to SupabaseKeyCollector, but using hardcoded keys instead of fetching
+ * from the database.
+ *
+ * A key can be added both with and without a kid, in case wildcard matching is desired.
+ */
+export class StaticSupabaseKeyCollector implements KeyCollector {
+  static async importKeys(keys: jose.JWK[]) {
+    const parsedKeys = await Promise.all(keys.map((key) => KeySpec.importKey(key, SUPABASE_KEY_OPTIONS)));
+    return new StaticSupabaseKeyCollector(parsedKeys);
+  }
+
+  constructor(private keys: KeySpec[]) {}
+
+  async getKeys(): Promise<KeyResult> {
+    return { keys: this.keys, errors: [] };
+  }
+}

--- a/packages/service-core/src/auth/auth-index.ts
+++ b/packages/service-core/src/auth/auth-index.ts
@@ -7,3 +7,4 @@ export * from './KeyStore.js';
 export * from './LeakyBucket.js';
 export * from './RemoteJWKSCollector.js';
 export * from './StaticKeyCollector.js';
+export * from './StaticSupabaseKeyCollector.js';

--- a/packages/service-core/src/util/config/compound-config-collector.ts
+++ b/packages/service-core/src/util/config/compound-config-collector.ts
@@ -65,8 +65,13 @@ export class CompoundConfigCollector {
 
     const inputKeys = baseConfig.client_auth?.jwks?.keys ?? [];
     const staticCollector = await auth.StaticKeyCollector.importKeys(inputKeys);
-
     collectors.add(staticCollector);
+
+    if (baseConfig.client_auth?.supabase) {
+      // Re-use the same static keys, but with different audience and timeout
+      // for Supabase.
+      collectors.add(await auth.StaticSupabaseKeyCollector.importKeys(inputKeys));
+    }
 
     let jwks_uris = baseConfig.client_auth?.jwks_uri ?? [];
     if (typeof jwks_uris == 'string') {

--- a/packages/service-core/src/util/config/compound-config-collector.ts
+++ b/packages/service-core/src/util/config/compound-config-collector.ts
@@ -67,10 +67,23 @@ export class CompoundConfigCollector {
     const staticCollector = await auth.StaticKeyCollector.importKeys(inputKeys);
     collectors.add(staticCollector);
 
-    if (baseConfig.client_auth?.supabase) {
-      // Re-use the same static keys, but with different audience and timeout
-      // for Supabase.
-      collectors.add(await auth.StaticSupabaseKeyCollector.importKeys(inputKeys));
+    if (baseConfig.client_auth?.supabase && baseConfig.client_auth?.supabase_jwt_secret != null) {
+      // This replaces the old SupabaseKeyCollector, with a statically-configured key.
+      // You can get the same effect with manual HS256 key configuration, but this
+      // makes the config simpler.
+      // We also a custom audience ("authenticated"), increased max lifetime (1 week),
+      // and auto base64-url-encode the key.
+      collectors.add(
+        await auth.StaticSupabaseKeyCollector.importKeys([
+          {
+            kty: 'oct',
+            alg: 'HS256',
+            // In this case, the key is not base64-encoded yet.
+            k: Buffer.from(baseConfig.client_auth.supabase_jwt_secret, 'utf8').toString('base64url'),
+            kid: undefined // Wildcard kid - any kid can match
+          }
+        ])
+      );
     }
 
     let jwks_uris = baseConfig.client_auth?.jwks_uri ?? [];

--- a/packages/types/src/config/PowerSyncConfig.ts
+++ b/packages/types/src/config/PowerSyncConfig.ts
@@ -115,6 +115,7 @@ export const powerSyncConfig = t.object({
       block_local_jwks: t.boolean.optional(),
       jwks: strictJwks.optional(),
       supabase: t.boolean.optional(),
+      supabase_jwt_secret: t.string.optional(),
       audience: t.array(t.string).optional()
     })
     .optional(),


### PR DESCRIPTION
This adds a new `supabase_jwt_secret` config option. This can be set to the same value as the deprecated `app.settings.jwt_secret` value, without any additional config.

Specifically, this does:
1. Avoid needing boilerplate for key type and alg.
2. Avoid needing to specify the audience "authenticated".
3. Increase the max key lifetime to match Supabase (1 week),
4. Automatically base64-url-encode the key.

The idea is this would allow just copying the Supabase JWT key from the Supabase project dashboard, without any more complications.

As soon as Supabase rolls out asymmetric keys, we can deprecate this workflow.
