### PR TITLE
[Postgres] Fix slot recovery & improve log output

### DIFF
--- a/.changeset/chatty-boxes-repeat.md
+++ b/.changeset/chatty-boxes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-postgres': patch
+---
+
+Fix replication slot recovery

--- a/.changeset/serious-rivers-sin.md
+++ b/.changeset/serious-rivers-sin.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Reduce noise in log output

--- a/modules/module-postgres/test/src/wal_stream.test.ts
+++ b/modules/module-postgres/test/src/wal_stream.test.ts
@@ -293,7 +293,7 @@ bucket_definitions:
     expect(endTxCount - startTxCount).toEqual(1);
   });
 
-  test.only('reporting slot issues', async () => {
+  test('reporting slot issues', async () => {
     {
       await using context = await WalStreamTestContext.open(factory);
       const { pool } = context;

--- a/modules/module-postgres/test/src/wal_stream_utils.ts
+++ b/modules/module-postgres/test/src/wal_stream_utils.ts
@@ -77,6 +77,16 @@ export class WalStreamTestContext implements AsyncDisposable {
     return this.storage!;
   }
 
+  async loadActiveSyncRules() {
+    const syncRules = await this.factory.getActiveSyncRulesContent();
+    if (syncRules == null) {
+      throw new Error(`Active sync rules not available`);
+    }
+
+    this.storage = this.factory.getInstance(syncRules);
+    return this.storage!;
+  }
+
   get walStream() {
     if (this.storage == null) {
       throw new Error('updateSyncRules() first');

--- a/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
+++ b/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
@@ -522,11 +522,13 @@ export class MongoSyncBucketStorage
     while (true) {
       try {
         await this.clearIteration();
+
+        logger.info(`${this.slot_name} Done clearing data`);
         return;
       } catch (e: unknown) {
         if (e instanceof mongo.MongoServerError && e.codeName == 'MaxTimeMSExpired') {
           logger.info(
-            `Clearing took longer than ${db.mongo.MONGO_CLEAR_OPERATION_TIMEOUT_MS}ms, waiting and triggering another iteration.`
+            `${this.slot_name} Cleared batch of data in ${db.mongo.MONGO_CLEAR_OPERATION_TIMEOUT_MS}ms, continuing...`
           );
           await timers.setTimeout(db.mongo.MONGO_CLEAR_OPERATION_TIMEOUT_MS / 5);
           continue;


### PR DESCRIPTION
Fixes regression from #150.

When starting replication, there are 4 different scenarios we cater for, depending on whether or not we have already completed the initial snapshot before, and whether or not we have a working logical replication slot.

```
1. haveSnapshot: false, haveWorkingSlot: false -> initial sync from scratch
2. haveSnapshot: true,  haveWorkingSlot: true  -> resume streaming replication
3. haveSnapshot: false, haveWorkingSlot: true  -> resume initial sync (new in #150)
4. haveSnapshot: true,  haveWorkingSlot: false -> initial sync from scratch (broken in #150)
```

The regression was in case 4 above - the slot would not get re-created, and replication would remain stuck. It can be triggered by something like replication lag falling too far behind, or anything else that makes the replication slot invalid.

The fix here is to raise a MissingReplicationSlotError error again for that case. That is caught higher up in the process, creates a new replication slot with an incremented index (while keeping the current data active), and then replicating with that new slot.

This PR also makes minor improvements to log output.