### PR TITLE
HTTP Liveness Probe Stopgap Fix

### DIFF
--- a/.changeset/warm-coins-wave.md
+++ b/.changeset/warm-coins-wave.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Minor improvement to the HTTP liveness probe. The liveness probe will return an HTTP `200` response code when running in the `API` mode. Any HTTP response in the `API` mode indicates the service is running. When running in the `UNIFIED` mode the HTTP response code is `200` if the last `touched_at` timestamp value is less than 10 seconds ago - this indicates the replication worker is running.

--- a/packages/service-core/test/src/routes/probes.integration.test.ts
+++ b/packages/service-core/test/src/routes/probes.integration.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import Fastify, { FastifyInstance } from 'fastify';
 import { container } from '@powersync/lib-services-framework';
-import * as auth from '../../../src/routes/auth.js';
-import * as system from '../../../src/system/system-index.js';
+import Fastify, { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { configureFastifyServer } from '../../../src/index.js';
+import * as auth from '../../../src/routes/auth.js';
 import { ProbeRoutes } from '../../../src/routes/endpoints/probes.js';
+import * as system from '../../../src/system/system-index.js';
 
 vi.mock('@powersync/lib-services-framework', async () => {
   const actual = (await vi.importActual('@powersync/lib-services-framework')) as any;
@@ -25,7 +25,7 @@ describe('Probe Routes Integration', () => {
 
   beforeEach(async () => {
     app = Fastify();
-    mockSystem = { routerEngine: {} } as system.ServiceContext;
+    mockSystem = { routerEngine: {}, replicationEngine: {} } as system.ServiceContext;
     await configureFastifyServer(app, { service_context: mockSystem });
     await app.ready();
   });

--- a/packages/service-core/test/src/routes/probes.test.ts
+++ b/packages/service-core/test/src/routes/probes.test.ts
@@ -83,7 +83,7 @@ describe('Probe Routes', () => {
   });
 
   describe('livenessCheck', () => {
-    const mockedContext = { service_context: { replicationEngine: {} } } as any;
+    const mockedContext = { context: { service_context: { replicationEngine: {} } } } as any;
     it('has the correct route definitions', () => {
       expect(livenessCheck.path).toBe('/probes/liveness');
       expect(livenessCheck.method).toBe('GET');

--- a/packages/service-core/test/src/routes/probes.test.ts
+++ b/packages/service-core/test/src/routes/probes.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { container } from '@powersync/lib-services-framework';
-import { startupCheck, livenessCheck, readinessCheck } from '../../../src/routes/endpoints/probes.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { livenessCheck, readinessCheck, startupCheck } from '../../../src/routes/endpoints/probes.js';
 
 // Mock the container
 vi.mock('@powersync/lib-services-framework', () => ({
@@ -83,6 +83,7 @@ describe('Probe Routes', () => {
   });
 
   describe('livenessCheck', () => {
+    const mockedContext = { service_context: { replicationEngine: {} } } as any;
     it('has the correct route definitions', () => {
       expect(livenessCheck.path).toBe('/probes/liveness');
       expect(livenessCheck.method).toBe('GET');
@@ -97,7 +98,7 @@ describe('Probe Routes', () => {
 
       vi.mocked(container.probes.state).mockReturnValue(mockState);
 
-      const response = await livenessCheck.handler();
+      const response = await livenessCheck.handler(mockedContext);
 
       expect(response.status).toBe(200);
       expect(response.data).toEqual(mockState);
@@ -112,7 +113,7 @@ describe('Probe Routes', () => {
 
       vi.mocked(container.probes.state).mockReturnValue(mockState);
 
-      const response = await livenessCheck.handler();
+      const response = await livenessCheck.handler(mockedContext);
 
       expect(response.status).toBe(400);
       expect(response.data).toEqual(mockState);


### PR DESCRIPTION
# Overview

The HTTP liveness probe currently always returns a 400 HTTP response code in the API service mode. This is due to the `touched_at` value not being updated in the last 10 seconds. Generally, in the API mode, the PowerSync service should be alive if it returned any HTTP response. The logic has been updated to always return 200 if the service has been started in the API mode.

The current logic is preserved if the service is started in the UNIFIED mode. The liveness probe will return a 400 HTTP status code if the replicator engine has not updated the last `touched_at` value in 10 seconds. The replicator loop is most likely stuck if the touched at value has not been updated.

The HTTP probes are still not yet functional if the service was started purely in the SYNC mode. Future work will introduce more improvements such as an opt-in HTTP sever for this mode and configurable timeouts. 

