### PR TITLE
Fix and test "has_more" for data batches

### DIFF
--- a/.changeset/pretty-eagles-fail.md
+++ b/.changeset/pretty-eagles-fail.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core-tests': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Fix has_more and other data batch metadata

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -87,7 +87,11 @@ describe('sync - mongodb', () => {
     });
 
     const batch2 = await test_utils.fromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch1[0].batch.next_after)]]), options)
+      bucketStorage.getBucketDataBatch(
+        checkpoint,
+        new Map([['global[]', BigInt(batch1[0].chunkData.next_after)]]),
+        options
+      )
     );
     expect(test_utils.getBatchData(batch2)).toEqual([
       { op_id: '3', op: 'PUT', object_id: 'large2', checksum: 1607205872 }
@@ -99,7 +103,11 @@ describe('sync - mongodb', () => {
     });
 
     const batch3 = await test_utils.fromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch2[0].batch.next_after)]]), options)
+      bucketStorage.getBucketDataBatch(
+        checkpoint,
+        new Map([['global[]', BigInt(batch2[0].chunkData.next_after)]]),
+        options
+      )
     );
     expect(test_utils.getBatchData(batch3)).toEqual([
       { op_id: '4', op: 'PUT', object_id: 'test3', checksum: 1359888332 }

--- a/modules/module-mongodb/test/src/change_stream_utils.ts
+++ b/modules/module-mongodb/test/src/change_stream_utils.ts
@@ -138,7 +138,7 @@ export class ChangeStreamTestContext {
       chunkLimitBytes: options?.chunkLimitBytes
     });
     const batches = await test_utils.fromAsync(batch);
-    return batches[0]?.batch.data ?? [];
+    return batches[0]?.chunkData.data ?? [];
   }
 
   async getChecksums(buckets: string[], options?: { timeout?: number }) {

--- a/modules/module-mysql/test/src/BinlogStreamUtils.ts
+++ b/modules/module-mysql/test/src/BinlogStreamUtils.ts
@@ -157,7 +157,7 @@ export class BinlogStreamTestContext {
     const map = new Map<string, InternalOpId>([[bucket, start]]);
     const batch = this.storage!.getBucketDataBatch(checkpoint, map);
     const batches = await test_utils.fromAsync(batch);
-    return batches[0]?.batch.data ?? [];
+    return batches[0]?.chunkData.data ?? [];
   }
 }
 

--- a/modules/module-postgres-storage/test/src/storage.test.ts
+++ b/modules/module-postgres-storage/test/src/storage.test.ts
@@ -93,7 +93,11 @@ describe('Postgres Sync Bucket Storage', () => {
     });
 
     const batch2 = await test_utils.fromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch1[0].batch.next_after)]]), options)
+      bucketStorage.getBucketDataBatch(
+        checkpoint,
+        new Map([['global[]', BigInt(batch1[0].chunkData.next_after)]]),
+        options
+      )
     );
     expect(test_utils.getBatchData(batch2)).toEqual([
       { op_id: '2', op: 'PUT', object_id: 'large1', checksum: 1178768505 }
@@ -105,7 +109,11 @@ describe('Postgres Sync Bucket Storage', () => {
     });
 
     const batch3 = await test_utils.fromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch2[0].batch.next_after)]]), options)
+      bucketStorage.getBucketDataBatch(
+        checkpoint,
+        new Map([['global[]', BigInt(batch2[0].chunkData.next_after)]]),
+        options
+      )
     );
     expect(test_utils.getBatchData(batch3)).toEqual([
       { op_id: '3', op: 'PUT', object_id: 'large2', checksum: 1607205872 }
@@ -117,7 +125,11 @@ describe('Postgres Sync Bucket Storage', () => {
     });
 
     const batch4 = await test_utils.fromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch3[0].batch.next_after)]]), options)
