### PR TITLE
Include attachments queue in FlutterFlow schema

### DIFF
--- a/.changeset/flat-bees-dream.md
+++ b/.changeset/flat-bees-dream.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Include local `attachments_queue` table when exporting schema for FlutterFlow.

--- a/packages/sync-rules/test/src/generate_schema.test.ts
+++ b/packages/sync-rules/test/src/generate_schema.test.ts
@@ -80,7 +80,7 @@ bucket_definitions:
 
   test('flutterflow', () => {
     expect(new DartFlutterFlowSchemaGenerator().generate(rules, schema)).toEqual(
-      '{"tables":[{"name":"assets1","view_name":null,"local_only":false,"insert_only":false,"columns":[{"name":"name","type":"text"},{"name":"count","type":"integer"},{"name":"owner_id","type":"text"}],"indexes":[]},{"name":"assets2","view_name":null,"local_only":false,"insert_only":false,"columns":[{"name":"name","type":"text"},{"name":"count","type":"integer"},{"name":"other_id","type":"text"},{"name":"foo","type":"text"}],"indexes":[]}]}'
+      '{"tables":[{"name":"assets1","view_name":null,"local_only":false,"insert_only":false,"columns":[{"name":"name","type":"text"},{"name":"count","type":"integer"},{"name":"owner_id","type":"text"}],"indexes":[]},{"name":"assets2","view_name":null,"local_only":false,"insert_only":false,"columns":[{"name":"name","type":"text"},{"name":"count","type":"integer"},{"name":"other_id","type":"text"},{"name":"foo","type":"text"}],"indexes":[]},{"name":"attachments_queue","view_name":null,"local_only":true,"insert_only":false,"columns":[{"name":"filename","type":"text"},{"name":"local_uri","type":"text"},{"name":"timestamp","type":"integer"},{"name":"size","type":"integer"},{"name":"media_type","type":"text"},{"name":"state","type":"integer"}],"indexes":[]}]}'
     );
   });
 


### PR DESCRIPTION
When exporting the schema for FlutterFlow clients, include the [local attachments queue table](https://github.com/powersync-ja/powersync.dart/blob/0949fe1982fcbc07a6a6b801c2b4cfc246fc51c5/packages/powersync_attachments_helper/lib/src/attachments_queue_table.dart#L71-L90) for the Dart SDK.

Since the table is local-only, it doesn't actually get synced (and thus can't cause any harm for users not needing attachments). Since the JSON we export is fairly opaque to users though, unconditionally including the table makes things easier for users that do need attachments (patching the JSON manually is not that easy).