### PR TITLE
Health Check Improvements

### DIFF
--- a/.changeset/bright-gifts-turn.md
+++ b/.changeset/bright-gifts-turn.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': minor
+---
+
+- Added `ServiceContextMode` to `ServiceContext`. This conveys the mode in which the PowerSync service was started in.
+- `RouterEngine` is now always present on `ServiceContext`. The router will only configure actual servers if routes have been registered.

--- a/.changeset/shaggy-bikes-relax.md
+++ b/.changeset/shaggy-bikes-relax.md
@@ -1,0 +1,5 @@
+---
+'@powersync/lib-services-framework': minor
+---
+
+Switched default health check probe mechagnism from filesystem to in-memory implementation. Consumers now need to manually opt-in to filesystem probes.

--- a/.changeset/thick-wolves-invent.md
+++ b/.changeset/thick-wolves-invent.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-core': minor
+---
+
+Initial core module release. This moves RouterEngine API route registrations, health check probe configuration and metrics configuration from the service runners to this shared module.

--- a/libs/lib-services/src/container.ts
+++ b/libs/lib-services/src/container.ts
@@ -1,9 +1,14 @@
+import { ServiceAssertionError } from '@powersync/service-errors';
 import _ from 'lodash';
 import { ErrorReporter } from './alerts/definitions.js';
 import { NoOpReporter } from './alerts/no-op-reporter.js';
 import { MigrationManager } from './migrations/MigrationManager.js';
-import { ProbeModule, TerminationHandler, createFSProbe, createTerminationHandler } from './signals/signals-index.js';
-import { ServiceAssertionError } from '@powersync/service-errors';
+import {
+  ProbeModule,
+  TerminationHandler,
+  createInMemoryProbe,
+  createTerminationHandler
+} from './signals/signals-index.js';
 
 export enum ContainerImplementation {
   REPORTER = 'reporter',
@@ -45,7 +50,7 @@ export type ServiceIdentifier<T = unknown> = string | symbol | Newable<T> | Abst
 
 const DEFAULT_GENERATORS: ContainerImplementationDefaultGenerators = {
   [ContainerImplementation.REPORTER]: () => NoOpReporter,
-  [ContainerImplementation.PROBES]: () => createFSProbe(),
+  [ContainerImplementation.PROBES]: () => createInMemoryProbe(),
   [ContainerImplementation.TERMINATION_HANDLER]: () => createTerminationHandler(),
   [ContainerImplementation.MIGRATION_MANAGER]: () => new MigrationManager()
 };

--- a/modules/module-core/CHANGELOG.md
+++ b/modules/module-core/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @powersync/service-module-core

--- a/modules/module-core/LICENSE
+++ b/modules/module-core/LICENSE
@@ -1,0 +1,67 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2023-2024 Journey Mobile, Inc.
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under these Terms and Conditions, as indicated by our inclusion of these Terms and Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents, Redistribution and Trademark clauses below, we hereby grant you the right to use, copy, modify, create derivative works, publicly perform, publicly display and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use means making the Software available to others in a commercial product or service that:
+
+1. substitutes for the Software;
+2. substitutes for any other product or service we offer using the Software that exists as of the date we make the Software available; or
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our patents, the license grant above includes a license under our patents. If you make a claim against any party that the Software infringes or contributes to the infringement of any patent, then your patent license to the Software ends immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of the Software.
+If you redistribute any copies, modifications or derivatives of the Software, you must include a copy of or a link to these Terms and Conditions and not remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of the Software, you have no right under these Terms and Conditions to use our trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under the Apache License, Version 2.0 that is effective on the second anniversary of the date we make the Software available. On or after that date, you may use the Software under the Apache License, Version 2.0, in which case the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/modules/module-core/README.md
+++ b/modules/module-core/README.md
@@ -1,0 +1,3 @@
+# PowerSync Service Module Core
+
+Module which registers and configures basic core functionality for PowerSync services.

--- a/modules/module-core/package.json
+++ b/modules/module-core/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@powersync/service-module-core",
+  "repository": "https://github.com/powersync-ja/powersync-service",
+  "types": "dist/index.d.ts",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "license": "FSL-1.1-Apache-2.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "build:tests": "tsc -b test/tsconfig.json",
+    "clean": "rm -rf ./dist && tsc -b --clean",
+    "test": "vitest"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./types": {
+      "import": "./dist/types/types.js",
+      "require": "./dist/types/types.js",
+      "default": "./dist/types/types.js"
+    }
+  },
+  "dependencies": {
+    "@powersync/lib-services-framework": "workspace:*",
+    "@powersync/service-core": "workspace:*",
+    "@powersync/service-rsocket-router": "workspace:*",
+    "@powersync/service-types": "workspace:*",
+    "fastify": "4.23.2",
+    "@fastify/cors": "8.4.1"
+  },
+  "devDependencies": {}
+}