+      bucketStorage.getBucketDataBatch(
+        checkpoint,
+        new Map([['global[]', BigInt(batch3[0].chunkData.next_after)]]),
+        options
+      )
     );
     expect(test_utils.getBatchData(batch4)).toEqual([
       { op_id: '4', op: 'PUT', object_id: 'test3', checksum: 1359888332 }

--- a/modules/module-postgres/test/src/wal_stream_utils.ts
+++ b/modules/module-postgres/test/src/wal_stream_utils.ts
@@ -161,11 +161,11 @@ export class WalStreamTestContext implements AsyncDisposable {
       const batch = this.storage!.getBucketDataBatch(checkpoint, map);
 
       const batches = await test_utils.fromAsync(batch);
-      data = data.concat(batches[0]?.batch.data ?? []);
-      if (batches.length == 0 || !batches[0]!.batch.has_more) {
+      data = data.concat(batches[0]?.chunkData.data ?? []);
+      if (batches.length == 0 || !batches[0]!.chunkData.has_more) {
         break;
       }
-      map.set(bucket, BigInt(batches[0]!.batch.next_after));
+      map.set(bucket, BigInt(batches[0]!.chunkData.next_after));
     }
     return data;
   }
@@ -182,6 +182,6 @@ export class WalStreamTestContext implements AsyncDisposable {
     const map = new Map<string, InternalOpId>([[bucket, start]]);
     const batch = this.storage!.getBucketDataBatch(checkpoint, map);
     const batches = await test_utils.fromAsync(batch);
-    return batches[0]?.batch.data ?? [];
+    return batches[0]?.chunkData.data ?? [];
   }
 }

--- a/packages/service-core-tests/src/test-utils/general-utils.ts
+++ b/packages/service-core-tests/src/test-utils/general-utils.ts
@@ -47,7 +47,7 @@ export function makeTestTable(name: string, replicaIdColumns?: string[] | undefi
 }
 
 export function getBatchData(
-  batch: utils.SyncBucketData[] | storage.SyncBucketDataBatch[] | storage.SyncBucketDataBatch
+  batch: utils.SyncBucketData[] | storage.SyncBucketDataChunk[] | storage.SyncBucketDataChunk
 ) {
   const first = getFirst(batch);
   if (first == null) {
@@ -64,7 +64,7 @@ export function getBatchData(
 }
 
 export function getBatchMeta(
-  batch: utils.SyncBucketData[] | storage.SyncBucketDataBatch[] | storage.SyncBucketDataBatch
+  batch: utils.SyncBucketData[] | storage.SyncBucketDataChunk[] | storage.SyncBucketDataChunk
 ) {
   const first = getFirst(batch);
   if (first == null) {
@@ -78,17 +78,17 @@ export function getBatchMeta(
 }
 
 function getFirst(
-  batch: utils.SyncBucketData[] | storage.SyncBucketDataBatch[] | storage.SyncBucketDataBatch
+  batch: utils.SyncBucketData[] | storage.SyncBucketDataChunk[] | storage.SyncBucketDataChunk
 ): utils.SyncBucketData | null {
   if (!Array.isArray(batch)) {
-    return batch.batch;
+    return batch.chunkData;
   }
   if (batch.length == 0) {
     return null;
   }
   let first = batch[0];
-  if ((first as storage.SyncBucketDataBatch).batch != null) {
-    return (first as storage.SyncBucketDataBatch).batch;
+  if ((first as storage.SyncBucketDataChunk).chunkData != null) {
+    return (first as storage.SyncBucketDataChunk).chunkData;
   } else {
     return first as utils.SyncBucketData;
   }

--- a/packages/service-core-tests/src/tests/register-compacting-tests.ts
+++ b/packages/service-core-tests/src/tests/register-compacting-tests.ts
@@ -60,7 +60,7 @@ bucket_definitions:
     const batchBefore = await test_utils.oneFromAsync(
       bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]]))
     );
-    const dataBefore = batchBefore.batch.data;
+    const dataBefore = batchBefore.chunkData.data;
     const checksumBefore = await bucketStorage.getChecksums(checkpoint, ['global[]']);
 
     expect(dataBefore).toMatchObject([
@@ -93,7 +93,7 @@ bucket_definitions:
     const batchAfter = await test_utils.oneFromAsync(
       bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]]))
     );
-    const dataAfter = batchAfter.batch.data;
+    const dataAfter = batchAfter.chunkData.data;
     const checksumAfter = await bucketStorage.getChecksums(checkpoint, ['global[]']);
 
     expect(batchAfter.targetOp).toEqual(3n);
@@ -175,7 +175,7 @@ bucket_definitions:
     const batchBefore = await test_utils.oneFromAsync(
       bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]]))
     );
