### PR TITLE
[Postgres] Fix replication slot name

### DIFF
--- a/.changeset/cyan-otters-sleep.md
+++ b/.changeset/cyan-otters-sleep.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Use slot_name_prefix from the replication connection again.

--- a/packages/service-core/src/util/config/compound-config-collector.ts
+++ b/packages/service-core/src/util/config/compound-config-collector.ts
@@ -170,8 +170,7 @@ export class CompoundConfigCollector {
           baseConfig.api?.parameters?.max_data_fetch_concurrency ?? DEFAULT_MAX_DATA_FETCH_CONCURRENCY
       },
       // TODO maybe move this out of the connection or something
-      // slot_name_prefix: connections[0]?.slot_name_prefix ?? 'powersync_'
-      slot_name_prefix: 'powersync_',
+      slot_name_prefix: baseConfig.replication?.connections?.[0]?.slot_name_prefix ?? 'powersync_',
       parameters: baseConfig.parameters ?? {}
     };
 


### PR DESCRIPTION
This appears to be an oversight from the refactoring in https://github.com/powersync-ja/powersync-service/pull/133 - the `slot_name_prefix` was not respected anymore. We specifically use this in the cloud version to include the instance id in the slot name, making it easier to identify powersync instances connected to a specific postgres instance.

The actual structure behind this config option is still not ideal, but this does not make it any worse.


