### PR TITLE
MongoDB: Fix replication of undefined values

### DIFF
--- a/.changeset/sweet-chairs-build.md
+++ b/.changeset/sweet-chairs-build.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+MongoDB: Fix replication of undefined values causing missing documents

--- a/modules/module-mongodb/src/replication/MongoRelation.ts
+++ b/modules/module-mongodb/src/replication/MongoRelation.ts
@@ -38,9 +38,12 @@ export function constructAfterRecord(document: mongo.Document): SqliteRow {
 
 export function toMongoSyncRulesValue(data: any): SqliteValue {
   const autoBigNum = true;
-  if (data == null) {
-    // null or undefined
-    return data;
+  if (data === null) {
+    return null;
+  } else if (typeof data == 'undefined') {
+    // We consider `undefined` in top-level fields as missing replicated value,
+    // so use null instead.
+    return null;
   } else if (typeof data == 'string') {
     return data;
   } else if (typeof data == 'number') {
@@ -95,8 +98,13 @@ function filterJsonData(data: any, depth = 0): any {
     // This is primarily to prevent infinite recursion
     throw new Error(`json nested object depth exceeds the limit of ${DEPTH_LIMIT}`);
   }
-  if (data == null) {
-    return data; // null or undefined
+  if (data === null) {
+    return data;
+  } else if (typeof data == 'undefined') {
+    // For nested data, keep as undefined.
+    // In arrays, this is converted to null.
+    // In objects, the key is excluded.
+    return undefined;
   } else if (typeof data == 'string') {
     return data;
   } else if (typeof data == 'number') {

--- a/modules/module-mongodb/test/src/mongo_test.test.ts
+++ b/modules/module-mongodb/test/src/mongo_test.test.ts
@@ -86,6 +86,9 @@ describe('mongo data types', () => {
         }
       ])
       .toArray();
+
+    await mapInput.drop();
+    await db.collection('map_output').drop();
   }
 
   async function insertNested(collection: mongo.Collection) {
@@ -307,6 +310,7 @@ describe('mongo data types', () => {
     const collection = db.collection('test_data');
     await setupTable(db);
     await insert(collection);
+    await insertUndefined(db, 'test_data');
 
     const schema = await adapter.getConnectionSchema();
     const dbSchema = schema.filter((s) => s.name == TEST_CONNECTION_OPTIONS.database)[0];

--- a/packages/service-core/src/storage/mongo/MongoBucketBatch.ts
+++ b/packages/service-core/src/storage/mongo/MongoBucketBatch.ts
@@ -411,7 +411,7 @@ export class MongoBucketBatch extends DisposableObserver<BucketBatchStorageListe
     // However, it will be valid by the end of the transaction.
     //
     // In this case, we don't save the op, but we do save the current data.
-    if (afterId && after && util.isCompleteRow(after)) {
+    if (afterId && after && util.isCompleteRow(this.storeCurrentData, after)) {
       // Insert or update
       if (sourceTable.syncData) {
         const { results: evaluated, errors: syncErrors } = this.sync_rules.evaluateRowWithErrors({
@@ -722,8 +722,8 @@ export class MongoBucketBatch extends DisposableObserver<BucketBatchStorageListe
           table: sourceTable,
           data: {
             op: tag,
-            after: after && util.isCompleteRow(after) ? after : undefined,
-            before: before && util.isCompleteRow(before) ? before : undefined
+            after: after && util.isCompleteRow(this.storeCurrentData, after) ? after : undefined,
+            before: before && util.isCompleteRow(this.storeCurrentData, before) ? before : undefined
           },
           event
         })

--- a/packages/service-core/src/util/utils.ts
+++ b/packages/service-core/src/util/utils.ts
@@ -131,7 +131,16 @@ export function hasToastedValues(row: sync_rules.ToastableSqliteRow) {
   return false;
 }
 
-export function isCompleteRow(row: sync_rules.ToastableSqliteRow): row is sync_rules.SqliteRow {
+/**
+ * Returns true if we have a complete row.
+ *
+ * If we don't store data, we assume we always have a complete row.
+ */
+export function isCompleteRow(storeData: boolean, row: sync_rules.ToastableSqliteRow): row is sync_rules.SqliteRow {
+  if (!storeData) {
+    // Assume the row is complete - no need to check
+    return true;
+  }
   return !hasToastedValues(row);
 }
 


### PR DESCRIPTION
When replicating Postgres rows, in some edge cases we have toasted (missing) values in rows. We use `undefined` in our internal "current_data" storage to indicate these values are missing, and wait until we have all values before processing the row in sync rules.

With MongoDB replication, we always get the full document - we don't run into the case above. However, we had a bug where `undefined` values were kept as-is when replicating, triggering that logic. This caused rows with undefined values to not be replicated, without any indication why.

Our tests appeared to check for this case, but didn't in reality. MongoDB deprecated the undefined value in BSON, making it very difficult to actually insert an undefined value in the database. Our tests actually only tested for `null`, and never for `undefined`. The tests now use a nasty workaround using `mapReduce` to insert an `undefined` value.

This only changes the behavior for top-level `undefined` values. Behavior for `undefined` in nested objects and arrays is unchanged:

```js
// top-level: converted to null
{value: undefined} -> {value: null}
// array: converted to null
{array: [undefined] -> {array: "[null]"}
// nested document: treated as missing key
{nested: {value: undefined} -> {nested: "{}"}
```

The the [Discord thread](https://discord.com/channels/1138230179878154300/1324331616973361202/1324430130558533643) reporting this issue.