### PR TITLE
Handle storage metrics > 2GB

### DIFF
--- a/.changeset/small-socks-lay.md
+++ b/.changeset/small-socks-lay.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix reported metrics for storage size > 2GB.

--- a/packages/service-core/src/storage/MongoBucketStorage.ts
+++ b/packages/service-core/src/storage/MongoBucketStorage.ts
@@ -347,9 +347,9 @@ export class MongoBucketStorage
       .catch(ignoreNotExiting);
 
     return {
-      operations_size_bytes: operations_aggregate[0].storageStats.size,
-      parameters_size_bytes: parameters_aggregate[0].storageStats.size,
-      replication_size_bytes: replication_aggregate[0].storageStats.size
+      operations_size_bytes: Number(operations_aggregate[0].storageStats.size),
+      parameters_size_bytes: Number(parameters_aggregate[0].storageStats.size),
+      replication_size_bytes: Number(replication_aggregate[0].storageStats.size)
     };
   }
 


### PR DESCRIPTION
For storage metrics over 2GB, the limit of a 32-bit signed integer is reached, so MongoDB returns the value as a bigint. OpenTelemetry metrics doesn't support bigint, so it just omit those metrics, resulting in no reported value.

This change forces conversion of these metrics to a number. We should not get any loss of precision in any realistic metric values, since `number` can still accurately store values up to 2^53-1.