### PR TITLE
[Fix] Mongo Server Error Detection

### DIFF
--- a/.changeset/swift-trains-behave.md
+++ b/.changeset/swift-trains-behave.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-module-mongodb': minor
+'@powersync/lib-service-mongodb': minor
+---
+
+Shared MongoDB dependency between modules. This should help avoid potential multiple versions of MongoDB being present in a project.

--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -77,3 +77,7 @@ export async function waitForAuth(db: mongo.Db) {
     }
   }
 }
+
+export const isMongoServerError = (error: any): error is mongo.MongoServerError => {
+  return error instanceof mongo.MongoServerError || error?.name == 'MongoServerError';
+};

--- a/libs/lib-mongodb/src/index.ts
+++ b/libs/lib-mongodb/src/index.ts
@@ -6,3 +6,6 @@ export * as locks from './locks/locks-index.js';
 
 export * from './types/types.js';
 export * as types from './types/types.js';
+
+// Re-export mongodb which can avoid using multiple versions of Mongo in a project
+export * as mongo from 'mongodb';

--- a/modules/module-mongodb-storage/package.json
+++ b/modules/module-mongodb-storage/package.json
@@ -34,7 +34,6 @@
     "@powersync/service-sync-rules": "workspace:*",
     "@powersync/service-types": "workspace:*",
     "@powersync/lib-service-mongodb": "workspace:*",
-    "mongodb": "^6.11.0",
     "bson": "^6.8.0",
     "ts-codec": "^1.3.0",
     "ix": "^5.0.0",

--- a/modules/module-mongodb-storage/src/migrations/mongo-migration-store.ts
+++ b/modules/module-mongodb-storage/src/migrations/mongo-migration-store.ts
@@ -1,12 +1,13 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { migrations } from '@powersync/lib-services-framework';
-import { Db } from 'mongodb';
+
 import * as path from 'path';
 
 /**
  * A custom store for node-migrate which is used to save and load migrations that have
  * been operated on to mongo.
  */