-    const dataBefore = batchBefore.batch.data;
+    const dataBefore = batchBefore.chunkData.data;
     const checksumBefore = await bucketStorage.getChecksums(checkpoint, ['global[]']);
 
     expect(dataBefore).toMatchObject([
@@ -214,7 +214,7 @@ bucket_definitions:
     const batchAfter = await test_utils.oneFromAsync(
       bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]]))
     );
-    const dataAfter = batchAfter.batch.data;
+    const dataAfter = batchAfter.chunkData.data;
     const checksumAfter = await bucketStorage.getChecksums(checkpoint, ['global[]']);
 
     expect(batchAfter.targetOp).toEqual(4n);
@@ -299,7 +299,7 @@ bucket_definitions:
     const batchAfter = await test_utils.oneFromAsync(
       bucketStorage.getBucketDataBatch(checkpoint2, new Map([['global[]', 0n]]))
     );
-    const dataAfter = batchAfter.batch.data;
+    const dataAfter = batchAfter.chunkData.data;
     const checksumAfter = await bucketStorage.getChecksums(checkpoint2, ['global[]']);
 
     expect(batchAfter.targetOp).toEqual(4n);
@@ -414,7 +414,7 @@ bucket_definitions:
         ])
       )
     );
-    const dataAfter = batchAfter.flatMap((b) => b.batch.data);
+    const dataAfter = batchAfter.flatMap((b) => b.chunkData.data);
 
     // The op_ids will vary between MongoDB and Postgres storage
     expect(dataAfter).toMatchObject(

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -1,6 +1,12 @@
-import { getUuidReplicaIdentityBson, OplogEntry, storage } from '@powersync/service-core';
+import {
+  BucketDataBatchOptions,
+  getUuidReplicaIdentityBson,
+  InternalOpId,
+  OplogEntry,
+  storage
+} from '@powersync/service-core';
 import { ParameterLookup, RequestParameters } from '@powersync/service-sync-rules';
-import { expect, test } from 'vitest';
+import { expect, test, describe, beforeEach } from 'vitest';
 import * as test_utils from '../test-utils/test-utils-index.js';
 
 export const TEST_TABLE = test_utils.makeTestTable('test', ['id']);
@@ -1423,6 +1429,159 @@ bucket_definitions:
     expect(test_utils.getBatchData(batch3)).toEqual([]);
 
     expect(test_utils.getBatchMeta(batch3)).toEqual(null);
+  });
+
+  describe('batch has_more', () => {
+    const setup = async (options: BucketDataBatchOptions) => {
+      const sync_rules = test_utils.testRules(
+        `
+  bucket_definitions:
+    global1:
+      data:
+        - SELECT id, description FROM test WHERE bucket = 'global1'
+    global2:
+      data:
+        - SELECT id, description FROM test WHERE bucket = 'global2'
+  `
+      );
+      await using factory = await generateStorageFactory();
+      const bucketStorage = factory.getInstance(sync_rules);
+
+      const result = await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+        const sourceTable = TEST_TABLE;
+
+        for (let i = 1; i <= 10; i++) {
+          await batch.save({
+            sourceTable,
+            tag: storage.SaveOperationTag.INSERT,
+            after: {
+              id: `test${i}`,
+              description: `test${i}`,
+              bucket: i == 1 ? 'global1' : 'global2'
+            },
+            afterReplicaId: `test${i}`
+          });
+        }
+      });
+
+      const checkpoint = result!.flushed_op;
+      return await test_utils.fromAsync(
+        bucketStorage.getBucketDataBatch(
+          checkpoint,
+          new Map([
+            ['global1[]', 0n],
+            ['global2[]', 0n]
+          ]),
+          options
+        )
+      );
+    };
+
+    test('batch has_more (1)', async () => {
+      const batch = await setup({ limit: 5 });
+      expect(batch.length).toEqual(2);
+
+      expect(batch[0].batch.bucket).toEqual('global1[]');
+      expect(batch[1].batch.bucket).toEqual('global2[]');
+
+      expect(test_utils.getBatchData(batch[0])).toEqual([
+        { op_id: '1', op: 'PUT', object_id: 'test1', checksum: 2871785649 }
+      ]);
+
+      expect(test_utils.getBatchData(batch[1])).toEqual([
+        { op_id: '2', op: 'PUT', object_id: 'test2', checksum: 730027011 },
+        { op_id: '3', op: 'PUT', object_id: 'test3', checksum: 1359888332 },
+        { op_id: '4', op: 'PUT', object_id: 'test4', checksum: 2049153252 },
+        { op_id: '5', op: 'PUT', object_id: 'test5', checksum: 3686902721 }
+      ]);
+
+      expect(test_utils.getBatchMeta(batch[0])).toEqual({
+        after: '0',
+        has_more: false,
+        next_after: '1'
+      });
+
+      expect(test_utils.getBatchMeta(batch[1])).toEqual({
+        after: '0',
+        has_more: true,
+        next_after: '5'
+      });
+    });
+
+    test('batch has_more (2)', async () => {
+      const batch = await setup({ limit: 11 });
+      expect(batch.length).toEqual(2);
+
+      expect(batch[0].batch.bucket).toEqual('global1[]');
+      expect(batch[1].batch.bucket).toEqual('global2[]');
+
+      expect(test_utils.getBatchData(batch[0])).toEqual([
+        { op_id: '1', op: 'PUT', object_id: 'test1', checksum: 2871785649 }
+      ]);
+
+      expect(test_utils.getBatchData(batch[1])).toEqual([
+        { op_id: '2', op: 'PUT', object_id: 'test2', checksum: 730027011 },
+        { op_id: '3', op: 'PUT', object_id: 'test3', checksum: 1359888332 },
+        { op_id: '4', op: 'PUT', object_id: 'test4', checksum: 2049153252 },
+        { op_id: '5', op: 'PUT', object_id: 'test5', checksum: 3686902721 },
+        { op_id: '6', op: 'PUT', object_id: 'test6', checksum: 1974820016 },
+        { op_id: '7', op: 'PUT', object_id: 'test7', checksum: 2477637855 },
+        { op_id: '8', op: 'PUT', object_id: 'test8', checksum: 3644033632 },
+        { op_id: '9', op: 'PUT', object_id: 'test9', checksum: 1011055869 },
+        { op_id: '10', op: 'PUT', object_id: 'test10', checksum: 1331456365 }
+      ]);
+
+      expect(test_utils.getBatchMeta(batch[0])).toEqual({
+        after: '0',
+        has_more: false,
+        next_after: '1'
+      });
+
+      expect(test_utils.getBatchMeta(batch[1])).toEqual({
+        after: '0',
+        has_more: false,
+        next_after: '10'
+      });
+    });
+
+    test('batch has_more (3)', async () => {
+      // 50 bytes is more than 1 row, less than 2 rows
+      const batch = await setup({ limit: 3, chunkLimitBytes: 50 });
+
+      expect(batch.length).toEqual(3);
+      expect(batch[0].batch.bucket).toEqual('global1[]');
+      expect(batch[1].batch.bucket).toEqual('global2[]');
+      expect(batch[2].batch.bucket).toEqual('global2[]');
+
+      expect(test_utils.getBatchData(batch[0])).toEqual([
+        { op_id: '1', op: 'PUT', object_id: 'test1', checksum: 2871785649 }
+      ]);
+
+      expect(test_utils.getBatchData(batch[1])).toEqual([
+        { op_id: '2', op: 'PUT', object_id: 'test2', checksum: 730027011 }
+      ]);
+      expect(test_utils.getBatchData(batch[2])).toEqual([
+        { op_id: '3', op: 'PUT', object_id: 'test3', checksum: 1359888332 }
+      ]);
+
+      expect(test_utils.getBatchMeta(batch[0])).toEqual({
+        after: '0',
+        has_more: false,
+        next_after: '1'
+      });
+
+      expect(test_utils.getBatchMeta(batch[1])).toEqual({
+        after: '0',
+        has_more: true,
+        next_after: '2'
+      });
+
+      expect(test_utils.getBatchMeta(batch[2])).toEqual({
+        after: '2',
+        has_more: true,
+        next_after: '3'
+      });
+    });
   });
 
   test('empty storage metrics', async () => {

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -344,7 +344,7 @@ bucket_definitions:
     const checkpoint = result!.flushed_op;
 
     const batch = await test_utils.fromAsync(bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]])));
