### PR TITLE
Limit GH actions to only run on push or external PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   test-service-container-build:
     name: Build and Test PowerSync Service
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,6 +35,7 @@ jobs:
 
   run-core-tests:
     name: Core Test
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
In #203 I enabled running tests on pull_request, which allows running tests when a PR is made from a fork.

The issue is that it now results in a total of 29 checks being run for every commit. This changes the jobs to only run on push or _external_ pull request, to avoid that duplication.

See:
1. This PR, running all checks on push, skipping all checks on pull_request.
2. #206 as an example of a forked PR, running all checks on pull_request.