### PR TITLE
Add schema generator for FlutterFlow

### DIFF
--- a/.changeset/violet-zebras-deliver.md
+++ b/.changeset/violet-zebras-deliver.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Add schema generator for FlutterFlow library

--- a/packages/sync-rules/src/DartSchemaGenerator.ts
+++ b/packages/sync-rules/src/DartSchemaGenerator.ts
@@ -41,15 +41,50 @@ ${generated.join('\n')}
   }
 
   private generateColumn(column: ColumnDefinition) {
-    const t = column.type;
-    if (t.typeFlags & TYPE_TEXT) {
-      return `Column.text('${column.name}')`;
-    } else if (t.typeFlags & TYPE_REAL) {
-      return `Column.real('${column.name}')`;
-    } else if (t.typeFlags & TYPE_INTEGER) {
-      return `Column.integer('${column.name}')`;
-    } else {
-      return `Column.text('${column.name}')`;
-    }
+    return `Column.${dartColumnType(column)}('${column.name}')`;
   }
 }
+
+export class DartFlutterFlowSchemaGenerator extends SchemaGenerator {
+  readonly key = 'dart-flutterflow';
+  readonly label = 'FlutterFlow';
+  readonly mediaType = 'application/json';
+  readonly fileName = 'schema.json';
+
+  generate(source: SqlSyncRules, schema: SourceSchema, options?: GenerateSchemaOptions): string {
+    return JSON.stringify({
+      tables: this.getAllTables(source, schema).map((e) => this.generateTable(e.name, e.columns))
+    });
+  }
+
+  private generateTable(name: string, columns: ColumnDefinition[]): object {
+    return {
+      name,
+      view_name: null,
+      local_only: false,
+      insert_only: false,
+      columns: columns.map(this.generateColumn),
+      indexes: []
+    };
+  }
+
+  private generateColumn(definition: ColumnDefinition): object {
+    return {
+      name: definition.name,
+      type: dartColumnType(definition)
+    };
+  }
+}
+
+const dartColumnType = (def: ColumnDefinition) => {
+  const t = def.type;
+  if (t.typeFlags & TYPE_TEXT) {
+    return 'text';
+  } else if (t.typeFlags & TYPE_REAL) {
+    return 'real';
+  } else if (t.typeFlags & TYPE_INTEGER) {
+    return 'integer';
+  } else {
+    return 'text';
+  }
+};

--- a/packages/sync-rules/src/generators.ts
+++ b/packages/sync-rules/src/generators.ts
@@ -1,4 +1,4 @@
-import { DartSchemaGenerator } from './DartSchemaGenerator.js';
+import { DartFlutterFlowSchemaGenerator, DartSchemaGenerator } from './DartSchemaGenerator.js';
 import { JsLegacySchemaGenerator } from './JsLegacySchemaGenerator.js';
 import { TsSchemaGenerator, TsSchemaLanguage } from './TsSchemaGenerator.js';
 
@@ -6,5 +6,6 @@ export const schemaGenerators = {
   ts: new TsSchemaGenerator(),
   js: new TsSchemaGenerator({ language: TsSchemaLanguage.js }),
   jsLegacy: new JsLegacySchemaGenerator(),
-  dart: new DartSchemaGenerator()
+  dart: new DartSchemaGenerator(),
+  flutterFlow: new DartFlutterFlowSchemaGenerator()
 };

--- a/packages/sync-rules/test/src/generate_schema.test.ts
+++ b/packages/sync-rules/test/src/generate_schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   DEFAULT_TAG,
+  DartFlutterFlowSchemaGenerator,
   DartSchemaGenerator,
   JsLegacySchemaGenerator,
   SqlSyncRules,
@@ -75,6 +76,12 @@ bucket_definitions:
   ])
 ]);
 `);
+  });
+
+  test('flutterflow', () => {
+    expect(new DartFlutterFlowSchemaGenerator().generate(rules, schema)).toEqual(
+      '{"tables":[{"name":"assets1","view_name":null,"local_only":false,"insert_only":false,"columns":[{"name":"name","type":"text"},{"name":"count","type":"integer"},{"name":"owner_id","type":"text"}],"indexes":[]},{"name":"assets2","view_name":null,"local_only":false,"insert_only":false,"columns":[{"name":"name","type":"text"},{"name":"count","type":"integer"},{"name":"other_id","type":"text"},{"name":"foo","type":"text"}],"indexes":[]}]}'
+    );
   });
 
   test('js legacy', () => {


### PR DESCRIPTION
Our new FlutterFlow integration will take a JSON string as a parameter and deserialize the schema from that. This avoids users having to write custom code for the schema.
