### PR TITLE
Disable checkpoint interruption

### DIFF
--- a/.changeset/shaggy-actors-confess.md
+++ b/.changeset/shaggy-actors-confess.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix hanging sync connections due to checkpoint interruptions.

--- a/packages/service-core-tests/src/tests/register-sync-tests.ts
+++ b/packages/service-core-tests/src/tests/register-sync-tests.ts
@@ -158,7 +158,8 @@ bucket_definitions:
     expect(lines).toMatchSnapshot();
   });
 
-  test('sync interrupts low-priority buckets on new checkpoints', async () => {
+  // Temporarily skipped - interruption disabled
+  test.skip('sync interrupts low-priority buckets on new checkpoints', async () => {
     await using f = await factory();
 
     const syncRules = await f.updateSyncRules({

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -180,7 +180,14 @@ async function* streamResponseInner(
       function markOperationsSent(operations: number) {
         syncedOperations += operations;
         tracker.addOperationsSynced(operations);
-        maybeRaceForNewCheckpoint();
+        // Disable interrupting checkpoints for now.
+        // There is a bug with interrupting checkpoints where:
+        // 1. User is in the middle of syncing a large batch of data (for example initial sync).
+        // 2. A new checkpoint comes in, which interrupts the batch.
+        // 3. However, the new checkpoint does not contain any new data for this connection, so nothing further is synced.
+        // This then causes the client to wait indefinitely for the remaining data or checkpoint_complete message. That is
+        // only resolved when a new checkpoint comes in that does have data for this connection, or the connection is restarted.
+        // maybeRaceForNewCheckpoint();
       }
 
       // This incrementally updates dataBuckets with each individual bucket position.


### PR DESCRIPTION
Disable interrupting checkpoints for now.

There is a bug with interrupting checkpoints where:
1. User is in the middle of syncing a large batch of data (for example initial sync).
2. A new checkpoint comes in, which interrupts the batch.
3. However, the new checkpoint does not contain any new data for this connection, so nothing further is synced.

This then causes the client to wait indefinitely for the remaining data or checkpoint_complete message. That is only resolved when a new checkpoint comes in that does have data for this connection, or the connection is restarted.

This is typically triggered when:
1. A user is downloading a large set of data, _and_:
2. New data updates are coming in at a high rate, _without_ modifying any data for that specific user.

Interrupting checkpoints is specifically for high-priority buckets, to allow syncing new high-priority changes while bulk low-priority buckets are still being downloaded - this functionality is therefore disabled for now. Properly fixing this is not trivial, so we're just disabling it as a quick-fix.

Properly fixing it could involve either:
1. Avoiding interruption of existing batches unless there is actual new data for the connection. This is tricky, since the computation is stateful currently, making it risky to do while we're sending data.
2. Still interrupting the batch, but resuming it if the new checkpoint doesn't contain new data. If we do this, we need to check that we're not adding too much overhead if we're repeatedly interrupting and resuming the same batch.
