### PR TITLE
[Postgres] Fix replication lag diagnostics

### DIFF
--- a/.changeset/six-rings-greet.md
+++ b/.changeset/six-rings-greet.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-postgres': patch
+'@powersync/service-image': patch
+---
+
+Fix replication lag diagnostics for Postgres.

--- a/modules/module-postgres/src/api/PostgresRouteAPIAdapter.ts
+++ b/modules/module-postgres/src/api/PostgresRouteAPIAdapter.ts
@@ -213,7 +213,8 @@ export class PostgresRouteAPIAdapter implements api.RouteAPI {
   }
 
   async getReplicationLag(options: api.ReplicationLagOptions): Promise<number | undefined> {
-    const { bucketStorage: slotName } = options;
+    const { bucketStorage } = options;
+    const slotName = bucketStorage.slot_name;
     const results = await pg_utils.retriedQuery(this.pool, {
       statement: `SELECT
   slot_name,


### PR DESCRIPTION
Fixes this error showing up in the logs:

```
Unable to get replication lag Could not determine replication lag for slot [object Object]
```

This does not affect end-users, and we don't actually display that in the instance diagnostics yet. So it was primarily an issue of confusing developers when they view the logs.
