### PR TITLE
MySQL replication fixes

### DIFF
--- a/.changeset/honest-cats-draw.md
+++ b/.changeset/honest-cats-draw.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mysql': patch
+'@powersync/service-image': patch
+---
+
+Fix timestamp replication issues for MySQL.

--- a/.changeset/many-shrimps-watch.md
+++ b/.changeset/many-shrimps-watch.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mysql': patch
+'@powersync/service-image': patch
+---
+
+Fix resuming MySQL replication after a restart.

--- a/modules/module-mysql/src/common/mysql-to-sqlite.ts
+++ b/modules/module-mysql/src/common/mysql-to-sqlite.ts
@@ -108,13 +108,31 @@ export function toSQLiteRow(row: Record<string, any>, columns: Map<string, Colum
       switch (column.typeId) {
         case mysql.Types.DATE:
           // Only parse the date part
-          result[key] = row[key].toISOString().split('T')[0];
+          {
+            const date = row[key] as Date;
+            if (isNaN(date.getTime()) && false) {
+              // Invalid dates, such as 2024-00-00.
+              // we can't do anything meaningful with this, so just use null.
+              result[key] = null;
+            } else {
+              result[key] = date.toISOString().split('T')[0];
+            }
+          }
           break;
         case mysql.Types.DATETIME:
         case ADDITIONAL_MYSQL_TYPES.DATETIME2:
         case mysql.Types.TIMESTAMP:
         case ADDITIONAL_MYSQL_TYPES.TIMESTAMP2:
-          result[key] = row[key].toISOString();
+          {
+            const date = row[key] as Date;
+            if (isNaN(date.getTime())) {
+              // Invalid dates, such as 2024-00-00.
+              // we can't do anything meaningful with this, so just use null.
+              result[key] = null;
+            } else {
+              result[key] = date.toISOString();
+            }
+          }
           break;
         case mysql.Types.JSON:
           if (typeof row[key] === 'string') {

--- a/modules/module-mysql/src/common/mysql-to-sqlite.ts
+++ b/modules/module-mysql/src/common/mysql-to-sqlite.ts
@@ -110,7 +110,7 @@ export function toSQLiteRow(row: Record<string, any>, columns: Map<string, Colum
           // Only parse the date part
           {
             const date = row[key] as Date;
-            if (isNaN(date.getTime()) && false) {
+            if (isNaN(date.getTime())) {
               // Invalid dates, such as 2024-00-00.
               // we can't do anything meaningful with this, so just use null.
               result[key] = null;

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -588,7 +588,7 @@ AND table_type = 'BASE TABLE';`,
           beforeReplicaId: beforeUpdated
             ? getUuidReplicaIdentityBson(beforeUpdated, payload.sourceTable.replicaIdColumns)
             : undefined,
-          after: common.toSQLiteRow(payload.data, payload.columns),
+          after: after,
           afterReplicaId: getUuidReplicaIdentityBson(after, payload.sourceTable.replicaIdColumns)
         });
 

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -11,7 +11,7 @@ import * as zongji_utils from './zongji/zongji-utils.js';
 import { MySQLConnectionManager } from './MySQLConnectionManager.js';
 import { isBinlogStillAvailable, ReplicatedGTID, toColumnDescriptors } from '../common/common-index.js';
 import mysqlPromise from 'mysql2/promise';
-import { createRandomServerId } from '../utils/mysql-utils.js';
+import { createRandomServerId, escapeMysqlTableName } from '../utils/mysql-utils.js';
 
 export interface BinLogStreamOptions {
   connections: MySQLConnectionManager;
@@ -296,7 +296,7 @@ AND table_type = 'BASE TABLE';`,
     // TODO count rows and log progress at certain batch sizes
 
     // MAX_EXECUTION_TIME(0) hint disables execution timeout for this query
-    const query = connection.query(`SELECT /*+ MAX_EXECUTION_TIME(0) */ * FROM ${table.schema}.${table.table}`);
+    const query = connection.query(`SELECT /*+ MAX_EXECUTION_TIME(0) */ * FROM ${escapeMysqlTableName(table)}`);
     const stream = query.stream();
 
     let columns: Map<string, ColumnDescriptor> | undefined = undefined;

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -114,8 +114,10 @@ export class BinLogStream {
       // Start the snapshot inside a transaction.
       // We use a dedicated connection for this.
       const connection = await this.connections.getStreamingConnection();
+
       const promiseConnection = (connection as mysql.Connection).promise();
       try {
+        await promiseConnection.query(`SET time_zone = '+00:00'`);
         await promiseConnection.query('BEGIN');
         try {
           gtid = await common.readExecutedGtid(promiseConnection);
@@ -258,6 +260,8 @@ AND table_type = 'BASE TABLE';`,
         'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY'
       );
       await promiseConnection.query<mysqlPromise.RowDataPacket[]>('START TRANSACTION');
+      await promiseConnection.query(`SET time_zone = '+00:00'`);
+
       const sourceTables = this.syncRules.getSourceTables();
       await this.storage.startBatch(
         { zeroLSN: ReplicatedGTID.ZERO.comparable, defaultSchema: this.defaultSchema, storeCurrentData: true },

--- a/modules/module-mysql/src/replication/MySQLConnectionManager.ts
+++ b/modules/module-mysql/src/replication/MySQLConnectionManager.ts
@@ -65,7 +65,7 @@ export class MySQLConnectionManager {
     let connection: mysqlPromise.PoolConnection | undefined;
     try {
       connection = await this.promisePool.getConnection();
-      connection.query(`SET time_zone = "+00:00"`);
+      await connection.query(`SET time_zone = '+00:00'`);
       return connection.query<RowDataPacket[]>(query, params);
     } finally {
       connection?.release();

--- a/modules/module-mysql/src/replication/MySQLConnectionManager.ts
+++ b/modules/module-mysql/src/replication/MySQLConnectionManager.ts
@@ -62,7 +62,14 @@ export class MySQLConnectionManager {
    *  @param params
    */
   async query(query: string, params?: any[]): Promise<[RowDataPacket[], FieldPacket[]]> {
-    return this.promisePool.query<RowDataPacket[]>(query, params);
+    let connection: mysqlPromise.PoolConnection | undefined;
+    try {
+      connection = await this.promisePool.getConnection();
+      connection.query(`SET time_zone = "+00:00"`);
+      return connection.query<RowDataPacket[]>(query, params);
+    } finally {
+      connection?.release();
+    }
   }
 
   /**

--- a/modules/module-mysql/src/utils/mysql-utils.ts
+++ b/modules/module-mysql/src/utils/mysql-utils.ts
@@ -3,6 +3,7 @@ import mysql from 'mysql2';
 import mysqlPromise from 'mysql2/promise';
 import * as types from '../types/types.js';
 import { coerce, gte } from 'semver';
+import { SourceTable } from '@powersync/service-core';
 
 export type RetriedQueryOptions = {
   connection: mysqlPromise.Connection;
@@ -81,4 +82,8 @@ export function isVersionAtLeast(version: string, minimumVersion: string): boole
   const coercedMinimumVersion = coerce(minimumVersion);
 
   return gte(coercedVersion!, coercedMinimumVersion!, { loose: true });
+}
+
+export function escapeMysqlTableName(table: SourceTable): string {
+  return `\`${table.schema.replaceAll('`', '``')}\`.\`${table.table.replaceAll('`', '``')}\``;
 }

--- a/modules/module-mysql/test/src/BinLogStream.test.ts
+++ b/modules/module-mysql/test/src/BinLogStream.test.ts
@@ -14,7 +14,7 @@ bucket_definitions:
       - SELECT id, description FROM "test_data"
 `;
 
-describe(' Binlog stream - mongodb', { timeout: 20_000 }, function () {
+describe('Binlog stream - mongodb', { timeout: 20_000 }, function () {
   defineBinlogStreamTests(MONGO_STORAGE_FACTORY);
 });
 
@@ -219,7 +219,7 @@ function defineBinlogStreamTests(factory: StorageFactory) {
       `);
 
     await connectionManager.query(
-      `CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description TEXT, date DATE, datetime DATETIME, timestamp TIMESTAMP)`
+      `CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description TEXT, date DATE, datetime DATETIME NULL, timestamp TIMESTAMP NULL)`
     );
 
     await context.replicateSnapshot();

--- a/modules/module-mysql/test/src/BinLogStream.test.ts
+++ b/modules/module-mysql/test/src/BinLogStream.test.ts
@@ -1,9 +1,9 @@
 import { putOp, removeOp } from '@core-tests/stream_utils.js';
 import { MONGO_STORAGE_FACTORY } from '@core-tests/util.js';
 import { BucketStorageFactory, Metrics } from '@powersync/service-core';
-import { describe, expect, test } from 'vitest';
-import { binlogStreamTest } from './BinlogStreamUtils.js';
 import { v4 as uuid } from 'uuid';
+import { describe, expect, test } from 'vitest';
+import { BinlogStreamTestContext } from './BinlogStreamUtils.js';
 
 type StorageFactory = () => Promise<BucketStorageFactory>;
 
@@ -19,83 +19,76 @@ describe(' Binlog stream - mongodb', { timeout: 20_000 }, function () {
 });
 
 function defineBinlogStreamTests(factory: StorageFactory) {
-  test(
-    'Replicate basic values',
-    binlogStreamTest(factory, async (context) => {
-      const { connectionManager } = context;
-      await context.updateSyncRules(`
+  test('Replicate basic values', async () => {
+    await using context = await BinlogStreamTestContext.create(factory);
+    const { connectionManager } = context;
+    await context.updateSyncRules(`
   bucket_definitions:
     global:
       data:
         - SELECT id, description, num FROM "test_data"`);
 
-      await connectionManager.query(`CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description TEXT, num BIGINT)`);
+    await connectionManager.query(`CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description TEXT, num BIGINT)`);
 
-      await context.replicateSnapshot();
+    await context.replicateSnapshot();
 
-      const startRowCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
-      const startTxCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
+    const startRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
+    const startTxCount =
+      (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
 
-      context.startStreaming();
-      const testId = uuid();
-      await connectionManager.query(
-        `INSERT INTO test_data(id, description, num) VALUES('${testId}', 'test1', 1152921504606846976)`
-      );
-      const data = await context.getBucketData('global[]');
+    context.startStreaming();
+    const testId = uuid();
+    await connectionManager.query(
+      `INSERT INTO test_data(id, description, num) VALUES('${testId}', 'test1', 1152921504606846976)`
+    );
+    const data = await context.getBucketData('global[]');
 
-      expect(data).toMatchObject([putOp('test_data', { id: testId, description: 'test1', num: 1152921504606846976n })]);
-      const endRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
-      const endTxCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
-      expect(endRowCount - startRowCount).toEqual(1);
-      expect(endTxCount - startTxCount).toEqual(1);
-    })
-  );
+    expect(data).toMatchObject([putOp('test_data', { id: testId, description: 'test1', num: 1152921504606846976n })]);
+    const endRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
+    const endTxCount =
+      (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
+    expect(endRowCount - startRowCount).toEqual(1);
+    expect(endTxCount - startTxCount).toEqual(1);
+  });
 
-  test(
-    'replicating case sensitive table',
-    binlogStreamTest(factory, async (context) => {
-      const { connectionManager } = context;
-      await context.updateSyncRules(`
+  test('replicating case sensitive table', async () => {
+    await using context = await BinlogStreamTestContext.create(factory);
+    const { connectionManager } = context;
+    await context.updateSyncRules(`
       bucket_definitions:
         global:
           data:
             - SELECT id, description FROM "test_DATA"
       `);
 
-      await connectionManager.query(`CREATE TABLE test_DATA (id CHAR(36) PRIMARY KEY, description text)`);
+    await connectionManager.query(`CREATE TABLE test_DATA (id CHAR(36) PRIMARY KEY, description text)`);
 
-      await context.replicateSnapshot();
+    await context.replicateSnapshot();
 
-      const startRowCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
-      const startTxCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
+    const startRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
+    const startTxCount =
+      (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
 
-      context.startStreaming();
+    context.startStreaming();
 
-      const testId = uuid();
-      await connectionManager.query(`INSERT INTO test_DATA(id, description) VALUES('${testId}','test1')`);
+    const testId = uuid();
+    await connectionManager.query(`INSERT INTO test_DATA(id, description) VALUES('${testId}','test1')`);
 
-      const data = await context.getBucketData('global[]');
+    const data = await context.getBucketData('global[]');
 
-      expect(data).toMatchObject([putOp('test_DATA', { id: testId, description: 'test1' })]);
-      const endRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
-      const endTxCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
-      expect(endRowCount - startRowCount).toEqual(1);
-      expect(endTxCount - startTxCount).toEqual(1);
-    })
-  );
+    expect(data).toMatchObject([putOp('test_DATA', { id: testId, description: 'test1' })]);
+    const endRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
+    const endTxCount =
+      (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
+    expect(endRowCount - startRowCount).toEqual(1);
+    expect(endTxCount - startTxCount).toEqual(1);
+  });
 
-  //   TODO: Not supported yet
-  //   test(
-  //     'replicating TRUNCATE',
-  //     binlogStreamTest(factory, async (context) => {
-  //       const { connectionManager } = context;
-  //       const syncRuleContent = `
+  // TODO: Not supported yet
+  // test('replicating TRUNCATE', async () => {
+  //   await using context = await BinlogStreamTestContext.create(factory);
+  //   const { connectionManager } = context;
+  //   const syncRuleContent = `
   // bucket_definitions:
   //   global:
   //     data:
@@ -104,207 +97,194 @@ function defineBinlogStreamTests(factory: StorageFactory) {
   //     parameters: SELECT id FROM test_data WHERE id = token_parameters.user_id
   //     data: []
   // `;
-  //       await context.updateSyncRules(syncRuleContent);
-  //       await connectionManager.query(`DROP TABLE IF EXISTS test_data`);
-  //       await connectionManager.query(
-  //         `CREATE TABLE test_data(id uuid primary key default uuid_generate_v4(), description text)`
-  //       );
-  //
-  //       await context.replicateSnapshot();
-  //       context.startStreaming();
-  //
-  //       const [{ test_id }] = pgwireRows(
-  //         await connectionManager.query(`INSERT INTO test_data(description) VALUES('test1') returning id as test_id`)
-  //       );
-  //       await connectionManager.query(`TRUNCATE test_data`);
-  //
-  //       const data = await context.getBucketData('global[]');
-  //
-  //       expect(data).toMatchObject([
-  //         putOp('test_data', { id: test_id, description: 'test1' }),
-  //         removeOp('test_data', test_id)
-  //       ]);
-  //     })
+  //   await context.updateSyncRules(syncRuleContent);
+  //   await connectionManager.query(`DROP TABLE IF EXISTS test_data`);
+  //   await connectionManager.query(
+  //     `CREATE TABLE test_data(id uuid primary key default uuid_generate_v4(), description text)`
   //   );
 
-  test(
-    'replicating changing primary key',
-    binlogStreamTest(factory, async (context) => {
-      const { connectionManager } = context;
-      await context.updateSyncRules(BASIC_SYNC_RULES);
+  //   await context.replicateSnapshot();
+  //   context.startStreaming();
 
-      await connectionManager.query(`CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description text)`);
+  //   const [{ test_id }] = pgwireRows(
+  //     await connectionManager.query(`INSERT INTO test_data(description) VALUES('test1') returning id as test_id`)
+  //   );
+  //   await connectionManager.query(`TRUNCATE test_data`);
 
-      await context.replicateSnapshot();
-      context.startStreaming();
+  //   const data = await context.getBucketData('global[]');
 
-      const testId1 = uuid();
-      await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('${testId1}','test1')`);
+  //   expect(data).toMatchObject([
+  //     putOp('test_data', { id: test_id, description: 'test1' }),
+  //     removeOp('test_data', test_id)
+  //   ]);
+  // });
 
-      const testId2 = uuid();
-      await connectionManager.query(
-        `UPDATE test_data SET id = '${testId2}', description = 'test2a' WHERE id = '${testId1}'`
-      );
+  test('replicating changing primary key', async () => {
+    await using context = await BinlogStreamTestContext.create(factory);
+    const { connectionManager } = context;
+    await context.updateSyncRules(BASIC_SYNC_RULES);
 
-      // This update may fail replicating with:
-      // Error: Update on missing record public.test_data:074a601e-fc78-4c33-a15d-f89fdd4af31d :: {"g":1,"t":"651e9fbe9fec6155895057ec","k":"1a0b34da-fb8c-5e6f-8421-d7a3c5d4df4f"}
-      await connectionManager.query(`UPDATE test_data SET description = 'test2b' WHERE id = '${testId2}'`);
+    await connectionManager.query(`CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description text)`);
 
-      // Re-use old id again
-      await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('${testId1}', 'test1b')`);
-      await connectionManager.query(`UPDATE test_data SET description = 'test1c' WHERE id = '${testId1}'`);
+    await context.replicateSnapshot();
+    context.startStreaming();
 
-      const data = await context.getBucketData('global[]');
-      expect(data).toMatchObject([
-        // Initial insert
-        putOp('test_data', { id: testId1, description: 'test1' }),
-        // Update id, then description
-        removeOp('test_data', testId1),
-        putOp('test_data', { id: testId2, description: 'test2a' }),
-        putOp('test_data', { id: testId2, description: 'test2b' }),
-        // Re-use old id
-        putOp('test_data', { id: testId1, description: 'test1b' }),
-        putOp('test_data', { id: testId1, description: 'test1c' })
-      ]);
-    })
-  );
+    const testId1 = uuid();
+    await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('${testId1}','test1')`);
 
-  test(
-    'initial sync',
-    binlogStreamTest(factory, async (context) => {
-      const { connectionManager } = context;
-      await context.updateSyncRules(BASIC_SYNC_RULES);
+    const testId2 = uuid();
+    await connectionManager.query(
+      `UPDATE test_data SET id = '${testId2}', description = 'test2a' WHERE id = '${testId1}'`
+    );
 
-      await connectionManager.query(`CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description text)`);
+    // This update may fail replicating with:
+    // Error: Update on missing record public.test_data:074a601e-fc78-4c33-a15d-f89fdd4af31d :: {"g":1,"t":"651e9fbe9fec6155895057ec","k":"1a0b34da-fb8c-5e6f-8421-d7a3c5d4df4f"}
+    await connectionManager.query(`UPDATE test_data SET description = 'test2b' WHERE id = '${testId2}'`);
 
-      const testId = uuid();
-      await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('${testId}','test1')`);
+    // Re-use old id again
+    await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('${testId1}', 'test1b')`);
+    await connectionManager.query(`UPDATE test_data SET description = 'test1c' WHERE id = '${testId1}'`);
 
-      await context.replicateSnapshot();
+    const data = await context.getBucketData('global[]');
+    expect(data).toMatchObject([
+      // Initial insert
+      putOp('test_data', { id: testId1, description: 'test1' }),
+      // Update id, then description
+      removeOp('test_data', testId1),
+      putOp('test_data', { id: testId2, description: 'test2a' }),
+      putOp('test_data', { id: testId2, description: 'test2b' }),
+      // Re-use old id
+      putOp('test_data', { id: testId1, description: 'test1b' }),
+      putOp('test_data', { id: testId1, description: 'test1c' })
+    ]);
+  });
 
-      const data = await context.getBucketData('global[]');
-      expect(data).toMatchObject([putOp('test_data', { id: testId, description: 'test1' })]);
-    })
-  );
+  test('initial sync', async () => {
+    await using context = await BinlogStreamTestContext.create(factory);
+    const { connectionManager } = context;
+    await context.updateSyncRules(BASIC_SYNC_RULES);
 
-  test(
-    'snapshot with date values',
-    binlogStreamTest(factory, async (context) => {
-      const { connectionManager } = context;
-      await context.updateSyncRules(`
+    await connectionManager.query(`CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description text)`);
+
+    const testId = uuid();
+    await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('${testId}','test1')`);
+
+    await context.replicateSnapshot();
+
+    const data = await context.getBucketData('global[]');
+    expect(data).toMatchObject([putOp('test_data', { id: testId, description: 'test1' })]);
+  });
+
+  test('snapshot with date values', async () => {
+    await using context = await BinlogStreamTestContext.create(factory);
+    const { connectionManager } = context;
+    await context.updateSyncRules(`
       bucket_definitions:
         global:
           data:
             - SELECT * FROM "test_data"
       `);
 
-      await connectionManager.query(
-        `CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description TEXT, date DATE, datetime DATETIME, timestamp TIMESTAMP)`
-      );
+    await connectionManager.query(
+      `CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description TEXT, date DATE, datetime DATETIME, timestamp TIMESTAMP)`
+    );
 
-      const testId = uuid();
-      await connectionManager.query(`
+    const testId = uuid();
+    await connectionManager.query(`
         INSERT INTO test_data(id, description, date, datetime, timestamp) VALUES('${testId}','testDates', '2023-03-06', '2023-03-06 15:47', '2023-03-06 15:47')
       `);
 
-      await context.replicateSnapshot();
+    await context.replicateSnapshot();
 
-      const data = await context.getBucketData('global[]');
-      expect(data).toMatchObject([
-        putOp('test_data', {
-          id: testId,
-          description: 'testDates',
-          date: `2023-03-06`,
-          datetime: '2023-03-06T15:47:00.000Z',
-          timestamp: '2023-03-06T15:47:00.000Z'
-        })
-      ]);
-    })
-  );
+    const data = await context.getBucketData('global[]');
+    expect(data).toMatchObject([
+      putOp('test_data', {
+        id: testId,
+        description: 'testDates',
+        date: `2023-03-06`,
+        datetime: '2023-03-06T15:47:00.000Z',
+        timestamp: '2023-03-06T15:47:00.000Z'
+      })
+    ]);
+  });
 
