### PR TITLE
Fix write checkpoint race condition

### DIFF
--- a/.changeset/shy-news-smell.md
+++ b/.changeset/shy-news-smell.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-postgres': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-module-mysql': patch
+---
+
+Fix write checkpoint race condition

--- a/modules/module-mysql/src/api/MySQLRouteAPIAdapter.ts
+++ b/modules/module-mysql/src/api/MySQLRouteAPIAdapter.ts
@@ -1,4 +1,4 @@
-import { api, ParseSyncRulesOptions, storage } from '@powersync/service-core';
+import { api, ParseSyncRulesOptions, ReplicationHeadCallback, storage } from '@powersync/service-core';
 
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as service_types from '@powersync/service-types';
@@ -273,6 +273,15 @@ export class MySQLRouteAPIAdapter implements api.RouteAPI {
     const result = await common.readExecutedGtid(connection);
     connection.release();
     return result.comparable;
+  }
+
+  async createReplicationHead<T>(callback: ReplicationHeadCallback<T>): Promise<T> {
+    const head = await this.getReplicationHead();
+    const r = await callback(head);
+
+    // TODO: make sure another message is replicated
+
+    return r;
   }
 
   async getConnectionSchema(): Promise<service_types.DatabaseSchema[]> {

--- a/modules/module-postgres/test/src/checkpoints.test.ts
+++ b/modules/module-postgres/test/src/checkpoints.test.ts
@@ -1,0 +1,70 @@
+import { PostgresRouteAPIAdapter } from '@module/api/PostgresRouteAPIAdapter.js';
+import { checkpointUserId, createWriteCheckpoint } from '@powersync/service-core';
+import { describe, test } from 'vitest';
+import { INITIALIZED_MONGO_STORAGE_FACTORY } from './util.js';
+import { WalStreamTestContext } from './wal_stream_utils.js';
+
+import timers from 'node:timers/promises';
+
+const BASIC_SYNC_RULES = `bucket_definitions:
+  global:
+    data:
+      - SELECT id, description, other FROM "test_data"`;
+
+describe('checkpoint tests', () => {
+  test('write checkpoints', { timeout: 30_000 }, async () => {
+    const factory = INITIALIZED_MONGO_STORAGE_FACTORY;
+    await using context = await WalStreamTestContext.open(factory);
+
+    await context.updateSyncRules(BASIC_SYNC_RULES);
+    const { pool } = context;
+    const api = new PostgresRouteAPIAdapter(pool);
+
+    await pool.query(`CREATE TABLE test_data(id text primary key, description text, other text)`);
+
+    await context.replicateSnapshot();
+
+    context.startStreaming();
+
+    const controller = new AbortController();
+    try {
+      const stream = context.factory.watchWriteCheckpoint(
+        checkpointUserId('test_user', 'test_client'),
+        controller.signal
+      );
+
+      let lastWriteCheckpoint: bigint | null = null;
+
+      (async () => {
+        try {
+          for await (const cp of stream) {
+            lastWriteCheckpoint = cp.writeCheckpoint;
+          }
+        } catch (e) {
+          if (e.name != 'AbortError') {
+            throw e;
+          }
+        }
+      })();
+
+      for (let i = 0; i < 10; i++) {
+        const cp = await createWriteCheckpoint({
+          userId: 'test_user',
+          clientId: 'test_client',
+          api,
+          storage: context.factory
+        });
+
+        const start = Date.now();
+        while (lastWriteCheckpoint == null || lastWriteCheckpoint < BigInt(cp.writeCheckpoint)) {
+          if (Date.now() - start > 2_000) {
+            throw new Error(`Timeout while waiting for checkpoint`);
+          }
+          await timers.setTimeout(0, undefined, { signal: controller.signal });
+        }
+      }
+    } finally {
+      controller.abort();
+    }
+  });
+});

--- a/modules/module-postgres/test/src/util.ts
+++ b/modules/module-postgres/test/src/util.ts
@@ -68,7 +68,7 @@ export async function getClientCheckpoint(
   const start = Date.now();
 
   const api = new PostgresRouteAPIAdapter(db);
-  const lsn = await api.getReplicationHead();
+  const lsn = await api.createReplicationHead(async (lsn) => lsn);
 
   // This old API needs a persisted checkpoint id.
   // Since we don't use LSNs anymore, the only way to get that is to wait.

--- a/packages/service-core/src/api/RouteAPI.ts
+++ b/packages/service-core/src/api/RouteAPI.ts
@@ -55,6 +55,14 @@ export interface RouteAPI {
   getReplicationHead(): Promise<string>;
 
   /**
+   * Get the current LSN or equivalent replication HEAD position identifier.
+   *
+   * The position is provided to the callback. After the callback returns,
+   * the replication head or a greater one will be streamed on the replication stream.
+   */
+  createReplicationHead<T>(callback: ReplicationHeadCallback<T>): Promise<T>;
+
+  /**
    * @returns The schema for tables inside the connected database. This is typically
    *          used to validate sync rules.
    */
@@ -76,3 +84,5 @@ export interface RouteAPI {
    */
   getParseSyncRulesOptions(): ParseSyncRulesOptions;
 }
+
+export type ReplicationHeadCallback<T> = (head: string) => Promise<T>;

--- a/packages/service-core/src/routes/endpoints/checkpointing.ts
+++ b/packages/service-core/src/routes/endpoints/checkpointing.ts
@@ -25,7 +25,7 @@ export const writeCheckpoint = routeDefinition({
     // Since we don't use LSNs anymore, the only way to get that is to wait.
     const start = Date.now();
 
-    const head = await apiHandler.getReplicationHead();
+    const head = await apiHandler.createReplicationHead(async (head) => head);
 
     const timeout = 50_000;
 

--- a/packages/service-core/src/routes/endpoints/checkpointing.ts
+++ b/packages/service-core/src/routes/endpoints/checkpointing.ts
@@ -56,25 +56,14 @@ export const writeCheckpoint2 = routeDefinition({
 
     const apiHandler = service_context.routerEngine!.getAPI();
 
-    const client_id = payload.params.client_id;
-    const full_user_id = util.checkpointUserId(user_id, client_id);
-
-    const currentCheckpoint = await apiHandler.getReplicationHead();
-    const {
-      storageEngine: { activeBucketStorage }
-    } = service_context;
-
-    const activeSyncRules = await activeBucketStorage.getActiveSyncRulesContent();
-    if (!activeSyncRules) {
-      throw new framework.errors.ValidationError(`Cannot create Write Checkpoint since no sync rules are active.`);
-    }
-
-    using syncBucketStorage = activeBucketStorage.getInstance(activeSyncRules);
-    const writeCheckpoint = await syncBucketStorage.createManagedWriteCheckpoint({
-      user_id: full_user_id,
-      heads: { '1': currentCheckpoint }
+    const { replicationHead, writeCheckpoint } = await util.createWriteCheckpoint({
+      userId: user_id,
+      clientId: payload.params.client_id,
+      api: apiHandler,
+      storage: service_context.storageEngine.activeBucketStorage
     });
-    logger.info(`Write checkpoint 2: ${JSON.stringify({ currentCheckpoint, id: String(full_user_id) })}`);
+
+    logger.info(`Write checkpoint for ${user_id}/${payload.params.client_id}: ${writeCheckpoint} | ${replicationHead}`);
 
     return {
       write_checkpoint: String(writeCheckpoint)

--- a/packages/service-core/src/util/checkpointing.ts
+++ b/packages/service-core/src/util/checkpointing.ts
@@ -1,0 +1,40 @@
+import { ErrorCode, logger, ServiceError } from '@powersync/lib-services-framework';
+import { RouteAPI } from '../api/RouteAPI.js';
+import { BucketStorageFactory } from '../storage/BucketStorage.js';
+
+export interface CreateWriteCheckpointOptions {
+  userId: string | undefined;
+  clientId: string | undefined;
+  api: RouteAPI;
+  storage: BucketStorageFactory;
+}
+export async function createWriteCheckpoint(options: CreateWriteCheckpointOptions) {
+  const full_user_id = checkpointUserId(options.userId, options.clientId);
+
+  const currentCheckpoint = await options.api.getReplicationHead();
+
+  const activeSyncRules = await options.storage.getActiveSyncRulesContent();
+  if (!activeSyncRules) {
+    throw new ServiceError(ErrorCode.PSYNC_S2302, `Cannot create Write Checkpoint since no sync rules are active.`);
+  }
+
+  using syncBucketStorage = options.storage.getInstance(activeSyncRules);
+  const writeCheckpoint = await syncBucketStorage.createManagedWriteCheckpoint({
+    user_id: full_user_id,
+    heads: { '1': currentCheckpoint }
+  });
+  return {
+    writeCheckpoint: String(writeCheckpoint),
+    replicationHead: currentCheckpoint
+  };
+}
+
+export function checkpointUserId(user_id: string | undefined, client_id: string | undefined) {
+  if (user_id == null) {
+    throw new Error('user_id is required');
+  }
+  if (client_id == null) {
+    return user_id;
+  }
+  return `${user_id}/${client_id}`;
+}

--- a/packages/service-core/src/util/util-index.ts
+++ b/packages/service-core/src/util/util-index.ts
@@ -5,6 +5,7 @@ export * from './Mutex.js';
 export * from './protocol-types.js';
 export * from './secs.js';
 export * from './utils.js';
+export * from './checkpointing.js';
 
 export * from './config.js';
 export * from './config/compound-config-collector.js';

--- a/packages/service-core/src/util/utils.ts
+++ b/packages/service-core/src/util/utils.ts
@@ -145,16 +145,6 @@ export function isCompleteRow(storeData: boolean, row: sync_rules.ToastableSqlit
   return !hasToastedValues(row);
 }
 
-export function checkpointUserId(user_id: string | undefined, client_id: string | undefined) {
-  if (user_id == null) {
-    throw new Error('user_id is required');
-  }
-  if (client_id == null) {
-    return user_id;
-  }
-  return `${user_id}/${client_id}`;
-}
-
 /**
  * Reduce a bucket to the final state as stored on the client.
  *


### PR DESCRIPTION
## The issue

The issue is a race condition that sometimes causes a new write checkpoint to not be acknowledged on an existing connection.

Symptoms of the issue:
1. The client would stay in `downloaded: true` state.
2. If the client was offline before, changes made in that offline period would not be applied.
3. Once an additional change is made on the backend db, the write checkpoint will be acknowledged and the issue will be resolved.

The issue appeared to more prevalent on React Native than on other platforms, likely due to the specific timing of requests, although the underlying cause is on the service.

## What happened

The expected sequence of events with a write checkpoint is:
1. Client has an active sync connection, listening for new checkpoints.
5. Client calls write-checkpoint2.json.
6. The service creates a new LSN, which also emits it on the WAL / mongo changestream.
7. The service writes the LSN to write_checkpoints and returns a numeric write checkpoint to the client.
8. The replication process picks up the new LSN, writes it to the sync-rules document.
9. The sync process picks up the new LSN/checkpoint from the sync-rules.
10. The sync process compares it to write_checkpoints, and sees that it matches, and sends it to the client.

Now what could happen is that step 4 is delayed, resulting in this order:
1. Client has an active sync connection, listening for new checkpoints.
2. Client calls write-checkpoint2.json.
3. The service creates a new LSN, which also emits it on the WAL / mongo changestream.
5. The replication process picks up the new LSN, writes it to the sync-rules document.
6. The sync process picks up the new LSN/checkpoint from the sync-rules.
7. The sync process compares it to write_checkpoints, but _there is no new entry in write checkpoints yet_.
8. The service writes the LSN to write_checkpoints and returns a numeric write checkpoint to the client.
11. When a new LSN comes in, that will re-check write_checkpoints, and send the write checkpoint to the client. But if there is no traffic on the db, that can be delayed significantly.

This is difficult to reproduce in practice, since it's very sensitive to timings. I added a test, but the test never managed to reproduce the issue unless I added an artificial delay in the process.

The issue is more likely to happen when there is a low latency to the source database, and a higher latency or higher load on the bucket storage database.

## The fix

This fixes the issue for MongoDB and Postgres source dbs by splitting the `getReplicationHead` into a three-phase process:
1. Get the current replication position from the source database.
2. Persist that position in the storage database write_checkpoints.
3. Send a new message on the replication stream.

This makes sure that by the time the message is received, the position would already be present in write_checkpoints.

This does not fix the issue for MySQL yet, but does not make it any worse for MySQL.