### PR TITLE
Allow JSON request payload for RSocket

### DIFF
--- a/.changeset/happy-taxis-lick.md
+++ b/.changeset/happy-taxis-lick.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-image': minor
+---
+
+Support WebSocket requests to be encoded as JSON, which will enable more SDKs to use WebSockets as a transport protocol when receiving sync lines.

--- a/.changeset/wild-maps-brake.md
+++ b/.changeset/wild-maps-brake.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-rsocket-router': patch
+'@powersync/service-errors': patch
+'@powersync/service-core': patch
+---
+
+Allow RSocket request payload to be encoded as JSON

--- a/.changeset/wild-maps-brake.md
+++ b/.changeset/wild-maps-brake.md
@@ -1,7 +1,7 @@
 ---
 '@powersync/service-rsocket-router': patch
 '@powersync/service-errors': patch
-'@powersync/service-core': patch
+'@powersync/service-core': minor
 ---
 
 Allow RSocket request payload to be encoded as JSON

--- a/packages/rsocket-router/src/router/ReactiveSocketRouter.ts
+++ b/packages/rsocket-router/src/router/ReactiveSocketRouter.ts
@@ -18,6 +18,14 @@ import {
   SocketResponder
 } from './types.js';
 
+export interface ReactiveStreamRequest {
+  payload: Payload;
+  metadataMimeType: string;
+  dataMimeType: string;
+  initialN: number;
+  responder: SocketResponder;
+}
+
 export class ReactiveSocketRouter<C> {
   constructor(protected options?: ReactiveSocketRouterOptions<C>) {}
 
@@ -121,14 +129,6 @@ export class ReactiveSocketRouter<C> {
 
     return rSocketServer.bind();
   }
-}
-
-export interface ReactiveStreamRequest {
-  payload: Payload;
-  metadataMimeType: string;
-  dataMimeType: string;
-  initialN: number;
-  responder: SocketResponder;
 }
 
 export async function handleReactiveStream<Context>(

--- a/packages/rsocket-router/src/router/types.ts
+++ b/packages/rsocket-router/src/router/types.ts
@@ -47,8 +47,16 @@ export type IReactiveStream<I = any, O = any, C = any> = Omit<
    * Decodes raw payload buffer to [I].
    * Falls back to router level decoder if not specified.
    */
-  decoder?: (rawData?: Buffer) => Promise<I>;
+  decoder?: (rawData?: TypedBuffer) => Promise<I>;
 };
+
+/**
+ * A {@link Buffer} with an associated mimeType inferred from the RSocket `SETUP` frame.
+ */
+export interface TypedBuffer {
+  mimeType: string;
+  contents: Buffer;
+}
 
 export type IReactiveStreamInput<I, O, C> = Omit<IReactiveStream<I, O, C>, 'path' | 'type' | 'method'>;
 
@@ -56,7 +64,7 @@ export type ReactiveEndpoint = IReactiveStream;
 
 export type CommonParams<C> = {
   endpoints: Array<ReactiveEndpoint>;
-  contextProvider: (metaData: Buffer) => Promise<C>;
-  metaDecoder: (meta: Buffer) => Promise<RequestMeta>;
-  payloadDecoder: (rawData?: Buffer) => Promise<any>;
+  contextProvider: (metaData: TypedBuffer) => Promise<C>;
+  metaDecoder: (meta: TypedBuffer) => Promise<RequestMeta>;
+  payloadDecoder: (rawData?: TypedBuffer) => Promise<any>;
 };

--- a/packages/rsocket-router/tests/src/requests.test.ts
+++ b/packages/rsocket-router/tests/src/requests.test.ts
@@ -12,19 +12,24 @@ import { EndpointHandlerPayload, ErrorCode } from '@powersync/lib-services-frame
  * @param responder a mock responder
  * @returns
  */