-  test(
-    'replication with date values',
-    binlogStreamTest(factory, async (context) => {
-      const { connectionManager } = context;
-      await context.updateSyncRules(`
+  test('replication with date values', async () => {
+    await using context = await BinlogStreamTestContext.create(factory);
+    const { connectionManager } = context;
+    await context.updateSyncRules(`
       bucket_definitions:
         global:
           data:
             - SELECT * FROM "test_data"
       `);
 
-      await connectionManager.query(
-        `CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description TEXT, date DATE, datetime DATETIME, timestamp TIMESTAMP)`
-      );
+    await connectionManager.query(
+      `CREATE TABLE test_data (id CHAR(36) PRIMARY KEY, description TEXT, date DATE, datetime DATETIME, timestamp TIMESTAMP)`
+    );
 
-      await context.replicateSnapshot();
+    await context.replicateSnapshot();
 
-      const startRowCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
-      const startTxCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
+    const startRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
+    const startTxCount =
+      (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
 
-      context.startStreaming();
+    context.startStreaming();
 
-      const testId = uuid();
-      await connectionManager.query(`
+    const testId = uuid();
+    await connectionManager.query(`
         INSERT INTO test_data(id, description, date, datetime, timestamp) VALUES('${testId}','testDates', '2023-03-06', '2023-03-06 15:47', '2023-03-06 15:47')
       `);
-      await connectionManager.query(`UPDATE test_data SET description = ? WHERE id = ?`, ['testUpdated', testId]);
+    await connectionManager.query(`UPDATE test_data SET description = ? WHERE id = ?`, ['testUpdated', testId]);
 
-      const data = await context.getBucketData('global[]');
-      expect(data).toMatchObject([
-        putOp('test_data', {
-          id: testId,
-          description: 'testDates',
-          date: `2023-03-06`,
-          datetime: '2023-03-06T15:47:00.000Z',
-          timestamp: '2023-03-06T15:47:00.000Z'
-        }),
-        putOp('test_data', {
-          id: testId,
-          description: 'testUpdated',
-          date: `2023-03-06`,
-          datetime: '2023-03-06T15:47:00.000Z',
-          timestamp: '2023-03-06T15:47:00.000Z'
-        })
-      ]);
-      const endRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
-      const endTxCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
-      expect(endRowCount - startRowCount).toEqual(2);
-      expect(endTxCount - startTxCount).toEqual(2);
-    })
-  );
+    const data = await context.getBucketData('global[]');
+    expect(data).toMatchObject([
+      putOp('test_data', {
+        id: testId,
+        description: 'testDates',
+        date: `2023-03-06`,
+        datetime: '2023-03-06T15:47:00.000Z',
+        timestamp: '2023-03-06T15:47:00.000Z'
+      }),
+      putOp('test_data', {
+        id: testId,
+        description: 'testUpdated',
+        date: `2023-03-06`,
+        datetime: '2023-03-06T15:47:00.000Z',
+        timestamp: '2023-03-06T15:47:00.000Z'
+      })
+    ]);
+    const endRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
+    const endTxCount =
+      (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
+    expect(endRowCount - startRowCount).toEqual(2);
+    expect(endTxCount - startTxCount).toEqual(2);
+  });
 
