### PR TITLE
[MySQL] Fix errors being hidden by ROLLBACK failure

### DIFF
--- a/.changeset/fuzzy-items-look.md
+++ b/.changeset/fuzzy-items-look.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-mysql': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+[MySQL] Fix errors being hidden by ROLLBACK failure

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -273,7 +273,6 @@ AND table_type = 'BASE TABLE';`,
       );
       await promiseConnection.query<mysqlPromise.RowDataPacket[]>('START TRANSACTION');
       await promiseConnection.query(`SET time_zone = '+00:00'`);
-      await this.connections.end();
 
       const sourceTables = this.syncRules.getSourceTables();
       await this.storage.startBatch(


### PR DESCRIPTION
Previously, replication could fail with an unhelpful error like this:

```
Replication error Can't add new command when connection is in closed state
```

This error was raised during ROLLBACK, hiding the actual underlying issue.

This now logs the rollback error, then continues throwing the original error.