### PR TITLE
Postgres Compact Fix

### DIFF
--- a/.changeset/rotten-items-explode.md
+++ b/.changeset/rotten-items-explode.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-postgres-storage': patch
+---
+
+Fix issue where compacting might fail with an "unexpected PUT operation" error.

--- a/.changeset/rotten-nails-cheat.md
+++ b/.changeset/rotten-nails-cheat.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core-tests': minor
+---
+
+Added compacting test for interleaved bucket operations.

--- a/.changeset/six-dragons-whisper.md
+++ b/.changeset/six-dragons-whisper.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-postgres-storage': minor
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-core-tests': minor
+'@powersync/service-core': minor
+---
+
+Unified compacting options between storage providers.

--- a/.changeset/six-dragons-whisper.md
+++ b/.changeset/six-dragons-whisper.md
@@ -1,8 +1,8 @@
 ---
-'@powersync/service-module-postgres-storage': minor
-'@powersync/service-module-mongodb-storage': minor
-'@powersync/service-core-tests': minor
-'@powersync/service-core': minor
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core-tests': patch
+'@powersync/service-core': patch
 ---
 
 Unified compacting options between storage providers.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
@@ -32,14 +32,7 @@ interface CurrentBucketState {
 /**
  * Additional options, primarily for testing.
  */
-export interface MongoCompactOptions extends storage.CompactOptions {
-  /** Minimum of 2 */
-  clearBatchLimit?: number;
-  /** Minimum of 1 */
-  moveBatchLimit?: number;
-  /** Minimum of 1 */
-  moveBatchQueryLimit?: number;
-}
+export interface MongoCompactOptions extends storage.CompactOptions {}
 
 const DEFAULT_CLEAR_BATCH_LIMIT = 5000;
 const DEFAULT_MOVE_BATCH_LIMIT = 2000;

--- a/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
@@ -1,11 +1,5 @@
-import { MongoCompactOptions } from '@module/storage/implementation/MongoCompactor.js';
 import { register } from '@powersync/service-core-tests';
 import { describe } from 'vitest';
 import { INITIALIZED_MONGO_STORAGE_FACTORY } from './util.js';
 
-describe('Mongo Sync Bucket Storage Compact', () =>
-  register.registerCompactTests<MongoCompactOptions>(INITIALIZED_MONGO_STORAGE_FACTORY, {
-    clearBatchLimit: 2,
-    moveBatchLimit: 1,
-    moveBatchQueryLimit: 1
-  }));
+describe('Mongo Sync Bucket Storage Compact', () => register.registerCompactTests(INITIALIZED_MONGO_STORAGE_FACTORY));

--- a/modules/module-postgres-storage/src/storage/PostgresCompactor.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresCompactor.ts
@@ -92,9 +92,7 @@ export class PostgresCompactor {
 
     let bucketLower: string | null = null;
     let bucketUpper: string | null = null;
-    // 0xFFFF fails to compare correctly. Querying with bucket_name < `\uffff` returns no results
-    // This seems to be due to 0xFFFF being a `Noncharacter` in Unicode.
-    const MAX_CHAR = String.fromCodePoint(0xfffd);
+    const MAX_CHAR = String.fromCodePoint(0xffff);
 
     if (bucket == null) {
       bucketLower = '';
@@ -131,7 +129,7 @@ export class PostgresCompactor {
               bucket_name = ${{ type: 'varchar', value: bucketUpper }}
               AND op_id < ${{ type: 'int8', value: upperOpIdLimit }}
             )
-            OR bucket_name < ${{ type: 'varchar', value: bucketUpper }}
+            OR bucket_name < ${{ type: 'varchar', value: bucketUpper }} COLLATE "C" -- Use binary comparison
           )
         ORDER BY
           bucket_name DESC,

--- a/modules/module-postgres-storage/src/storage/PostgresCompactor.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresCompactor.ts
@@ -35,14 +35,7 @@ interface CurrentBucketState {
 /**
  * Additional options, primarily for testing.
  */
-export interface PostgresCompactOptions extends storage.CompactOptions {
-  /** Minimum of 2 */
-  clearBatchLimit?: number;
-  /** Minimum of 1 */
-  moveBatchLimit?: number;
-  /** Minimum of 1 */
-  moveBatchQueryLimit?: number;
-}
+export interface PostgresCompactOptions extends storage.CompactOptions {}
 
 const DEFAULT_CLEAR_BATCH_LIMIT = 5000;
 const DEFAULT_MOVE_BATCH_LIMIT = 2000;

--- a/modules/module-postgres-storage/test/src/storage_compacting.test.ts
+++ b/modules/module-postgres-storage/test/src/storage_compacting.test.ts
@@ -2,4 +2,4 @@ import { register } from '@powersync/service-core-tests';
 import { describe } from 'vitest';
 import { POSTGRES_STORAGE_FACTORY } from './util.js';
 
-describe('Postgres Sync Bucket Storage Compact', () => register.registerCompactTests(POSTGRES_STORAGE_FACTORY, {}));
+describe('Postgres Sync Bucket Storage Compact', () => register.registerCompactTests(POSTGRES_STORAGE_FACTORY));

--- a/packages/service-core-tests/src/tests/register-compacting-tests.ts
+++ b/packages/service-core-tests/src/tests/register-compacting-tests.ts
@@ -15,10 +15,7 @@ const TEST_TABLE = test_utils.makeTestTable('test', ['id']);
  * compactTests(() => new MongoStorageFactory(), { clearBatchLimit: 2, moveBatchLimit: 1, moveBatchQueryLimit: 1 }));
  * ```
  */
-export function registerCompactTests<CompactOptions extends storage.CompactOptions = storage.CompactOptions>(
-  generateStorageFactory: storage.TestStorageFactory,
-  compactOptions: CompactOptions
-) {
+export function registerCompactTests(generateStorageFactory: storage.TestStorageFactory) {
   test('compacting (1)', async () => {
     const sync_rules = test_utils.testRules(`
 bucket_definitions:
@@ -87,7 +84,11 @@ bucket_definitions:
       }
     ]);
 
