### PR TITLE
[MongoDB] Improve initial replication performance

### DIFF
--- a/.changeset/hot-pets-itch.md
+++ b/.changeset/hot-pets-itch.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-module-mongodb': patch
+---
+
+Improve intial replication performance for MongoDB by avoiding sessions.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -270,7 +270,7 @@ export class MongoBucketBatch
       }
     }
 
-    return resumeBatch;
+    return resumeBatch?.hasData() ? resumeBatch : null;
   }
 
   private saveOperation(

--- a/modules/module-mongodb-storage/src/storage/implementation/OperationBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/OperationBatch.ts
@@ -41,6 +41,10 @@ export class OperationBatch {
     return this.batch.length >= MAX_BATCH_COUNT || this.currentSize > MAX_RECORD_BATCH_SIZE;
   }
 
+  hasData() {
+    return this.length > 0;
+  }
+
   /**
    *
    * @param sizes Map of source key to estimated size of the current_data document, or undefined if current_data is not persisted.

--- a/modules/module-mongodb-storage/src/storage/implementation/PersistedBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/PersistedBatch.ts
@@ -245,6 +245,7 @@ export class PersistedBatch {
   }
 
   async flush(db: PowerSyncMongo, session: mongo.ClientSession) {
+    const startAt = performance.now();
     if (this.bucketData.length > 0) {
       await db.bucket_data.bulkWrite(this.bucketData, {
         session,
@@ -267,10 +268,11 @@ export class PersistedBatch {
       });
     }
 
+    const duration = performance.now() - startAt;
     logger.info(
       `powersync_${this.group_id} Flushed ${this.bucketData.length} + ${this.bucketParameters.length} + ${
         this.currentData.length
-      } updates, ${Math.round(this.currentSize / 1024)}kb. Last op_id: ${this.debugLastOpId}`
+      } updates, ${Math.round(this.currentSize / 1024)}kb in ${duration.toFixed(0)}ms. Last op_id: ${this.debugLastOpId}`
     );
 
     this.bucketData = [];


### PR DESCRIPTION
In some cases, MongoDB initial replication replicated at a rate as low as 150 documents/second, while we're aiming for 5-10k/second. After some investigation, the main bottleneck appears to be _reading_ the documents from the source database, rather than writing to bucket storage.

I can't figure out why, but reading the documents using a MongoDB session appears to be the main culprit. Using the session, it could take as long as 10-20s to read 10k documents in some cases. This is not consistent, which makes it difficult to test. Without the session, that drops down to 0.5-1s for the same 10k documents. ~The latter is fairly consistent.~

This changes the query to not use a session anymore. Initially we used a session for snapshot reads, but that is not required anymore, so there is no good reason to use sessions for this.

The performance both before and after is fairly inconsistent, and I could not find clear patterns. Even with the changes here, replication is slow in some cases. However, the median performance does appear to be better with these changes.


Other smaller changes:
1. Use `readBufferedDocuments()` to read documents in batches, rather than an async iterator.
2. Increase the read batch size from the default 1000 to 6000. This has no effect if the cursor is limited due to the size of the documents, so does not increase memory in the worst case scenario. This improves read latency in some cases.
3. Log the duration of each read batch (up to 6k documents), as well as the flushing of each PersistedBatch (up to 2k documents).
4. Filter out empty "resumeBatch" batches to avoid the empty `Flushed 0 + 0 + 0 updates` messages after each actual batch.
5. Start reading the next batch while processing the current batch.