--- a/modules/module-core/src/CoreModule.ts
+++ b/modules/module-core/src/CoreModule.ts
@@ -1,0 +1,160 @@
+import cors from '@fastify/cors';
+import * as framework from '@powersync/lib-services-framework';
+import * as core from '@powersync/service-core';
+import { ReactiveSocketRouter } from '@powersync/service-rsocket-router';
+import { configFile } from '@powersync/service-types';
+import fastify from 'fastify';
+
+export class CoreModule extends core.modules.AbstractModule {
+  constructor() {
+    super({
+      name: 'Core'
+    });
+  }
+
+  public async initialize(context: core.ServiceContextContainer): Promise<void> {
+    if ([core.system.ServiceContextMode.API, core.system.ServiceContextMode.UNIFIED].includes(context.mode)) {
+      // Service should include API routes
+      this.registerAPIRoutes(context);
+    }
+
+    // Configures a Fastify server and RSocket server
+    this.configureRouterImplementation(context);
+
+    // Configures health check probes based off configuration
+    this.configureHealthChecks(context);
+
+    await this.configureMetrics(context);
+  }
+
+  protected registerAPIRoutes(context: core.ServiceContextContainer) {
+    // Register API routes
+    context.routerEngine.registerRoutes({
+      api_routes: [
+        ...core.routes.endpoints.ADMIN_ROUTES,
+        ...core.routes.endpoints.CHECKPOINT_ROUTES,
+        ...core.routes.endpoints.SYNC_RULES_ROUTES
+      ],
+      stream_routes: [...core.routes.endpoints.SYNC_STREAM_ROUTES],
+      socket_routes: [core.routes.endpoints.syncStreamReactive]
+    });
+  }
+
+  /**
+   * Registers the HTTP server which will handle routes once the router engine is started
+   */
+  protected configureRouterImplementation(context: core.ServiceContextContainer) {
+    context.lifeCycleEngine.withLifecycle(context.routerEngine, {
+      start: async (routerEngine) => {
+        // The router engine will only start servers if routes have been registered
+        await routerEngine.start(async (routes) => {
+          const server = fastify.fastify();
+
+          server.register(cors, {
+            origin: '*',
+            allowedHeaders: ['Content-Type', 'Authorization', 'User-Agent', 'X-User-Agent'],
+            exposedHeaders: ['Content-Type'],
+            // Cache time for preflight response
+            maxAge: 3600
+          });
+
+          core.routes.configureFastifyServer(server, {
+            service_context: context,
+            routes: {
+              api: { routes: routes.api_routes },
+              sync_stream: {
+                routes: routes.stream_routes,
+                queue_options: {
+                  concurrency: context.configuration.api_parameters.max_concurrent_connections,
+                  max_queue_depth: 0
+                }
+              }
+            }
+          });
+
+          const socketRouter = new ReactiveSocketRouter<core.routes.Context>({
+            max_concurrent_connections: context.configuration.api_parameters.max_concurrent_connections
+          });
+
+          core.routes.configureRSocket(socketRouter, {
+            server: server.server,
+            service_context: context,
+            route_generators: routes.socket_routes
+          });
+
+          const { port } = context.configuration;
+
+          await server.listen({
+            host: '0.0.0.0',
+            port
+          });
+
+          framework.logger.info(`Running on port ${port}`);
+
+          return {
+            onShutdown: async () => {
+              framework.logger.info('Shutting down HTTP server...');
+              await server.close();
+              framework.logger.info('HTTP server stopped');
+            }
+          };
+        });
+      }
+    });
+  }
+
+  protected configureHealthChecks(context: core.ServiceContextContainer) {
+    const {
+      configuration: {
+        service: { health_checks }
+      }
+    } = context;
+
+    /**
+     * Maintains backwards compatibility if LEGACY_DEFAULT is present by:
+     *  - Enabling HTTP probes if the service started in API or UNIFIED mode
+     *  - Always enabling filesystem probes always exposing HTTP probes
+     * Probe types must explicitly be selected if not using LEGACY_DEFAULT
+     */
+    const enableHTTPProbes =
+      health_checks.probe_modes.includes(configFile.ProbeType.HTTP) ||
+      ([core.system.ServiceContextMode.API, core.system.ServiceContextMode.UNIFIED].includes(context.mode) &&
+        health_checks.probe_modes.includes(configFile.ProbeType.LEGACY_DEFAULT));
+
+    if (enableHTTPProbes) {
+      context.routerEngine.registerRoutes({
+        api_routes: core.routes.endpoints.PROBES_ROUTES
+      });
+    }
+
+    const enableFSProbes =
+      health_checks.probe_modes.includes(configFile.ProbeType.FILESYSTEM) ||
+      health_checks.probe_modes.includes(configFile.ProbeType.LEGACY_DEFAULT);
+
+    if (enableFSProbes) {
+      context.register(framework.ContainerImplementation.PROBES, framework.createFSProbe());
+    }
+  }
+
+  protected async configureMetrics(context: core.ServiceContextContainer) {
+    // Could maybe do this in the core metrics registration function
+    const apiMetrics = [core.metrics.MetricModes.API];
+    const streamMetrics = [core.metrics.MetricModes.REPLICATION, core.metrics.MetricModes.STORAGE];
+    const metricsModeMap: Record<core.system.ServiceContextMode, core.metrics.MetricModes[]> = {
+      [core.system.ServiceContextMode.API]: apiMetrics,
+      [core.system.ServiceContextMode.SYNC]: streamMetrics,
+      [core.system.ServiceContextMode.UNIFIED]: [...apiMetrics, ...streamMetrics],
+      [core.system.ServiceContextMode.COMPACT]: [],
+      [core.system.ServiceContextMode.MIGRATION]: [],
+      [core.system.ServiceContextMode.TEARDOWN]: [],
+      [core.system.ServiceContextMode.TEST_CONNECTION]: []
+    };
+
+    await core.metrics.registerMetrics({
+      service_context: context,
+      modes: metricsModeMap[context.mode]
+    });
+  }
+
+  public async teardown(options: core.modules.TearDownOptions): Promise<void> {}
+}

