### PR TITLE
[Postgres] Optimize transaction replication throughput

### DIFF
--- a/.changeset/chilly-flowers-fix.md
+++ b/.changeset/chilly-flowers-fix.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-postgres': minor
+'@powersync/service-core': minor
+'@powersync/service-image': minor
+---
+
+[Postgres] Only flush once per replicated chunk, increasing transaction replication throughput.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres-version: [11, 12, 13, 14, 15, 16]
+        postgres-version: [11, 12, 13, 14, 15, 16, 17]
 
     steps:
       - uses: actions/checkout@v4

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -673,8 +673,10 @@ WHERE  oid = $1::regclass`,
     await this.storage.startBatch(
       { zeroLSN: ZERO_LSN, defaultSchema: POSTGRES_DEFAULT_SCHEMA, storeCurrentData: true, skipExistingRows: false },
       async (batch) => {
-        // Replication never starts in the middle of a transaction
-        let inTx = false;
+        // We don't handle any plain keepalive messages while we have transactions.
+        // While we have transactions, we use that to advance the position.
+        // Replication never starts in the middle of a transaction, so this starts as false.
+        let skipKeepalive = false;
         let count = 0;
 
         for await (const chunk of replicationStream.pgoutputDecode()) {
@@ -695,17 +697,24 @@ WHERE  oid = $1::regclass`,
            */
           const assumeKeepAlive = !exposesLogicalMessages;
           let keepAliveDetected = false;
+          const lastCommit = messages.findLast((msg) => msg.tag == 'commit');
 
           for (const msg of messages) {
             if (msg.tag == 'relation') {
               await this.handleRelation(batch, getPgOutputRelation(msg), true);
             } else if (msg.tag == 'begin') {
-              inTx = true;
+              // This may span multiple transactions in the same chunk, or even across chunks.
+              skipKeepalive = true;
             } else if (msg.tag == 'commit') {
               Metrics.getInstance().transactions_replicated_total.add(1);
-              inTx = false;
-              await batch.commit(msg.lsn!, { createEmptyCheckpoints });
-              await this.ack(msg.lsn!, replicationStream);
+              if (msg == lastCommit) {
+                // Only commit if this is the last commit in the chunk.
+                // This effectively lets us batch multiple transactions within the same chunk
+                // into a single flush, increasing throughput for many small transactions.
+                skipKeepalive = false;
+                await batch.commit(msg.lsn!, { createEmptyCheckpoints });
+                await this.ack(msg.lsn!, replicationStream);
+              }
             } else {
               if (count % 100 == 0) {
                 logger.info(`${this.slot_name} replicating op ${count} ${msg.lsn}`);
@@ -726,7 +735,7 @@ WHERE  oid = $1::regclass`,
             }
           }
 
-          if (!inTx) {
+          if (!skipKeepalive) {
             if (assumeKeepAlive || keepAliveDetected) {
               // Reset the detection flag.
               keepAliveDetected = false;


### PR DESCRIPTION
Previously, if we got 100k transactions each with a single operation, we'd commit/flush that 100k times to the bucket storage. Flushing is slow - in the case of a storage cluster under load, this can take 100-500ms per flush, resulting in throughput of less than 10 transactions per second.

Lucky for us, Postgres already chunks messages together in the replication stream. So now we look ahead in the current chunk to see if there are any more commit messages. If there are, we only flush/commit on the _last_ one. This means if we get many transactions in a single chunk, they are all batched together in a single flush to the bucket storage.

For reference, we already have similar behavior in our MongoDB replication implementation.

In theory we could also batch transactions across multiple replication chunks, but I don't expect significant further gains from that, and it could increase complexity and memory usage.

This also adds Postgres 17 to the test matrix (released Sept 2024).
