### PR TITLE
Fix missing parameter storage metrics

### DIFF
--- a/.changeset/old-ties-retire.md
+++ b/.changeset/old-ties-retire.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Always report 0 value storage metrics

--- a/.changeset/old-ties-retire.md
+++ b/.changeset/old-ties-retire.md
@@ -1,5 +1,0 @@
----
-'@powersync/service-core': patch
----
-
-Always report 0 value storage metrics

--- a/.changeset/small-clouds-collect.md
+++ b/.changeset/small-clouds-collect.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+---
+
+Fixed opentelemetry observable gauge value provider ignoring 0 values

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -306,7 +306,7 @@ export class MongoBucketStorage
   }
 
   async getStorageMetrics(): Promise<storage.StorageMetrics> {
-    const ignoreNotExiting = (e: unknown) => {
+    const ignoreNotExisting = (e: unknown) => {
       if (lib_mongo.isMongoServerError(e) && e.codeName == 'NamespaceNotFound') {
         // Collection doesn't exist - return 0
         return [{ storageStats: { size: 0 } }];
@@ -333,7 +333,7 @@ export class MongoBucketStorage
         }
       ])
       .toArray()
-      .catch(ignoreNotExiting);
+      .catch(ignoreNotExisting);
 
     const parameters_aggregate = await this.db.bucket_parameters
       .aggregate([
@@ -344,7 +344,7 @@ export class MongoBucketStorage
         }
       ])
       .toArray()
-      .catch(ignoreNotExiting);
+      .catch(ignoreNotExisting);
 
     const replication_aggregate = await this.db.current_data
       .aggregate([
@@ -355,7 +355,7 @@ export class MongoBucketStorage
         }
       ])
       .toArray()
-      .catch(ignoreNotExiting);
+      .catch(ignoreNotExisting);
 
     return {
       operations_size_bytes: Number(operations_aggregate[0].storageStats.size),

--- a/packages/service-core/src/metrics/open-telemetry/OpenTelemetryMetricsFactory.ts
+++ b/packages/service-core/src/metrics/open-telemetry/OpenTelemetryMetricsFactory.ts
@@ -35,7 +35,7 @@ export class OpenTelemetryMetricsFactory implements MetricsFactory {
         gauge.addCallback(async (result) => {
           const value = await valueProvider();
 
-          if (value) {
+          if (value != undefined) {
             result.observe(value);
           }
         });

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -34,7 +34,7 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
   let cacheTimestamp = 0;
 
   const getMetrics = () => {
-    if (cachedRequest == null || Date.now() - cacheTimestamp > MINIMUM_INTERVAL) {
+    if (!cachedRequest || Date.now() - cacheTimestamp > MINIMUM_INTERVAL) {
       cachedRequest = storage.getStorageMetrics().catch((e) => {
         logger.error(`Failed to get storage metrics`, e);
         return null;
@@ -47,21 +47,21 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
   replication_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return metrics.replication_size_bytes;
+      return metrics.replication_size_bytes ?? 0;
     }
   });
 
   operation_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return metrics.operations_size_bytes;
+      return metrics.operations_size_bytes ?? 0;
     }
   });
 
   parameter_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return metrics.parameters_size_bytes;
+      return metrics.parameters_size_bytes ?? 0;
     }
   });
 }

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -47,21 +47,21 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
   replication_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return metrics.replication_size_bytes ?? 0;
+      return metrics.replication_size_bytes;
     }
   });
 
   operation_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return metrics.operations_size_bytes ?? 0;
+      return metrics.operations_size_bytes;
     }
   });
 
   parameter_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return metrics.parameters_size_bytes ?? 0;
+      return metrics.parameters_size_bytes;
     }
   });
 }


### PR DESCRIPTION
The storage metric `powersync_parameter_storage_size_bytes` was missing when there were not any parameter queries in the sync rules. 