### PR TITLE
fix: release action

### DIFF
--- a/.github/workflows/packages_release.yaml
+++ b/.github/workflows/packages_release.yaml
@@ -55,6 +55,7 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm release
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check if @powersync/service-image Released


### PR DESCRIPTION
# Overview

https://github.com/powersync-ja/powersync-service/pull/136 removed the `GITHUB_TOKEN` from the service Dockerfile (since it is no longer needed). It also incorrectly removed the token from the Changesets release action. See failed action [run](https://github.com/powersync-ja/powersync-service/actions/runs/12669421548). This should fix the action. 