-    const data = batch[0].batch.data.map((d) => {
+    const data = batch[0].chunkData.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -641,7 +641,7 @@ bucket_definitions:
     });
     const checkpoint = result!.flushed_op;
     const batch = await test_utils.fromAsync(bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]])));
-    const data = batch[0].batch.data.map((d) => {
+    const data = batch[0].chunkData.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id
@@ -705,7 +705,7 @@ bucket_definitions:
     const checkpoint = result!.flushed_op;
 
     const batch = await test_utils.fromAsync(bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]])));
-    const data = batch[0].batch.data.map((d) => {
+    const data = batch[0].chunkData.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -821,7 +821,7 @@ bucket_definitions:
 
     const batch = await test_utils.fromAsync(bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]])));
 
-    const data = batch[0].batch.data.map((d) => {
+    const data = batch[0].chunkData.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -1020,7 +1020,7 @@ bucket_definitions:
       bucketStorage.getBucketDataBatch(checkpoint2, new Map([['global[]', checkpoint1]]))
     );
 
-    const data = batch[0].batch.data.map((d) => {
+    const data = batch[0].chunkData.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -1119,7 +1119,7 @@ bucket_definitions:
     const batch = await test_utils.fromAsync(
       bucketStorage.getBucketDataBatch(checkpoint3, new Map([['global[]', checkpoint1]]))
     );
-    const data = batch[0].batch.data.map((d) => {
+    const data = batch[0].chunkData.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -1227,7 +1227,7 @@ bucket_definitions:
     const batch = await test_utils.fromAsync(
       bucketStorage.getBucketDataBatch(checkpoint3, new Map([['global[]', checkpoint1]]))
     );
-    const data = batch[0].batch.data.map((d) => {
+    const data = batch[0].chunkData.data.map((d) => {
       return {
         op: d.op,
         object_id: d.object_id,
@@ -1338,7 +1338,11 @@ bucket_definitions:
     });
 
     const batch2 = await test_utils.fromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch1[0].batch.next_after)]]), options)
+      bucketStorage.getBucketDataBatch(
+        checkpoint,
+        new Map([['global[]', BigInt(batch1[0].chunkData.next_after)]]),
+        options
+      )
     );
     expect(test_utils.getBatchData(batch2)).toEqual([
       { op_id: '3', op: 'PUT', object_id: 'large2', checksum: 1795508474 },
@@ -1351,7 +1355,11 @@ bucket_definitions:
     });
 
     const batch3 = await test_utils.fromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch2[0].batch.next_after)]]), options)
