### PR TITLE
Fix bulkWrite BSON error

### DIFF
--- a/.changeset/perfect-fireants-warn.md
+++ b/.changeset/perfect-fireants-warn.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-postgres': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Fix "BSONObj size is invalid" error during replication.

--- a/modules/module-mongodb/package.json
+++ b/modules/module-mongodb/package.json
@@ -33,7 +33,7 @@
     "@powersync/service-jsonbig": "workspace:*",
     "@powersync/service-sync-rules": "workspace:*",
     "@powersync/service-types": "workspace:*",
-    "mongodb": "^6.7.0",
+    "mongodb": "^6.11.0",
     "ts-codec": "^1.2.2",
     "uuid": "^9.0.1",
     "uri-js": "^4.4.1"

--- a/modules/module-postgres/test/src/large_batch.test.ts
+++ b/modules/module-postgres/test/src/large_batch.test.ts
@@ -176,6 +176,71 @@ function defineBatchTests(factory: StorageFactory) {
     console.log(`Truncated ${truncateCount} ops in ${truncateDuration}ms ${truncatePerSecond} ops/s. ${used}MB heap`);
   });
 
+  test('large number of bucket_data docs', async () => {
+    // This tests that we don't run into this error:
+    //   MongoBulkWriteError: BSONObj size: 16814023 (0x1008FC7) is invalid. Size must be between 0 and 16793600(16MB) First element: insert: "bucket_data"
+    // The test is quite sensitive to internals, since we need to
+    // generate an internal batch that is just below 16MB.
+    //
+    // For the test to work, we need a:
+    // 1. Large number of documents in the batch.
+    // 2. More bucket_data documents than current_data documents,
+    //    otherwise other batch limiting thresholds are hit.
+    // 3. A large document to make sure we get to just below the 16MB
+    //    limit.
+    // 4. Another document to make sure the internal batching overflows
+    //    to a second batch.
+
+    await using context = await WalStreamTestContext.open(factory);
+    await context.updateSyncRules(`bucket_definitions:
+  global:
+    data:
+      # Sync 4x so we get more bucket_data documents
+      - SELECT * FROM test_data
+      - SELECT * FROM test_data
+      - SELECT * FROM test_data
+      - SELECT * FROM test_data
+      `);
+    const { pool } = context;
+
+    await pool.query(`CREATE TABLE test_data(id serial primary key, description text)`);
+
+    const numDocs = 499;
+    let description = '';
+    while (description.length < 2650) {
+      description += '.';
+    }
+
+    await pool.query({
+      statement: `INSERT INTO test_data(description) SELECT $2 FROM generate_series(1, $1) i`,
+      params: [
+        { type: 'int4', value: numDocs },
+        { type: 'varchar', value: description }
+      ]
+    });
+
+    let largeDescription = '';
+
+    while (largeDescription.length < 2_768_000) {
+      largeDescription += '.';
+    }
+    await pool.query({
+      statement: 'INSERT INTO test_data(description) VALUES($1)',
+      params: [{ type: 'varchar', value: largeDescription }]
+    });
+    await pool.query({
+      statement: 'INSERT INTO test_data(description) VALUES($1)',
+      params: [{ type: 'varchar', value: 'testingthis' }]
+    });
+    await context.replicateSnapshot();
+
+    context.startStreaming();
+
+    const checkpoint = await context.getCheckpoint({ timeout: 50_000 });
+    const checksum = await context.storage!.getChecksums(checkpoint, ['global[]']);
+    expect(checksum.get('global[]')!.count).toEqual((numDocs + 2) * 4);
+  });
+
   test('resuming initial replication (1)', async () => {
     // Stop early - likely to not include deleted row in first replication attempt.
     await testResumingReplication(2000);

--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -37,7 +37,7 @@
     "jose": "^4.15.1",
     "lodash": "^4.17.21",
     "lru-cache": "^10.2.2",
-    "mongodb": "^6.7.0",
+    "mongodb": "^6.11.0",
     "node-fetch": "^3.3.2",
     "ts-codec": "^1.2.2",
     "uri-js": "^4.4.1",

--- a/packages/service-core/src/storage/mongo/MongoCompactor.ts
+++ b/packages/service-core/src/storage/mongo/MongoCompactor.ts
@@ -5,6 +5,7 @@ import { PowerSyncMongo } from './db.js';
 import { BucketDataDocument, BucketDataKey } from './models.js';
 import { CompactOptions } from '../BucketStorage.js';
 import { cacheKey } from './OperationBatch.js';
+import { safeBulkWrite } from './util.js';
 
 interface CurrentBucketState {
   /** Bucket name */
@@ -264,7 +265,7 @@ export class MongoCompactor {
   private async flush() {
     if (this.updates.length > 0) {
       logger.info(`Compacting ${this.updates.length} ops`);
-      await this.db.bucket_data.bulkWrite(this.updates, {
+      await safeBulkWrite(this.db.bucket_data, this.updates, {
         // Order is not important.
         // Since checksums are not affected, these operations can happen in any order,
         // and it's fine if the operations are partially applied.

--- a/packages/service-core/src/storage/mongo/MongoWriteCheckpointAPI.ts
+++ b/packages/service-core/src/storage/mongo/MongoWriteCheckpointAPI.ts
@@ -9,6 +9,7 @@ import {
   WriteCheckpointMode
 } from '../WriteCheckpointAPI.js';
 import { PowerSyncMongo } from './db.js';
+import { safeBulkWrite } from './util.js';
 
 export type MongoCheckpointAPIOptions = {
   db: PowerSyncMongo;
@@ -134,7 +135,8 @@ export async function batchCreateCustomWriteCheckpoints(
     return;
   }
 
-  await db.custom_write_checkpoints.bulkWrite(
+  await safeBulkWrite(
+    db.custom_write_checkpoints,
     checkpoints.map((checkpointOptions) => ({
       updateOne: {
         filter: { user_id: checkpointOptions.user_id, sync_rules_id: checkpointOptions.sync_rules_id },
@@ -146,6 +148,7 @@ export async function batchCreateCustomWriteCheckpoints(
         },
         upsert: true
       }
-    }))
+    })),
+    {}
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/types
       mongodb:
-        specifier: ^6.7.0
-        version: 6.8.0(socks@2.8.3)
+        specifier: ^6.11.0
+        version: 6.11.0(socks@2.8.3)
       ts-codec:
         specifier: ^1.2.2
         version: 1.2.2
@@ -344,8 +344,8 @@ importers:
         specifier: ^10.2.2
         version: 10.4.3
       mongodb:
-        specifier: ^6.7.0
-        version: 6.8.0(socks@2.8.3)
+        specifier: ^6.11.0
+        version: 6.11.0(socks@2.8.3)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -496,8 +496,8 @@ importers:
         specifier: ^10.0.1
         version: 10.4.3
       mongodb:
-        specifier: ^6.7.0
-        version: 6.8.0(socks@2.8.3)
+        specifier: ^6.11.0
+        version: 6.11.0(socks@2.8.3)
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -830,8 +830,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mongodb-js/saslprep@1.1.7':
-    resolution: {integrity: sha512-dCHW/oEX0KJ4NjDULBo3JiOaK5+6axtpBbS+ao2ZInoAL9/YRQLhXzSNAFz7hP4nzLkIqsfYAK/PDE3+XHny0Q==}
+  '@mongodb-js/saslprep@1.1.9':
+    resolution: {integrity: sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1586,6 +1586,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  bson@6.10.1:
+    resolution: {integrity: sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==}
+    engines: {node: '>=16.20.1'}
 
   bson@6.8.0:
     resolution: {integrity: sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==}
@@ -2571,8 +2575,8 @@ packages:
   mongodb-connection-string-url@3.0.1:
     resolution: {integrity: sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==}
 
-  mongodb@6.8.0:
-    resolution: {integrity: sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==}
+  mongodb@6.11.0:
+    resolution: {integrity: sha512-yVbPw0qT268YKhG241vAMLaDQAPbRyTgo++odSgGc9kXnzOujQI60Iyj23B9sQQFPSvmNPvMZ3dsFz0aN55KgA==}
     engines: {node: '>=16.20.1'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.188.0
@@ -4100,7 +4104,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mongodb-js/saslprep@1.1.7':
+  '@mongodb-js/saslprep@1.1.9':
     dependencies:
       sparse-bitfield: 3.0.3
 
@@ -4636,7 +4640,7 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.25.1
       '@prisma/instrumentation': 5.16.1
       '@sentry/core': 8.17.0
-      '@sentry/opentelemetry': 8.17.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.6.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.6.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.6.0))(@opentelemetry/semantic-conventions@1.25.1)
+      '@sentry/opentelemetry': 8.17.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.6.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.1)
       '@sentry/types': 8.17.0
       '@sentry/utils': 8.17.0
     optionalDependencies:
@@ -4644,7 +4648,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@8.17.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.6.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.6.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.6.0))(@opentelemetry/semantic-conventions@1.25.1)':
+  '@sentry/opentelemetry@8.17.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.6.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.0)
@@ -4984,6 +4988,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  bson@6.10.1: {}
 
   bson@6.8.0: {}
 
@@ -6041,10 +6047,10 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 13.0.0
 
-  mongodb@6.8.0(socks@2.8.3):
+  mongodb@6.11.0(socks@2.8.3):
     dependencies:
-      '@mongodb-js/saslprep': 1.1.7
-      bson: 6.8.0
+      '@mongodb-js/saslprep': 1.1.9
+      bson: 6.10.1
       mongodb-connection-string-url: 3.0.1
     optionalDependencies:
       socks: 2.8.3

--- a/service/package.json
+++ b/service/package.json
@@ -34,7 +34,7 @@
     "ix": "^5.0.0",
     "jose": "^4.15.1",
     "lru-cache": "^10.0.1",
-    "mongodb": "^6.7.0",
+    "mongodb": "^6.11.0",
     "node-fetch": "^3.3.2",
     "pgwire": "github:kagis/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87",
     "ts-codec": "^1.2.2",


### PR DESCRIPTION
Sample error seen during replication:

```
MongoBulkWriteError: BSONObj size: 16814023 (0x1008FC7) is invalid. Size must be between 0 and 16793600(16MB) First element: insert: "bucket_data"
```

This appears to be a regression in v6.10.0 of the MongoDB NodeJS driver, which we're using on the cloud service.

See the comments for details on the issue and the fix. I'll file a driver bug report after we get this out.