### PR TITLE
Increase connection timeout for MongoDB

### DIFF
--- a/.changeset/hungry-planets-smell.md
+++ b/.changeset/hungry-planets-smell.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': patch
+---
+
+Increase connection timeouts for MongoDB "Test Connection".

--- a/modules/module-mongodb/src/module/MongoModule.ts
+++ b/modules/module-mongodb/src/module/MongoModule.ts
@@ -66,8 +66,9 @@ export class MongoModule extends replication.ReplicationModule<types.MongoConnec
     const connectionManager = new MongoManager(normalizedConfig, {
       // Use short timeouts for testing connections.
       // Must be < 30s, to ensure we get a proper timeout error.
-      socketTimeoutMS: 1_000,
-      serverSelectionTimeoutMS: 1_000
+      // It must be large enough to cover the high latency of testing connections across regions
+      socketTimeoutMS: 3_000,
+      serverSelectionTimeoutMS: 5_000
     });
     try {
       await checkSourceConfiguration(connectionManager);


### PR DESCRIPTION
For testing MongoDB connections, we use a relatively short connection timeout (specifically `serverSelectionTimeoutMS`), since that is the only way to detect clusters we cannot connect to due to IP access list issues. However, the timeout of 1000ms was too short when connecting to a cluster in for example AWS `ap-southeast-2`, from our test node in `us-east-1`.

This increases the timeout sufficiently to cover these cases.