### PR TITLE
MongoDB initial replication progress

### DIFF
--- a/.changeset/forty-doors-deliver.md
+++ b/.changeset/forty-doors-deliver.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': minor
+---
+
+Added progress logs to initial snapshot

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -164,7 +164,7 @@ export class ChangeStream {
 
   async estimatedCount(table: storage.SourceTable): Promise<string> {
     const db = this.client.db(table.schema);
-    const count = db.collection(table.table).estimatedDocumentCount();
+    const count = await db.collection(table.table).estimatedDocumentCount();
     return `~${count}`;
   }
 
@@ -298,6 +298,7 @@ export class ChangeStream {
     logger.info(`Replicating ${table.qualifiedName}`);
     const estimatedCount = await this.estimatedCount(table);
     let at = 0;
+    let lastLogIndex = 0;
 
     const db = this.client.db(table.schema);
     const collection = db.collection(table.table);
@@ -309,8 +310,6 @@ export class ChangeStream {
       if (this.abort_signal.aborted) {
         throw new ReplicationAbortedError(`Aborted initial replication`);
       }
-
-      at += 1;
 
       const record = constructAfterRecord(document);
 
@@ -325,6 +324,10 @@ export class ChangeStream {
       });
 
       at += 1;
+      if (at - lastLogIndex >= 5000) {
+        logger.info(`[${this.group_id}] Replicating ${table.qualifiedName} ${at}/${estimatedCount}`);
+        lastLogIndex = at;
+      }
       Metrics.getInstance().rows_replicated_total.add(1);
 
       await touch();


### PR DESCRIPTION
# Overview

This adds a log entry to indicate the estimated progress during MongoDB initial replication. 

The screenshot shows the logs for an initial replication of 1000001 rows. 

![image](https://github.com/user-attachments/assets/87214fa8-688b-4a26-b0c2-4ebacdc3648a)
