### PR TITLE
Fix truncating collections from MongoDB source database

### DIFF
--- a/.changeset/rare-birds-peel.md
+++ b/.changeset/rare-birds-peel.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-module-mysql': patch
+---
+
+Improve handling of some edge cases which could trigger truncating of synced tables.

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -642,8 +642,6 @@ export class ChangeStream {
             throw new ReplicationAssertionError(`Incomplete splitEvent: ${JSON.stringify(splitDocument.splitEvent)}`);
           }
 
-          console.log('event', changeDocument);
-
           if (
             !filters.multipleDatabases &&
             'ns' in changeDocument &&
@@ -651,10 +649,10 @@ export class ChangeStream {
             changeDocument.ns.db.endsWith(`_${this.defaultDb.databaseName}`)
           ) {
             // When all of the following conditions are met:
-            // 1. We're replicating from a Flex instance.
+            // 1. We're replicating from an Atlas Flex instance.
             // 2. There were changestream events recorded while the PowerSync service is paused.
             // 3. We're only replicating from a single database.
-            // Then we've obeserved an ns with for example {db: '67b83e86cd20730f1e766dde_ps'},
+            // Then we've observed an ns with for example {db: '67b83e86cd20730f1e766dde_ps'},
             // instead of the expected {db: 'ps'}.
             // We correct this.
             changeDocument.ns.db = this.defaultDb.databaseName;

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -714,6 +714,8 @@ export class ChangeStream {
             const table = await this.getRelation(batch, rel, {
               // In most cases, we should not need to snapshot this. But if this is the first time we see the collection
               // for whatever reason, then we do need to snapshot it.
+              // This may result in some duplicate operations when a collection is created for the first time after
+              // sync rules was deployed.
               snapshot: true
             });
             if (table.syncAny) {

--- a/modules/module-mongodb/src/replication/MongoRelation.ts
+++ b/modules/module-mongodb/src/replication/MongoRelation.ts
@@ -11,9 +11,17 @@ export function getMongoRelation(source: mongo.ChangeStreamNameSpace): storage.S
   return {
     name: source.coll,
     schema: source.db,
-    objectId: source.coll,
+    // Not relevant for MongoDB - we use db + coll name as the identifier
+    objectId: undefined,
     replicationColumns: [{ name: '_id' }]
   } satisfies storage.SourceEntityDescriptor;
+}
+
+/**
+ * For in-memory cache only.
+ */
+export function getCacheIdentifier(source: storage.SourceEntityDescriptor): string {
+  return `${source.schema}.${source.name}`;
 }
 
 export function constructAfterRecord(document: mongo.Document): SqliteRow {

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -239,6 +239,7 @@ bucket_definitions:
             - SELECT _id as id, description FROM "test_DATA"
       `);
 
+    await db.createCollection('test_DATA');
     await context.replicateSnapshot();
 
     context.startStreaming();
@@ -261,6 +262,7 @@ bucket_definitions:
           data:
             - SELECT _id as id, name, description FROM "test_data"
       `);
+    await db.createCollection('test_data');
 
     await context.replicateSnapshot();
     context.startStreaming();
@@ -371,6 +373,8 @@ bucket_definitions:
           - SELECT _id as id, name, other FROM "test_data"`);
     const { db } = context;
 
+    await db.createCollection('test_data');
+
     await context.replicateSnapshot();
 
     const collection = db.collection('test_data');
@@ -451,6 +455,8 @@ bucket_definitions:
 
     const data = await context.getBucketData('global[]');
     expect(data).toMatchObject([
+      // An extra op here, since this triggers a snapshot in addition to getting the event.
+      test_utils.putOp('test_data', { id: test_id!.toHexString(), description: 'test2' }),
       test_utils.putOp('test_data', { id: test_id!.toHexString(), description: 'test1' }),
       test_utils.putOp('test_data', { id: test_id!.toHexString(), description: 'test2' })
     ]);

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -106,7 +106,8 @@ export class BinLogStream {
       entity_descriptor: entity,
       sync_rules: this.syncRules
     });
-    this.tableCache.set(entity.objectId, result.table);
+    // objectId is always defined for mysql
+    this.tableCache.set(entity.objectId!, result.table);
 
     // Drop conflicting tables. This includes for example renamed tables.
     await batch.drop(result.dropTables);

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -21,13 +21,14 @@ import * as timers from 'timers/promises';
 
 import * as framework from '@powersync/lib-services-framework';
 import { StatementParam } from '@powersync/service-jpgwire';
-import { StoredRelationId } from '../types/models/SourceTable.js';
+import { SourceTableDecoded, StoredRelationId } from '../types/models/SourceTable.js';
 import { pick } from '../utils/ts-codec.js';
 import { PostgresBucketBatch } from './batch/PostgresBucketBatch.js';
 import { PostgresWriteCheckpointAPI } from './checkpoints/PostgresWriteCheckpointAPI.js';
 import { PostgresBucketStorageFactory } from './PostgresBucketStorageFactory.js';
 import { PostgresCompactor } from './PostgresCompactor.js';
 import { wrapWithAbort } from 'ix/asynciterable/operators/withabort.js';
+import { Decoded } from 'ts-codec';
 
 export type PostgresSyncRulesStorageOptions = {
   factory: PostgresBucketStorageFactory;
@@ -225,25 +226,47 @@ export class PostgresSyncRulesStorage
       sourceTable.syncData = options.sync_rules.tableSyncsData(sourceTable);
       sourceTable.syncParameters = options.sync_rules.tableSyncsParameters(sourceTable);
 
-      const truncatedTables = await db.sql`
-        SELECT
-          *
-        FROM
-          source_tables
-        WHERE
-          group_id = ${{ type: 'int4', value: group_id }}
-          AND connection_id = ${{ type: 'int4', value: connection_id }}
-          AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
-          AND (
-            relation_id = ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }}
-            OR (
+      let truncatedTables: SourceTableDecoded[] = [];
+      if (objectId != null) {
+        // relation_id present - check for renamed tables
+        truncatedTables = await db.sql`
+          SELECT
+            *
+          FROM
+            source_tables
+          WHERE
+            group_id = ${{ type: 'int4', value: group_id }}
+            AND connection_id = ${{ type: 'int4', value: connection_id }}
+            AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
+            AND (
+              relation_id = ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }}
+              OR (
+                schema_name = ${{ type: 'varchar', value: schema }}
+                AND table_name = ${{ type: 'varchar', value: table }}
+              )
+            )
+        `
+          .decoded(models.SourceTable)
+          .rows();
+      } else {
+        // relation_id not present - only check for changed replica_id_columns
+        truncatedTables = await db.sql`
+          SELECT
+            *
+          FROM
+            source_tables
+          WHERE
+            group_id = ${{ type: 'int4', value: group_id }}
+            AND connection_id = ${{ type: 'int4', value: connection_id }}
+            AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
+            AND (
               schema_name = ${{ type: 'varchar', value: schema }}
               AND table_name = ${{ type: 'varchar', value: table }}
             )
-          )
-      `
-        .decoded(models.SourceTable)
-        .rows();
+        `
+          .decoded(models.SourceTable)
+          .rows();
+      }
 
       return {
         table: sourceTable,

--- a/modules/module-postgres-storage/src/types/models/SourceTable.ts
+++ b/modules/module-postgres-storage/src/types/models/SourceTable.ts
@@ -2,7 +2,7 @@ import * as t from 'ts-codec';
 import { bigint, jsonb, jsonb_raw, pgwire_number } from '../codecs.js';
 
 export type StoredRelationId = {
-  object_id: string | number;
+  object_id: string | number | undefined;
 };
 
 export const ColumnDescriptor = t.object({

--- a/packages/service-core/src/storage/SourceEntity.ts
+++ b/packages/service-core/src/storage/SourceEntity.ts
@@ -13,9 +13,13 @@ export interface ColumnDescriptor {
 // TODO: This needs to be consolidated with SourceTable into something new.
 export interface SourceEntityDescriptor {
   /**
-   *  The internal id of the data source structure in the database
+   * The internal id of the data source structure in the database.
+   *
+   * If undefined, the schema and name are used as the identifier.
+   *
+   * If specified, this is specifically used to detect renames.
    */
-  objectId: number | string;
+  objectId: number | string | undefined;
   schema: string;
   name: string;
   replicationColumns: ColumnDescriptor[];

--- a/packages/service-core/src/storage/SourceTable.ts
+++ b/packages/service-core/src/storage/SourceTable.ts
@@ -35,7 +35,7 @@ export class SourceTable {
   constructor(
     public readonly id: any,
     public readonly connectionTag: string,
-    public readonly objectId: number | string,
+    public readonly objectId: number | string | undefined,
     public readonly schema: string,
     public readonly table: string,
 


### PR DESCRIPTION
Specific scenario is when all of the following conditions are met:
1. We're replicating from an Atlas Flex instance.
2. There were changestream events recorded while the PowerSync service is paused.
3. We're only replicating from a single database.

Then we've observed an ns with for example `{db: '67b83e86cd20730f1e766dde_ps'}`, instead of the expected `{db: 'ps'}` on the change stream.

This caused issues on multiple levels internally:
1. We only used the collection name as the "relation_id" for the internal "source table" (bug 1).
2. The storage module then detected the equivalent of a renamed collection, since it saw the same relation_id, but a different schema.
3. We then truncate the table, but never did a snapshot of the "new" collection (bug 2).
4. This resulted in the collection being missing, apart from documents specifically updated again.

This fixes the issue on multiple levels:
1. Remove the `relation_id` for MongoDB source databases, and only rely on the db and collection names directly.
     1. This was simpler than consistently migrating the `relation_id`.
     2. We should probably do the same for MySQL, but that would require more testing.
     3. This means we can now correctly handle multiple collections of the same name in different dbs.
     4. This would avoid the "truncating" issue from above.
2. If we do see a new collection, snapshot it. While we don't expect this to happen, it will allow for more graceful handling of edge cases if we run into any again.
3. Implement a workaround for the incorrect `ns` from Flex instances.
4. Add proper logging for operations like truncating collections, for if we do run into scenarios like these again.

---

There is another report with similar symptoms, but not using a Flex instance. See [this thread](https://discord.com/channels/1138230179878154300/1343243467350081566).