### PR TITLE
Extend connection options

### DIFF
--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -1,6 +1,7 @@
 import * as mongo from 'mongodb';
 import * as timers from 'timers/promises';
 import { BaseMongoConfigDecoded, normalizeMongoConfig } from '../types/types.js';
+import { validateIpHostname } from '@powersync/lib-services-framework';
 
 /**
  * Time for new connection to timeout.
@@ -41,6 +42,8 @@ export function createMongoClient(config: BaseMongoConfigDecoded) {
     socketTimeoutMS: MONGO_SOCKET_TIMEOUT_MS,
     // How long to wait for new primary selection
     serverSelectionTimeoutMS: 30_000,
+
+    lookup: normalized.lookup,
 
     // Avoid too many connections:
     // 1. It can overwhelm the source database.

--- a/libs/lib-mongodb/src/types/types.ts
+++ b/libs/lib-mongodb/src/types/types.ts
@@ -1,3 +1,4 @@
+import { LookupOptions, makeHostnameLookupFunction } from '@powersync/lib-services-framework';
 import * as t from 'ts-codec';
 import * as urijs from 'uri-js';
 
@@ -8,7 +9,9 @@ export const BaseMongoConfig = t.object({
   uri: t.string,
   database: t.string.optional(),
   username: t.string.optional(),
-  password: t.string.optional()
+  password: t.string.optional(),
+
+  reject_ip_ranges: t.array(t.string).optional()
 });
 
 export type BaseMongoConfig = t.Encoded<typeof BaseMongoConfig>;
@@ -46,11 +49,18 @@ export function normalizeMongoConfig(options: BaseMongoConfigDecoded) {
 
   delete uri.userinfo;
 
+  const lookupOptions: LookupOptions = {
+    reject_ip_ranges: options.reject_ip_ranges ?? []
+  };
+  const lookup = makeHostnameLookupFunction(uri.host ?? '', lookupOptions);
+
   return {
     uri: urijs.serialize(uri),
     database,
 
     username,
-    password
+    password,
+
+    lookup
   };
 }

--- a/libs/lib-postgres/package.json
+++ b/libs/lib-postgres/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@powersync/lib-services-framework": "workspace:*",
     "@powersync/service-jpgwire": "workspace:*",
-    "@powersync/service-sync-rules": "workspace:*",
     "@powersync/service-types": "workspace:*",
     "p-defer": "^4.0.1",
     "ts-codec": "^1.3.0",

--- a/libs/lib-postgres/src/types/types.ts
+++ b/libs/lib-postgres/src/types/types.ts
@@ -1,24 +1,10 @@
+import { makeHostnameLookupFunction } from '@powersync/lib-services-framework';
+import type * as jpgwire from '@powersync/service-jpgwire';
 import * as service_types from '@powersync/service-types';
 import * as t from 'ts-codec';
 import * as urijs from 'uri-js';
 
-export interface NormalizedBasePostgresConnectionConfig {
-  id: string;
-  tag: string;
-
-  hostname: string;
-  port: number;
-  database: string;
-
-  username: string;
-  password: string;
-
-  sslmode: 'verify-full' | 'verify-ca' | 'disable';
-  cacert: string | undefined;
-
-  client_certificate: string | undefined;
-  client_private_key: string | undefined;
-}
+export interface NormalizedBasePostgresConnectionConfig extends jpgwire.NormalizedConnectionConfig {}
 
 export const POSTGRES_CONNECTION_TYPE = 'postgresql' as const;
 
@@ -43,8 +29,15 @@ export const BasePostgresConnectionConfig = t.object({
   client_certificate: t.string.optional(),
   client_private_key: t.string.optional(),
 
-  /** Expose database credentials */
-  demo_database: t.boolean.optional(),
+  /** Specify to use a servername for TLS that is different from hostname. */
+  tls_servername: t.string.optional(),
+
+  /**
+   * Block connections in any of these IP ranges.
+   *
+   * Use 'local' to block anything not in public unicast ranges.
+   */
+  reject_ip_ranges: t.array(t.string).optional(),
 
   /**
    * Prefix for the slot name. Defaults to "powersync_"
@@ -106,6 +99,9 @@ export function normalizeConnectionConfig(options: BasePostgresConnectionConfigD
     throw new Error(`database required`);
   }
 
+  const lookupOptions = { reject_ip_ranges: options.reject_ip_ranges ?? [] };
+  const lookup = makeHostnameLookupFunction(hostname, lookupOptions);
+
   return {
     id: options.id ?? 'default',
     tag: options.tag ?? 'default',
@@ -118,6 +114,9 @@ export function normalizeConnectionConfig(options: BasePostgresConnectionConfigD
     password,
     sslmode,
     cacert,
+
+    tls_servername: options.tls_servername ?? undefined,
+    lookup,
 
     client_certificate: options.client_certificate ?? undefined,
     client_private_key: options.client_private_key ?? undefined

--- a/libs/lib-postgres/src/utils/pgwire_utils.ts
+++ b/libs/lib-postgres/src/utils/pgwire_utils.ts
@@ -1,7 +1,6 @@
 // Adapted from https://github.com/kagis/pgwire/blob/0dc927f9f8990a903f238737326e53ba1c8d094f/mod.js#L2218
 
 import * as pgwire from '@powersync/service-jpgwire';
-import { SqliteJsonValue } from '@powersync/service-sync-rules';
 
 import { logger } from '@powersync/lib-services-framework';
 
@@ -9,7 +8,7 @@ export function escapeIdentifier(identifier: string) {
   return `"${identifier.replace(/"/g, '""').replace(/\./g, '"."')}"`;
 }
 
-export function autoParameter(arg: SqliteJsonValue | boolean): pgwire.StatementParam {
+export function autoParameter(arg: any): pgwire.StatementParam {
   if (arg == null) {
     return { type: 'varchar', value: null };
   } else if (typeof arg == 'string') {

--- a/libs/lib-postgres/tsconfig.json
+++ b/libs/lib-postgres/tsconfig.json
@@ -8,5 +8,5 @@
     "sourceMap": true
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../../packages/jpgwire" }, { "path": "../lib-services" }]
 }

--- a/libs/lib-services/package.json
+++ b/libs/lib-services/package.json
@@ -24,6 +24,7 @@
     "better-ajv-errors": "^1.2.0",
     "bson": "^6.8.0",
     "dotenv": "^16.4.5",
+    "ipaddr.js": "^2.1.0",
     "lodash": "^4.17.21",
     "ts-codec": "^1.3.0",
     "uuid": "^9.0.1",

--- a/libs/lib-services/src/index.ts
+++ b/libs/lib-services/src/index.ts
@@ -31,3 +31,6 @@ export * as system from './system/system-index.js';
 
 export * from './utils/utils-index.js';
 export * as utils from './utils/utils-index.js';
+
+export * from './ip/ip-index.js';
+export * as ip from './ip/ip-index.js';

--- a/libs/lib-services/src/ip/ip-index.ts
+++ b/libs/lib-services/src/ip/ip-index.ts
@@ -1,0 +1,1 @@
+export * from './lookup.js';

--- a/libs/lib-services/src/ip/lookup.ts
+++ b/libs/lib-services/src/ip/lookup.ts
@@ -1,0 +1,114 @@
+import * as net from 'node:net';
+import * as dns from 'node:dns';
+import * as dnsp from 'node:dns/promises';
+import ip from 'ipaddr.js';
+
+export interface LookupOptions {
+  reject_ip_ranges: string[];
+  reject_ipv6?: boolean;
+}
+
+/**
+ * Generate a custom DNS lookup function, that rejects specific IP ranges.
+ *
+ * If hostname is an IP, this synchronously validates it.
+ *
+ * @returns a function to use as the `lookup` option in `net.connect`.
+ */
+export function makeHostnameLookupFunction(
+  hostname: string,
+  lookupOptions: LookupOptions
+): net.LookupFunction | undefined {
+  validateIpHostname(hostname, lookupOptions);
+  return makeLookupFunction(lookupOptions);
+}
+
+/**
+ * Generate a custom DNS lookup function, that rejects specific IP ranges.
+ *
+ * Note: Lookup functions are not used for IPs configured directly.
+ * For those, validate the IP directly using validateIpHostname().
+ *
+ * @param reject_ip_ranges IPv4 and/or IPv6 subnets to reject, or 'local' to reject any IP that isn't public unicast.
+ * @returns a function to use as the `lookup` option in `net.connect`.
+ */
+export function makeLookupFunction(lookupOptions: LookupOptions): net.LookupFunction | undefined {
+  return (hostname, options, callback) => {
+    resolveIp(hostname, lookupOptions)
+      .then((resolvedAddress) => {
+        if (options.all) {
+          callback(null, [resolvedAddress]);
+        } else {
+          callback(null, resolvedAddress.address, resolvedAddress.family);
+        }
+      })
+      .catch((err) => {
+        callback(err, undefined as any, undefined);
+      });
+  };
+}
+
+/**
+ * Validate IPs synchronously.
+ *
+ * If the hostname is not an ip, this does nothing.
+ *
+ * @param hostname IP or DNS name
+ * @param options
+ */
+export function validateIpHostname(hostname: string, options: LookupOptions): void {
+  const { reject_ip_ranges: reject_ranges } = options;
+  if (!ip.isValid(hostname)) {
+    // Treat as a DNS name.
+    return;
+  }
+
+  const parsed = ip.parse(hostname);
+  const rejectLocal = reject_ranges.includes('local');
+  const rejectSubnets = reject_ranges.filter((range) => range != 'local');
+
+  const reject = { blocked: (rejectSubnets ?? []).map((r) => ip.parseCIDR(r)) };
+
+  if (options.reject_ipv6 && parsed.kind() == 'ipv6') {
+    throw new Error('IPv6 not supported');
+  }
+
+  if (ip.subnetMatch(parsed, reject) == 'blocked') {
+    // Ranges explicitly blocked, e.g. private IPv6 ranges
+    throw new Error(`IPs in this range are not supported: ${hostname}`);
+  }
+
+  if (!rejectLocal) {
+    return;
+  }
+
+  if (parsed.kind() == 'ipv4' && parsed.range() == 'unicast') {
+    // IPv4 - All good
+    return;
+  } else if (parsed.kind() == 'ipv6' && parsed.range() == 'unicast') {
+    // IPv6 - All good
+    return;
+  } else {
+    // Do not connect to any reserved IPs, including loopback and private ranges
+    throw new Error(`IPs in this range are not supported: ${hostname}`);
+  }
+}
+
+/**
+ * Resolve IP, and check that it is in an allowed range.
+ */
+export async function resolveIp(hostname: string, options: LookupOptions): Promise<dns.LookupAddress> {
+  let resolvedAddress: dns.LookupAddress;
+  if (net.isIPv4(hostname)) {
+    // Direct ipv4 - all good so far
+    resolvedAddress = { address: hostname, family: 4 };
+  } else if (net.isIPv6(hostname) || net.isIPv4(hostname)) {
+    // Direct ipv6 - all good so far
+    resolvedAddress = { address: hostname, family: 6 };
+  } else {
+    // DNS name - resolve it
+    resolvedAddress = await dnsp.lookup(hostname);
+  }
+  validateIpHostname(resolvedAddress.address, options);
+  return resolvedAddress;
+}

