### PR TITLE
Added heartbeat to Mysql Binlog Listener connection

### DIFF
--- a/.changeset/grumpy-cameras-breathe.md
+++ b/.changeset/grumpy-cameras-breathe.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mysql': patch
+---
+
+Added a heartbeat mechanism to the MySQL binlog listener replication connection to detect connection timeouts.

--- a/modules/module-mysql/src/replication/zongji/zongji.d.ts
+++ b/modules/module-mysql/src/replication/zongji/zongji.d.ts
@@ -1,4 +1,6 @@
 declare module '@powersync/mysql-zongji' {
+  import { Socket } from 'net';
+
   export type ZongjiOptions = {
     host: string;
     user: string;
@@ -108,7 +110,15 @@ declare module '@powersync/mysql-zongji' {
 
   export type BinLogEvent = BinLogRotationEvent | BinLogGTIDLogEvent | BinLogXidEvent | BinLogMutationEvent;
 
+  // @vlasky/mysql Connection
+  export interface MySQLConnection {
+    _socket?: Socket;
+    /** There are other forms of this method as well - this is the most basic one. */
+    query(sql: string, callback: (error: any, results: any, fields: any) => void): void;
+  }
+
   export default class ZongJi {
+    connection: MySQLConnection;
     constructor(options: ZongjiOptions);
 
     start(options: StartOptions): void;


### PR DESCRIPTION
It was found that under some circumstance mysql replication stops without any errors, and only starts up correctly again when the powersync instance is restarted. We suspect that this may be happening to due an error on the replication connection that is not picked up by the Binlog listener. 

This adds a heartbeat mechanism on the listener's replication connection to ensure we timeously pick up when the connection has stalled. 