--- a/modules/module-core/src/index.ts
+++ b/modules/module-core/src/index.ts
@@ -1,0 +1,1 @@
+export * from './CoreModule.js';

--- a/modules/module-core/src/types/types.ts
+++ b/modules/module-core/src/types/types.ts
@@ -1,0 +1,1 @@
+// No types for this module yet

--- a/modules/module-core/test/tsconfig.json
+++ b/modules/module-core/test/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "baseUrl": "./",
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "paths": {
+      "@/*": ["../../../packages/service-core/src/*"],
+      "@module/*": ["../src/*"],
+      "@core-tests/*": ["../../../packages/service-core/test/src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../"
+    }
+  ]
+}

--- a/modules/module-core/tsconfig.json
+++ b/modules/module-core/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../../packages/types"
+    },
+    {
+      "path": "../../packages/service-core"
+    },
+    {
+      "path": "../../libs/lib-services"
+    }
+  ]
+}

--- a/modules/module-core/vitest.config.ts
+++ b/modules/module-core/vitest.config.ts
@@ -1,0 +1,15 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    setupFiles: './test/src/setup.ts',
+    poolOptions: {
+      threads: {
+        singleThread: true
+      }
+    },
+    pool: 'threads'
+  }
+});

--- a/packages/service-core/src/entry/commands/compact-action.ts
+++ b/packages/service-core/src/entry/commands/compact-action.ts
@@ -37,7 +37,10 @@ export function registerCompactAction(program: Command) {
       logger.info(`Compacting storage for ${buckets?.join(', ')}...`);
     }
     const config = await utils.loadConfig(extractRunnerOptions(options));
-    const serviceContext = new system.ServiceContextContainer(config);
+    const serviceContext = new system.ServiceContextContainer({
+      mode: system.ServiceContextMode.COMPACT,
+      configuration: config
+    });
 
     // Register modules in order to allow custom module compacting
     const moduleManager = container.getImplementation(modules.ModuleManager);

