### PR TITLE
iif function based in the iif function of sqlite

### DIFF
--- a/.changeset/six-chicken-decide.md
+++ b/.changeset/six-chicken-decide.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': minor
+---
+
+add iif function to the sync rules

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -255,18 +255,7 @@ const ifnull: DocumentedSqlFunction = {
 const iif: DocumentedSqlFunction = {
   debugName: 'iif',
   call(x: SqliteValue, y: SqliteValue, z: SqliteValue) {
-    let isTrue: boolean;
-    if (Number.isNaN(x)) {
-      isTrue = false;
-    } else if (typeof x == 'number') {
-      isTrue = x !== 0;
-    } else if (typeof x == 'bigint') {
-      isTrue = x !== 0n;
-    } else {
-      isTrue = false;
-    }
-
-    return isTrue ? y : z;
+    return sqliteBool(x) ? y : z;
   },
   parameters: [
     { name: 'x', type: ExpressionType.ANY, optional: false },

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -251,6 +251,34 @@ const ifnull: DocumentedSqlFunction = {
   detail: 'Returns the first non-null parameter'
 };
 
+// This is the same behavior as the iif function in SQLite
+const iif: DocumentedSqlFunction = {
+  debugName: 'iif',
+  call(x: SqliteValue, y: SqliteValue, z: SqliteValue) {
+    let isTrue: boolean;
+    if (Number.isNaN(x)) {
+      isTrue = false;
+    } else if (typeof x == 'number') {
+      isTrue = x !== 0;
+    } else if (typeof x == 'bigint') {
+      isTrue = x !== 0n;
+    } else {
+      isTrue = false;
+    }
+
+    return isTrue ? y : z;
+  },
+  parameters: [
+    { name: 'x', type: ExpressionType.ANY, optional: false },
+    { name: 'y', type: ExpressionType.ANY, optional: false },
+    { name: 'z', type: ExpressionType.ANY, optional: false },
+  ],
+  getReturnType() {
+    return ExpressionType.ANY;
+  },
+  detail: 'If x is true then returns y else returns z'
+};
+
 const json_extract: DocumentedSqlFunction = {
   debugName: 'json_extract',
   call(json: SqliteValue, path: SqliteValue) {
@@ -514,6 +542,7 @@ export const SQL_FUNCTIONS_NAMED = {
   uuid_blob,
   typeof: fn_typeof,
   ifnull,
+  iif,
   json_extract,
   json_array_length,
   json_valid,

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -124,6 +124,18 @@ describe('SQL functions', () => {
     expect(fn.ifnull('test1', 'test2')).toEqual('test1');
   });
 
+  test('iif', () => {
+    expect(fn.iif(null, 1, 2)).toEqual(2);
+    expect(fn.iif(0, 1, 2)).toEqual(2);
+    expect(fn.iif(1, "first", "second")).toEqual("first");
+    expect(fn.iif(0.1, "is_true", "is_false")).toEqual("is_true");
+    expect(fn.iif("a", "is_true", "is_false")).toEqual("is_false");
+    expect(fn.iif(0n, "is_true", "is_false")).toEqual("is_false");
+    expect(fn.iif(2n, "is_true", "is_false")).toEqual("is_true");
+    expect(fn.iif(new Uint8Array([]), "is_true", "is_false")).toEqual("is_false");
+    expect(fn.iif(Uint8Array.of(0x61, 0x62, 0x43), "is_true", "is_false")).toEqual("is_false");
+  });
+
   test('upper', () => {
     expect(fn.upper(null)).toEqual(null);
     expect(fn.upper('abc')).toEqual('ABC');


### PR DESCRIPTION
When implementing the base64 uuid functionality we noticed that UUID foreign keys that were null were being transformed as empty string in the client.

This is because of the implementation of base64 function, which returns an empty string when passing it null. 

I guess changing this would be a breaking change, so with this function we should be able to handle null values without breaking existing functionality.

We followed the behavior of the SQLite IIF function described [here](https://www.sqlite.org/lang_corefunc.html#iif), which is essentially an if-else.

Alternatively it might make sense to change the base64 and hex functions so that they behave like the other functions, where they return null when inputted null. For example the length function. 