### PR TITLE
Handle MySQL servers with non-UTC timezone

### DIFF
--- a/modules/module-mysql/src/replication/MySQLConnectionManager.ts
+++ b/modules/module-mysql/src/replication/MySQLConnectionManager.ts
@@ -62,7 +62,14 @@ export class MySQLConnectionManager {
    *  @param params
    */
   async query(query: string, params?: any[]): Promise<[RowDataPacket[], FieldPacket[]]> {
-    return this.promisePool.query<RowDataPacket[]>(query, params);
+    let connection: mysqlPromise.PoolConnection | undefined;
+    try {
+      connection = await this.promisePool.getConnection();
+      connection.query(`SET time_zone = "+00:00"`);
+      return connection.query<RowDataPacket[]>(query, params);
+    } finally {
+      connection?.release();
+    }
   }
 
   /**

--- a/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
+++ b/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
@@ -202,7 +202,7 @@ INSERT INTO test_data (
     await setupTable();
     await connectionManager.query(`
         INSERT INTO test_data(date_col, datetime_col, timestamp_col, time_col, year_col)
-        VALUES('2023-03-06', '2023-03-06 15:47', '2023-03-06 15:47', '15:47:00', '2023');
+        VALUES('2023-03-06', '2023-03-06 15:47:00+00:00', '2023-03-06 15:47:00+00:00', '15:47:00', '2023');
       `);
 
     const databaseRows = await getDatabaseRows(connectionManager, 'test_data');
@@ -222,8 +222,8 @@ INSERT INTO test_data (
   test('Date types edge cases mappings', async () => {
     await setupTable();
 
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01')`);
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499')`);
+    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01+00:00')`);
+    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499+00:00')`);
     await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('1000-01-01 00:00:00')`);
     await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('9999-12-31 23:59:59.499')`);
 

--- a/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
+++ b/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
@@ -282,8 +282,7 @@ async function getReplicatedRows(expectedTransactionsCount?: number): Promise<Sq
   const zongji = new ZongJi({
     host: TEST_CONNECTION_OPTIONS.hostname,
     user: TEST_CONNECTION_OPTIONS.username,
-    password: TEST_CONNECTION_OPTIONS.password,
-    timeZone: 'Z' // Ensure no auto timezone manipulation of the dates occur
+    password: TEST_CONNECTION_OPTIONS.password
   });
 
   const completionPromise = new Promise<SqliteRow[]>((resolve, reject) => {

--- a/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
+++ b/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
@@ -200,9 +200,10 @@ INSERT INTO test_data (
 
   test('Date types mappings', async () => {
     await setupTable();
+    // Timezone offset is set on the pool to +00:00
     await connectionManager.query(`
         INSERT INTO test_data(date_col, datetime_col, timestamp_col, time_col, year_col)
-        VALUES('2023-03-06', '2023-03-06 15:47:00+00:00', '2023-03-06 15:47:00+00:00', '15:47:00', '2023');
+        VALUES('2023-03-06', '2023-03-06 15:47', '2023-03-06 15:47', '15:47:00', '2023');
       `);
 
     const databaseRows = await getDatabaseRows(connectionManager, 'test_data');
@@ -222,8 +223,9 @@ INSERT INTO test_data (
   test('Date types edge cases mappings', async () => {
     await setupTable();
 
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01+00:00')`);
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499+00:00')`);
+    // Timezone offset is set on the pool to +00:00
+    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01')`);
+    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499')`);
     await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('1000-01-01 00:00:00')`);
     await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('9999-12-31 23:59:59.499')`);
 


### PR DESCRIPTION
Tests currently fail if the MySQL server is configured with a timezone other than UTC.

The issue is that MySQL always returns timestamps in the session timezone, without any timezone indicator. So there is no way to know what we should configure the client `timezone` with if we don't know the server timezone.

The current tests also stored timestamps in the default/server timezone, but expected them to be returned in UTC timezone.

This changes:
1. Fix the tests to use `+00:00` timezone in literals.
2. Always set the timezone on the mysql connection used for queries: `SET time_zone = "+00:00"`. This is somehow not needed for zongji. This is currently set on every query - not sure if there is a more efficient way to do this with a pool.