### PR TITLE
Fix -> operator on missing values to return null

### DIFF
--- a/.changeset/fast-monkeys-approve.md
+++ b/.changeset/fast-monkeys-approve.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix -> operator on missing values to return null.

--- a/packages/sync-rules/src/TableValuedFunctions.ts
+++ b/packages/sync-rules/src/TableValuedFunctions.ts
@@ -27,7 +27,7 @@ export const JSON_EACH: TableValuedFunction = {
       throw new Error('Expected JSON string');
     }
     if (!Array.isArray(values)) {
-      throw new Error('Expected an array');
+      throw new Error(`Expected an array, got ${valueString}`);
     }
 
     return values.map((v) => {

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -865,7 +865,7 @@ export function jsonExtract(sourceValue: SqliteValue, path: SqliteValue, operato
     value = value[c];
   }
   if (operator == '->') {
-    // -> must always stringify, expect when it's null
+    // -> must always stringify, except when it's null
     if (value == null) {
       return null;
     }

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -260,7 +260,7 @@ const iif: DocumentedSqlFunction = {
   parameters: [
     { name: 'x', type: ExpressionType.ANY, optional: false },
     { name: 'y', type: ExpressionType.ANY, optional: false },
-    { name: 'z', type: ExpressionType.ANY, optional: false },
+    { name: 'z', type: ExpressionType.ANY, optional: false }
   ],
   getReturnType() {
     return ExpressionType.ANY;
@@ -865,7 +865,10 @@ export function jsonExtract(sourceValue: SqliteValue, path: SqliteValue, operato
     value = value[c];
   }
   if (operator == '->') {
-    // -> must always stringify
+    // -> must always stringify, expect when it's null
+    if (value == null) {
+      return null;
+    }
     return JSONBig.stringify(value);
   } else {
     // Plain scalar value - simple conversion.

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -12,6 +12,9 @@ describe('SQL functions', () => {
     expect(fn.json_extract(JSON.stringify({ foo: 42 }), '$')).toEqual('{"foo":42}');
     expect(fn.json_extract(`{"foo": 42.0}`, '$')).toEqual('{"foo":42.0}');
     expect(fn.json_extract(`{"foo": true}`, '$')).toEqual('{"foo":true}');
+    // Null and missing are different here; matches SQLite
+    expect(fn.json_extract(`{"foo": null}`, '$.foo')).toEqual('null');
+    expect(fn.json_extract(`{}`, '$.foo')).toBeNull();
   });
 
   test('->>', () => {
@@ -23,6 +26,9 @@ describe('SQL functions', () => {
     expect(jsonExtract(`{"foo": 42.0}`, 'foo', '->>')).toEqual(42.0);
     expect(jsonExtract(`{"foo": 42.0}`, '$', '->>')).toEqual(`{"foo":42.0}`);
     expect(jsonExtract(`{"foo": true}`, '$.foo', '->>')).toEqual(1n);
+    // Null and missing are different here; matches SQLite
+    expect(jsonExtract(`{"foo": null}`, '$.foo', '->>')).toEqual('null');
+    expect(jsonExtract(`{}`, '$.foo', '->>')).toBeNull();
   });
 
   test('->', () => {
@@ -34,6 +40,9 @@ describe('SQL functions', () => {
     expect(jsonExtract(`{"foo": 42.0}`, 'foo', '->')).toEqual('42.0');
     expect(jsonExtract(`{"foo": 42.0}`, '$', '->')).toEqual(`{"foo":42.0}`);
     expect(jsonExtract(`{"foo": true}`, '$.foo', '->')).toEqual('true');
+    // Null and missing are the same here; matches SQLite
+    expect(jsonExtract(`{"foo": null}`, '$.foo', '->')).toBeNull();
+    expect(jsonExtract(`{"foo": true}`, '$.bar', '->')).toBeNull();
   });
 
   test('json_array_length', () => {
@@ -127,13 +136,13 @@ describe('SQL functions', () => {
   test('iif', () => {
     expect(fn.iif(null, 1, 2)).toEqual(2);
     expect(fn.iif(0, 1, 2)).toEqual(2);
-    expect(fn.iif(1, "first", "second")).toEqual("first");
-    expect(fn.iif(0.1, "is_true", "is_false")).toEqual("is_true");
-    expect(fn.iif("a", "is_true", "is_false")).toEqual("is_false");
-    expect(fn.iif(0n, "is_true", "is_false")).toEqual("is_false");
-    expect(fn.iif(2n, "is_true", "is_false")).toEqual("is_true");
-    expect(fn.iif(new Uint8Array([]), "is_true", "is_false")).toEqual("is_false");
-    expect(fn.iif(Uint8Array.of(0x61, 0x62, 0x43), "is_true", "is_false")).toEqual("is_false");
+    expect(fn.iif(1, 'first', 'second')).toEqual('first');
+    expect(fn.iif(0.1, 'is_true', 'is_false')).toEqual('is_true');
+    expect(fn.iif('a', 'is_true', 'is_false')).toEqual('is_false');
+    expect(fn.iif(0n, 'is_true', 'is_false')).toEqual('is_false');
+    expect(fn.iif(2n, 'is_true', 'is_false')).toEqual('is_true');
+    expect(fn.iif(new Uint8Array([]), 'is_true', 'is_false')).toEqual('is_false');
+    expect(fn.iif(Uint8Array.of(0x61, 0x62, 0x43), 'is_true', 'is_false')).toEqual('is_false');
   });
 
   test('upper', () => {

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -42,7 +42,7 @@ describe('SQL functions', () => {
     expect(jsonExtract(`{"foo": true}`, '$.foo', '->')).toEqual('true');
     // Null and missing are the same here; matches SQLite
     expect(jsonExtract(`{"foo": null}`, '$.foo', '->')).toBeNull();
-    expect(jsonExtract(`{"foo": true}`, '$.bar', '->')).toBeNull();
+    expect(jsonExtract(`{}`, '$.bar', '->')).toBeNull();
   });
 
   test('json_array_length', () => {

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -12,8 +12,9 @@ describe('SQL functions', () => {
     expect(fn.json_extract(JSON.stringify({ foo: 42 }), '$')).toEqual('{"foo":42}');
     expect(fn.json_extract(`{"foo": 42.0}`, '$')).toEqual('{"foo":42.0}');
     expect(fn.json_extract(`{"foo": true}`, '$')).toEqual('{"foo":true}');
-    // Null and missing are different here; matches SQLite
+    // SQLite gives null instead of 'null'. We should match that, but it's a breaking change.
     expect(fn.json_extract(`{"foo": null}`, '$.foo')).toEqual('null');
+    // Matches SQLite
     expect(fn.json_extract(`{}`, '$.foo')).toBeNull();
   });
 
@@ -26,8 +27,9 @@ describe('SQL functions', () => {
     expect(jsonExtract(`{"foo": 42.0}`, 'foo', '->>')).toEqual(42.0);
     expect(jsonExtract(`{"foo": 42.0}`, '$', '->>')).toEqual(`{"foo":42.0}`);
     expect(jsonExtract(`{"foo": true}`, '$.foo', '->>')).toEqual(1n);
-    // Null and missing are different here; matches SQLite
+    // SQLite gives null instead of 'null'. We should match that, but it's a breaking change.
     expect(jsonExtract(`{"foo": null}`, '$.foo', '->>')).toEqual('null');
+    // Matches SQLite
     expect(jsonExtract(`{}`, '$.foo', '->>')).toBeNull();
   });
 
@@ -40,9 +42,10 @@ describe('SQL functions', () => {
     expect(jsonExtract(`{"foo": 42.0}`, 'foo', '->')).toEqual('42.0');
     expect(jsonExtract(`{"foo": 42.0}`, '$', '->')).toEqual(`{"foo":42.0}`);
     expect(jsonExtract(`{"foo": true}`, '$.foo', '->')).toEqual('true');
-    // Null and missing are the same here; matches SQLite
+    // SQLite gives 'null' instead of null. We should match that, but it's a breaking change.
     expect(jsonExtract(`{"foo": null}`, '$.foo', '->')).toBeNull();
-    expect(jsonExtract(`{}`, '$.bar', '->')).toBeNull();
+    // Matches SQLite
+    expect(jsonExtract(`{}`, '$.foo', '->')).toBeNull();
   });
 
   test('json_array_length', () => {

--- a/packages/sync-rules/test/src/table_valued_function_queries.test.ts
+++ b/packages/sync-rules/test/src/table_valued_function_queries.test.ts
@@ -66,6 +66,19 @@ describe('table-valued function queries', () => {
     expect(query.getStaticBucketIds(new RequestParameters({ sub: '' }, {}))).toEqual([]);
   });
 
+  test('json_each on json_keys', function () {
+    const sql = `SELECT value FROM json_each(json_keys('{"a": [], "b": 2, "c": null}'))`;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.bucket_parameters).toEqual(['value']);
+
+    expect(query.getStaticBucketIds(new RequestParameters({ sub: '' }, {}))).toEqual([
+      'mybucket["a"]',
+      'mybucket["b"]',
+      'mybucket["c"]'
+    ]);
+  });
+
   test('json_each with fn alias', function () {
     const sql = "SELECT e.value FROM json_each(request.parameters() -> 'array') e";
     const query = SqlParameterQuery.fromSql('mybucket', sql, {

--- a/packages/sync-rules/test/src/table_valued_function_queries.test.ts
+++ b/packages/sync-rules/test/src/table_valued_function_queries.test.ts
@@ -42,6 +42,30 @@ describe('table-valued function queries', () => {
     expect(query.getStaticBucketIds(new RequestParameters({ sub: '' }, {}))).toEqual([]);
   });
 
+  test('json_each(array param not present)', function () {
+    const sql = "SELECT json_each.value as v FROM json_each(request.parameters() -> 'array_not_present')";
+    const query = SqlParameterQuery.fromSql('mybucket', sql, {
+      ...PARSE_OPTIONS,
+      accept_potentially_dangerous_queries: true
+    }) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.bucket_parameters).toEqual(['v']);
+
+    expect(query.getStaticBucketIds(new RequestParameters({ sub: '' }, {}))).toEqual([]);
+  });
+
+  test('json_each(array param not present, ifnull)', function () {
+    const sql = "SELECT json_each.value as v FROM json_each(ifnull(request.parameters() -> 'array_not_present', '[]'))";
+    const query = SqlParameterQuery.fromSql('mybucket', sql, {
+      ...PARSE_OPTIONS,
+      accept_potentially_dangerous_queries: true
+    }) as StaticSqlParameterQuery;
+    expect(query.errors).toEqual([]);
+    expect(query.bucket_parameters).toEqual(['v']);
+
+    expect(query.getStaticBucketIds(new RequestParameters({ sub: '' }, {}))).toEqual([]);
+  });
+
   test('json_each with fn alias', function () {
     const sql = "SELECT e.value FROM json_each(request.parameters() -> 'array') e";
     const query = SqlParameterQuery.fromSql('mybucket', sql, {


### PR DESCRIPTION
Using the `->` operator with a missing value, for example `select '{}' -> 'test'`, would return `undefined` instead of `null`. We use SQLite types, so there should never be an `undefined` value.

This was specifically an issue when used together with `json_each`, for example `SELECT value as project_id FROM json_each(request.jwt() -> 'project_ids')`. This query would throw an error `Expected json_each to be called with a string, got undefined`, instead of treating it like an empty array like with `null` values.

This fixes `select '{}' -> 'test'` to return `null` correctly.

This also adds tests for all the following forms:

```sql
select '{"t": null}' -> 't' -- null in PowerSync, 'null' in SQLite
select '{}' -> 't' -- null in PowerSync and SQLite, fixed by this PR

select '{"t": null}' ->> 't' -- 'null' in PowerSync, null in SQLite
select '{}' ->> 't' -- null in PowerSync and SQLite

select json_extract('{"t": null}', '$.t') -- 'null' in PowerSync, null in SQLite
select json_extract('{}', '$.t') -- null in PowerSync and SQLite
```

Notice the difference in handling of `{"t": null}` values between PowerSync and SQLite. That is not affected by this PR though, and fixing it to match SQLite would be a breaking change, so keeping it as-is for now.

