### PR TITLE
Dont interrupt sync for unrelated checkpoint

### DIFF
--- a/.changeset/cool-seas-compete.md
+++ b/.changeset/cool-seas-compete.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Restore support for interrupting low-priority syncs for new checkpoints.

--- a/packages/service-core-tests/src/tests/register-sync-tests.ts
+++ b/packages/service-core-tests/src/tests/register-sync-tests.ts
@@ -11,7 +11,7 @@ import { RequestParameters } from '@powersync/service-sync-rules';
 import path from 'path';
 import * as timers from 'timers/promises';
 import { fileURLToPath } from 'url';
-import { expect, test } from 'vitest';
+import { assert, expect, test } from 'vitest';
 import * as test_utils from '../test-utils/test-utils-index.js';
 import { METRICS_HELPER } from '../test-utils/test-utils-index.js';
 
@@ -160,8 +160,7 @@ bucket_definitions:
     expect(lines).toMatchSnapshot();
   });
 
-  // Temporarily skipped - interruption disabled
-  test.skip('sync interrupts low-priority buckets on new checkpoints', async () => {
+  test('sync interrupts low-priority buckets on new checkpoints', async () => {
     await using f = await factory();
 
     const syncRules = await f.updateSyncRules({
@@ -269,6 +268,114 @@ bucket_definitions:
 
     expect(sentCheckpoints).toBe(2);
     expect(sentRows).toBe(10002);
+  });
+
+  test('sync interruptions with unrelated data', async () => {
+    await using f = await factory();
+
+    const syncRules = await f.updateSyncRules({
+      content: `
+bucket_definitions:
+  b0:
+    priority: 2
+    data:
+      - SELECT * FROM test WHERE LENGTH(id) <= 5;
+  b1:
+    priority: 1
+    parameters: SELECT request.user_id() as user_id
+    data:
+      - SELECT * FROM test WHERE LENGTH(id) > 5 AND description = bucket.user_id;
+    `
+    });
+
+    const bucketStorage = f.getInstance(syncRules);
+    await bucketStorage.autoActivate();
+
+    await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      // Initial data: Add one priority row and 10k low-priority rows.
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: storage.SaveOperationTag.INSERT,
+        after: {
+          id: 'highprio',
+          description: 'user_one'
+        },
+        afterReplicaId: 'highprio'
+      });
+      for (let i = 0; i < 10_000; i++) {
+        await batch.save({
+          sourceTable: TEST_TABLE,
+          tag: storage.SaveOperationTag.INSERT,
+          after: {
+            id: `${i}`,
+            description: 'low prio'
+          },
+          afterReplicaId: `${i}`
+        });
+      }
+
+      await batch.commit('0/1');
+    });
+
+    const stream = sync.streamResponse({
+      syncContext,
+      bucketStorage,
+      syncRules: bucketStorage.getParsedSyncRules(test_utils.PARSE_OPTIONS),
+      params: {
+        buckets: [],
+        include_checksum: true,
+        raw_data: true
+      },
+      tracker,
+      syncParams: new RequestParameters({ sub: 'user_one' }, {}),
+      token: { sub: 'user_one', exp: Date.now() / 1000 + 100000 } as any
+    });
+
+    let sentCheckpoints = 0;
+    let sentRows = 0;
+
+    for await (let next of stream) {
+      if (typeof next == 'string') {
+        next = JSON.parse(next);
+      }
+      if (typeof next === 'object' && next !== null) {
+        if ('partial_checkpoint_complete' in next) {
+          if (sentCheckpoints == 1) {
+            await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+              // Add a high-priority row that doesn't affect this sync stream.
+              await batch.save({
+                sourceTable: TEST_TABLE,
+                tag: storage.SaveOperationTag.INSERT,
+                after: {
+                  id: 'highprio2',
+                  description: 'user_two'
+                },
+                afterReplicaId: 'highprio2'
+              });
+
+              await batch.commit('0/2');
+            });
+          } else {
+            // Low-priority sync from the first checkpoint was interrupted. This should not happen, the new
+            // row doesn't affect this stream.
+            assert.fail('Did not expect second partial_checkpoint_complete message');
+          }
+        }
+        if ('checkpoint' in next || 'checkpoint_diff' in next) {
+          sentCheckpoints += 1;
+        }
+
+        if ('data' in next) {
+          sentRows += next.data.data.length;
+        }
+        if ('checkpoint_complete' in next) {
+          break;
+        }
+      }
+    }
+
+    expect(sentCheckpoints).toBe(1);
+    expect(sentRows).toBe(10001);
   });
 
   test('sends checkpoint complete line for empty checkpoint', async () => {

--- a/packages/service-core-tests/src/tests/register-sync-tests.ts
+++ b/packages/service-core-tests/src/tests/register-sync-tests.ts
@@ -11,7 +11,7 @@ import { RequestParameters } from '@powersync/service-sync-rules';
 import path from 'path';
 import * as timers from 'timers/promises';
 import { fileURLToPath } from 'url';
-import { assert, expect, test } from 'vitest';
+import { expect, test } from 'vitest';
 import * as test_utils from '../test-utils/test-utils-index.js';
 import { METRICS_HELPER } from '../test-utils/test-utils-index.js';
 
@@ -381,7 +381,7 @@ bucket_definitions:
           }
           if (completedCheckpoints == 1) {
             expect(sentRows).toBe(10001);
-            
+
             await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
               // Add a high-priority row that affects this sync stream.
               await batch.save({

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -63,6 +63,15 @@ export class BucketChecksumState {
     }
   }
 
+  /**
+   * Build a new checkpoint line for an underlying storage checkpoint update if any buckets have changed.
+   * 
+   * When this returns null, the call is idempotent (meaning that no internal state is updated until a line
+   * is generated).
+   * 
+   * @param next The updated checkpoint
+   * @returns A {@link CheckpointLine} if any of the buckets watched by this connected was updated, or otherwise `null`.
+   */
   async buildNextCheckpointLine(next: storage.StorageCheckpointUpdate): Promise<CheckpointLine | null> {
     const { writeCheckpoint, base } = next;
     const user_id = this.parameterState.syncParams.user_id;

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -65,10 +65,10 @@ export class BucketChecksumState {
 
   /**
    * Build a new checkpoint line for an underlying storage checkpoint update if any buckets have changed.
-   * 
+   *
    * When this returns null, the call is idempotent (meaning that no internal state is updated until a line
    * is generated).
-   * 
+   *
    * @param next The updated checkpoint
    * @returns A {@link CheckpointLine} if any of the buckets watched by this connected was updated, or otherwise `null`.
    */

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -265,6 +265,9 @@ export class BucketChecksumState {
       },
 
       getFilteredBucketPositions: (buckets?: BucketDescription[]): Map<string, util.InternalOpId> => {
+        if (!hasAdvanced) {
+          throw new ServiceAssertionError('Call line.advance() before getFilteredBucketPositions()');
+        }
         buckets ??= bucketsToFetch;
         const filtered = new Map<string, util.InternalOpId>();
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -190,7 +190,7 @@ async function* streamResponseInner(
                   continue;
                 }
 
-                // A new sync line can be emitted. Stop running the bucketDataInBatches() iterations, makeing the
+                // A new sync line can be emitted. Stop running the bucketDataInBatches() iterations, making the
                 // main flow reach the new checkpoint.
                 abortCheckpointController.abort();
               }

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -112,8 +112,8 @@ async function* streamResponseInner(
   const newCheckpoints = stream[Symbol.asyncIterator]();
 
   type CheckpointAndLine = {
-    checkpoint: bigint,
-    line: CheckpointLine | null,
+    checkpoint: bigint;
+    line: CheckpointLine | null;
   };
 
   async function waitForNewCheckpointLine(): Promise<IteratorResult<CheckpointAndLine>> {
@@ -127,9 +127,7 @@ async function* streamResponseInner(
   }
 
   try {
-    let nextCheckpointPromise:
-      | Promise<PromiseSettledResult<IteratorResult<CheckpointAndLine>>>
-      | undefined;
+    let nextCheckpointPromise: Promise<PromiseSettledResult<IteratorResult<CheckpointAndLine>>> | undefined;
 
     do {
       if (!nextCheckpointPromise) {

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -200,13 +200,6 @@ async function* streamResponseInner(
       function markOperationsSent(operations: number) {
         syncedOperations += operations;
         tracker.addOperationsSynced(operations);
-        // Disable interrupting checkpoints for now.
-        // There is a bug with interrupting checkpoints where:
-        // 1. User is in the middle of syncing a large batch of data (for example initial sync).
-        // 2. A new checkpoint comes in, which interrupts the batch.
-        // 3. However, the new checkpoint does not contain any new data for this connection, so nothing further is synced.
-        // This then causes the client to wait indefinitely for the remaining data or checkpoint_complete message. That is
-        // only resolved when a new checkpoint comes in that does have data for this connection, or the connection is restarted.
         maybeRaceForNewCheckpoint();
       }
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -77,11 +77,6 @@ export async function* streamResponse(
   }
 }
 
-export type BucketSyncState = {
-  description?: BucketDescription; // Undefined if the bucket has not yet been resolved by us.
-  start_op_id: util.InternalOpId;
-};
-
 async function* streamResponseInner(
   syncContext: SyncContext,
   bucketStorage: storage.SyncRulesBucketStorage,
@@ -151,8 +146,9 @@ async function* streamResponseInner(
 
       const { checkpointLine, bucketsToFetch } = line;
 
-      yield checkpointLine;
+      // Since yielding can block, we update the state just before yielding the line.
       line.advance();
+      yield checkpointLine;
 
       // Start syncing data for buckets up to the checkpoint. As soon as we have completed at least one priority and
       // at least 1000 operations, we also start listening for new checkpoints concurrently. When a new checkpoint comes

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -71,6 +71,7 @@ bucket_definitions:
       writeCheckpoint: null,
       update: CHECKPOINT_INVALIDATE_ALL
     }))!;
+    line.advance();
     expect(line.checkpointLine).toEqual({
       checkpoint: {
         buckets: [{ bucket: 'global[]', checksum: 1, count: 1, priority: 3 }],
@@ -105,6 +106,7 @@ bucket_definitions:
         invalidateParameterBuckets: false
       }
     }))!;
+    line2.advance();
     expect(line2.checkpointLine).toEqual({
       checkpoint_diff: {
         removed_buckets: [],
@@ -138,6 +140,7 @@ bucket_definitions:
       writeCheckpoint: null,
       update: CHECKPOINT_INVALIDATE_ALL
     }))!;
+    line.advance();
     expect(line.checkpointLine).toEqual({
       checkpoint: {
         buckets: [{ bucket: 'global[]', checksum: 1, count: 1, priority: 3 }],
@@ -242,6 +245,7 @@ bucket_definitions:
       writeCheckpoint: null,
       update: CHECKPOINT_INVALIDATE_ALL
     }))!;
+    line.advance();
     expect(line.checkpointLine).toEqual({
       checkpoint: {
         buckets: [{ bucket: 'global[]', checksum: 1, count: 1, priority: 3 }],
@@ -384,6 +388,7 @@ bucket_definitions:
       writeCheckpoint: null,
       update: CHECKPOINT_INVALIDATE_ALL
     }))!;
+    line.advance();
     expect(line.checkpointLine).toEqual({
       checkpoint: {
         buckets: [
@@ -429,6 +434,7 @@ bucket_definitions:
         updatedDataBuckets: new Set(['global[1]'])
       }
     }))!;
+    line2.advance();
     expect(line2.checkpointLine).toEqual({
       checkpoint_diff: {
         removed_buckets: [],
@@ -512,6 +518,7 @@ bucket_definitions:
         priority: 3
       }
     ]);
+    line.advance();
     // This is the bucket data to be fetched
     expect(line.getFilteredBucketPositions()).toEqual(
       new Map([
@@ -544,6 +551,7 @@ bucket_definitions:
         invalidateParameterBuckets: false
       }
     }))!;
+    line2.advance();
     expect(line2.checkpointLine).toEqual({
       checkpoint_diff: {
         removed_buckets: [],


### PR DESCRIPTION
This restores support for interrupting checkpoints (the functionality was disabled in https://github.com/powersync-ja/powersync-service/pull/236 due to a flaw where new checkpoints on unrelated bucket would interrupt sync).

To restore this functionality, we're expanding the work we're doing while the previous sync iteration is active: Instead of just waiting for a new checkpoint from storage, we're also building the new checkpoint line preemptively. If the new checkpoint does not result in a `checkpoint` line for the connection, we do nothing and keep waiting for the next checkpoint. 

This should be safe because the stateful logic to build checkpoint lines does not update its internal state if no line ends up being built.