### PR TITLE
[Fix] Missing Changeset

### DIFF
--- a/.changeset/poor-experts-care.md
+++ b/.changeset/poor-experts-care.md
@@ -1,0 +1,5 @@
+---
+'@powersync/lib-service-postgres': minor
+---
+
+Added utilities for Postgres server and database identification.


### PR DESCRIPTION
# Overview

https://github.com/powersync-ja/powersync-service/pull/186 made some changes to the `@powersync/service-lib-postgres` package which were missing a Changeset entry. The missing Changeset prevented the new features from being released, which causes issues downstream in our hosted repository when using the latest packages. The DockerHub image is not affected since the packages are locally sourced.