-    await bucketStorage.compact(compactOptions);
+    await bucketStorage.compact({
+      clearBatchLimit: 2,
+      moveBatchLimit: 1,
+      moveBatchQueryLimit: 1
+    });
 
     const batchAfter = await test_utils.oneFromAsync(
       bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']]))
@@ -204,7 +205,11 @@ bucket_definitions:
       }
     ]);
 
-    await bucketStorage.compact(compactOptions);
+    await bucketStorage.compact({
+      clearBatchLimit: 2,
+      moveBatchLimit: 1,
+      moveBatchQueryLimit: 1
+    });
 
     const batchAfter = await test_utils.oneFromAsync(
       bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', '0']]))
@@ -285,7 +290,11 @@ bucket_definitions:
     });
     const checkpoint2 = result2!.flushed_op;
 
-    await bucketStorage.compact(compactOptions);
+    await bucketStorage.compact({
+      clearBatchLimit: 2,
+      moveBatchLimit: 1,
+      moveBatchQueryLimit: 1
+    });
 
     const batchAfter = await test_utils.oneFromAsync(
       bucketStorage.getBucketDataBatch(checkpoint2, new Map([['global[]', '0']]))
@@ -313,7 +322,10 @@ bucket_definitions:
     const sync_rules = test_utils.testRules(/* yaml */
     ` bucket_definitions:
         grouped:
-          parameters: select b from test
+          # The parameter query here is not important
+          # We specifically don't want to create bucket_parameter records here
+          # since the op_ids for bucket_data could vary between storage implementations.
+          parameters: select 'b' as b
           data:
             - select * from test where b = bucket.b`);
 
@@ -325,10 +337,10 @@ bucket_definitions:
        * Repeatedly create operations which fall into different buckets.
        * The bucket operations are purposely interleaved as the op_id increases.
        * A large amount of operations are created here.
-       * The default window of compacting operations is 10_000. This means the initial window will
+       * The configured window of compacting operations is 100. This means the initial window will
        * contain operations from multiple buckets.
        */
-      for (let count = 0; count < 8_000; count++) {
+      for (let count = 0; count < 100; count++) {
         await batch.save({
           sourceTable: TEST_TABLE,
           tag: storage.SaveOperationTag.INSERT,
@@ -388,7 +400,11 @@ bucket_definitions:
 
     const checkpoint = result!.flushed_op;
 
-    await bucketStorage.compact(compactOptions);
+    await bucketStorage.compact({
+      clearBatchLimit: 2,
+      moveBatchLimit: 1,
+      moveBatchQueryLimit: 100 // Larger limit for a larger window of operations
+    });
 
     const batchAfter = await test_utils.fromAsync(
       bucketStorage.getBucketDataBatch(
@@ -404,24 +420,26 @@ bucket_definitions:
     // The op_ids will vary between MongoDB and Postgres storage
     expect(dataAfter).toMatchObject(
       expect.arrayContaining([
-        expect.objectContaining({ op: 'CLEAR', checksum: -2120931643 }),
-        expect.objectContaining({
+        { op_id: '497', op: 'CLEAR', checksum: -937074151 },
+        {
+          op_id: '499',
           op: 'PUT',
           object_type: 'test',
           object_id: 't1',
           checksum: 52221819,
           subkey: '6544e3899293153fa7b38331/117ab485-4b42-58a2-ab32-0053a22c3423',
           data: '{"id":"t1","b":"b1","value":"final"}'
-        }),
-        expect.objectContaining({ op: 'CLEAR', checksum: -1067381173 }),
-        expect.objectContaining({
+        },
+        { op_id: '498', op: 'CLEAR', checksum: -234380197 },
+        {
+          op_id: '500',
           op: 'PUT',
           object_type: 'test',
           object_id: 't2',
           checksum: 2126669493,
           subkey: '6544e3899293153fa7b38331/ec27c691-b47a-5d92-927a-9944feb89eee',
           data: '{"id":"t2","b":"b2","value":"final"}'
-        })
+        }
       ])
     );
   });

--- a/packages/service-core-tests/src/tests/register-compacting-tests.ts
+++ b/packages/service-core-tests/src/tests/register-compacting-tests.ts
@@ -307,4 +307,122 @@ bucket_definitions:
       checksum: 1874612650
     });
   });
+
+  // TODO: maybe only run this test for Postgres. MongoDB is extremely slow. This might indicate an issue with Postgres.
+  test('compacting (3)', { timeout: Infinity }, async () => {
+    const sync_rules = test_utils.testRules(/* yaml */
+    ` bucket_definitions:
+        grouped:
+          parameters: select b from test
+          data:
+            - select * from test where b = bucket.b`);
+
+    await using factory = await generateStorageFactory();
+    const bucketStorage = factory.getInstance(sync_rules);
+
+    const result = await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      /**
+       * Repeatedly create operations which fall into different buckets.
+       * The bucket operations are purposely interleaved as the op_id increases.
+       * A large amount of operations are created here.
+       * The default window of compacting operations is 10_000. This means the initial window will
+       * contain operations from multiple buckets.
+       */
+      for (let count = 0; count < 8_000; count++) {
+        await batch.save({
+          sourceTable: TEST_TABLE,
+          tag: storage.SaveOperationTag.INSERT,
+          after: {
+            id: 't1',
+            b: 'b1',
+            value: 'start'
+          },
+          afterReplicaId: test_utils.rid('t1')
+        });
+
+        await batch.save({
+          sourceTable: TEST_TABLE,
+          tag: storage.SaveOperationTag.UPDATE,
+          after: {
+            id: 't1',
+            b: 'b1',
+            value: 'intermediate'
+          },
+          afterReplicaId: test_utils.rid('t1')
+        });
+
+        await batch.save({
+          sourceTable: TEST_TABLE,
+          tag: storage.SaveOperationTag.INSERT,
+          after: {
+            id: 't2',
+            b: 'b2',
+            value: 'start'
+          },
+          afterReplicaId: test_utils.rid('t2')
+        });
+
+        await batch.save({
+          sourceTable: TEST_TABLE,
+          tag: storage.SaveOperationTag.UPDATE,
+          after: {
+            id: 't1',
+            b: 'b1',
+            value: 'final'
+          },
+          afterReplicaId: test_utils.rid('t1')
+        });
+
+        await batch.save({
+          sourceTable: TEST_TABLE,
+          tag: storage.SaveOperationTag.UPDATE,
+          after: {
+            id: 't2',
+            b: 'b2',
+            value: 'final'
+          },
+          afterReplicaId: test_utils.rid('t2')
+        });
+      }
+    });
+
+    const checkpoint = result!.flushed_op;
+
+    await bucketStorage.compact(compactOptions);
+
+    const batchAfter = await test_utils.fromAsync(
+      bucketStorage.getBucketDataBatch(
+        checkpoint,
+        new Map([
+          ['grouped["b1"]', '0'],
+          ['grouped["b2"]', '0']
+        ])
+      )
+    );
+    const dataAfter = batchAfter.flatMap((b) => b.batch.data);
+
+    // The op_ids will vary between MongoDB and Postgres storage
+    expect(dataAfter).toMatchObject(
+      expect.arrayContaining([
+        expect.objectContaining({ op: 'CLEAR', checksum: -2120931643 }),
+        expect.objectContaining({
+          op: 'PUT',
+          object_type: 'test',
+          object_id: 't1',
+          checksum: 52221819,
+          subkey: '6544e3899293153fa7b38331/117ab485-4b42-58a2-ab32-0053a22c3423',
+          data: '{"id":"t1","b":"b1","value":"final"}'
+        }),
+        expect.objectContaining({ op: 'CLEAR', checksum: -1067381173 }),
+        expect.objectContaining({
+          op: 'PUT',
+          object_type: 'test',
+          object_id: 't2',
+          checksum: 2126669493,
+          subkey: '6544e3899293153fa7b38331/ec27c691-b47a-5d92-927a-9944feb89eee',
+          data: '{"id":"t2","b":"b2","value":"final"}'
+        })
+      ])
+    );
+  });
 }