-  test(
-    'table not in sync rules',
-    binlogStreamTest(factory, async (context) => {
-      const { connectionManager } = context;
-      await context.updateSyncRules(BASIC_SYNC_RULES);
+  test('table not in sync rules', async () => {
+    await using context = await BinlogStreamTestContext.create(factory);
+    const { connectionManager } = context;
+    await context.updateSyncRules(BASIC_SYNC_RULES);
 
-      await connectionManager.query(`CREATE TABLE test_donotsync (id CHAR(36) PRIMARY KEY, description text)`);
+    await connectionManager.query(`CREATE TABLE test_donotsync (id CHAR(36) PRIMARY KEY, description text)`);
 
-      await context.replicateSnapshot();
+    await context.replicateSnapshot();
 
-      const startRowCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
-      const startTxCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
+    const startRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
+    const startTxCount =
+      (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
 
-      context.startStreaming();
+    context.startStreaming();
 
-      await connectionManager.query(`INSERT INTO test_donotsync(id, description) VALUES('${uuid()}','test1')`);
-      const data = await context.getBucketData('global[]');
+    await connectionManager.query(`INSERT INTO test_donotsync(id, description) VALUES('${uuid()}','test1')`);
+    const data = await context.getBucketData('global[]');
 
-      expect(data).toMatchObject([]);
-      const endRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
-      const endTxCount =
-        (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
+    expect(data).toMatchObject([]);
+    const endRowCount = (await Metrics.getInstance().getMetricValueForTests('powersync_rows_replicated_total')) ?? 0;
+    const endTxCount =
+      (await Metrics.getInstance().getMetricValueForTests('powersync_transactions_replicated_total')) ?? 0;
 
-      // There was a transaction, but we should not replicate any actual data
-      expect(endRowCount - startRowCount).toEqual(0);
-      expect(endTxCount - startTxCount).toEqual(1);
-    })
-  );
+    // There was a transaction, but we should not replicate any actual data
+    expect(endRowCount - startRowCount).toEqual(0);
+    expect(endTxCount - startTxCount).toEqual(1);
+  });
 }

--- a/modules/module-mysql/test/src/BinlogStreamUtils.ts
+++ b/modules/module-mysql/test/src/BinlogStreamUtils.ts
@@ -12,6 +12,7 @@ import { MySQLConnectionManager } from '@module/replication/MySQLConnectionManag
 import mysqlPromise from 'mysql2/promise';
 import { readExecutedGtid } from '@module/common/read-executed-gtid.js';
 import { logger } from '@powersync/lib-services-framework';
+import { StorageFactory } from '@core-tests/util.js';
 
 /**
  * Tests operating on the binlog stream need to configure the stream and manage asynchronous
@@ -27,13 +28,15 @@ export class BinlogStreamTestContext {
   public storage?: SyncRulesBucketStorage;
   private replicationDone = false;
 
-  static async create(factory: () => Promise<BucketStorageFactory>) {
-    const f = await factory();
+  static async open(factory: StorageFactory, options?: { doNotClear?: boolean }) {
+    const f = await factory({ doNotClear: options?.doNotClear });
     const connectionManager = new MySQLConnectionManager(TEST_CONNECTION_OPTIONS, {});
 
-    const connection = await connectionManager.getConnection();
-    await clearTestDb(connection);
-    connection.release();
+    if (!options?.doNotClear) {
+      const connection = await connectionManager.getConnection();
+      await clearTestDb(connection);
+      connection.release();
+    }
     return new BinlogStreamTestContext(f, connectionManager);
   }
 
@@ -59,6 +62,27 @@ export class BinlogStreamTestContext {
   async updateSyncRules(content: string): Promise<SyncRulesBucketStorage> {
     const syncRules = await this.factory.updateSyncRules({ content: content });
     this.storage = this.factory.getInstance(syncRules);
+    return this.storage!;
+  }
+
+  async loadNextSyncRules() {
+    const syncRules = await this.factory.getNextSyncRulesContent();
+    if (syncRules == null) {
+      throw new Error(`Next sync rules not available`);
+    }
+
+    this.storage = this.factory.getInstance(syncRules);
+    return this.storage!;
+  }
+
+  async loadActiveSyncRules() {
+    const syncRules = await this.factory.getActiveSyncRulesContent();
+    if (syncRules == null) {
+      throw new Error(`Active sync rules not available`);
+    }
+
+    this.storage = this.factory.getInstance(syncRules);
+    this.replicationDone = true;
     return this.storage!;
   }
 

--- a/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
+++ b/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
@@ -202,7 +202,7 @@ INSERT INTO test_data (
     await setupTable();
     await connectionManager.query(`
         INSERT INTO test_data(date_col, datetime_col, timestamp_col, time_col, year_col)
-        VALUES('2023-03-06', '2023-03-06 15:47', '2023-03-06 15:47', '15:47:00', '2023');
+        VALUES('2023-03-06', '2023-03-06 15:47:00+00:00', '2023-03-06 15:47:00+00:00', '15:47:00', '2023');
       `);
 
     const databaseRows = await getDatabaseRows(connectionManager, 'test_data');
@@ -222,8 +222,8 @@ INSERT INTO test_data (
   test('Date types edge cases mappings', async () => {
     await setupTable();
 
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01')`);
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499')`);
+    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01+00:00')`);
+    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499+00:00')`);
     await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('1000-01-01 00:00:00')`);
     await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('9999-12-31 23:59:59.499')`);
 

--- a/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
+++ b/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
@@ -260,27 +260,6 @@ INSERT INTO test_data (
     }
   });
 
-  test.skip('Date types mappings - null', async () => {
-    await setupTable();
-    await connectionManager.query(`
-        INSERT INTO test_data(date_col, datetime_col, timestamp_col, time_col, year_col)
-        VALUES(NULL, NULL, NULL, NULL, NULL);
-      `);
-
-    const databaseRows = await getDatabaseRows(connectionManager, 'test_data');
-    const replicatedRows = await getReplicatedRows();
-    const expectedResult = {
-      date_col: null,
-      datetime_col: null,
-      timestamp_col: null,
-      time_col: null,
-      year_col: null
-    };
-
-    expect(databaseRows[0]).toMatchObject(expectedResult);
-    expect(replicatedRows[0]).toMatchObject(expectedResult);
-  });
-
   test('Json types mappings', async () => {
     await setupTable();
 

--- a/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
+++ b/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
@@ -282,8 +282,7 @@ async function getReplicatedRows(expectedTransactionsCount?: number): Promise<Sq
   const zongji = new ZongJi({
     host: TEST_CONNECTION_OPTIONS.hostname,
     user: TEST_CONNECTION_OPTIONS.username,
-    password: TEST_CONNECTION_OPTIONS.password,
-    timeZone: 'Z' // Ensure no auto timezone manipulation of the dates occur
+    password: TEST_CONNECTION_OPTIONS.password
   });
 
   const completionPromise = new Promise<SqliteRow[]>((resolve, reject) => {

--- a/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
+++ b/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
@@ -223,25 +223,62 @@ INSERT INTO test_data (
   test('Date types edge cases mappings', async () => {
     await setupTable();
 
-    // Timezone offset is set on the pool to +00:00
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01')`);
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499')`);
-    await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('1000-01-01 00:00:00')`);
-    await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('9999-12-31 23:59:59.499')`);
+    const connection = await connectionManager.getConnection();
+    try {
+      // Disable strict mode, to allow dates such as '2024-00-00'.
+      await connection.query(`SET SESSION sql_mode=''`);
+      await connection.query(`SET SESSION time_zone='+00:00'`);
+
+      await connection.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01')`);
+      await connection.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499')`);
+      await connection.query(`INSERT INTO test_data(datetime_col) VALUES('1000-01-01 00:00:00')`);
+      await connection.query(`INSERT INTO test_data(datetime_col) VALUES('9999-12-31 23:59:59.499')`);
+      await connection.query(`INSERT INTO test_data(datetime_col) VALUES('0000-00-00 00:00:00')`);
+      await connection.query(`INSERT INTO test_data(datetime_col) VALUES('2024-00-00 00:00:00')`);
+      // TODO: This has a mismatch between querying directly and with Zongji.
+      // await connection.query(`INSERT INTO test_data(date_col) VALUES('2024-00-00')`);
+
+      const expectedResults = [
+        { timestamp_col: '1970-01-01T00:00:01.000Z' },
+        { timestamp_col: '2038-01-19T03:14:07.499Z' },
+        { datetime_col: '1000-01-01T00:00:00.000Z' },
+        { datetime_col: '9999-12-31T23:59:59.499Z' },
+        { datetime_col: null },
+        { datetime_col: null }
+        // { date_col: '2023-11-30' } or { date_col: null }?
+      ];
+
+      const databaseRows = await getDatabaseRows(connectionManager, 'test_data');
+      const replicatedRows = await getReplicatedRows(expectedResults.length);
+
+      for (let i = 0; i < expectedResults.length; i++) {
+        expect(databaseRows[i]).toMatchObject(expectedResults[i]);
+        expect(replicatedRows[i]).toMatchObject(expectedResults[i]);
+      }
+    } finally {
+      connection.release;
+    }
+  });
+
+  test.skip('Date types mappings - null', async () => {
+    await setupTable();
+    await connectionManager.query(`
+        INSERT INTO test_data(date_col, datetime_col, timestamp_col, time_col, year_col)
+        VALUES(NULL, NULL, NULL, NULL, NULL);
+      `);
 
     const databaseRows = await getDatabaseRows(connectionManager, 'test_data');
-    const replicatedRows = await getReplicatedRows(4);
-    const expectedResults = [
-      { timestamp_col: '1970-01-01T00:00:01.000Z' },
-      { timestamp_col: '2038-01-19T03:14:07.499Z' },
-      { datetime_col: '1000-01-01T00:00:00.000Z' },
-      { datetime_col: '9999-12-31T23:59:59.499Z' }
-    ];
+    const replicatedRows = await getReplicatedRows();
+    const expectedResult = {
+      date_col: null,
+      datetime_col: null,
+      timestamp_col: null,
+      time_col: null,
+      year_col: null
+    };
 
-    for (let i = 0; i < expectedResults.length; i++) {
-      expect(databaseRows[i]).toMatchObject(expectedResults[i]);
-      expect(replicatedRows[i]).toMatchObject(expectedResults[i]);
-    }
+    expect(databaseRows[0]).toMatchObject(expectedResult);
+    expect(replicatedRows[0]).toMatchObject(expectedResult);
   });
 
   test('Json types mappings', async () => {

--- a/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
+++ b/modules/module-mysql/test/src/mysql-to-sqlite.test.ts
@@ -200,9 +200,10 @@ INSERT INTO test_data (
 
   test('Date types mappings', async () => {
     await setupTable();
+    // Timezone offset is set on the pool to +00:00
     await connectionManager.query(`
         INSERT INTO test_data(date_col, datetime_col, timestamp_col, time_col, year_col)
-        VALUES('2023-03-06', '2023-03-06 15:47:00+00:00', '2023-03-06 15:47:00+00:00', '15:47:00', '2023');
+        VALUES('2023-03-06', '2023-03-06 15:47', '2023-03-06 15:47', '15:47:00', '2023');
       `);
 
     const databaseRows = await getDatabaseRows(connectionManager, 'test_data');
@@ -222,8 +223,9 @@ INSERT INTO test_data (
   test('Date types edge cases mappings', async () => {
     await setupTable();
 
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01+00:00')`);
-    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499+00:00')`);
+    // Timezone offset is set on the pool to +00:00
+    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('1970-01-01 00:00:01')`);
+    await connectionManager.query(`INSERT INTO test_data(timestamp_col) VALUES('2038-01-19 03:14:07.499')`);
     await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('1000-01-01 00:00:00')`);
     await connectionManager.query(`INSERT INTO test_data(datetime_col) VALUES('9999-12-31 23:59:59.499')`);
 

--- a/packages/service-core/src/storage/SourceTable.ts
+++ b/packages/service-core/src/storage/SourceTable.ts
@@ -48,6 +48,8 @@ export class SourceTable {
   }
 
   /**
+   * Use for postgres only.
+   *
    * Usage: db.query({statement: `SELECT $1::regclass`, params: [{type: 'varchar', value: table.qualifiedName}]})
    */
   get qualifiedName() {
@@ -55,6 +57,8 @@ export class SourceTable {
   }
 
   /**
+   * Use for postgres and logs only.
+   *
    * Usage: db.query(`SELECT * FROM ${table.escapedIdentifier}`)
    */
   get escapedIdentifier() {


### PR DESCRIPTION
Fixes some issues with MySQL replication:

### Timestamps: Timezone handling

Timezone in timestamps were not handled correctly if the MySQL server is configured with a timezone other than UTC. The issue is that MySQL always returns timestamps in the session timezone, without any timezone indicator. So there is no way to know what we should configure the client `timezone` with if we don't know the server timezone.

The current tests also stored timestamps in the default/server timezone, but expected them to be returned in UTC timezone.

This changes:
1. Fix the tests to use `+00:00` timezone in literals.
2. Always set the timezone on the mysql connection used for queries: `SET time_zone = "+00:00"`. This does not appear to be needed for zongji.

### Timestamps: Updates broken

When updating a row containing an update, the row was converted in-place to the SQLite format, then converted again. The first pass converted the timestamp to a string, then the second pass failed since it expected a Date. This results in an error `row[key].toISOString is not a function`.

This fixes the conversion to not modify the original row, and also avoids doing the conversion twice.

### Timestamps: Handling invalid dates

With MySQL, it is possible to disable strict mode and then persist a timestamp such as `2024-00-00 00:00:00`. This is not a valid Date in JavaScript, and results in an error `RangeError: Invalid time value` when calling `toISOString()`.

This fixes the issue by converting these to null.

### Initial replication: Improved error handling

The implementation of snapshot handling did not handle errors properly in all cases (such as the above issue) - it resulted in an unhandled promise rejection, which could cause either the process to crash, or replication to stall.

This changes the snapshot query to using a Readable stream, which does not have this issue.

### Resuming replication

When replication is resumed after a restart, the list of tables were not loaded, resulting in an empty list of tables in `includeSchema`, and no changes replicated. This now loads the list of tables when resuming replication.

### Quoting table names

This now properly quotes table names with backticks in snapshot queries, avoiding potential issues when a table name contains special characters for some reason. Unlike with Postgres, this is not required matching the table name case, but is still better to do either way.