+      bucketStorage.getBucketDataBatch(
+        checkpoint,
+        new Map([['global[]', BigInt(batch2[0].chunkData.next_after)]]),
+        options
+      )
     );
     expect(test_utils.getBatchData(batch3)).toEqual([]);
     expect(test_utils.getBatchMeta(batch3)).toEqual(null);
@@ -1406,7 +1414,7 @@ bucket_definitions:
     });
 
     const batch2 = await test_utils.oneFromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch1.batch.next_after)]]), {
+      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch1.chunkData.next_after)]]), {
         limit: 4
       })
     );
@@ -1422,7 +1430,7 @@ bucket_definitions:
     });
 
     const batch3 = await test_utils.fromAsync(
-      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch2.batch.next_after)]]), {
+      bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', BigInt(batch2.chunkData.next_after)]]), {
         limit: 4
       })
     );
@@ -1481,8 +1489,8 @@ bucket_definitions:
       const batch = await setup({ limit: 5 });
       expect(batch.length).toEqual(2);
 
-      expect(batch[0].batch.bucket).toEqual('global1[]');
-      expect(batch[1].batch.bucket).toEqual('global2[]');
+      expect(batch[0].chunkData.bucket).toEqual('global1[]');
+      expect(batch[1].chunkData.bucket).toEqual('global2[]');
 
       expect(test_utils.getBatchData(batch[0])).toEqual([
         { op_id: '1', op: 'PUT', object_id: 'test1', checksum: 2871785649 }
@@ -1512,8 +1520,8 @@ bucket_definitions:
       const batch = await setup({ limit: 11 });
       expect(batch.length).toEqual(2);
 
-      expect(batch[0].batch.bucket).toEqual('global1[]');
-      expect(batch[1].batch.bucket).toEqual('global2[]');
+      expect(batch[0].chunkData.bucket).toEqual('global1[]');
+      expect(batch[1].chunkData.bucket).toEqual('global2[]');
 
       expect(test_utils.getBatchData(batch[0])).toEqual([
         { op_id: '1', op: 'PUT', object_id: 'test1', checksum: 2871785649 }
@@ -1549,9 +1557,9 @@ bucket_definitions:
       const batch = await setup({ limit: 3, chunkLimitBytes: 50 });
 
       expect(batch.length).toEqual(3);
-      expect(batch[0].batch.bucket).toEqual('global1[]');
-      expect(batch[1].batch.bucket).toEqual('global2[]');
-      expect(batch[2].batch.bucket).toEqual('global2[]');
+      expect(batch[0].chunkData.bucket).toEqual('global1[]');
+      expect(batch[1].chunkData.bucket).toEqual('global2[]');
+      expect(batch[2].chunkData.bucket).toEqual('global2[]');
 
       expect(test_utils.getBatchData(batch[0])).toEqual([
         { op_id: '1', op: 'PUT', object_id: 'test1', checksum: 2871785649 }

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -107,7 +107,7 @@ export interface SyncRulesBucketStorage
     checkpoint: util.InternalOpId,
     dataBuckets: Map<string, util.InternalOpId>,
     options?: BucketDataBatchOptions
-  ): AsyncIterable<SyncBucketDataBatch>;
+  ): AsyncIterable<SyncBucketDataChunk>;
 
   /**
    * Compute checksums for a given list of buckets.
@@ -223,8 +223,8 @@ export interface BucketDataBatchOptions {
   chunkLimitBytes?: number;
 }
 
-export interface SyncBucketDataBatch {
-  batch: util.SyncBucketData;
+export interface SyncBucketDataChunk {
+  chunkData: util.SyncBucketData;
   targetOp: util.InternalOpId | null;
 }
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -327,7 +327,7 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
 
     let has_more = false;
 
-    for await (let { batch: r, targetOp } of dataBatches) {
+    for await (let { chunkData: r, targetOp } of dataBatches) {
       // Abort in current batch if the connection is closed
       if (abort_connection.aborted) {
         return;

--- a/packages/service-core/src/util/protocol-types.ts
+++ b/packages/service-core/src/util/protocol-types.ts
@@ -117,11 +117,11 @@ export interface SyncBucketData {
   bucket: string;
   data: OplogEntry[];
   /**
-   * True if the response does not contain all the data for this bucket, and another request must be made.
+   * True if there _could_ be more data for this bucket, and another request must be made.
    */
   has_more: boolean;
   /**
-   * The `after` specified in the request.
+   * The `after` specified in the request, or the next_after from the previous batch returned.
    */
   after: ProtocolOpId;
   /**


### PR DESCRIPTION
## Primary issue

With Postgres bucket storage, there are scenarios when a data line would have `has_more: false`, even though the bucket has more data. This leads to a checksum failure for the bucket, and the entire bucket re-downloaded.

This only occurred when there are multiple different buckets returned in a single `getBucketDataBatch()` call, with the first bucket returned not having this issue. This means the client did make progress on each sync attempt, and did not repeatedly run into the same checksum failure. So in most cases, users would not directly see the issue, but sync would take longer than it should.

This fixes the has_more logic to cover this case, with new tests.

## Additional fixed issues

The tests picked up another couple of consistency issues with batch metadata. None of these caused any visible symptoms on the client.
1. MongoDB storage: `has_more` could be true in some cases where it shouldn't be. This resulted in some duplicate work at worst, but no consistency issues with the data sent.
2. Postgres storage: Could return 1001 rows in a batch, where the limit should be 1000.
3. `after` for a batch could be `0`, or the `next_after` value of a different bucket. These are not used on any client, so did not cause actual issues despite the incorrect values.

## Naming things

This updates the variable naming inside the method to make a distinction between the entire "batch", and individual yielded "chunks" inside it. The distinction between length and byte size limits should also be more clear now.
