### PR TITLE
[MongoDB] Short timeout for testing connections

### DIFF
--- a/.changeset/moody-cobras-walk.md
+++ b/.changeset/moody-cobras-walk.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': patch
+---
+
+Use short timeout for testing mongodb connections.

--- a/modules/module-mongodb/src/module/MongoModule.ts
+++ b/modules/module-mongodb/src/module/MongoModule.ts
@@ -55,7 +55,11 @@ export class MongoModule extends replication.ReplicationModule<types.MongoConnec
   async testConnection(config: types.MongoConnectionConfig): Promise<void> {
     this.decodeConfig(config);
     const normalisedConfig = this.resolveConfig(this.decodedConfig!);
-    const connectionManager = new MongoManager(normalisedConfig);
+    const connectionManager = new MongoManager(normalisedConfig, {
+      // Use short timeouts for testing connections
+      socketTimeoutMS: 5_000,
+      serverSelectionTimeoutMS: 5_000
+    });
     try {
       return checkSourceConfiguration(connectionManager);
     } finally {

--- a/modules/module-mongodb/src/module/MongoModule.ts
+++ b/modules/module-mongodb/src/module/MongoModule.ts
@@ -56,12 +56,13 @@ export class MongoModule extends replication.ReplicationModule<types.MongoConnec
     this.decodeConfig(config);
     const normalisedConfig = this.resolveConfig(this.decodedConfig!);
     const connectionManager = new MongoManager(normalisedConfig, {
-      // Use short timeouts for testing connections
+      // Use short timeouts for testing connections.
+      // Must be < 30s, to ensure we get a proper timeout error.
       socketTimeoutMS: 5_000,
       serverSelectionTimeoutMS: 5_000
     });
     try {
-      return checkSourceConfiguration(connectionManager);
+      return await checkSourceConfiguration(connectionManager);
     } finally {
       await connectionManager.end();
     }

--- a/modules/module-mongodb/src/replication/MongoManager.ts
+++ b/modules/module-mongodb/src/replication/MongoManager.ts
@@ -8,7 +8,10 @@ export class MongoManager {
   public readonly client: mongo.MongoClient;
   public readonly db: mongo.Db;
 
-  constructor(public options: NormalizedMongoConnectionConfig) {
+  constructor(
+    public options: NormalizedMongoConnectionConfig,
+    overrides?: mongo.MongoClientOptions
+  ) {
     // The pool is lazy - no connections are opened until a query is performed.
     this.client = new mongo.MongoClient(options.uri, {
       auth: {
@@ -28,7 +31,8 @@ export class MongoManager {
       maxPoolSize: 8,
 
       maxConnecting: 3,
-      maxIdleTimeMS: 60_000
+      maxIdleTimeMS: 60_000,
+      ...overrides
     });
     this.db = this.client.db(options.database, {});
   }

--- a/modules/module-postgres/src/module/PostgresModule.ts
+++ b/modules/module-postgres/src/module/PostgresModule.ts
@@ -133,7 +133,7 @@ export class PostgresModule extends replication.ReplicationModule<types.Postgres
     });
     const connection = await connectionManager.snapshotConnection();
     try {
-      return checkSourceConfiguration(connection, PUBLICATION_NAME);
+      return await checkSourceConfiguration(connection, PUBLICATION_NAME);
     } finally {
       await connectionManager.end();
     }


### PR DESCRIPTION
This is relevant for testing connections on the cloud dashboard. Currently the worker_thread is killed before the connection times out. The shorter timeout will ensure we get a proper error when failing to connect.