### PR TITLE
Fix deleteMany for bucket_parameters to use an index

### DIFF
--- a/.changeset/gentle-coins-lie.md
+++ b/.changeset/gentle-coins-lie.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Fix slow clearing of bucket_parameters collection.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -571,7 +571,7 @@ export class MongoSyncBucketStorage
     );
     await this.db.bucket_parameters.deleteMany(
       {
-        key: idPrefixFilter<SourceKey>({ g: this.group_id }, ['t', 'k'])
+        'key.g': this.group_id
       },
       { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
     );


### PR DESCRIPTION
The `deleteMany` for clearning bucket_parameters data used a filter like this:

```js
     "key": {
        "$gte": {
          "g": 3,
          "t": MinKey(),
          "k": MinKey()
        },
        "$lt": {
          "g": 3,
          "t": MaxKey(),
          "k": MaxKey()
        }
      }
```

This followed the same pattern as the _id filters on other collections. However, there is no direct index on `key`, only this index:

```js
await database.bucket_parameters.createIndex(
      {
        'key.g': 1,
        lookup: 1,
        _id: 1
      },
      { name: 'lookup1' }
    );
```

So in this case we can just use a simpler filter on `key.g`, to achieve the same thing but using an index.