### PR TITLE
[MongoDB] Fix resume token handling when no events are received

### DIFF
--- a/.changeset/friendly-rings-accept.md
+++ b/.changeset/friendly-rings-accept.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-errors': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/lib-service-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+[MongoDB] Fix resume token handling when no events are received

--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -88,3 +88,7 @@ export async function waitForAuth(db: mongo.Db) {
 export const isMongoServerError = (error: any): error is mongo.MongoServerError => {
   return error instanceof mongo.MongoServerError || error?.name == 'MongoServerError';
 };
+
+export const isMongoNetworkTimeoutError = (error: any): error is mongo.MongoNetworkTimeoutError => {
+  return error instanceof mongo.MongoNetworkTimeoutError || error?.name == 'MongoNetworkTimeoutError';
+};

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -557,7 +557,7 @@ export class ChangeStream {
 
         const streamOptions: mongo.ChangeStreamOptions = {
           showExpandedEvents: true,
-          maxAwaitTimeMS: 200,
+          maxAwaitTimeMS: 10_000,
           fullDocument: fullDocument
         };
 

--- a/modules/module-mongodb/src/replication/ChangeStreamReplicationJob.ts
+++ b/modules/module-mongodb/src/replication/ChangeStreamReplicationJob.ts
@@ -86,8 +86,6 @@ export class ChangeStreamReplicationJob extends replication.AbstractReplicationJ
       }
       if (e instanceof ChangeStreamInvalidatedError) {
         throw e;
-      } else if (isMongoServerError(e) && e.hasErrorLabel('NonResumableChangeStreamError')) {
-        throw new ChangeStreamInvalidatedError(e.message, e);
       } else {
         // Report the error if relevant, before retrying
         container.reporter.captureException(e, {

--- a/modules/module-mongodb/test/src/change_stream_utils.ts
+++ b/modules/module-mongodb/test/src/change_stream_utils.ts
@@ -85,7 +85,10 @@ export class ChangeStreamTestContext {
       storage: this.storage,
       metrics: METRICS_HELPER.metricsEngine,
       connections: this.connectionManager,
-      abort_signal: this.abortController.signal
+      abort_signal: this.abortController.signal,
+      // Specifically reduce this from the default for tests on MongoDB <= 6.0, otherwise it can take
+      // a long time to abort the stream.
+      maxAwaitTimeMS: 200
     };
     this._walStream = new ChangeStream(options);
     return this._walStream!;

--- a/modules/module-mongodb/test/src/resume.test.ts
+++ b/modules/module-mongodb/test/src/resume.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test, vi } from 'vitest';
 import { ChangeStreamTestContext } from './change_stream_utils.js';
 import { env } from './env.js';
 import { INITIALIZED_MONGO_STORAGE_FACTORY, INITIALIZED_POSTGRES_STORAGE_FACTORY } from './util.js';
+import { ChangeStreamInvalidatedError } from '@module/replication/ChangeStream.js';
 
 describe('mongo lsn', () => {
   test('LSN with resume tokens should be comparable', () => {
@@ -145,8 +146,7 @@ function defineResumeTest(factoryGenerator: (options?: TestStorageOptions) => Pr
     context2.storage = factory.getInstance(activeContent!);
 
     const error = await context2.startStreaming().catch((ex) => ex);
-    expect(error).exist;
     // The ChangeStreamReplicationJob will detect this and throw a ChangeStreamInvalidatedError
-    expect(isMongoServerError(error) && error.hasErrorLabel('NonResumableChangeStreamError'));
+    expect(error).toBeInstanceOf(ChangeStreamInvalidatedError);
   });
 }

--- a/modules/module-mongodb/test/src/resume_token.test.ts
+++ b/modules/module-mongodb/test/src/resume_token.test.ts
@@ -1,0 +1,37 @@
+// Write tests for parseResumeTokenTimestamp
+import { parseResumeTokenTimestamp } from '@module/common/MongoLSN.js';
+import { mongo } from '@powersync/lib-service-mongodb';
+import { describe, expect, it } from 'vitest';
+
+describe('parseResumeTokenTimestamp', () => {
+  it('parses a valid resume token (1)', () => {
+    const timestamp = parseResumeTokenTimestamp({ _data: '826811D298000000012B0429296E1404' });
+    expect(timestamp.t).toEqual(1745998488);
+    expect(timestamp.i).toEqual(1);
+  });
+
+  it('parses a valid resume token (2)', () => {
+    const timestamp = parseResumeTokenTimestamp({
+      _data:
+        '8267B4B1F8000000322B042C0100296E5A10041831DD5EEE2B4D6495A610E5430872B6463C6F7065726174696F6E54797065003C7570646174650046646F63756D656E744B657900463C5F6964003C636865636B706F696E7400000004'
+    });
+    expect(timestamp.t).toEqual(1739895288);
+    expect(timestamp.i).toEqual(50);
+  });
+
+  it('parses a valid resume token (3)', () => {
+    const timestamp = parseResumeTokenTimestamp({
+      _data:
+        '826811D228000000022B042C0100296E5A10048725A7954ED247538A4851BAB78B0560463C6F7065726174696F6E54797065003C7570646174650046646F63756D656E744B657900463C5F6964003C636865636B706F696E7400000004'
+    });
+    expect(timestamp.t).toEqual(1745998376);
+    expect(timestamp.i).toEqual(2);
+  });
+
+  it('throws for invalid prefix', () => {
+    const hex = 'FF0102030405060708';
+    const resumeToken: any = { _data: hex };
+
+    expect(() => parseResumeTokenTimestamp(resumeToken)).toThrowError(/^Invalid resume token/);
+  });
+});

--- a/modules/module-mongodb/test/src/resume_token.test.ts
+++ b/modules/module-mongodb/test/src/resume_token.test.ts
@@ -1,6 +1,4 @@
-// Write tests for parseResumeTokenTimestamp
 import { parseResumeTokenTimestamp } from '@module/common/MongoLSN.js';
-import { mongo } from '@powersync/lib-service-mongodb';
 import { describe, expect, it } from 'vitest';
 
 describe('parseResumeTokenTimestamp', () => {

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -253,6 +253,22 @@ export enum ErrorCode {
    */
   PSYNC_S1344 = 'PSYNC_S1344',
 
+  /**
+   * Failed to read MongoDB Change Stream to to a timeout.
+   *
+   * This may happen if there is a significant delay on the source database in reading the change stream.
+   *
+   * If this is not resolved after retries, replication may need to be restarted from scratch.
+   */
+  PSYNC_S1345 = 'PSYNC_S1345',
+
+  /**
+   * Failed to read MongoDB Change Stream.
+   *
+   * See the error cause for more details.
+   */
+  PSYNC_S1346 = 'PSYNC_S1346',
+
   // ## PSYNC_S14xx: MongoDB storage replication issues
 
   /**

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -254,7 +254,7 @@ export enum ErrorCode {
   PSYNC_S1344 = 'PSYNC_S1344',
 
   /**
-   * Failed to read MongoDB Change Stream to to a timeout.
+   * Failed to read MongoDB Change Stream due to a timeout.
    *
    * This may happen if there is a significant delay on the source database in reading the change stream.
    *


### PR DESCRIPTION
Our current implementation used resume tokens received from change stream events to resume the stream after a restart.

However, if the source collections do not receive writes, we do not receive any actual events, and the token is never advanced. If the source cluster receives many other oplog events, resuming the stream can become very slow after a while, or time out completely. Once it starts timing out, we don't have a way to recover other than restarting replication from scratch. The timeout typically shows up as an error "connection 2 to 159.41.94.47:27017 timed out". The error can be simulated by reducing `socketTimeoutMS` significantly (say 50ms).

MongoDB does however provide new resume tokens even when there are no events:
https://www.mongodb.com/docs/manual/changeStreams/#std-label-change-stream-resume-token

> The [$changeStream](https://www.mongodb.com/docs/manual/reference/operator/aggregation/changeStream/#mongodb-pipeline-pipe.-changeStream) aggregation stage includes a resume token on the cursor.postBatchResumeToken field.
> The [getMore](https://www.mongodb.com/docs/manual/reference/command/getMore/#mongodb-dbcommand-dbcmd.getMore) command includes a resume token on the cursor.postBatchResumeToken field.

The MongoDB driver exposes these as `stream.resumeToken`. There are some implementation details on exactly when this is updated, but in general it is safe to use that when `stream.tryNext()` returned null.

This will avoid the case of the resume token falling to far behind, at least in the case where the service is running. For self-hosted cases, when the service is stopped for a while (or when there were connection errors for a while), it is still possible to run into the timeout. This doesn't implement automatic recovery from the timeout yet (since it is difficult to know whether the timeout is permanent or can just be retried), but does improve the error message.