--- a/modules/module-mongodb/src/replication/MongoManager.ts
+++ b/modules/module-mongodb/src/replication/MongoManager.ts
@@ -19,6 +19,8 @@ export class MongoManager {
         username: options.username,
         password: options.password
       },
+
+      lookup: options.lookup,
       // Time for connection to timeout
       connectTimeoutMS: 5_000,
       // Time for individual requests to timeout

--- a/modules/module-mongodb/src/types/types.ts
+++ b/modules/module-mongodb/src/types/types.ts
@@ -1,5 +1,6 @@
 import * as lib_mongo from '@powersync/lib-service-mongodb/types';
 import * as service_types from '@powersync/service-types';
+import { LookupFunction } from 'node:net';
 import * as t from 'ts-codec';
 
 export enum PostImagesOption {
@@ -47,6 +48,8 @@ export interface NormalizedMongoConnectionConfig {
 
   username?: string;
   password?: string;
+
+  lookup?: LookupFunction;
 
   postImages: PostImagesOption;
 }

--- a/modules/module-mysql/src/utils/mysql-utils.ts
+++ b/modules/module-mysql/src/utils/mysql-utils.ts
@@ -37,6 +37,7 @@ export function createPool(config: types.NormalizedMySQLConnectionConfig, option
     cert: config.client_certificate
   };
   const hasSSLOptions = Object.values(sslOptions).some((v) => !!v);
+  // TODO: Use config.lookup for DNS resolution
   return mysql.createPool({
     host: config.hostname,
     user: config.username,

--- a/modules/module-postgres/src/replication/PgManager.ts
+++ b/modules/module-postgres/src/replication/PgManager.ts
@@ -50,6 +50,7 @@ export class PgManager {
     // for the full 6 minutes.
     // This we are constantly using the connection, we don't need any
     // custom keepalives.
+
     (connection as any)._socket.setTimeout(SNAPSHOT_SOCKET_TIMEOUT);
 
     // Disable statement timeout for snapshot queries.

--- a/modules/module-postgres/src/utils/pgwire_utils.ts
+++ b/modules/module-postgres/src/utils/pgwire_utils.ts
@@ -1,7 +1,7 @@
 // Adapted from https://github.com/kagis/pgwire/blob/0dc927f9f8990a903f238737326e53ba1c8d094f/mod.js#L2218
 
 import * as pgwire from '@powersync/service-jpgwire';
-import { SqliteRow, toSyncRulesRow } from '@powersync/service-sync-rules';
+import { DatabaseInputRow, SqliteRow, toSyncRulesRow } from '@powersync/service-sync-rules';
 
 /**
  * pgwire message -> SQLite row.
@@ -10,7 +10,7 @@ import { SqliteRow, toSyncRulesRow } from '@powersync/service-sync-rules';
 export function constructAfterRecord(message: pgwire.PgoutputInsert | pgwire.PgoutputUpdate): SqliteRow {
   const rawData = (message as any).afterRaw;
 
-  const record = pgwire.decodeTuple(message.relation, rawData);
+  const record = decodeTuple(message.relation, rawData);
   return toSyncRulesRow(record);
 }
 
@@ -23,6 +23,24 @@ export function constructBeforeRecord(message: pgwire.PgoutputDelete | pgwire.Pg
   if (rawData == null) {
     return undefined;
   }
-  const record = pgwire.decodeTuple(message.relation, rawData);
+  const record = decodeTuple(message.relation, rawData);
   return toSyncRulesRow(record);
+}
+
+/**
+ * We need a high level of control over how values are decoded, to make sure there is no loss
+ * of precision in the process.
+ */
+export function decodeTuple(relation: pgwire.PgoutputRelation, tupleRaw: Record<string, any>): DatabaseInputRow {
+  let result: Record<string, any> = {};
+  for (let columnName in tupleRaw) {
+    const rawval = tupleRaw[columnName];
+    const typeOid = (relation as any)._tupleDecoder._typeOids.get(columnName);
+    if (typeof rawval == 'string' && typeOid) {
+      result[columnName] = pgwire.PgType.decode(rawval, typeOid);
+    } else {
+      result[columnName] = rawval;
+    }
+  }
+  return result;
 }

--- a/packages/jpgwire/package.json
+++ b/packages/jpgwire/package.json
@@ -19,8 +19,6 @@
   },
   "dependencies": {
     "@powersync/service-jsonbig": "workspace:^",
-    "@powersync/service-types": "workspace:^",
-    "@powersync/service-sync-rules": "workspace:^",
     "date-fns": "^4.1.0",
     "pgwire": "github:kagis/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87"
   }

--- a/packages/jpgwire/src/pgwire_types.ts
+++ b/packages/jpgwire/src/pgwire_types.ts
@@ -1,9 +1,7 @@
 // Adapted from https://github.com/kagis/pgwire/blob/0dc927f9f8990a903f238737326e53ba1c8d094f/mod.js#L2218
 
-import type { PgoutputRelation } from 'pgwire/mod.js';
-import { dateToSqlite, lsnMakeComparable, timestampToSqlite, timestamptzToSqlite } from './util.js';
 import { JsonContainer } from '@powersync/service-jsonbig';
-import { DatabaseInputRow } from '@powersync/service-sync-rules';
+import { dateToSqlite, lsnMakeComparable, timestampToSqlite, timestamptzToSqlite } from './util.js';
 
 export class PgType {
   static decode(text: string, typeOid: number) {
@@ -235,22 +233,4 @@ export class PgType {
   static _encodeBytea(bytes: Uint8Array): string {
     return '\\x' + Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
   }
-}
-
-/**
- * We need a high level of control over how values are decoded, to make sure there is no loss
- * of precision in the process.
- */
-export function decodeTuple(relation: PgoutputRelation, tupleRaw: Record<string, any>): DatabaseInputRow {
-  let result: Record<string, any> = {};
-  for (let columnName in tupleRaw) {
-    const rawval = tupleRaw[columnName];
-    const typeOid = (relation as any)._tupleDecoder._typeOids.get(columnName);
-    if (typeof rawval == 'string' && typeOid) {
-      result[columnName] = PgType.decode(rawval, typeOid);
-    } else {
-      result[columnName] = rawval;
-    }
-  }
-  return result;
 }

--- a/packages/jpgwire/src/socket_adapter.ts
+++ b/packages/jpgwire/src/socket_adapter.ts
@@ -1,0 +1,158 @@
+// Fork of pgwire/index.js, customized to handle additional TLS options
+
+import { once } from 'node:events';
+import net from 'node:net';
+import tls from 'node:tls';
+import { recordBytesRead } from './metrics.js';
+
+// pgwire doesn't natively support configuring timeouts, but we just hardcode a default.
+// Timeout idle connections after 6 minutes (we ping at least every 5 minutes).
+const POWERSYNC_SOCKET_DEFAULT_TIMEOUT = 360_000;
+
+// Timeout for the initial connection (pre-TLS)
+// Must be less than the timeout for a HTTP request
+const POWERSYNC_SOCKET_CONNECT_TIMEOUT = 20_000;
+
+// TCP keepalive delay in milliseconds.
+// This can help detect dead connections earlier.
+const POWERSYNC_SOCKET_KEEPALIVE_INITIAL_DELAY = 40_000;
+
+export interface ConnectOptions {
+  hostname: string;
+  port: number;
+  tlsOptions?: tls.ConnectionOptions | false;
+  lookup?: net.LookupFunction;
+}
+
+export class SocketAdapter {
+  static async connect(options: ConnectOptions) {
+    // Custom timeout handling
+    const socket = net.connect({
+      host: options.hostname,
+      port: options.port,
+      lookup: options.lookup,
+
+      // This closes the connection if no data was sent or received for the given time,
+      // even if the connection is still actaully alive.
+      timeout: POWERSYNC_SOCKET_DEFAULT_TIMEOUT,
+
+      // This configures TCP keepalive.
+      keepAlive: true,
+      keepAliveInitialDelay: POWERSYNC_SOCKET_KEEPALIVE_INITIAL_DELAY
+      // Unfortunately it is not possible to set tcp_keepalive_intvl or
+      // tcp_keepalive_probes here.
+    });
+    try {
+      const timeout = setTimeout(() => {
+        socket.destroy(new Error(`Timeout while connecting to ${options.hostname}:${options.port}`));
+      }, POWERSYNC_SOCKET_CONNECT_TIMEOUT);
+      await once(socket, 'connect');
+      clearTimeout(timeout);
+      return new SocketAdapter(socket, options);
+    } catch (e) {
+      socket.destroy();
+      throw e;
+    }
+    // END POWERSYNC
+  }
+
+  _socket: net.Socket;
+  _error: Error | null;
+
+  constructor(
+    socket: net.Socket,
+    private options: ConnectOptions
+  ) {
+    this._error = null;
+    this._socket = socket;
+    this._socket.on('readable', (_) => this._readResume());
+    this._socket.on('end', () => this._readResume());
+    // Custom timeout handling
+    this._socket.on('timeout', () => {
+      this._socket.destroy(new Error('Socket idle timeout'));
+    });
+    this._socket.on('error', (error) => {
+      this._error = error;
+      this._readResume();
+      this._writeResume();
+    });
+  }
+
+  _readResume = () => {
+    // noop
+    return;
+  };
+  _writeResume = () => {
+    // noop
+    return;
+  };
+
+  _readPauseAsync = (resolve: () => void) => {
+    this._readResume = resolve;
+  };
+  _writePauseAsync = (resolve: () => void) => {
+    this._writeResume = resolve;
+  };
+
+  setTimeout(timeout: number) {
+    this._socket.setTimeout(timeout);
+  }
+
+  async startTls(host: string, ca: any) {
+    // START POWERSYNC CUSTOM OPTIONS HANDLING
+    const tlsOptions = this.options.tlsOptions;
+
+    // https://nodejs.org/docs/latest-v14.x/api/tls.html#tls_tls_connect_options_callback
+    const socket = this._socket;
+    const tlsSocket = tls.connect({ socket, host, ...tlsOptions });
+    // END POWERSYNC CUSTOM OPTIONS HANDLING
+    await once(tlsSocket, 'secureConnect');
+    // TODO check tlsSocket.authorized
+
+    // if secure connection succeeded then we take underlying socket ownership,
+    // otherwise underlying socket should be closed outside.
+    tlsSocket.on('close', (_) => socket.destroy());
+    return new SocketAdapter(tlsSocket, this.options);
+  }
+
+  async read(out: Uint8Array) {
+    let buf;
+    for (;;) {
+      if (this._error) throw this._error; // TODO callstack
+      if (this._socket.readableEnded) return null;
+      // POWERSYNC FIX: Read only as much data as available, instead of reading everything and
+      // unshifting back onto the socket
+      const toRead = Math.min(out.length, this._socket.readableLength);
+      buf = this._socket.read(toRead);
+
+      if (buf?.length) break;
+      if (!buf) await new Promise<void>(this._readPauseAsync);
+    }
+
+    if (buf.length > out.length) {
+      throw new Error('Read more data than expected');
+    }
+    out.set(buf);
+    // POWERSYNC: Add metrics
+    recordBytesRead(buf.length);
+    return buf.length;
+  }
+  async write(data: Uint8Array) {
+    // TODO assert Uint8Array
+    // TODO need to copy data?
+    if (this._error) throw this._error; // TODO callstack
+    const p = new Promise<void>(this._writePauseAsync);
+    this._socket.write(data, this._writeResume);
+    await p;
+    if (this._error) throw this._error; // TODO callstack
+    return data.length;
+  }
+  // async closeWrite() {
+  //   if (this._error) throw this._error; // TODO callstack
+  //   const socket_end = promisify(cb => this._socket.end(cb));
+  //   await socket_end();
+  // }
+  close() {
+    this._socket.destroy(Error('socket destroyed'));
+  }
+}

--- a/packages/service-core/src/auth/RemoteJWKSCollector.ts
+++ b/packages/service-core/src/auth/RemoteJWKSCollector.ts
@@ -1,19 +1,14 @@
-import * as https from 'https';
 import * as http from 'http';
-import * as dns from 'dns/promises';
-import ip from 'ipaddr.js';
+import * as https from 'https';
 import * as jose from 'jose';
-import * as net from 'net';
 import fetch from 'node-fetch';
 
-import { KeySpec } from './KeySpec.js';
+import { LookupOptions, makeHostnameLookupFunction } from '@powersync/lib-services-framework';
 import { KeyCollector, KeyResult } from './KeyCollector.js';
+import { KeySpec } from './KeySpec.js';
 
 export type RemoteJWKSCollectorOptions = {
-  /**
-   * Blocks IP Ranges from the BLOCKED_IP_RANGES array
-   */
-  block_local_ip?: boolean;
+  lookupOptions?: LookupOptions;
 };
 
 /**
@@ -21,6 +16,7 @@ export type RemoteJWKSCollectorOptions = {
  */
 export class RemoteJWKSCollector implements KeyCollector {
   private url: URL;
+  private agent: http.Agent;
 
   constructor(
     url: string,
@@ -37,6 +33,8 @@ export class RemoteJWKSCollector implements KeyCollector {
     if (this.url.protocol != 'https:' && this.url.protocol != 'http:') {
       throw new Error(`Only http(s) is supported for jwks_uri, got: ${url}`);
     }
+
+    this.agent = this.resolveAgent();
   }
 
   async getKeys(): Promise<KeyResult> {
@@ -51,7 +49,7 @@ export class RemoteJWKSCollector implements KeyCollector {
         Accept: 'application/json'
       },
       signal: abortController.signal,
-      agent: await this.resolveAgent()
+      agent: this.agent
     });
 
     if (!res.ok) {
@@ -97,29 +95,14 @@ export class RemoteJWKSCollector implements KeyCollector {
   }
 
   /**
-   * Resolve IP, and check that it is in an allowed range.
+   * Agent that uses a custom lookup function.
    */
-  async resolveAgent(): Promise<http.Agent | https.Agent> {
-    const hostname = this.url.hostname;
-    let resolved_ip: string;
-    if (net.isIPv6(hostname)) {
-      throw new Error('IPv6 not supported yet');
-    } else if (net.isIPv4(hostname)) {
-      // All good
-      resolved_ip = hostname;
-    } else {
-      resolved_ip = (await dns.resolve4(hostname))[0];
-    }
+  resolveAgent(): http.Agent | https.Agent {
+    const lookupOptions = this.options?.lookupOptions ?? { reject_ip_ranges: [] };
+    const lookup = makeHostnameLookupFunction(this.url.hostname, lookupOptions);
 
-    const parsed = ip.parse(resolved_ip);
-    if (parsed.kind() != 'ipv4' || (this.options?.block_local_ip && parsed.range() !== 'unicast')) {
-      // Do not connect to any reserved IPs, including loopback and private ranges
-      throw new Error(`IPs in this range are not supported: ${resolved_ip}`);
-    }
-
-    const options = {
-      // This is the host that the agent connects to
-      host: resolved_ip
+    const options: http.AgentOptions = {
+      lookup
     };
 
     switch (this.url.protocol) {

--- a/packages/service-core/test/src/auth.test.ts
+++ b/packages/service-core/test/src/auth.test.ts
@@ -284,11 +284,23 @@ describe('JWT Auth', () => {
     expect(errors).toEqual([]);
     expect(keys.length).toBeGreaterThanOrEqual(1);
 
-    // The localhost hostname fails to resolve correctly on MacOS https://github.com/nodejs/help/issues/2163
-    const invalid = new RemoteJWKSCollector('https://127.0.0.1/.well-known/jwks.json', {
-      block_local_ip: true
+    // Domain names are resolved when retrieving keys
+    const invalid = new RemoteJWKSCollector('https://localhost/.well-known/jwks.json', {
+      lookupOptions: {
+        reject_ip_ranges: ['local']
+      }
     });
     expect(invalid.getKeys()).rejects.toThrow('IPs in this range are not supported');
+
+    // IPS throw an error immediately
+    expect(
+      () =>
+        new RemoteJWKSCollector('https://127.0.0.1/.well-known/jwks.json', {
+          lookupOptions: {
+            reject_ip_ranges: ['local']
+          }
+        })
+    ).toThrowError('IPs in this range are not supported');
   });
 
   test('http not blocking local IPs', async () => {
@@ -301,10 +313,13 @@ describe('JWT Auth', () => {
     expect(errors).toEqual([]);
     expect(keys.length).toBeGreaterThanOrEqual(1);
 
-    // The localhost hostname fails to resolve correctly on MacOS https://github.com/nodejs/help/issues/2163
     const invalid = new RemoteJWKSCollector('https://127.0.0.1/.well-known/jwks.json');
     // Should try and fetch
     expect(invalid.getKeys()).rejects.toThrow('ECONNREFUSED');
+
+    const invalid2 = new RemoteJWKSCollector('https://localhost/.well-known/jwks.json');
+    // Should try and fetch
+    expect(invalid2.getKeys()).rejects.toThrow('ECONNREFUSED');
   });
 
   test('caching', async () => {

--- a/packages/types/src/config/PowerSyncConfig.ts
+++ b/packages/types/src/config/PowerSyncConfig.ts
@@ -137,7 +137,7 @@ export const powerSyncConfig = t.object({
   client_auth: t
     .object({
       jwks_uri: t.string.or(t.array(t.string)).optional(),
-      block_local_jwks: t.boolean.optional(),
+      block_local_jwks: t.boolean.or(t.array(t.string)).optional(),
       jwks: strictJwks.optional(),
       supabase: t.boolean.optional(),
       supabase_jwt_secret: t.string.optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       '@powersync/service-jpgwire':
         specifier: workspace:*
         version: link:../../packages/jpgwire
-      '@powersync/service-sync-rules':
-        specifier: workspace:*
-        version: link:../../packages/sync-rules
       '@powersync/service-types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -129,6 +126,9 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
+      ipaddr.js:
+        specifier: ^2.1.0
+        version: 2.2.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -405,12 +405,6 @@ importers:
       '@powersync/service-jsonbig':
         specifier: workspace:^
         version: link:../jsonbig
-      '@powersync/service-sync-rules':
-        specifier: workspace:^
-        version: link:../sync-rules
-      '@powersync/service-types':
-        specifier: workspace:^
-        version: link:../types
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -4899,7 +4893,7 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.25.1
       '@prisma/instrumentation': 5.16.1
       '@sentry/core': 8.17.0
-      '@sentry/opentelemetry': 8.17.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.1)
+      '@sentry/opentelemetry': 8.17.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.6.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.1)
       '@sentry/types': 8.17.0
       '@sentry/utils': 8.17.0
     optionalDependencies:
@@ -4907,7 +4901,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@8.17.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.1)':
+  '@sentry/opentelemetry@8.17.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.6.0))(@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.25.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
This extends database connection a little:
1. Postgres connections now support a `tls_servername` option. This can be used with `sslmode: verify-full` when the hostname does not match the TLS certificate name, for example when connecting to a specific IP. This is not relevant for `sslmode: disable` or `sslmode: verify-ca`, since neither of those verify the hostname.
2. Add `reject_ip_ranges: [...]` support to all connections, to avoid connecting to specific hosts. The implementation does not check all cases for MongoDB and MySQL yet, but combined enforced TLS, this should be fairly effective.
3. Similarly, the `client_auth.block_local_jwks` option now accepts an array of ranges. This means we now also support IPv6-only servers for the JWKS URI.

This required a bit of restructuring to the connection libs. I also restructured things a bit to improve internal dependencies: the jpgwire package no longer depends on sync-rules or service-types.

The implementation of blocking IP ranges operates on two levels:
1. Override the `lookup` function used for DNS lookups. This is the same as the normal lookup, except it now validates the IP ranges.
2. If the connection specifies an IP directly, validate it synchronously (since it's never passed to the lookup function).
