### PR TITLE
Sync rules function to convert uuid to base64

### DIFF
--- a/.changeset/swift-ways-live.md
+++ b/.changeset/swift-ways-live.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': minor
+---
+
+Sync rules function to convert uuid to base64

--- a/packages/sync-rules/package.json
+++ b/packages/sync-rules/package.json
@@ -25,10 +25,12 @@
     "@syncpoint/wkx": "^0.5.0",
     "ajv": "^8.12.0",
     "pgsql-ast-parser": "^11.1.0",
-    "yaml": "^2.3.1"
+    "yaml": "^2.3.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.5.5",
-    "vitest": "^2.1.1"
+    "vitest": "^2.1.1",
+    "@types/uuid": "^9.0.4"
   }
 }

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -189,8 +189,8 @@ const base64: DocumentedSqlFunction = {
   detail: 'Convert a blob to base64 text'
 };
 
-const uuid_base64: DocumentedSqlFunction = {
-  debugName: 'uuid_base64',
+const uuid_blob: DocumentedSqlFunction = {
+  debugName: 'uuid_blob',
   call(value: SqliteValue) {
     const uuidText = castAsText(value);
 
@@ -201,20 +201,18 @@ const uuid_base64: DocumentedSqlFunction = {
     const isValid = uuid.validate(uuidText);
 
     if (!isValid) {
-      throw new Error(`Cannot call uuid_base64 on a non UUID value`);
+      throw new Error(`Cannot call uuid_blob on a non UUID value`);
     }
 
-    const uuidBytes = uuid.parse(uuidText);
-
-    return Buffer.from(uuidBytes).toString('base64');
+    return uuid.parse(uuidText);
   },
   parameters: [
     { name: 'uuid', type: ExpressionType.TEXT, optional: false }
   ],
   getReturnType(args) {
-    return ExpressionType.TEXT;
+    return ExpressionType.BLOB;
   },
-  detail: 'Convert the underlying UUID bytes to base64'
+  detail: 'Convert the UUID string to bytes'
 };
 
 const fn_typeof: DocumentedSqlFunction = {
@@ -515,7 +513,7 @@ export const SQL_FUNCTIONS_NAMED = {
   hex,
   length,
   base64,
-  uuid_base64,
+  uuid_blob,
   typeof: fn_typeof,
   ifnull,
   json_extract,

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -102,6 +102,14 @@ describe('SQL functions', () => {
     expect(fn.base64(123.4)).toEqual('MTIzLjQ=');
   });
 
+
+  test('uuid_base64', () => {
+    expect(fn.uuid_base64(null)).toEqual(null);
+    expect(fn.uuid_base64('550e8400-e29b-41d4-a716-446655440000')).toEqual('VQ6EAOKbQdSnFkRmVUQAAA==');
+    expect(fn.uuid_base64('877b8be2-5a63-48e9-8ece-5e45b1d4f4ae')).toEqual('h3uL4lpjSOmOzl5FsdT0rg==');
+    expect(() => fn.uuid_base64("non-uuid")).toThrowError();
+  });
+
   test('ifnull', () => {
     expect(fn.ifnull(null, null)).toEqual(null);
     expect(fn.ifnull('test', null)).toEqual('test');

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -103,11 +103,18 @@ describe('SQL functions', () => {
   });
 
 
-  test('uuid_base64', () => {
-    expect(fn.uuid_base64(null)).toEqual(null);
-    expect(fn.uuid_base64('550e8400-e29b-41d4-a716-446655440000')).toEqual('VQ6EAOKbQdSnFkRmVUQAAA==');
-    expect(fn.uuid_base64('877b8be2-5a63-48e9-8ece-5e45b1d4f4ae')).toEqual('h3uL4lpjSOmOzl5FsdT0rg==');
-    expect(() => fn.uuid_base64("non-uuid")).toThrowError();
+  test('uuid_blob', () => {
+    expect(fn.uuid_blob(null)).toEqual(null);
+    expect(fn.uuid_blob('550e8400-e29b-41d4-a716-446655440000')).toEqual(
+      new Uint8Array([85, 14, 132, 0, 226, 155, 65, 212, 167, 22, 68, 102, 85, 68, 0, 0]));
+    expect(fn.uuid_blob('877b8be2-5a63-48e9-8ece-5e45b1d4f4ae')).toEqual(
+      new Uint8Array([135, 123, 139, 226, 90, 99, 72, 233, 142, 206, 94, 69, 177, 212, 244, 174])
+    );
+    expect(() => fn.uuid_blob("non-uuid")).toThrowError();
+
+    // Combine with base64
+    const blob = fn.uuid_blob('550e8400-e29b-41d4-a716-446655440000');
+    expect(fn.base64(blob)).toEqual("VQ6EAOKbQdSnFkRmVUQAAA==");
   });
 
   test('ifnull', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       pgsql-ast-parser:
         specifier: ^11.1.0
         version: 11.2.0
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
       yaml:
         specifier: ^2.3.1
         version: 2.4.5
@@ -402,6 +405,9 @@ importers:
       '@types/node':
         specifier: ^22.5.5
         version: 22.5.5
+      '@types/uuid':
+        specifier: ^9.0.4
+        version: 9.0.8
       vitest:
         specifier: ^2.1.1
         version: 2.1.1(@types/node@22.5.5)


### PR DESCRIPTION
In our project we use base64 encoded uuids on the client, for faster indexes and joins. 

This PR adds a function to convert the underline uuid bytes into base64, alternatively there could be a function to convert to just bytes and then use the base64 sync rule function. Let us know what you think is best.

This is our Discord discussion: https://discord.com/channels/1138230179878154300/1312036536849666118