### PR TITLE
Prepare for v1.7.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@powersync/service-core", "@powersync/service-image"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "origin/main",

--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -5,7 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.18.1",
+  "version": "1.6.999",
   "main": "dist/index.js",
   "license": "FSL-1.1-Apache-2.0",
   "type": "module",

--- a/packages/service-core/test/src/auth.test.ts
+++ b/packages/service-core/test/src/auth.test.ts
@@ -274,7 +274,7 @@ describe('JWT Auth', () => {
     ).rejects.toThrow('Token must expire in a maximum of');
   });
 
-  test('http', async () => {
+  test('http', { timeout: 20_000 }, async () => {
     // Not ideal to rely on an external endpoint for tests, but it is good to test that this
     // one actually works.
     const remote = new RemoteJWKSCollector(

--- a/packages/service-core/test/src/auth.test.ts
+++ b/packages/service-core/test/src/auth.test.ts
@@ -290,9 +290,9 @@ describe('JWT Auth', () => {
         reject_ip_ranges: ['local']
       }
     });
-    expect(invalid.getKeys()).rejects.toThrow('IPs in this range are not supported');
+    await expect(invalid.getKeys()).rejects.toThrow('IPs in this range are not supported');
 
-    // IPS throw an error immediately
+    // IPs throw an error immediately
     expect(
       () =>
         new RemoteJWKSCollector('https://127.0.0.1/.well-known/jwks.json', {
@@ -315,11 +315,11 @@ describe('JWT Auth', () => {
 
     const invalid = new RemoteJWKSCollector('https://127.0.0.1/.well-known/jwks.json');
     // Should try and fetch
-    expect(invalid.getKeys()).rejects.toThrow();
+    await expect(invalid.getKeys()).rejects.toThrow();
 
     const invalid2 = new RemoteJWKSCollector('https://localhost/.well-known/jwks.json');
     // Should try and fetch
-    expect(invalid2.getKeys()).rejects.toThrow();
+    await expect(invalid2.getKeys()).rejects.toThrow();
   });
 
   test('caching', async () => {

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersync/service-image",
-  "version": "1.4.1",
+  "version": "1.6.999",
   "private": true,
   "license": "FSL-1.1-Apache-2.0",
   "type": "module",


### PR DESCRIPTION
1. Fix the versions of `@powersync/service-core` - these will now be versioned together  `@powersync/service-image`. That basically means that the version of `@powersync/service-core` would be bumped even if there are only changes in the service image.
2. Bump to v1.6.999, so that the next version will be 1.7.0, aligning with our cloud image versions.
3. Sneak in some test stability improvements and fixes to warnings.