### PR TITLE
[Postgres] Improve timeouts and table snapshots

### DIFF
--- a/.changeset/chilled-bears-kneel.md
+++ b/.changeset/chilled-bears-kneel.md
@@ -1,6 +1,7 @@
 ---
 '@powersync/service-core': minor
 '@powersync/service-types': minor
+'@powersync/service-image': minor
 ---
 
-Add EdDSA support for signing JWTs
+Add EdDSA support for JWTs.

--- a/.changeset/young-rings-fold.md
+++ b/.changeset/young-rings-fold.md
@@ -1,7 +1,7 @@
 ---
 '@powersync/service-module-postgres': minor
 '@powersync/service-jpgwire': patch
-'@powersync/service-image': patch
+'@powersync/service-image': minor
 ---
 
 Improve timeouts and table snapshots for Postgres initial replication.

--- a/.changeset/young-rings-fold.md
+++ b/.changeset/young-rings-fold.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-postgres': minor
+'@powersync/service-jpgwire': patch
+'@powersync/service-image': patch
+---
+
+Improve timeouts and table snapshots for Postgres initial replication.

--- a/modules/module-postgres/src/replication/PgManager.ts
+++ b/modules/module-postgres/src/replication/PgManager.ts
@@ -1,6 +1,11 @@
 import * as pgwire from '@powersync/service-jpgwire';
 import { NormalizedPostgresConnectionConfig } from '../types/types.js';
 
+/**
+ * Shorter timeout for snapshot connections than for replication connections.
+ */
+const SNAPSHOT_SOCKET_TIMEOUT = 30_000;
+
 export class PgManager {
   /**
    * Do not use this for any transactions.
@@ -39,9 +44,18 @@ export class PgManager {
     const p = pgwire.connectPgWire(this.options, { type: 'standard' });
     this.connectionPromises.push(p);
     const connection = await p;
+
+    // Use an shorter timeout for snapshot connections.
+    // This is to detect broken connections early, instead of waiting
+    // for the full 6 minutes.
+    // This we are constantly using the connection, we don't need any
+    // custom keepalives.
+    (connection as any)._socket.setTimeout(SNAPSHOT_SOCKET_TIMEOUT);
+
     // Disable statement timeout for snapshot queries.
     // On Supabase, the default is 2 minutes.
     await connection.query(`set session statement_timeout = 0`);
+
     return connection;
   }
 


### PR DESCRIPTION
Builds on #150.

This configures both TCP keepalive and connection timeouts, to detect broken snapshot connections in around 30 seconds instead of 6 minutes.

This now also uses `DECLARE CURSOR` and `FETCH` to fetch data in batches, instead of one large stream. This may reduce the chance of these connections hanging.
