### PR TITLE
Make module names consistent

### DIFF
--- a/modules/module-mongodb-storage/src/module/MongoStorageModule.ts
+++ b/modules/module-mongodb-storage/src/module/MongoStorageModule.ts
@@ -7,7 +7,7 @@ import * as types from '../types/types.js';
 export class MongoStorageModule extends core.modules.AbstractModule {
   constructor() {
     super({
-      name: 'MongoDB Storage'
+      name: 'MongoDB Bucket Storage'
     });
   }
 


### PR DESCRIPTION
The descriptive name for `PostgresStorageModule` is printed as 'Postgres Bucket Storage'

The descriptive name for `MongoStorageModule` is printed as 'MongoDB Storage'

Change the latter to 'MongoDB Bucket Storage' to be consistent with Postgres and avoid any potential confusion

We had an Enterprise prospect that was confused about these module registration messages