### PR TITLE
Improve test stability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
+        uses: supercharge/mongodb-github-action@1.12.0
         with:
-          mongodb-version: '6.0'
+          mongodb-version: '8.0'
           mongodb-replica-set: test-rs
 
       - name: Setup Node.js
@@ -117,9 +117,9 @@ jobs:
             -d postgres:${{ matrix.postgres-version }}
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
+        uses: supercharge/mongodb-github-action@1.12.0
         with:
-          mongodb-version: '6.0'
+          mongodb-version: '8.0'
           mongodb-replica-set: test-rs
 
       - name: Setup Node.js
@@ -183,9 +183,9 @@ jobs:
           --server-id=1
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
+        uses: supercharge/mongodb-github-action@1.12.0
         with:
-          mongodb-version: '6.0'
+          mongodb-version: '8.0'
           mongodb-replica-set: test-rs
 
       - name: Start PostgreSQL (Storage)
@@ -245,7 +245,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
+        uses: supercharge/mongodb-github-action@1.12.0
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
           mongodb-replica-set: test-rs

--- a/modules/module-postgres/test/src/checkpoints.test.ts
+++ b/modules/module-postgres/test/src/checkpoints.test.ts
@@ -3,6 +3,7 @@ import { checkpointUserId, createWriteCheckpoint } from '@powersync/service-core
 import { describe, test } from 'vitest';
 import { INITIALIZED_MONGO_STORAGE_FACTORY } from './util.js';
 import { WalStreamTestContext } from './wal_stream_utils.js';
+import { env } from './env.js';
 
 import timers from 'node:timers/promises';
 
@@ -11,8 +12,8 @@ const BASIC_SYNC_RULES = `bucket_definitions:
     data:
       - SELECT id, description, other FROM "test_data"`;
 
-describe('checkpoint tests', () => {
-  test('write checkpoints', { timeout: 30_000 }, async () => {
+describe.skipIf(!(env.CI || env.SLOW_TESTS))('checkpoint tests', () => {
+  test('write checkpoints', { timeout: 50_000 }, async () => {
     const factory = INITIALIZED_MONGO_STORAGE_FACTORY;
     await using context = await WalStreamTestContext.open(factory);
 
@@ -58,10 +59,12 @@ describe('checkpoint tests', () => {
 
         const start = Date.now();
         while (lastWriteCheckpoint == null || lastWriteCheckpoint < BigInt(cp.writeCheckpoint)) {
-          if (Date.now() - start > 2_000) {
-            throw new Error(`Timeout while waiting for checkpoint`);
+          if (Date.now() - start > 5_000) {
+            throw new Error(
+              `Timeout while waiting for checkpoint. last: ${lastWriteCheckpoint}, waiting for: ${cp.writeCheckpoint}`
+            );
           }
-          await timers.setTimeout(0, undefined, { signal: controller.signal });
+          await timers.setTimeout(5, undefined, { signal: controller.signal });
         }
       }
     } finally {


### PR DESCRIPTION
#201 introduced a new test that turned out to be quite unstable. This increases the time thresholds to make it more stable.

This also updates `supercharge/mongodb-github-action@1.12.0` for some stability fixes in starting the container, and switches to using mongodb 8.0 by default. The mongodb modules are still tested on 6.0 and 7.0.