-async function handleRoute(path: string, endpoints: ReactiveEndpoint[], responder: SocketResponder, request?: Partial<ReactiveStreamRequest>) {
+async function handleRoute(
+  path: string,
+  endpoints: ReactiveEndpoint[],
+  responder: SocketResponder,
+  request?: Partial<ReactiveStreamRequest>
+) {
   return handleReactiveStream<{}>(
     {},
     {
       payload: {
         data: Buffer.from(serialize({})),
-        metadata: Buffer.from(serialize({ path })),
+        metadata: Buffer.from(serialize({ path }))
       },
       initialN: 1,
       dataMimeType: 'application/bson',
       metadataMimeType: 'application/bson',
       responder,
-      ...request,
+      ...request
     },
     createMockObserver(),
     new AbortController(),
@@ -145,7 +150,7 @@ describe('Requests', () => {
     const path = '/test-route';
 
     const fn = vi.fn(async (p: EndpointHandlerPayload<any, any>) => {
-      expect(p.params).toStrictEqual({'hello': 'world'});
+      expect(p.params).toStrictEqual({ hello: 'world' });
       return undefined;
     });
 
@@ -153,13 +158,13 @@ describe('Requests', () => {
       {},
       {
         payload: {
-          data: Buffer.from(encodeJson({'hello': 'world'})),
-          metadata: Buffer.from(encodeJson({ path })),
+          data: Buffer.from(encodeJson({ hello: 'world' })),
+          metadata: Buffer.from(encodeJson({ path }))
         },
         metadataMimeType: 'application/json',
         dataMimeType: 'application/json',
         initialN: 1,
-        responder,
+        responder
       },
       createMockObserver(),
       new AbortController(),
@@ -169,7 +174,7 @@ describe('Requests', () => {
           {
             path,
             type: RS_ENDPOINT_TYPE.STREAM,
-            handler: fn,
+            handler: fn
           }
         ],
         metaDecoder: async (buffer) => {

--- a/packages/service-core/src/routes/configure-rsocket.ts
+++ b/packages/service-core/src/routes/configure-rsocket.ts
@@ -2,7 +2,7 @@ import { deserialize } from 'bson';
 import * as http from 'http';
 
 import { ErrorCode, errors, logger } from '@powersync/lib-services-framework';
-import { ReactiveSocketRouter, RSocketRequestMeta } from '@powersync/service-rsocket-router';
+import { ReactiveSocketRouter, RSocketRequestMeta, TypedBuffer } from '@powersync/service-rsocket-router';
 
 import { ServiceContext } from '../system/ServiceContext.js';
 import { generateContext, getTokenFromHeader } from './auth.js';
@@ -22,8 +22,8 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
   const { route_generators = DEFAULT_SOCKET_ROUTES, server, service_context } = options;
 
   router.applyWebSocketEndpoints(server, {
-    contextProvider: async (data: Buffer): Promise<Context & { token: string }> => {
-      const { token, user_agent } = RSocketContextMeta.decode(deserialize(data) as any);
+    contextProvider: async (data: TypedBuffer): Promise<Context & { token: string }> => {
+      const { token, user_agent } = RSocketContextMeta.decode(decodeTyped(data) as any);
 
       if (!token) {
         throw new errors.AuthorizationError(ErrorCode.PSYNC_S2106, 'No token provided');
@@ -58,9 +58,21 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
       }
     },
     endpoints: route_generators.map((generator) => generator(router)),
-    metaDecoder: async (meta: Buffer) => {
-      return RSocketRequestMeta.decode(deserialize(meta) as any);
+    metaDecoder: async (meta: TypedBuffer) => {
+      return RSocketRequestMeta.decode(decodeTyped(meta) as any);
     },
-    payloadDecoder: async (rawData?: Buffer) => rawData && deserialize(rawData)
+    payloadDecoder: async (rawData?: TypedBuffer) => rawData && decodeTyped(rawData)
   });
+}
+
+function decodeTyped(data: TypedBuffer) {
+  switch (data.mimeType) {
+    case 'application/json':
+      const decoder = new TextDecoder();
+      return JSON.parse(decoder.decode(data.contents));
+    case 'application/bson':
+      return deserialize(data.contents);
+  }
+
+  throw new errors.UnsupportedMediaType(`Expected JSON or BSON request, got ${data.mimeType}`);
 }

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -297,6 +297,13 @@ export enum ErrorCode {
    */
   PSYNC_S2003 = 'PSYNC_S2003',
 
+  /**
+   * 415 unsupported media type.
+   * 
+   * This code always indicates an issue with the client.
+   */
+  PSYNC_S2004 = 'PSYNC_S2004',
+
   // ## PSYNC_S21xx: Auth errors originating on the client.
   //
   // This does not include auth configuration errors on the service.

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -299,7 +299,7 @@ export enum ErrorCode {
 
   /**
    * 415 unsupported media type.
-   * 
+   *
    * This code always indicates an issue with the client.
    */
   PSYNC_S2004 = 'PSYNC_S2004',

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -159,6 +159,19 @@ export class ReplicationAbortedError extends ServiceError {
   }
 }
 
+export class UnsupportedMediaType extends ServiceError {
+  static readonly CODE = ErrorCode.PSYNC_S2004;
+
+  constructor(errors: any) {
+    super({
+      code: UnsupportedMediaType.CODE,
+      status: 415,
+      description: 'Unsupported Media Type',
+      details: errors
+    });
+  }
+}
+
 export class AuthorizationError extends ServiceError {
   /**
    * String describing the token. Does not contain the full token, but may help with debugging.


### PR DESCRIPTION
With the ongoing work to move more parts of the sync logic into the core extension, client SDKs no longer need to implement the BSON deserialization logic themselves (instead relying on our Rust decoder to take care of that). But while that covers response handing, clients are still responsible for crafting RSocket _requests_ (e.g. to transmit tokens or a user agent).

At the moment, our code to handle RSocket requests always assumes that the connection data and metadata will be encoded as BSON. This is unfortunate for clients, because they then need to ship a BSON encoder for the sole purpose of creating these tiny request payloads (and especially on JavaScript, our dependency on the BSON library requires special compilation support for `@powersync/common`). So while we continue to serve BSON only for RSocket requests, we should look for ways to get rid of BSON support on the client SDKs.

The RSocket protocol has space for two mime types for metadata and data fields as part of the `SETUP` frame, and the JavaScript SDK correctly sets those to `application/bson`. To support other clients without a BSON library in the future, this changes the sync service to also accept requests with an `application/json` content type. This allows e.g. the Kotlin SDK to adopt the RSocket protocol.