--- a/packages/service-core/src/entry/commands/migrate-action.ts
+++ b/packages/service-core/src/entry/commands/migrate-action.ts
@@ -18,7 +18,10 @@ export function registerMigrationAction(program: Command) {
     .argument('<direction>', 'Migration direction. `up` or `down`')
     .action(async (direction: migrations.Direction, options) => {
       const config = await utils.loadConfig(extractRunnerOptions(options));
-      const serviceContext = new system.ServiceContextContainer(config);
+      const serviceContext = new system.ServiceContextContainer({
+        mode: system.ServiceContextMode.MIGRATION,
+        configuration: config
+      });
 
       // Register modules in order to allow custom module migrations
       const moduleManager = container.getImplementation(modules.ModuleManager);

--- a/packages/service-core/src/entry/commands/test-connection-action.ts
+++ b/packages/service-core/src/entry/commands/test-connection-action.ts
@@ -17,7 +17,10 @@ export function registerTestConnectionAction(program: Command) {
   return testConnectionCommand.description('Test connection').action(async (options) => {
     try {
       const config = await utils.loadConfig(extractRunnerOptions(options));
-      const serviceContext = new system.ServiceContextContainer(config);
+      const serviceContext = new system.ServiceContextContainer({
+        mode: system.ServiceContextMode.TEST_CONNECTION,
+        configuration: config
+      });
 
       const replication = new ReplicationEngine();
       serviceContext.register(ReplicationEngine, replication);

--- a/packages/service-core/src/routes/RouterEngine.ts
+++ b/packages/service-core/src/routes/RouterEngine.ts
@@ -2,15 +2,8 @@ import { logger } from '@powersync/lib-services-framework';
 
 import * as api from '../api/api-index.js';
 
-import { ADMIN_ROUTES } from './endpoints/admin.js';
-import { CHECKPOINT_ROUTES } from './endpoints/checkpointing.js';
-import { PROBES_ROUTES } from './endpoints/probes.js';
-import { syncStreamReactive } from './endpoints/socket-route.js';
-import { SYNC_RULES_ROUTES } from './endpoints/sync-rules.js';
-import { SYNC_STREAM_ROUTES } from './endpoints/sync-stream.js';
 import { SocketRouteGenerator } from './router-socket.js';
 import { RouteDefinition } from './router.js';
-import { SyncContext } from '../sync/SyncContext.js';
 
 export type RouterSetupResponse = {
   onShutdown: () => Promise<void>;
@@ -47,12 +40,23 @@ export class RouterEngine {
     this.cleanupHandler = null;
     this.closed = false;
 
-    // Default routes
     this.routes = {
-      api_routes: [...ADMIN_ROUTES, ...CHECKPOINT_ROUTES, ...SYNC_RULES_ROUTES, ...PROBES_ROUTES],
-      stream_routes: [...SYNC_STREAM_ROUTES],
-      socket_routes: [syncStreamReactive]
+      api_routes: [],
+      stream_routes: [],
+      socket_routes: []
     };
+  }
+
+  public registerRoutes(routes: Partial<RouterEngineRoutes>) {
+    this.routes.api_routes.push(...(routes.api_routes ?? []));
+    this.routes.stream_routes.push(...(routes.stream_routes ?? []));
+    this.routes.socket_routes.push(...(routes.socket_routes ?? []));
+  }
+
+  public get hasRoutes() {
+    return (
+      this.routes.api_routes.length > 0 || this.routes.stream_routes.length > 0 || this.routes.socket_routes.length > 0
+    );
   }
 
   public registerAPI(api: api.RouteAPI) {
@@ -75,6 +79,12 @@ export class RouterEngine {
    */
   async start(setup: RouterSetup) {
     logger.info('Starting Router Engine...');
+
+    if (!this.hasRoutes) {
+      logger.warn('No routes have been registered. Router Engine will not continue.');
+      return;
+    }
+
     const { onShutdown } = await setup(this.routes);
     this.cleanupHandler = onShutdown;
     logger.info('Successfully started Router Engine.');

--- a/packages/service-core/src/routes/endpoints/route-endpoints-index.ts
+++ b/packages/service-core/src/routes/endpoints/route-endpoints-index.ts
@@ -1,5 +1,6 @@
 export * from './admin.js';
 export * from './checkpointing.js';
+export * from './probes.js';
 export * from './socket-route.js';
 export * from './sync-rules.js';
 export * from './sync-stream.js';

--- a/packages/service-core/src/runner/teardown.ts
+++ b/packages/service-core/src/runner/teardown.ts
@@ -14,7 +14,11 @@ export async function teardown(runnerConfig: utils.RunnerConfig) {
   try {
     logger.info(`Tearing down PowerSync instance...`);
     const config = await utils.loadConfig(runnerConfig);
-    const serviceContext = new system.ServiceContextContainer(config);
+    const serviceContext = new system.ServiceContextContainer({
+      mode: system.ServiceContextMode.TEARDOWN,
+      configuration: config
+    });
+
     const moduleManager = container.getImplementation(modules.ModuleManager);
     await moduleManager.initialize(serviceContext);
     // This is mostly done to ensure that the storage is ready

--- a/packages/service-core/src/util/config/compound-config-collector.ts
+++ b/packages/service-core/src/util/config/compound-config-collector.ts
@@ -1,6 +1,5 @@
 import { logger, LookupOptions } from '@powersync/lib-services-framework';
 import { configFile } from '@powersync/service-types';
-import { ProbeType } from '@powersync/service-types/src/config/PowerSyncConfig.js';
 import * as auth from '../../auth/auth-index.js';
 import { ConfigCollector } from './collectors/config-collector.js';
 import { Base64ConfigCollector } from './collectors/impl/base64-config-collector.js';
@@ -161,8 +160,8 @@ export class CompoundConfigCollector {
           baseConfig.telemetry?.internal_service_endpoint ?? 'https://pulse.journeyapps.com/v1/metrics'
       },
       service: {
-        health_checks: {
-          probe_modes: baseConfig.service?.health_checks?.probe_modes ?? [ProbeType.LEGACY_DEFAULT]
+        healthcheck: {
+          probe_modes: baseConfig.service?.health_checks?.probe_modes ?? [configFile.ProbeType.LEGACY_DEFAULT]
         }
       },
       api_parameters: {

--- a/packages/service-core/src/util/config/compound-config-collector.ts
+++ b/packages/service-core/src/util/config/compound-config-collector.ts
@@ -1,15 +1,11 @@
 import { logger, LookupOptions } from '@powersync/lib-services-framework';
 import { configFile } from '@powersync/service-types';
+import { ProbeType } from '@powersync/service-types/src/config/PowerSyncConfig.js';
 import * as auth from '../../auth/auth-index.js';
 import { ConfigCollector } from './collectors/config-collector.js';
 import { Base64ConfigCollector } from './collectors/impl/base64-config-collector.js';
 import { FallbackConfigCollector } from './collectors/impl/fallback-config-collector.js';
 import { FileSystemConfigCollector } from './collectors/impl/filesystem-config-collector.js';
-import { Base64SyncRulesCollector } from './sync-rules/impl/base64-sync-rules-collector.js';
-import { FileSystemSyncRulesCollector } from './sync-rules/impl/filesystem-sync-rules-collector.js';
-import { InlineSyncRulesCollector } from './sync-rules/impl/inline-sync-rules-collector.js';
-import { SyncRulesCollector } from './sync-rules/sync-collector.js';
-import { ResolvedPowerSyncConfig, RunnerConfig, SyncRulesConfig } from './types.js';
 import {
   DEFAULT_MAX_BUCKETS_PER_CONNECTION,
   DEFAULT_MAX_CONCURRENT_CONNECTIONS,
@@ -17,6 +13,11 @@ import {
   DEFAULT_MAX_PARAMETER_QUERY_RESULTS,
   DEFAULT_MAX_POOL_SIZE
 } from './defaults.js';
+import { Base64SyncRulesCollector } from './sync-rules/impl/base64-sync-rules-collector.js';
+import { FileSystemSyncRulesCollector } from './sync-rules/impl/filesystem-sync-rules-collector.js';
+import { InlineSyncRulesCollector } from './sync-rules/impl/inline-sync-rules-collector.js';
+import { SyncRulesCollector } from './sync-rules/sync-collector.js';
+import { ResolvedPowerSyncConfig, RunnerConfig, SyncRulesConfig } from './types.js';
 
 export type CompoundConfigCollectorOptions = {
   /**
@@ -158,6 +159,11 @@ export class CompoundConfigCollector {
         disable_telemetry_sharing: baseConfig.telemetry?.disable_telemetry_sharing ?? false,
         internal_service_endpoint:
           baseConfig.telemetry?.internal_service_endpoint ?? 'https://pulse.journeyapps.com/v1/metrics'
+      },
+      service: {
+        health_checks: {
+          probe_modes: baseConfig.service?.health_checks?.probe_modes ?? [ProbeType.LEGACY_DEFAULT]
+        }
       },
       api_parameters: {
         max_buckets_per_connection:

--- a/packages/service-core/src/util/config/types.ts
+++ b/packages/service-core/src/util/config/types.ts
@@ -70,7 +70,7 @@ export type ResolvedPowerSyncConfig = {
   /** Prefix for postgres replication slot names. May eventually be connection-specific. */
   slot_name_prefix: string;
   service: {
-    health_checks: {
+    healthcheck: {
       probe_modes: configFile.ProbeType[];
     };
   };

--- a/packages/service-core/src/util/config/types.ts
+++ b/packages/service-core/src/util/config/types.ts
@@ -69,5 +69,10 @@ export type ResolvedPowerSyncConfig = {
 
   /** Prefix for postgres replication slot names. May eventually be connection-specific. */
   slot_name_prefix: string;
+  service: {
+    health_checks: {
+      probe_modes: configFile.ProbeType[];
+    };
+  };
   parameters: Record<string, number | string | boolean | null>;
 };

--- a/packages/types/src/config/PowerSyncConfig.ts
+++ b/packages/types/src/config/PowerSyncConfig.ts
@@ -19,6 +19,21 @@ export const portParser = {
   })
 };
 
+/**
+ * Health check probe types
+ */
+export enum ProbeType {
+  FILESYSTEM = 'filesystem',
+  HTTP = 'http',
+  /**
+   * @deprecated
+   * This applies legacy defaults. This should  not be used directly.
+   * This enables HTTP probes when the service is started in the API or UNIFIED mode.
+   * The FILESYTEM probe is always registered by default.
+   */
+  LEGACY_DEFAULT = 'legacy_default'
+}
+
 export const DataSourceConfig = t.object({
   // Unique string identifier for the data source
   type: t.string,
@@ -204,6 +219,16 @@ export const powerSyncConfig = t.object({
       prometheus_port: portCodec.optional(),
       disable_telemetry_sharing: t.boolean,
       internal_service_endpoint: t.string.optional()
+    })
+    .optional(),
+
+  service: t
+    .object({
+      health_checks: t
+        .object({
+          probe_modes: t.array(t.Enum(ProbeType)).optional()
+        })
+        .optional()
     })
     .optional(),
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ importers:
       '@powersync/service-core':
         specifier: workspace:*
         version: link:../packages/service-core
+      '@powersync/service-module-core':
+        specifier: workspace:*
+        version: link:../modules/module-core
       '@powersync/service-module-mongodb':
         specifier: workspace:*
         version: link:../modules/module-mongodb

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,27 @@ importers:
         specifier: ^3.0.5
         version: 3.0.5(@types/node@22.13.1)(yaml@2.5.0)
 
+  modules/module-core:
+    dependencies:
+      '@fastify/cors':
+        specifier: 8.4.1
+        version: 8.4.1
+      '@powersync/lib-services-framework':
+        specifier: workspace:*
+        version: link:../../libs/lib-services
+      '@powersync/service-core':
+        specifier: workspace:*
+        version: link:../../packages/service-core
+      '@powersync/service-rsocket-router':
+        specifier: workspace:*
+        version: link:../../packages/rsocket-router
+      '@powersync/service-types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      fastify:
+        specifier: 4.23.2
+        version: 4.23.2
+
   modules/module-mongodb:
     dependencies:
       '@powersync/lib-service-mongodb':
@@ -627,9 +648,6 @@ importers:
 
   service:
     dependencies:
-      '@fastify/cors':
-        specifier: 8.4.1
-        version: 8.4.1
       '@powersync/lib-services-framework':
         specifier: workspace:*
         version: link:../libs/lib-services
@@ -657,9 +675,6 @@ importers:
       '@sentry/node':
         specifier: ^8.9.2
         version: 8.17.0
-      fastify:
-        specifier: 4.23.2
-        version: 4.23.2
     devDependencies:
       '@sentry/types':
         specifier: ^8.9.2

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -16,6 +16,7 @@ COPY libs/lib-services/package.json libs/lib-services/tsconfig.json libs/lib-ser
 COPY libs/lib-mongodb/package.json libs/lib-mongodb/tsconfig.json libs/lib-mongodb/
 COPY libs/lib-postgres/package.json libs/lib-postgres/tsconfig.json libs/lib-postgres/
 
+COPY modules/module-core/package.json modules/module-core/tsconfig.json modules/module-core/
 COPY modules/module-postgres/package.json modules/module-postgres/tsconfig.json modules/module-postgres/
 COPY modules/module-postgres-storage/package.json modules/module-postgres-storage/tsconfig.json modules/module-postgres-storage/
 COPY modules/module-mongodb/package.json modules/module-mongodb/tsconfig.json modules/module-mongodb/
@@ -41,6 +42,7 @@ COPY libs/lib-services/src libs/lib-services/src/
 COPY libs/lib-mongodb/src libs/lib-mongodb/src/
 COPY libs/lib-postgres/src libs/lib-postgres/src/
 
+COPY modules/module-core/src modules/module-core/src/
 COPY modules/module-postgres/src modules/module-postgres/src/
 COPY modules/module-postgres-storage/src modules/module-postgres-storage/src/
 COPY modules/module-mongodb/src modules/module-mongodb/src/

--- a/service/package.json
+++ b/service/package.json
@@ -18,6 +18,7 @@
     "@powersync/service-module-mongodb-storage": "workspace:*",
     "@powersync/service-module-mysql": "workspace:*",
     "@powersync/service-rsocket-router": "workspace:*",
+    "@powersync/service-module-core": "workspace:*",
     "@sentry/node": "^8.9.2"
   },
   "devDependencies": {

--- a/service/package.json
+++ b/service/package.json
@@ -10,7 +10,6 @@
     "clean": "rm -rf ./lib && tsc -b --clean"
   },
   "dependencies": {
-    "@fastify/cors": "8.4.1",
     "@powersync/service-core": "workspace:*",
     "@powersync/lib-services-framework": "workspace:*",
     "@powersync/service-module-postgres": "workspace:*",
@@ -19,8 +18,7 @@
     "@powersync/service-module-mongodb-storage": "workspace:*",
     "@powersync/service-module-mysql": "workspace:*",
     "@powersync/service-rsocket-router": "workspace:*",
-    "@sentry/node": "^8.9.2",
-    "fastify": "4.23.2"
+    "@sentry/node": "^8.9.2"
   },
   "devDependencies": {
     "@sentry/types": "^8.9.2",

--- a/service/src/entry.ts
+++ b/service/src/entry.ts
@@ -1,6 +1,7 @@
 import { container, ContainerImplementation } from '@powersync/lib-services-framework';
 import * as core from '@powersync/service-core';
 
+import { CoreModule } from '@powersync/service-module-core';
 import { MongoModule } from '@powersync/service-module-mongodb';
 import { MongoStorageModule } from '@powersync/service-module-mongodb-storage';
 import { MySQLModule } from '@powersync/service-module-mysql';
@@ -17,10 +18,11 @@ container.register(ContainerImplementation.REPORTER, createSentryReporter());
 
 const moduleManager = new core.modules.ModuleManager();
 moduleManager.register([
-  new PostgresModule(),
-  new MySQLModule(),
+  new CoreModule(),
   new MongoModule(),
   new MongoStorageModule(),
+  new MySQLModule(),
+  new PostgresModule(),
   new PostgresStorageModule()
 ]);
 // This is a bit of a hack. Commands such as the teardown command or even migrations might

--- a/service/src/runners/server.ts
+++ b/service/src/runners/server.ts
@@ -9,16 +9,9 @@ export async function startServer(runnerConfig: core.utils.RunnerConfig) {
   logBooting('API Container');
 
   const config = await core.utils.loadConfig(runnerConfig);
-  core.utils.setTags(config.metadata);
-
   const serviceContext = new core.system.ServiceContextContainer({
     mode: core.system.ServiceContextMode.API,
     configuration: config
-  });
-
-  await core.metrics.registerMetrics({
-    service_context: serviceContext,
-    modes: [core.metrics.MetricModes.API]
   });
 
   const moduleManager = container.getImplementation(core.modules.ModuleManager);

--- a/service/src/runners/server.ts
+++ b/service/src/runners/server.ts
@@ -1,75 +1,6 @@
-import cors from '@fastify/cors';
-import fastify from 'fastify';
-
 import { container, logger } from '@powersync/lib-services-framework';
 import * as core from '@powersync/service-core';
-
-import { ReactiveSocketRouter } from '@powersync/service-rsocket-router';
 import { logBooting } from '../util/version.js';
-
-/**
- * Configures the server portion on a {@link ServiceContext}
- */
-export function registerServerServices(serviceContext: core.system.ServiceContextContainer) {
-  serviceContext.register(core.routes.RouterEngine, new core.routes.RouterEngine());
-  serviceContext.lifeCycleEngine.withLifecycle(serviceContext.routerEngine!, {
-    start: async (routerEngine) => {
-      await routerEngine!.start(async (routes) => {
-        const server = fastify.fastify();
-
-        server.register(cors, {
-          origin: '*',
-          allowedHeaders: ['Content-Type', 'Authorization', 'User-Agent', 'X-User-Agent'],
-          exposedHeaders: ['Content-Type'],
-          // Cache time for preflight response
-          maxAge: 3600
-        });
-
-        core.routes.configureFastifyServer(server, {
-          service_context: serviceContext,
-          routes: {
-            api: { routes: routes.api_routes },
-            sync_stream: {
-              routes: routes.stream_routes,
-              queue_options: {
-                concurrency: serviceContext.configuration.api_parameters.max_concurrent_connections,
-                max_queue_depth: 0
-              }
-            }
-          }
-        });
-
-        const socketRouter = new ReactiveSocketRouter<core.routes.Context>({
-          max_concurrent_connections: serviceContext.configuration.api_parameters.max_concurrent_connections
-        });
-
-        core.routes.configureRSocket(socketRouter, {
-          server: server.server,
-          service_context: serviceContext,
-          route_generators: routes.socket_routes
-        });
-
-        const { port } = serviceContext.configuration;
-
-        await server.listen({
-          host: '0.0.0.0',
-          port
-        });
-
-        logger.info(`Running on port ${port}`);
-
-        return {
-          onShutdown: async () => {
-            logger.info('Shutting down HTTP server...');
-            await server.close();
-            logger.info('HTTP server stopped');
-          }
-        };
-      });
-    },
-    stop: (routerEngine) => routerEngine!.shutDown()
-  });
-}
 
 /**
  * Starts an API server
@@ -79,9 +10,11 @@ export async function startServer(runnerConfig: core.utils.RunnerConfig) {
 
   const config = await core.utils.loadConfig(runnerConfig);
   core.utils.setTags(config.metadata);
-  const serviceContext = new core.system.ServiceContextContainer(config);
 
-  registerServerServices(serviceContext);
+  const serviceContext = new core.system.ServiceContextContainer({
+    mode: core.system.ServiceContextMode.API,
+    configuration: config
+  });
 
   await core.metrics.registerMetrics({
     service_context: serviceContext,

--- a/service/src/runners/stream-worker.ts
+++ b/service/src/runners/stream-worker.ts
@@ -23,14 +23,12 @@ export const startStreamRunner = async (runnerConfig: core.utils.RunnerConfig) =
   core.utils.setTags(config.metadata);
 
   // Self-hosted version allows for automatic migrations
-  const serviceContext = new core.system.ServiceContextContainer(config);
+  const serviceContext = new core.system.ServiceContextContainer({
+    mode: core.system.ServiceContextMode.SYNC,
+    configuration: config
+  });
 
   registerReplicationServices(serviceContext);
-
-  await core.metrics.registerMetrics({
-    service_context: serviceContext,
-    modes: [core.metrics.MetricModes.REPLICATION, core.metrics.MetricModes.STORAGE]
-  });
 
   const moduleManager = container.getImplementation(core.modules.ModuleManager);
   await moduleManager.initialize(serviceContext);

--- a/service/src/runners/stream-worker.ts
+++ b/service/src/runners/stream-worker.ts
@@ -20,8 +20,6 @@ export const startStreamRunner = async (runnerConfig: core.utils.RunnerConfig) =
   logBooting('Replication Container');
 
   const config = await core.utils.loadConfig(runnerConfig);
-  core.utils.setTags(config.metadata);
-
   // Self-hosted version allows for automatic migrations
   const serviceContext = new core.system.ServiceContextContainer({
     mode: core.system.ServiceContextMode.SYNC,

--- a/service/src/runners/unified-runner.ts
+++ b/service/src/runners/unified-runner.ts
@@ -1,9 +1,8 @@
 import { container, logger } from '@powersync/lib-services-framework';
 import * as core from '@powersync/service-core';
 
-import { registerServerServices } from './server.js';
-import { registerReplicationServices } from './stream-worker.js';
 import { logBooting } from '../util/version.js';
+import { registerReplicationServices } from './stream-worker.js';
 
 /**
  * Starts an API server
@@ -12,16 +11,12 @@ export const startUnifiedRunner = async (runnerConfig: core.utils.RunnerConfig) 
   logBooting('Unified Container');
 
   const config = await core.utils.loadConfig(runnerConfig);
-  core.utils.setTags(config.metadata);
-  const serviceContext = new core.system.ServiceContextContainer(config);
-
-  registerServerServices(serviceContext);
-  registerReplicationServices(serviceContext);
-
-  await core.metrics.registerMetrics({
-    service_context: serviceContext,
-    modes: [core.metrics.MetricModes.API, core.metrics.MetricModes.REPLICATION, core.metrics.MetricModes.STORAGE]
+  const serviceContext = new core.system.ServiceContextContainer({
+    mode: core.system.ServiceContextMode.UNIFIED,
+    configuration: config
   });
+
+  registerReplicationServices(serviceContext);
 
   const moduleManager = container.getImplementation(core.modules.ModuleManager);
   await moduleManager.initialize(serviceContext);

--- a/service/tsconfig.json
+++ b/service/tsconfig.json
@@ -31,6 +31,9 @@
       "path": "../libs/lib-services"
     },
     {
+      "path": "../modules/module-core"
+    },
+    {
       "path": "../modules/module-postgres"
     },
     {


### PR DESCRIPTION
# Overview

The PowerSync service uses a probing system to communicate health check statuses. Internally, the probe state is updated when the service becomes ready or active. This state is maintained in memory and can be exposed externally via the filesystem or HTTP endpoints.

Previously, probe state was always exposed via the filesystem by writing timestamps to .probes/startup, .probes/ready, and .probes/poll. This required the service to run with write access to the filesystem, which isn't always feasible or recommended. There was no way to disable filesystem probes.

In addition, the same probe state was exposed via HTTP routes, but only if the RouterEngine started an HTTP server. This occurred only in API and UNIFIED modes. In SYNC mode, the only way to access probe state externally was through the filesystem.

## What's new
This PR introduces configurable probe types through the PowerSync configuration file. You can now enable or disable probe outputs via YAML:

yaml
Copy
Edit
service:
  healthchecks:
    probe_types:
      - filesystem
      - http
The specified probe_types determine how probe state is exposed. Selecting http will now start an HTTP server even when running in SYNC mode.

**Backwards compatibility**
If no healthchecks configuration is provided, the service retains its previous behavior.

## Implementation

Internally this moves some  configuration from the `service` runner to a new shared module. This should remove some minor   duplication throughout our hosted codebases.

