### PR TITLE
Bucket Parameters Lookup Fix

### DIFF
--- a/.changeset/pretty-hotels-wonder.md
+++ b/.changeset/pretty-hotels-wonder.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix bucket parameters grouping.

--- a/.changeset/rare-knives-pump.md
+++ b/.changeset/rare-knives-pump.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-image': patch
+---
+
+test

--- a/.changeset/rare-knives-pump.md
+++ b/.changeset/rare-knives-pump.md
@@ -1,5 +1,0 @@
----
-'@powersync/service-image': patch
----
-
-test

--- a/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
+++ b/packages/service-core/src/storage/mongo/MongoSyncBucketStorage.ts
@@ -265,7 +265,7 @@ export class MongoSyncBucketStorage
         },
         {
           $group: {
-            _id: '$key',
+            _id: { key: '$key', lookup: '$lookup' },
             bucket_parameters: {
               $first: '$bucket_parameters'
             }

--- a/packages/service-core/test/src/data_storage.test.ts
+++ b/packages/service-core/test/src/data_storage.test.ts
@@ -119,6 +119,76 @@ bucket_definitions:
     ]);
   });
 
+  test('it should use the latest version after updates', async () => {
+    const sync_rules = testRules(
+      `
+bucket_definitions:
+  mybucket:
+    parameters:
+      - SELECT id AS todo_id
+        FROM todos
+        WHERE list_id IN token_parameters.list_id
+    data: [] 
+    `
+    );
+
+    const storage = (await factory()).getInstance(sync_rules);
+
+    const table = makeTestTable('todos', ['id', 'list_id']);
+
+    await storage.startBatch(BATCH_OPTIONS, async (batch) => {
+      // Create two todos which initially belong to different lists
+      await batch.save({
+        sourceTable: table,
+        tag: SaveOperationTag.INSERT,
+        after: {
+          id: 'todo1',
+          list_id: 'list1'
+        },
+        afterReplicaId: rid('todo1')
+      });
+      await batch.save({
+        sourceTable: table,
+        tag: SaveOperationTag.INSERT,
+        after: {
+          id: 'todo2',
+          list_id: 'list2'
+        },
+        afterReplicaId: rid('todo2')
+      });
+    });
+
+    const result2 = await storage.startBatch(BATCH_OPTIONS, async (batch) => {
+      // Update the second todo item to now belong to list 1
+      await batch.save({
+        sourceTable: table,
+        tag: SaveOperationTag.UPDATE,
+        after: {
+          id: 'todo2',
+          list_id: 'list1'
+        },
+        afterReplicaId: rid('todo2')
+      });
+    });
+
+    // We specifically request the todo_ids for both lists.
+    // There removal operation for the association of `list2`::`todo2` should not interfere with the new
+    // association of `list1`::`todo2`
+    const parameters = await storage.getParameterSets(BigInt(result2!.flushed_op).toString(), [
+      ['mybucket', '1', 'list1'],
+      ['mybucket', '1', 'list2']
+    ]);
+
+    expect(parameters.sort((a, b) => (a.todo_id as string).localeCompare(b.todo_id as string))).toEqual([
+      {
+        todo_id: 'todo1'
+      },
+      {
+        todo_id: 'todo2'
+      }
+    ]);
+  });
+
   test('save and load parameters with different number types', async () => {
     const sync_rules = testRules(
       `


### PR DESCRIPTION
# Overview

For reference see [Discord thread](https://discord.com/channels/1138230179878154300/1315652010518904893).

The resolved sync buckets would be missing entries which matched data after updating (moving) relational linked columns. 

## Root Cause

The `getParameterSets` method was not returning the correct parameter sets after updating a `todo_list`'s `list_id` column. The query fetched all `bucket_parameters` that:

- Match the provided lookups (related to the input `list_ids`),
- Have `_id` values smaller than the current `checkpoint`, and
- Match the `group_id` (sync rules set).

The issue arose during the `$group` stage, where results were grouped by the `key` field alone. Since the `key` was not unique for different lookup values, updates introducing REMOVE entries with empty `bucket_parameters` could override valid entries, leading to incorrect results.

### Steps to Reproduce

See the screenshot of the `bucket_parameters` collection in MongoDB before and after executing an `UPDATE todos set list_id =  2 where id = 12`.

Initial State:

Todo `id=12` belongs to list `id=10` with its corresponding `lookup` and `bucket_parameters`.
Todo `id=11` belongs to list `id=2`.

The `bucket_parameters` entries match the input lookups for:
- `list_id=10` => `todo_id=12` and
- `list_id=2` => `todo_id=11`

Update:

Update Todo `id=12` to belong to list `id=2`..

This creates a `bucket_parameters` entry which now associates `list_id=2` => `todo_id=12` and a  `REMOVE` `bucket_parameters` entry which removes the association of `list_id=10` (lookup) to `todo_id=12`.  The REMOVE entry is created after the new association.

Issue:

When grouping results by key, the REMOVE entry (with empty bucket_parameters) overrides valid entries with the same key but a different lookup (e.g., for list 2).

Refer to the attached screenshot for a clear visual of the issue:

![image](https://github.com/user-attachments/assets/b5c12d2e-9656-44e0-8247-381b4b006b42)

Before the update: the relevant lookups for each todo item are valid. 

After the update: A REMOVE operation appears, the grouping in the `getParameterSets` query will return the `bucket_parameters` for the last entry which is the empty array from the remove entry. 

Solution

The `$group` stage was updated to use a composite `_id` object:

```javascript
{ key: '$key', lookup: '$lookup' }
```

This ensures that each unique combination of `key` and `lookup` is preserved in the grouped results, preventing REMOVE entries from overriding valid data.

Verification
Tested the fix by reproducing the issue as described above.

After applying the fix, the query correctly groups results by both key and lookup, preserving the valid bucket_parameters for each combination.