--- a/packages/service-core-tests/src/tests/register-compacting-tests.ts
+++ b/packages/service-core-tests/src/tests/register-compacting-tests.ts
@@ -317,8 +317,7 @@ bucket_definitions:
     });
   });
 
-  // TODO: maybe only run this test for Postgres. MongoDB is extremely slow. This might indicate an issue with Postgres.
-  test('compacting (3)', { timeout: Infinity }, async () => {
+  test('compacting (3)', async () => {
     const sync_rules = test_utils.testRules(/* yaml */
     ` bucket_definitions:
         grouped:

--- a/packages/service-core-tests/src/tests/register-compacting-tests.ts
+++ b/packages/service-core-tests/src/tests/register-compacting-tests.ts
@@ -317,7 +317,7 @@ bucket_definitions:
     });
   });
 
-  test('compacting (3)', async () => {
+  test('compacting (4)', async () => {
     const sync_rules = test_utils.testRules(/* yaml */
     ` bucket_definitions:
         grouped:
@@ -400,8 +400,8 @@ bucket_definitions:
     const checkpoint = result!.flushed_op;
 
     await bucketStorage.compact({
-      clearBatchLimit: 2,
-      moveBatchLimit: 1,
+      clearBatchLimit: 100,
+      moveBatchLimit: 100,
       moveBatchQueryLimit: 100 // Larger limit for a larger window of operations
     });
 

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -179,6 +179,15 @@ export interface CompactOptions {
    * These can be individual bucket names, or bucket definition names.
    */
   compactBuckets?: string[];
+
+  /** Minimum of 2 */
+  clearBatchLimit?: number;
+
+  /** Minimum of 1 */
+  moveBatchLimit?: number;
+
+  /** Minimum of 1 */
+  moveBatchQueryLimit?: number;
 }
 
 export interface TerminateOptions {


### PR DESCRIPTION
# Overview

A bug was recently identified in the Postgres compacting logic. Compacting can fail due to an "unexpected PUT operation" error.

The Postgres compacting operations logic contained an error in the bucket operation processing logic. 

The current Postgres windowing logic functions as follows:

- Bucket operations are processed in a moving window of batched operations.
- Each batch queries over all buckets. 
- On the second batch, the window is still over all buckets, only limiting the last `op_id`.

Suppose the scenario:
-  There are two buckets: `bucket1` and `bucket2`, each with 8k ops.
- `bucket1` is ops [1:8_000]`, `bucket2` is ops `[8_001:16_000]`.
- Batch 1 returns 8k ops from `bucket1`, and 2k ops `[14_001:16_000]` from `bucket2`.
- For batch 2, the compactor queries for `op_id < 14_001`. It gets the 8k ops from `bucket1` again. But since it was busy with `bucket2`, and now gets data for `bucket1`, it thinks `bucket2` is done. The compactor does `clearBucket('bucket2', 14123),` even though there are more _PUT_ operations in `bucket2`.

The updated Postgres compactor is now better aligned with the MongoDB implementation. The bucket data operations are sorted in descending order of `bucket_name` and `op_id`. The last operation of the batch is now correctly used as an upper limit when querying the next batches.

A unit test has been added to ensure correct compaction in the scenario above.

The compacting tests were also improved to use varying compacting options.