### PR TITLE
Disable SupabaseKeyCollector when a secret is configured

### DIFF
--- a/.changeset/plenty-poets-tan.md
+++ b/.changeset/plenty-poets-tan.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-postgres': patch
+'@powersync/service-image': patch
+---
+
+Disable SupabaseKeyCollector when a specific secret is configured.

--- a/modules/module-postgres/src/module/PostgresModule.ts
+++ b/modules/module-postgres/src/module/PostgresModule.ts
@@ -23,7 +23,16 @@ export class PostgresModule extends replication.ReplicationModule<types.Postgres
   async initialize(context: system.ServiceContextContainer): Promise<void> {
     await super.initialize(context);
 
-    if (context.configuration.base_config.client_auth?.supabase) {
+    const client_auth = context.configuration.base_config.client_auth;
+
+    if (client_auth?.supabase && client_auth?.supabase_jwt_secret == null) {
+      // Only use the deprecated SupabaseKeyCollector when there is no
+      // secret hardcoded. Hardcoded secrets are handled elsewhere, using
+      // StaticSupabaseKeyCollector.
+
+      // Support for SupabaseKeyCollector is deprecated and support will be
+      // completely removed by Supabase soon. We can keep support a while
+      // longer for self-hosted setups, before also removing that on our side.
       this.registerSupabaseAuth(context);
     }
 


### PR DESCRIPTION
When a secret is explicitly configured, disable the SupabaseKeyCollector that uses `current_setting('app.settings.jwt_secret')`.

This helps to:
1. Make it easier to see when the secret is incorrectly configured (versus working now and failing at a later date).
2. Avoid errors in the logs when failing to lookup `current_setting('app.settings.jwt_secret')`, despite the hardcoded secret being configured.