-export const createMongoMigrationStore = (db: Db): migrations.MigrationStore => {
+export const createMongoMigrationStore = (db: mongo.Db): migrations.MigrationStore => {
   const collection = db.collection<migrations.MigrationState>('migrations');
 
   return {

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -1,7 +1,6 @@
 import { SqlSyncRules } from '@powersync/service-sync-rules';
 import { wrapWithAbort } from 'ix/asynciterable/operators/withabort.js';
 import { LRUCache } from 'lru-cache/min';
-import * as mongo from 'mongodb';
 import * as timers from 'timers/promises';
 
 import { storage, sync, utils } from '@powersync/service-core';
@@ -10,6 +9,8 @@ import { DisposableObserver, logger } from '@powersync/lib-services-framework';
 import { v4 as uuid } from 'uuid';
 
 import * as lib_mongo from '@powersync/lib-service-mongodb';
+import { mongo } from '@powersync/lib-service-mongodb';
+
 import { PowerSyncMongo } from './implementation/db.js';
 import { SyncRuleDocument } from './implementation/models.js';
 import { MongoPersistedSyncRulesContent } from './implementation/MongoPersistedSyncRulesContent.js';
@@ -285,7 +286,7 @@ export class MongoBucketStorage
 
   async getStorageMetrics(): Promise<storage.StorageMetrics> {
     const ignoreNotExiting = (e: unknown) => {
-      if (e instanceof mongo.MongoServerError && e.codeName == 'NamespaceNotFound') {
+      if (lib_mongo.isMongoServerError(e) && e.codeName == 'NamespaceNotFound') {
         // Collection doesn't exist - return 0
         return [{ storageStats: { size: 0 } }];
       } else {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -1,6 +1,6 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { SqlEventDescriptor, SqliteRow, SqlSyncRules } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
-import * as mongo from 'mongodb';
 
 import { container, DisposableObserver, errors, logger } from '@powersync/lib-services-framework';
 import { SaveOperationTag, storage, utils } from '@powersync/service-core';

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
@@ -1,6 +1,7 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { logger } from '@powersync/lib-services-framework';
 import { storage, utils } from '@powersync/service-core';
-import { AnyBulkWriteOperation, MaxKey, MinKey } from 'mongodb';
+
 import { PowerSyncMongo } from './db.js';
 import { BucketDataDocument, BucketDataKey } from './models.js';
 import { cacheKey } from './OperationBatch.js';
@@ -49,7 +50,7 @@ const DEFAULT_MOVE_BATCH_QUERY_LIMIT = 10_000;
 const DEFAULT_MEMORY_LIMIT_MB = 64;
 
 export class MongoCompactor {
-  private updates: AnyBulkWriteOperation<BucketDataDocument>[] = [];
+  private updates: mongo.AnyBulkWriteOperation<BucketDataDocument>[] = [];
 
   private idLimitBytes: number;
   private moveBatchLimit: number;
@@ -94,12 +95,12 @@ export class MongoCompactor {
 
     let currentState: CurrentBucketState | null = null;
 
-    let bucketLower: string | MinKey;
-    let bucketUpper: string | MaxKey;
+    let bucketLower: string | mongo.MinKey;
+    let bucketUpper: string | mongo.MaxKey;
 
     if (bucket == null) {
-      bucketLower = new MinKey();
-      bucketUpper = new MaxKey();
+      bucketLower = new mongo.MinKey();
+      bucketUpper = new mongo.MaxKey();
     } else if (bucket.includes('[')) {
       // Exact bucket name
       bucketLower = bucket;
@@ -114,14 +115,14 @@ export class MongoCompactor {
     const lowerBound: BucketDataKey = {
       g: this.group_id,
       b: bucketLower as string,
-      o: new MinKey() as any
+      o: new mongo.MinKey() as any
     };
 
     // Upper bound is adjusted for each batch
     let upperBound: BucketDataKey = {
       g: this.group_id,
       b: bucketUpper as string,
-      o: new MaxKey() as any
+      o: new mongo.MaxKey() as any
     };
 
     while (true) {
@@ -287,7 +288,7 @@ export class MongoCompactor {
         $gte: {
           g: this.group_id,
           b: bucket,
-          o: new MinKey() as any
+          o: new mongo.MinKey() as any
         },
         $lte: {
           g: this.group_id,
@@ -349,7 +350,7 @@ export class MongoCompactor {
                   $gte: {
                     g: this.group_id,
                     b: bucket,
-                    o: new MinKey() as any
+                    o: new mongo.MinKey() as any
                   },
                   $lte: lastOpId!
                 }

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoPersistedSyncRulesContent.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoPersistedSyncRulesContent.ts
@@ -1,6 +1,6 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { storage } from '@powersync/service-core';
 import { SqlSyncRules } from '@powersync/service-sync-rules';
-import * as mongo from 'mongodb';
 import { MongoPersistedSyncRules } from './MongoPersistedSyncRules.js';
 import { MongoSyncRulesLock } from './MongoSyncRulesLock.js';
 import { PowerSyncMongo } from './db.js';

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -1,10 +1,9 @@
-import { SqliteJsonRow, SqliteJsonValue, SqlSyncRules } from '@powersync/service-sync-rules';
-import * as bson from 'bson';
-import * as mongo from 'mongodb';
-
 import * as lib_mongo from '@powersync/lib-service-mongodb';
+import { mongo } from '@powersync/lib-service-mongodb';
 import { DisposableObserver, logger } from '@powersync/lib-services-framework';
 import { storage, utils } from '@powersync/service-core';
+import { SqliteJsonRow, SqliteJsonValue, SqlSyncRules } from '@powersync/service-sync-rules';
+import * as bson from 'bson';
 import * as timers from 'timers/promises';
 import { MongoBucketStorage } from '../MongoBucketStorage.js';
 import { PowerSyncMongo } from './db.js';

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -498,7 +498,7 @@ export class MongoSyncBucketStorage
         logger.info(`${this.slot_name} Done clearing data`);
         return;
       } catch (e: unknown) {
-        if (e instanceof mongo.MongoServerError && e.codeName == 'MaxTimeMSExpired') {
+        if (lib_mongo.isMongoServerError(e) && e.codeName == 'MaxTimeMSExpired') {
           logger.info(
             `${this.slot_name} Cleared batch of data in ${lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS}ms, continuing...`
           );

--- a/modules/module-mongodb-storage/src/storage/implementation/PersistedBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/PersistedBatch.ts
@@ -1,7 +1,7 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { JSONBig } from '@powersync/service-jsonbig';
 import { EvaluatedParameters, EvaluatedRow } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
-import * as mongo from 'mongodb';
 
 import { logger } from '@powersync/lib-services-framework';
 import { storage, utils } from '@powersync/service-core';

--- a/modules/module-mongodb-storage/src/storage/implementation/db.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/db.ts
@@ -1,6 +1,6 @@
 import * as lib_mongo from '@powersync/lib-service-mongodb';
+import { mongo } from '@powersync/lib-service-mongodb';
 import { storage } from '@powersync/service-core';
-import * as mongo from 'mongodb';
 
 import { MongoStorageConfig } from '../../types/types.js';
 import {

--- a/modules/module-mongodb-storage/src/storage/implementation/util.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/util.ts
@@ -1,8 +1,10 @@
-import { storage, utils } from '@powersync/service-core';
 import * as bson from 'bson';
 import * as crypto from 'crypto';
-import * as mongo from 'mongodb';
 import * as uuid from 'uuid';
+
+import { mongo } from '@powersync/lib-service-mongodb';
+import { storage, utils } from '@powersync/service-core';
+
 import { PowerSyncMongo } from './db.js';
 import { BucketDataDocument } from './models.js';
 

--- a/modules/module-mongodb/package.json
+++ b/modules/module-mongodb/package.json
@@ -34,7 +34,6 @@
     "@powersync/service-sync-rules": "workspace:*",
     "@powersync/service-types": "workspace:*",
     "@powersync/lib-service-mongodb": "workspace:*",
-    "mongodb": "^6.11.0",
     "bson": "^6.8.0",
     "ts-codec": "^1.3.0",
     "uuid": "^9.0.1"

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -1,8 +1,9 @@
 import * as lib_mongo from '@powersync/lib-service-mongodb';
+import { mongo } from '@powersync/lib-service-mongodb';
 import { api, ParseSyncRulesOptions, SourceTable } from '@powersync/service-core';
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as service_types from '@powersync/service-types';
-import * as mongo from 'mongodb';
+
 import { MongoManager } from '../replication/MongoManager.js';
 import { constructAfterRecord, createCheckpoint } from '../replication/MongoRelation.js';
 import { CHECKPOINTS_COLLECTION } from '../replication/replication-utils.js';
@@ -225,7 +226,7 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
         try {
           collections = await this.client.db(db.name).listCollections().toArray();
         } catch (e) {
-          if (e instanceof mongo.MongoServerError && e.codeName == 'Unauthorized') {
+          if (lib_mongo.isMongoServerError(e) && e.codeName == 'Unauthorized') {
             // Ignore databases we're not authorized to query
             return null;
           }
@@ -267,7 +268,7 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
               });
             }
           } catch (e) {
-            if (e instanceof mongo.MongoServerError && e.codeName == 'Unauthorized') {
+            if (lib_mongo.isMongoServerError(e) && e.codeName == 'Unauthorized') {
               // Ignore collections we're not authorized to query
               continue;
             }

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -1,7 +1,9 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { container, logger } from '@powersync/lib-services-framework';
 import { Metrics, SaveOperationTag, SourceEntityDescriptor, SourceTable, storage } from '@powersync/service-core';
 import { DatabaseInputRow, SqliteRow, SqlSyncRules, TablePattern } from '@powersync/service-sync-rules';
-import * as mongo from 'mongodb';
+import { PostImagesOption } from '../types/types.js';
+import { escapeRegExp } from '../utils.js';
 import { MongoManager } from './MongoManager.js';
 import {
   constructAfterRecord,
@@ -10,9 +12,7 @@ import {
   getMongoRelation,
   mongoLsnToTimestamp
 } from './MongoRelation.js';
-import { escapeRegExp } from '../utils.js';
 import { CHECKPOINTS_COLLECTION } from './replication-utils.js';
-import { PostImagesOption } from '../types/types.js';
 
 export const ZERO_LSN = '0000000000000000';
 

--- a/modules/module-mongodb/src/replication/ChangeStreamReplicationJob.ts
+++ b/modules/module-mongodb/src/replication/ChangeStreamReplicationJob.ts
@@ -1,10 +1,9 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { container } from '@powersync/lib-services-framework';
-import { ChangeStreamInvalidatedError, ChangeStream } from './ChangeStream.js';
-
 import { replication } from '@powersync/service-core';
-import { ConnectionManagerFactory } from './ConnectionManagerFactory.js';
 
-import * as mongo from 'mongodb';
+import { ChangeStream, ChangeStreamInvalidatedError } from './ChangeStream.js';
+import { ConnectionManagerFactory } from './ConnectionManagerFactory.js';
 
 export interface ChangeStreamReplicationJobOptions extends replication.AbstractReplicationJobOptions {
   connectionFactory: ConnectionManagerFactory;

--- a/modules/module-mongodb/src/replication/MongoManager.ts
+++ b/modules/module-mongodb/src/replication/MongoManager.ts
@@ -1,4 +1,5 @@
-import * as mongo from 'mongodb';
+import { mongo } from '@powersync/lib-service-mongodb';
+
 import { NormalizedMongoConnectionConfig } from '../types/types.js';
 
 export class MongoManager {

--- a/modules/module-mongodb/src/replication/MongoRelation.ts
+++ b/modules/module-mongodb/src/replication/MongoRelation.ts
@@ -1,7 +1,8 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { storage } from '@powersync/service-core';
-import { SqliteRow, SqliteValue, toSyncRulesRow } from '@powersync/service-sync-rules';
-import * as mongo from 'mongodb';
 import { JSONBig, JsonContainer } from '@powersync/service-jsonbig';
+import { SqliteRow, SqliteValue } from '@powersync/service-sync-rules';
+
 import { CHECKPOINTS_COLLECTION } from './replication-utils.js';
 
 export function getMongoRelation(source: mongo.ChangeStreamNameSpace): storage.SourceEntityDescriptor {

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -1,11 +1,12 @@
+import * as crypto from 'crypto';
+import { setTimeout } from 'node:timers/promises';
+import { describe, expect, test, vi } from 'vitest';
+
+import { mongo } from '@powersync/lib-service-mongodb';
+import { storage } from '@powersync/service-core';
 import { test_utils } from '@powersync/service-core-tests';
 
 import { PostImagesOption } from '@module/types/types.js';
-import { storage } from '@powersync/service-core';
-import * as crypto from 'crypto';
-import * as mongo from 'mongodb';
-import { setTimeout } from 'node:timers/promises';
-import { describe, expect, test, vi } from 'vitest';
 import { ChangeStreamTestContext } from './change_stream_utils.js';
 import { INITIALIZED_MONGO_STORAGE_FACTORY } from './util.js';
 

--- a/modules/module-mongodb/test/src/change_stream_utils.ts
+++ b/modules/module-mongodb/test/src/change_stream_utils.ts
@@ -1,11 +1,12 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { ActiveCheckpoint, BucketStorageFactory, OpId, SyncRulesBucketStorage } from '@powersync/service-core';
+import { test_utils } from '@powersync/service-core-tests';
 
 import { ChangeStream, ChangeStreamOptions } from '@module/replication/ChangeStream.js';
 import { MongoManager } from '@module/replication/MongoManager.js';
 import { createCheckpoint } from '@module/replication/MongoRelation.js';
 import { NormalizedMongoConnectionConfig } from '@module/types/types.js';
-import { test_utils } from '@powersync/service-core-tests';
-import * as mongo from 'mongodb';
+
 import { TEST_CONNECTION_OPTIONS, clearTestDb } from './util.js';
 
 export class ChangeStreamTestContext {

--- a/modules/module-mongodb/test/src/mongo_test.test.ts
+++ b/modules/module-mongodb/test/src/mongo_test.test.ts
@@ -1,11 +1,12 @@
+import { mongo } from '@powersync/lib-service-mongodb';
+import { SqliteRow, SqlSyncRules } from '@powersync/service-sync-rules';
+import { describe, expect, test } from 'vitest';
+
 import { MongoRouteAPIAdapter } from '@module/api/MongoRouteAPIAdapter.js';
 import { ChangeStream } from '@module/replication/ChangeStream.js';
 import { constructAfterRecord } from '@module/replication/MongoRelation.js';
-import { SqliteRow, SqlSyncRules } from '@powersync/service-sync-rules';
-import * as mongo from 'mongodb';
-import { describe, expect, test } from 'vitest';
-import { clearTestDb, connectMongoData, TEST_CONNECTION_OPTIONS } from './util.js';
 import { PostImagesOption } from '@module/types/types.js';
+import { clearTestDb, connectMongoData, TEST_CONNECTION_OPTIONS } from './util.js';
 
 describe('mongo data types', () => {
   async function setupTable(db: mongo.Db) {

--- a/modules/module-mongodb/test/src/slow_tests.test.ts
+++ b/modules/module-mongodb/test/src/slow_tests.test.ts
@@ -1,7 +1,9 @@
-import { storage } from '@powersync/service-core';
-import * as mongo from 'mongodb';
 import { setTimeout } from 'node:timers/promises';
 import { describe, expect, test } from 'vitest';
+
+import { mongo } from '@powersync/lib-service-mongodb';
+import { storage } from '@powersync/service-core';
+
 import { ChangeStreamTestContext, setSnapshotHistorySeconds } from './change_stream_utils.js';
 import { env } from './env.js';
 import { INITIALIZED_MONGO_STORAGE_FACTORY } from './util.js';

--- a/modules/module-mongodb/test/src/util.ts
+++ b/modules/module-mongodb/test/src/util.ts
@@ -1,7 +1,7 @@
-import * as types from '@module/types/types.js';
-
+import { mongo } from '@powersync/lib-service-mongodb';
 import * as mongo_storage from '@powersync/service-module-mongodb-storage';
-import * as mongo from 'mongodb';
+
+import * as types from '@module/types/types.js';
 import { env } from './env.js';
 
 export const TEST_URI = env.MONGO_TEST_DATA_URL;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,9 +141,6 @@ importers:
       bson:
         specifier: ^6.8.0
         version: 6.10.1
-      mongodb:
-        specifier: ^6.11.0
-        version: 6.11.0(socks@2.8.3)
       ts-codec:
         specifier: ^1.3.0
         version: 1.3.0
@@ -190,9 +187,6 @@ importers:
       lru-cache:
         specifier: ^10.2.2
         version: 10.4.3
-      mongodb:
-        specifier: ^6.11.0
-        version: 6.11.0(socks@2.8.3)
       ts-codec:
         specifier: ^1.3.0
         version: 1.3.0


### PR DESCRIPTION
# Overview

https://github.com/powersync-ja/powersync-service/pull/136 Moved common MongoDB logic to the `@powersync/lib-service-mongodb` package.

The bucket storage module's MongoDB connection is created using a utility from the shared library. The storage implementation checks certain caught `Error`s if they are instances of the MongoDB `MongoServerError` class. The `instanceof` checks fail if the shared library and the storage module use different versions of the MongoDB package. The core repository uses the same version throughout, but the hosted version's lockfile resolved different versions which caused the error detection to fail. Luckily the affected processes are retried, which did not cause any major issues.

This PR addresses the issue via two methods. 

A `isMongoServerError` utility function is now exported from `@powersync/lib-service-mongodb`. The `instanceof` check in this function should pass if the connection was created from the shared library. Additionally a fallback check is added by checking the `Error` prototype `name` field - this should detect the error type even if a different MongoDB package spawned the connection or error.

The direct `mongodb` NPM package dependency has been removed from the MongoDB replicator and storage modules. The shared MongoDB library now re-exports it's `mongodb` dependency. 

## Testing

Development packages were released and locally installed in the hosted repository. A sync rule change was applied which triggered the termination of previous sync rules. Sync rules were correctly terminated with no error logs.


Before:
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/7825b884-8973-48f1-97ac-c85d706e663c" />

After:
![image](https://github.com/user-attachments/assets/90cc9b2c-9f07-4be6-b702-abbe2826a790)

The MongoDB replicator was also smoke tested locally.
