### PR TITLE
Improve auth errors

### DIFF
--- a/.changeset/clever-kangaroos-thank.md
+++ b/.changeset/clever-kangaroos-thank.md
@@ -1,0 +1,10 @@
+---
+'@powersync/service-module-postgres': minor
+'@powersync/service-rsocket-router': minor
+'@powersync/service-errors': minor
+'@powersync/service-core': minor
+'@powersync/lib-services-framework': minor
+'@powersync/service-image': minor
+---
+
+Improve authentication error messages and logs

--- a/libs/lib-services/src/router/endpoint.ts
+++ b/libs/lib-services/src/router/endpoint.ts
@@ -16,7 +16,10 @@ export const executeEndpoint = async <I, O, C, P extends EndpointHandlerPayload<
   }
   const authorizer_response = await endpoint.authorize?.(payload);
   if (authorizer_response && !authorizer_response.authorized) {
-    throw new errors.AuthorizationError(authorizer_response.errors);
+    if (authorizer_response.error == null) {
+      throw new errors.AuthorizationError2(errors.ErrorCode.PSYNC_S2101, 'Authorization failed');
+    }
+    throw authorizer_response.error;
   }
 
   return endpoint.handler(payload);

--- a/libs/lib-services/src/router/endpoint.ts
+++ b/libs/lib-services/src/router/endpoint.ts
@@ -17,7 +17,7 @@ export const executeEndpoint = async <I, O, C, P extends EndpointHandlerPayload<
   const authorizer_response = await endpoint.authorize?.(payload);
   if (authorizer_response && !authorizer_response.authorized) {
     if (authorizer_response.error == null) {
-      throw new errors.AuthorizationError2(errors.ErrorCode.PSYNC_S2101, 'Authorization failed');
+      throw new errors.AuthorizationError(errors.ErrorCode.PSYNC_S2101, 'Authorization failed');
     }
     throw authorizer_response.error;
   }

--- a/libs/lib-services/src/router/router-definitions.ts
+++ b/libs/lib-services/src/router/router-definitions.ts
@@ -1,3 +1,4 @@
+import { ServiceError } from '@powersync/service-errors';
 import { MicroValidator } from '../schema/definitions.js';
 
 /**
@@ -22,7 +23,7 @@ export type AuthorizationResponse =
     }
   | {
       authorized: false;
-      errors?: any[];
+      error?: ServiceError | undefined;
     };
 
 /**

--- a/modules/module-postgres/src/auth/SupabaseKeyCollector.ts
+++ b/modules/module-postgres/src/auth/SupabaseKeyCollector.ts
@@ -4,7 +4,7 @@ import * as pgwire from '@powersync/service-jpgwire';
 import * as jose from 'jose';
 
 import * as types from '../types/types.js';
-import { AuthorizationError2, ErrorCode } from '@powersync/lib-services-framework';
+import { AuthorizationError, ErrorCode } from '@powersync/lib-services-framework';
 
 /**
  * Fetches key from the Supabase database.
@@ -45,7 +45,7 @@ export class SupabaseKeyCollector implements auth.KeyCollector {
       row = rows[0] as any;
     } catch (e) {
       if (e.message?.includes('unrecognized configuration parameter')) {
-        throw new AuthorizationError2(
+        throw new AuthorizationError(
           ErrorCode.PSYNC_S2201,
           'No JWT secret found in Supabase database. Manually configure the secret.'
         );
@@ -58,7 +58,7 @@ export class SupabaseKeyCollector implements auth.KeyCollector {
       return {
         keys: [],
         errors: [
-          new AuthorizationError2(
+          new AuthorizationError(
             ErrorCode.PSYNC_S2201,
             'No JWT secret found in Supabase database. Manually configure the secret.'
           )

--- a/packages/rsocket-router/src/router/ReactiveSocketRouter.ts
+++ b/packages/rsocket-router/src/router/ReactiveSocketRouter.ts
@@ -72,7 +72,7 @@ export class ReactiveSocketRouter<C> {
           // Throwing an exception in this context will be returned to the client side request
           if (!payload.metadata) {
             // Meta data is required for endpoint handler path matching
-            throw new errors.AuthorizationError('No context meta data provided');
+            throw new errors.AuthorizationError(ErrorCode.PSYNC_S2101, 'No context meta data provided');
           }
 
           const context = await params.contextProvider(payload.metadata!);
@@ -167,7 +167,7 @@ export async function handleReactiveStream<Context>(
     });
     if (!isAuthorized.authorized) {
       return exitWithError(
-        isAuthorized.error ?? new errors.AuthorizationError2(ErrorCode.PSYNC_S2101, 'Authorization failed')
+        isAuthorized.error ?? new errors.AuthorizationError(ErrorCode.PSYNC_S2101, 'Authorization failed')
       );
     }
   }

--- a/packages/rsocket-router/src/router/ReactiveSocketRouter.ts
+++ b/packages/rsocket-router/src/router/ReactiveSocketRouter.ts
@@ -3,7 +3,7 @@
  * to expose reactive websocket stream in an interface similar to
  * other Journey micro routers.
  */
-import { errors, logger } from '@powersync/lib-services-framework';
+import { ErrorCode, errors, logger } from '@powersync/lib-services-framework';
 import * as http from 'http';
 import { Payload, RSocketServer } from 'rsocket-core';
 import * as ws from 'ws';
@@ -166,7 +166,9 @@ export async function handleReactiveStream<Context>(
       responder
     });
     if (!isAuthorized.authorized) {
-      return exitWithError(new errors.AuthorizationError(isAuthorized.errors));
+      return exitWithError(
+        isAuthorized.error ?? new errors.AuthorizationError2(ErrorCode.PSYNC_S2101, 'Authorization failed')
+      );
     }
   }
 

--- a/packages/service-core/src/auth/CachedKeyCollector.ts
+++ b/packages/service-core/src/auth/CachedKeyCollector.ts
@@ -3,6 +3,8 @@ import timers from 'timers/promises';
 import { KeySpec } from './KeySpec.js';
 import { LeakyBucket } from './LeakyBucket.js';
 import { KeyCollector, KeyResult } from './KeyCollector.js';
+import { AuthorizationError2 } from '@powersync/lib-services-framework';
+import { mapAuthConfigError } from './utils.js';
 
 /**
  * Manages caching and refreshing for a key collector.
@@ -39,7 +41,7 @@ export class CachedKeyCollector implements KeyCollector {
    */
   private keyExpiry = 3600000;
 
-  private currentErrors: jose.errors.JOSEError[] = [];
+  private currentErrors: AuthorizationError2[] = [];
   /**
    * Indicates a "fatal" error that should be retried.
    */
@@ -103,11 +105,7 @@ export class CachedKeyCollector implements KeyCollector {
     } catch (e) {
       this.error = true;
       // No result - keep previous keys
-      if (e instanceof jose.errors.JOSEError) {
-        this.currentErrors = [e];
-      } else {
-        this.currentErrors = [new jose.errors.JOSEError(e.message ?? 'Failed to fetch keys')];
-      }
+      this.currentErrors = [mapAuthConfigError(e)];
     }
   }
 

--- a/packages/service-core/src/auth/CachedKeyCollector.ts
+++ b/packages/service-core/src/auth/CachedKeyCollector.ts
@@ -3,7 +3,7 @@ import timers from 'timers/promises';
 import { KeySpec } from './KeySpec.js';
 import { LeakyBucket } from './LeakyBucket.js';
 import { KeyCollector, KeyResult } from './KeyCollector.js';
-import { AuthorizationError2 } from '@powersync/lib-services-framework';
+import { AuthorizationError } from '@powersync/lib-services-framework';
 import { mapAuthConfigError } from './utils.js';
 
 /**
@@ -41,7 +41,7 @@ export class CachedKeyCollector implements KeyCollector {
    */
   private keyExpiry = 3600000;
 
-  private currentErrors: AuthorizationError2[] = [];
+  private currentErrors: AuthorizationError[] = [];
   /**
    * Indicates a "fatal" error that should be retried.
    */

--- a/packages/service-core/src/auth/CompoundKeyCollector.ts
+++ b/packages/service-core/src/auth/CompoundKeyCollector.ts
@@ -1,6 +1,7 @@
 import * as jose from 'jose';
 import { KeySpec } from './KeySpec.js';
 import { KeyCollector, KeyResult } from './KeyCollector.js';
+import { AuthorizationError2 } from '@powersync/lib-services-framework';
 
 export class CompoundKeyCollector implements KeyCollector {
   private collectors: KeyCollector[];
@@ -15,7 +16,7 @@ export class CompoundKeyCollector implements KeyCollector {
 
   async getKeys(): Promise<KeyResult> {
     let keys: KeySpec[] = [];
-    let errors: jose.errors.JOSEError[] = [];
+    let errors: AuthorizationError2[] = [];
     const promises = this.collectors.map((collector) =>
       collector.getKeys().then((result) => {
         keys.push(...result.keys);

--- a/packages/service-core/src/auth/CompoundKeyCollector.ts
+++ b/packages/service-core/src/auth/CompoundKeyCollector.ts
@@ -1,7 +1,7 @@
 import * as jose from 'jose';
 import { KeySpec } from './KeySpec.js';
 import { KeyCollector, KeyResult } from './KeyCollector.js';
-import { AuthorizationError2 } from '@powersync/lib-services-framework';
+import { AuthorizationError } from '@powersync/lib-services-framework';
 
 export class CompoundKeyCollector implements KeyCollector {
   private collectors: KeyCollector[];
@@ -16,7 +16,7 @@ export class CompoundKeyCollector implements KeyCollector {
 
   async getKeys(): Promise<KeyResult> {
     let keys: KeySpec[] = [];
-    let errors: AuthorizationError2[] = [];
+    let errors: AuthorizationError[] = [];
     const promises = this.collectors.map((collector) =>
       collector.getKeys().then((result) => {
         keys.push(...result.keys);

--- a/packages/service-core/src/auth/KeyCollector.ts
+++ b/packages/service-core/src/auth/KeyCollector.ts
@@ -1,4 +1,4 @@
-import { AuthorizationError2 } from '@powersync/lib-services-framework';
+import { AuthorizationError } from '@powersync/lib-services-framework';
 import { KeySpec } from './KeySpec.js';
 
 export interface KeyCollector {
@@ -22,6 +22,6 @@ export interface KeyCollector {
 }
 
 export interface KeyResult {
-  errors: AuthorizationError2[];
+  errors: AuthorizationError[];
   keys: KeySpec[];
 }

--- a/packages/service-core/src/auth/KeyCollector.ts
+++ b/packages/service-core/src/auth/KeyCollector.ts
@@ -1,4 +1,4 @@
-import * as jose from 'jose';
+import { AuthorizationError2 } from '@powersync/lib-services-framework';
 import { KeySpec } from './KeySpec.js';
 
 export interface KeyCollector {
@@ -22,6 +22,6 @@ export interface KeyCollector {
 }
 
 export interface KeyResult {
-  errors: jose.errors.JOSEError[];
+  errors: AuthorizationError2[];
   keys: KeySpec[];
 }

--- a/packages/service-core/src/auth/KeyStore.ts
+++ b/packages/service-core/src/auth/KeyStore.ts
@@ -1,4 +1,4 @@
-import { logger } from '@powersync/lib-services-framework';
+import { logger, errors, AuthorizationError2, ErrorCode } from '@powersync/lib-services-framework';
 import * as jose from 'jose';
 import secs from '../util/secs.js';
 import { JwtPayload } from './JwtPayload.js';
@@ -69,7 +69,11 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
         return audiences.includes(a);
       })
     ) {
-      throw new jose.errors.JWTClaimValidationFailed('unexpected "aud" claim value', 'aud', 'check_failed');
+      throw new AuthorizationError2(
+        ErrorCode.PSYNC_S2105,
+        `Unexpected "aud" claim value: ${JSON.stringify(tokenPayload.aud)}`,
+        { sensitiveDetails: `Current configuration allows these audience values: ${JSON.stringify(audiences)}` }
+      );
     }
 
     const tokenDuration = tokenPayload.exp! - tokenPayload.iat!;
@@ -78,12 +82,15 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
     // is too far into the future.
     const maxAge = keyOptions.maxLifetimeSeconds ?? secs(options.maxAge);
     if (tokenDuration > maxAge) {
-      throw new jose.errors.JWTInvalid(`Token must expire in a maximum of ${maxAge} seconds, got ${tokenDuration}`);
+      throw new AuthorizationError2(
+        ErrorCode.PSYNC_S2104,
+        `Token must expire in a maximum of ${maxAge} seconds, got ${tokenDuration}s`
+      );
     }
 
     const parameters = tokenPayload.parameters;
     if (parameters != null && (Array.isArray(parameters) || typeof parameters != 'object')) {
-      throw new jose.errors.JWTInvalid('parameters must be an object');
+      throw new AuthorizationError2(ErrorCode.PSYNC_S2101, `Payload parameters must be an object`);
     }
 
     return tokenPayload as JwtPayload;
@@ -112,7 +119,9 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
       for (let key of keys) {
         if (key.kid == kid) {
           if (!key.matchesAlgorithm(header.alg)) {
-            throw new jose.errors.JOSEAlgNotAllowed(`Unexpected token algorithm ${header.alg}`);
+            throw new AuthorizationError2(ErrorCode.PSYNC_S2101, `Unexpected token algorithm ${header.alg}`, {
+              sensitiveDetails: `Key kid: ${key.source.kid}, alg: ${key.source.alg}, kty: ${key.source.kty}`
+            });
           }
           return key;
         }
@@ -145,8 +154,12 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
         logger.error(`Failed to refresh keys`, e);
       });
 
-      throw new jose.errors.JOSEError(
-        'Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID'
+      throw new AuthorizationError2(
+        ErrorCode.PSYNC_S2101,
+        'Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID',
+        {
+          sensitiveDetails: `Token kid: ${kid}, token algorithm: ${header.alg}, known kid values: ${keys.map((key) => key.kid ?? '*').join(', ')}`
+        }
       );
     }
   }

--- a/packages/service-core/src/auth/KeyStore.ts
+++ b/packages/service-core/src/auth/KeyStore.ts
@@ -73,7 +73,7 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
       throw new AuthorizationError(
         ErrorCode.PSYNC_S2105,
         `Unexpected "aud" claim value: ${JSON.stringify(tokenPayload.aud)}`,
-        { sensitiveDetails: `Current configuration allows these audience values: ${JSON.stringify(audiences)}` }
+        { configurationDetails: `Current configuration allows these audience values: ${JSON.stringify(audiences)}` }
       );
     }
 
@@ -111,7 +111,7 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
       );
       return { result, keyOptions: keyOptions! };
     } catch (e) {
-      throw mapAuthError(e);
+      throw mapAuthError(e, token);
     }
   }
 
@@ -125,7 +125,7 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
         if (key.kid == kid) {
           if (!key.matchesAlgorithm(header.alg)) {
             throw new AuthorizationError(ErrorCode.PSYNC_S2101, `Unexpected token algorithm ${header.alg}`, {
-              sensitiveDetails: `Key kid: ${key.source.kid}, alg: ${key.source.alg}, kty: ${key.source.kty}`
+              // Token details automatically populated elsewhere
             });
           }
           return key;
@@ -163,7 +163,8 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
         ErrorCode.PSYNC_S2101,
         'Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID',
         {
-          sensitiveDetails: `Token kid: ${kid}, token algorithm: ${header.alg}, known kid values: ${keys.map((key) => key.kid ?? '*').join(', ')}`
+          configurationDetails: `Known kid values: ${keys.map((key) => key.kid ?? '*').join(', ')}`
+          // tokenDetails automatically populated later
         }
       );
     }

--- a/packages/service-core/src/auth/KeyStore.ts
+++ b/packages/service-core/src/auth/KeyStore.ts
@@ -1,4 +1,4 @@
-import { logger, errors, AuthorizationError2, ErrorCode } from '@powersync/lib-services-framework';
+import { logger, errors, AuthorizationError, ErrorCode } from '@powersync/lib-services-framework';
 import * as jose from 'jose';
 import secs from '../util/secs.js';
 import { JwtPayload } from './JwtPayload.js';
@@ -69,7 +69,7 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
         return audiences.includes(a);
       })
     ) {
-      throw new AuthorizationError2(
+      throw new AuthorizationError(
         ErrorCode.PSYNC_S2105,
         `Unexpected "aud" claim value: ${JSON.stringify(tokenPayload.aud)}`,
         { sensitiveDetails: `Current configuration allows these audience values: ${JSON.stringify(audiences)}` }
@@ -82,7 +82,7 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
     // is too far into the future.
     const maxAge = keyOptions.maxLifetimeSeconds ?? secs(options.maxAge);
     if (tokenDuration > maxAge) {
-      throw new AuthorizationError2(
+      throw new AuthorizationError(
         ErrorCode.PSYNC_S2104,
         `Token must expire in a maximum of ${maxAge} seconds, got ${tokenDuration}s`
       );
@@ -90,7 +90,7 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
 
     const parameters = tokenPayload.parameters;
     if (parameters != null && (Array.isArray(parameters) || typeof parameters != 'object')) {
-      throw new AuthorizationError2(ErrorCode.PSYNC_S2101, `Payload parameters must be an object`);
+      throw new AuthorizationError(ErrorCode.PSYNC_S2101, `Payload parameters must be an object`);
     }
 
     return tokenPayload as JwtPayload;
@@ -119,7 +119,7 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
       for (let key of keys) {
         if (key.kid == kid) {
           if (!key.matchesAlgorithm(header.alg)) {
-            throw new AuthorizationError2(ErrorCode.PSYNC_S2101, `Unexpected token algorithm ${header.alg}`, {
+            throw new AuthorizationError(ErrorCode.PSYNC_S2101, `Unexpected token algorithm ${header.alg}`, {
               sensitiveDetails: `Key kid: ${key.source.kid}, alg: ${key.source.alg}, kty: ${key.source.kty}`
             });
           }
@@ -154,7 +154,7 @@ export class KeyStore<Collector extends KeyCollector = KeyCollector> {
         logger.error(`Failed to refresh keys`, e);
       });
 
-      throw new AuthorizationError2(
+      throw new AuthorizationError(
         ErrorCode.PSYNC_S2101,
         'Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID',
         {

--- a/packages/service-core/src/auth/RemoteJWKSCollector.ts
+++ b/packages/service-core/src/auth/RemoteJWKSCollector.ts
@@ -4,7 +4,7 @@ import * as jose from 'jose';
 import fetch from 'node-fetch';
 
 import {
-  AuthorizationError2,
+  AuthorizationError,
   ErrorCode,
   LookupOptions,
   makeHostnameLookupFunction,
@@ -63,7 +63,7 @@ export class RemoteJWKSCollector implements KeyCollector {
     });
 
     if (!res.ok) {
-      throw new AuthorizationError2(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
+      throw new AuthorizationError(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
         sensitiveDetails: `JWKS URL: ${this.url}`
       });
     }
@@ -81,7 +81,7 @@ export class RemoteJWKSCollector implements KeyCollector {
       return {
         keys: [],
         errors: [
-          new AuthorizationError2(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
+          new AuthorizationError(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
             sensitiveDetails: `JWKS URL: ${this.url}. Response:\n${JSON.stringify(data, null, 2)}`
           })
         ]

--- a/packages/service-core/src/auth/RemoteJWKSCollector.ts
+++ b/packages/service-core/src/auth/RemoteJWKSCollector.ts
@@ -64,7 +64,7 @@ export class RemoteJWKSCollector implements KeyCollector {
 
     if (!res.ok) {
       throw new AuthorizationError(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
-        sensitiveDetails: `JWKS URL: ${this.url}`
+        configurationDetails: `JWKS URL: ${this.url}`
       });
     }
 
@@ -82,7 +82,7 @@ export class RemoteJWKSCollector implements KeyCollector {
         keys: [],
         errors: [
           new AuthorizationError(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
-            sensitiveDetails: `JWKS URL: ${this.url}. Response:\n${JSON.stringify(data, null, 2)}`
+            configurationDetails: `JWKS URL: ${this.url}. Response:\n${JSON.stringify(data, null, 2)}`
           })
         ]
       };

--- a/packages/service-core/src/auth/RemoteJWKSCollector.ts
+++ b/packages/service-core/src/auth/RemoteJWKSCollector.ts
@@ -47,30 +47,43 @@ export class RemoteJWKSCollector implements KeyCollector {
     this.agent = this.resolveAgent();
   }
 
-  async getKeys(): Promise<KeyResult> {
+  private async getJwksData(): Promise<any> {
     const abortController = new AbortController();
     const timeout = setTimeout(() => {
       abortController.abort();
     }, 30_000);
 
-    const res = await fetch(this.url, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json'
-      },
-      signal: abortController.signal,
-      agent: this.agent
-    });
-
-    if (!res.ok) {
-      throw new AuthorizationError(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
-        configurationDetails: `JWKS URL: ${this.url}`
+    try {
+      const res = await fetch(this.url, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json'
+        },
+        signal: abortController.signal,
+        agent: this.agent
       });
+
+      if (!res.ok) {
+        throw new AuthorizationError(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
+          configurationDetails: `JWKS URL: ${this.url}`
+        });
+      }
+
+      return (await res.json()) as any;
+    } catch (e) {
+      throw new AuthorizationError(ErrorCode.PSYNC_S2204, `JWKS request failed`, {
+        configurationDetails: `JWKS URL: ${this.url}`,
+        // This covers most cases of FetchError
+        // `cause: e` could lose the error message
+        cause: { message: e.message, code: e.code }
+      });
+    } finally {
+      clearTimeout(timeout);
     }
+  }
 
-    const data = (await res.json()) as any;
-
-    clearTimeout(timeout);
+  async getKeys(): Promise<KeyResult> {
+    const data = await this.getJwksData();
 
     // https://github.com/panva/jose/blob/358e864a0cccf1e0f9928a959f91f18f3f06a7de/src/jwks/local.ts#L36
     if (
@@ -81,7 +94,7 @@ export class RemoteJWKSCollector implements KeyCollector {
       return {
         keys: [],
         errors: [
-          new AuthorizationError(ErrorCode.PSYNC_S2204, `JWKS request failed with ${res.statusText}`, {
+          new AuthorizationError(ErrorCode.PSYNC_S2204, `Invalid JWKS response`, {
             configurationDetails: `JWKS URL: ${this.url}. Response:\n${JSON.stringify(data, null, 2)}`
           })
         ]

--- a/packages/service-core/src/auth/auth-index.ts
+++ b/packages/service-core/src/auth/auth-index.ts
@@ -8,3 +8,4 @@ export * from './LeakyBucket.js';
 export * from './RemoteJWKSCollector.js';
 export * from './StaticKeyCollector.js';
 export * from './StaticSupabaseKeyCollector.js';
+export * from './utils.js';

--- a/packages/service-core/src/auth/utils.ts
+++ b/packages/service-core/src/auth/utils.ts
@@ -3,10 +3,20 @@ import * as jose from 'jose';
 
 export function mapJoseError(error: jose.errors.JOSEError): AuthorizationError {
   // TODO: improved message for exp issues, etc
-  if (error.code === 'ERR_JWS_INVALID' || error.code === 'ERR_JWT_INVALID') {
+  if (error.code === jose.errors.JWSInvalid.code || error.code === jose.errors.JWTInvalid.code) {
     throw new AuthorizationError(ErrorCode.PSYNC_S2101, 'Token is not a well-formed JWT. Check the token format.', {
       details: error.message
     });
+  } else if (error.code === jose.errors.JWTClaimValidationFailed.code) {
+    // Example: missing required "sub" claim
+    const claim = (error as jose.errors.JWTClaimValidationFailed).claim;
+    throw new AuthorizationError(
+      ErrorCode.PSYNC_S2101,
+      `JWT payload is missing a required claim ${JSON.stringify(claim)}`,
+      {
+        cause: error
+      }
+    );
   }
   return new AuthorizationError(ErrorCode.PSYNC_S2101, error.message, { cause: error });
 }
@@ -21,7 +31,7 @@ export function mapAuthError(error: any): AuthorizationError {
 }
 
 export function mapJoseConfigError(error: jose.errors.JOSEError): AuthorizationError {
-  return new AuthorizationError(ErrorCode.PSYNC_S2201, error.message, { cause: error });
+  return new AuthorizationError(ErrorCode.PSYNC_S2201, error.message ?? 'Authorization error', { cause: error });
 }
 
 export function mapAuthConfigError(error: any): AuthorizationError {
@@ -30,5 +40,5 @@ export function mapAuthConfigError(error: any): AuthorizationError {
   } else if (error instanceof jose.errors.JOSEError) {
     return mapJoseConfigError(error);
   }
-  return new AuthorizationError(ErrorCode.PSYNC_S2201, error.message, { cause: error });
+  return new AuthorizationError(ErrorCode.PSYNC_S2201, error.message ?? 'Auth configuration error', { cause: error });
 }

--- a/packages/service-core/src/auth/utils.ts
+++ b/packages/service-core/src/auth/utils.ts
@@ -1,34 +1,34 @@
-import { AuthorizationError2, ErrorCode } from '@powersync/lib-services-framework';
+import { AuthorizationError, ErrorCode } from '@powersync/lib-services-framework';
 import * as jose from 'jose';
 
-export function mapJoseError(error: jose.errors.JOSEError): AuthorizationError2 {
+export function mapJoseError(error: jose.errors.JOSEError): AuthorizationError {
   // TODO: improved message for exp issues, etc
   if (error.code === 'ERR_JWS_INVALID' || error.code === 'ERR_JWT_INVALID') {
-    throw new AuthorizationError2(ErrorCode.PSYNC_S2101, 'Token is not a well-formed JWT. Check the token format.', {
+    throw new AuthorizationError(ErrorCode.PSYNC_S2101, 'Token is not a well-formed JWT. Check the token format.', {
       details: error.message
     });
   }
-  return new AuthorizationError2(ErrorCode.PSYNC_S2101, error.message, { cause: error });
+  return new AuthorizationError(ErrorCode.PSYNC_S2101, error.message, { cause: error });
 }
 
-export function mapAuthError(error: any): AuthorizationError2 {
-  if (error instanceof AuthorizationError2) {
+export function mapAuthError(error: any): AuthorizationError {
+  if (error instanceof AuthorizationError) {
     return error;
   } else if (error instanceof jose.errors.JOSEError) {
     return mapJoseError(error);
   }
-  return new AuthorizationError2(ErrorCode.PSYNC_S2101, error.message, { cause: error });
+  return new AuthorizationError(ErrorCode.PSYNC_S2101, error.message, { cause: error });
 }
 
-export function mapJoseConfigError(error: jose.errors.JOSEError): AuthorizationError2 {
-  return new AuthorizationError2(ErrorCode.PSYNC_S2201, error.message, { cause: error });
+export function mapJoseConfigError(error: jose.errors.JOSEError): AuthorizationError {
+  return new AuthorizationError(ErrorCode.PSYNC_S2201, error.message, { cause: error });
 }
 
-export function mapAuthConfigError(error: any): AuthorizationError2 {
-  if (error instanceof AuthorizationError2) {
+export function mapAuthConfigError(error: any): AuthorizationError {
+  if (error instanceof AuthorizationError) {
     return error;
   } else if (error instanceof jose.errors.JOSEError) {
     return mapJoseConfigError(error);
   }
-  return new AuthorizationError2(ErrorCode.PSYNC_S2201, error.message, { cause: error });
+  return new AuthorizationError(ErrorCode.PSYNC_S2201, error.message, { cause: error });
 }

--- a/packages/service-core/src/auth/utils.ts
+++ b/packages/service-core/src/auth/utils.ts
@@ -1,33 +1,45 @@
 import { AuthorizationError, ErrorCode } from '@powersync/lib-services-framework';
 import * as jose from 'jose';
 
-export function mapJoseError(error: jose.errors.JOSEError): AuthorizationError {
-  // TODO: improved message for exp issues, etc
+export function mapJoseError(error: jose.errors.JOSEError, token: string): AuthorizationError {
+  const tokenDetails = tokenDebugDetails(token);
   if (error.code === jose.errors.JWSInvalid.code || error.code === jose.errors.JWTInvalid.code) {
-    throw new AuthorizationError(ErrorCode.PSYNC_S2101, 'Token is not a well-formed JWT. Check the token format.', {
-      details: error.message
+    return new AuthorizationError(ErrorCode.PSYNC_S2101, 'Token is not a well-formed JWT. Check the token format.', {
+      tokenDetails,
+      cause: error
     });
   } else if (error.code === jose.errors.JWTClaimValidationFailed.code) {
-    // Example: missing required "sub" claim
+    // Jose message: missing required "sub" claim
     const claim = (error as jose.errors.JWTClaimValidationFailed).claim;
-    throw new AuthorizationError(
+    return new AuthorizationError(
       ErrorCode.PSYNC_S2101,
       `JWT payload is missing a required claim ${JSON.stringify(claim)}`,
       {
-        cause: error
+        cause: error,
+        tokenDetails
       }
     );
+  } else if (error.code == jose.errors.JWTExpired.code) {
+    // Jose message: "exp" claim timestamp check failed
+    return new AuthorizationError(ErrorCode.PSYNC_S2103, `JWT has expired`, {
+      cause: error,
+      tokenDetails
+    });
   }
   return new AuthorizationError(ErrorCode.PSYNC_S2101, error.message, { cause: error });
 }
 
-export function mapAuthError(error: any): AuthorizationError {
+export function mapAuthError(error: any, token: string): AuthorizationError {
   if (error instanceof AuthorizationError) {
+    error.tokenDetails ??= tokenDebugDetails(token);
     return error;
   } else if (error instanceof jose.errors.JOSEError) {
-    return mapJoseError(error);
+    return mapJoseError(error, token);
   }
-  return new AuthorizationError(ErrorCode.PSYNC_S2101, error.message, { cause: error });
+  return new AuthorizationError(ErrorCode.PSYNC_S2101, error.message, {
+    cause: error,
+    tokenDetails: tokenDebugDetails(token)
+  });
 }
 
 export function mapJoseConfigError(error: jose.errors.JOSEError): AuthorizationError {
@@ -41,4 +53,50 @@ export function mapAuthConfigError(error: any): AuthorizationError {
     return mapJoseConfigError(error);
   }
   return new AuthorizationError(ErrorCode.PSYNC_S2201, error.message ?? 'Auth configuration error', { cause: error });
+}
+
+/**
+ * Decode token for debugging purposes.
+ *
+ * We use this to add details to our logs. We don't log the entire token, since it may for example
+ * a password incorrectly used as a token.
+ */
+function tokenDebugDetails(token: string): string {
+  try {
+    // For valid tokens, we return the header and payload
+    const header = jose.decodeProtectedHeader(token);
+    const payload = jose.decodeJwt(token);
+    return `<header: ${JSON.stringify(header)} payload: ${JSON.stringify(payload)}>`;
+  } catch (e) {
+    // Token fails to parse. Return some details.
+    return invalidTokenDetails(token);
+  }
+}
+
+function invalidTokenDetails(token: string): string {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return `<token with ${parts.length} parts (needs 3), length=${token.length}>`;
+  }
+
+  const [headerB64, payloadB64, signatureB64] = parts;
+
+  try {
+    JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf8'));
+  } catch (e) {
+    return `<token with unparsable header>`;
+  }
+
+  try {
+    JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+  } catch (e) {
+    return `<token with unparsable payload>`;
+  }
+  try {
+    Buffer.from(signatureB64, 'base64url');
+  } catch (e) {
+    return `<token with unparsable signature>`;
+  }
+
+  return `<invalid JWT, length=${token.length}>`;
 }

--- a/packages/service-core/src/auth/utils.ts
+++ b/packages/service-core/src/auth/utils.ts
@@ -1,0 +1,34 @@
+import { AuthorizationError2, ErrorCode } from '@powersync/lib-services-framework';
+import * as jose from 'jose';
+
+export function mapJoseError(error: jose.errors.JOSEError): AuthorizationError2 {
+  // TODO: improved message for exp issues, etc
+  if (error.code === 'ERR_JWS_INVALID' || error.code === 'ERR_JWT_INVALID') {
+    throw new AuthorizationError2(ErrorCode.PSYNC_S2101, 'Token is not a well-formed JWT. Check the token format.', {
+      details: error.message
+    });
+  }
+  return new AuthorizationError2(ErrorCode.PSYNC_S2101, error.message, { cause: error });
+}
+
+export function mapAuthError(error: any): AuthorizationError2 {
+  if (error instanceof AuthorizationError2) {
+    return error;
+  } else if (error instanceof jose.errors.JOSEError) {
+    return mapJoseError(error);
+  }
+  return new AuthorizationError2(ErrorCode.PSYNC_S2101, error.message, { cause: error });
+}
+
+export function mapJoseConfigError(error: jose.errors.JOSEError): AuthorizationError2 {
+  return new AuthorizationError2(ErrorCode.PSYNC_S2201, error.message, { cause: error });
+}
+
+export function mapAuthConfigError(error: any): AuthorizationError2 {
+  if (error instanceof AuthorizationError2) {
+    return error;
+  } else if (error instanceof jose.errors.JOSEError) {
+    return mapJoseConfigError(error);
+  }
+  return new AuthorizationError2(ErrorCode.PSYNC_S2201, error.message, { cause: error });
+}

--- a/packages/service-core/src/routes/auth.ts
+++ b/packages/service-core/src/routes/auth.ts
@@ -141,7 +141,7 @@ export async function generateContext(serviceContext: ServiceContext, token: str
   } catch (err) {
     return {
       context: null,
-      tokenError: auth.mapAuthError(err)
+      tokenError: auth.mapAuthError(err, token)
     };
   }
 }

--- a/packages/service-core/src/routes/auth.ts
+++ b/packages/service-core/src/routes/auth.ts
@@ -4,7 +4,7 @@ import * as auth from '../auth/auth-index.js';
 import { ServiceContext } from '../system/ServiceContext.js';
 import * as util from '../util/util-index.js';
 import { BasicRouterRequest, Context, RequestEndpointHandlerPayload } from './router.js';
-import { AuthorizationError2, AuthorizationResponse, ErrorCode, ServiceError } from '@powersync/lib-services-framework';
+import { AuthorizationError, AuthorizationResponse, ErrorCode, ServiceError } from '@powersync/lib-services-framework';
 
 export function endpoint(req: BasicRouterRequest) {
   const protocol = req.headers['x-forwarded-proto'] ?? req.protocol;
@@ -105,7 +105,7 @@ export async function authorizeUser(context: Context, authHeader: string = ''): 
   if (token == null) {
     return {
       authorized: false,
-      error: new AuthorizationError2(ErrorCode.PSYNC_S2106, 'Authentication required')
+      error: new AuthorizationError(ErrorCode.PSYNC_S2106, 'Authentication required')
     };
   }
 

--- a/packages/service-core/src/routes/auth.ts
+++ b/packages/service-core/src/routes/auth.ts
@@ -105,7 +105,7 @@ export async function authorizeUser(context: Context, authHeader: string = ''): 
   if (token == null) {
     return {
       authorized: false,
-      error: new AuthorizationError2(ErrorCode.PSYNC_S2115, 'Authentication required')
+      error: new AuthorizationError2(ErrorCode.PSYNC_S2106, 'Authentication required')
     };
   }
 
@@ -139,20 +139,10 @@ export async function generateContext(serviceContext: ServiceContext, token: str
       }
     };
   } catch (err) {
-    if (err instanceof ServiceError) {
-      return {
-        context: null,
-        tokenError: err
-      };
-    } else {
-      return {
-        context: null,
-        tokenError: new AuthorizationError2(ErrorCode.PSYNC_S2101, 'Authentication error', {
-          details: err.message,
-          cause: err
-        })
-      };
-    }
+    return {
+      context: null,
+      tokenError: auth.mapAuthError(err)
+    };
   }
 }
 

--- a/packages/service-core/src/routes/auth.ts
+++ b/packages/service-core/src/routes/auth.ts
@@ -4,6 +4,7 @@ import * as auth from '../auth/auth-index.js';
 import { ServiceContext } from '../system/ServiceContext.js';
 import * as util from '../util/util-index.js';
 import { BasicRouterRequest, Context, RequestEndpointHandlerPayload } from './router.js';
+import { AuthorizationError2, AuthorizationResponse, ErrorCode, ServiceError } from '@powersync/lib-services-framework';
 
 export function endpoint(req: BasicRouterRequest) {
   const protocol = req.headers['x-forwarded-proto'] ?? req.protocol;
@@ -95,25 +96,25 @@ export function getTokenFromHeader(authHeader: string = ''): string | null {
   return token ?? null;
 }
 
-export const authUser = async (payload: RequestEndpointHandlerPayload) => {
+export const authUser = async (payload: RequestEndpointHandlerPayload): Promise<AuthorizationResponse> => {
   return authorizeUser(payload.context, payload.request.headers.authorization as string);
 };
 
-export async function authorizeUser(context: Context, authHeader: string = '') {
+export async function authorizeUser(context: Context, authHeader: string = ''): Promise<AuthorizationResponse> {
   const token = getTokenFromHeader(authHeader);
   if (token == null) {
     return {
       authorized: false,
-      errors: ['Authentication required']
+      error: new AuthorizationError2(ErrorCode.PSYNC_S2115, 'Authentication required')
     };
   }
 
-  const { context: tokenContext, errors } = await generateContext(context.service_context, token);
+  const { context: tokenContext, tokenError } = await generateContext(context.service_context, token);
 
   if (!tokenContext) {
     return {
       authorized: false,
-      errors
+      error: tokenError
     };
   }
 
@@ -138,10 +139,20 @@ export async function generateContext(serviceContext: ServiceContext, token: str
       }
     };
   } catch (err) {
-    return {
-      context: null,
-      errors: [err.message]
-    };
+    if (err instanceof ServiceError) {
+      return {
+        context: null,
+        tokenError: err
+      };
+    } else {
+      return {
+        context: null,
+        tokenError: new AuthorizationError2(ErrorCode.PSYNC_S2101, 'Authentication error', {
+          details: err.message,
+          cause: err
+        })
+      };
+    }
   }
 }
 

--- a/packages/service-core/src/routes/configure-rsocket.ts
+++ b/packages/service-core/src/routes/configure-rsocket.ts
@@ -26,7 +26,7 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
       const { token, user_agent } = RSocketContextMeta.decode(deserialize(data) as any);
 
       if (!token) {
-        throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2115, 'No token provided');
+        throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2106, 'No token provided');
       }
 
       try {
@@ -34,7 +34,7 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
         if (extracted_token != null) {
           const { context, tokenError } = await generateContext(options.service_context, extracted_token);
           if (context?.token_payload == null) {
-            throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2115, 'Authentication required');
+            throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2106, 'Authentication required');
           }
 
           if (!service_context.routerEngine) {
@@ -50,7 +50,7 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
           };
         } else {
           // Token field is present, but did not contain a token.
-          throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2115, 'No valid token provided');
+          throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2106, 'No valid token provided');
         }
       } catch (ex) {
         logger.error(ex);

--- a/packages/service-core/src/routes/configure-rsocket.ts
+++ b/packages/service-core/src/routes/configure-rsocket.ts
@@ -26,7 +26,7 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
       const { token, user_agent } = RSocketContextMeta.decode(deserialize(data) as any);
 
       if (!token) {
-        throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2106, 'No token provided');
+        throw new errors.AuthorizationError(ErrorCode.PSYNC_S2106, 'No token provided');
       }
 
       try {
@@ -34,7 +34,7 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
         if (extracted_token != null) {
           const { context, tokenError } = await generateContext(options.service_context, extracted_token);
           if (context?.token_payload == null) {
-            throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2106, 'Authentication required');
+            throw new errors.AuthorizationError(ErrorCode.PSYNC_S2106, 'Authentication required');
           }
 
           if (!service_context.routerEngine) {
@@ -50,7 +50,7 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
           };
         } else {
           // Token field is present, but did not contain a token.
-          throw new errors.AuthorizationError2(ErrorCode.PSYNC_S2106, 'No valid token provided');
+          throw new errors.AuthorizationError(ErrorCode.PSYNC_S2106, 'No valid token provided');
         }
       } catch (ex) {
         logger.error(ex);

--- a/packages/service-core/src/routes/router.ts
+++ b/packages/service-core/src/routes/router.ts
@@ -1,4 +1,4 @@
-import { router } from '@powersync/lib-services-framework';
+import { router, ServiceError } from '@powersync/lib-services-framework';
 import type { JwtPayload } from '../auth/auth-index.js';
 import { ServiceContext } from '../system/ServiceContext.js';
 import { RouterEngine } from './RouterEngine.js';
@@ -16,7 +16,7 @@ export type Context = {
   service_context: RouterServiceContext;
 
   token_payload?: JwtPayload;
-  token_errors?: string[];
+  token_error?: ServiceError;
   /**
    * Only on websocket endpoints.
    */

--- a/packages/service-core/test/src/auth.test.ts
+++ b/packages/service-core/test/src/auth.test.ts
@@ -308,7 +308,7 @@ describe('JWT Auth', () => {
         reject_ip_ranges: ['local']
       }
     });
-    await expect(invalid.getKeys()).rejects.toThrow('IPs in this range are not supported');
+    await expect(invalid.getKeys()).rejects.toThrow('[PSYNC_S2204] JWKS request failed');
 
     // IPs throw an error immediately
     expect(

--- a/packages/service-core/test/src/auth.test.ts
+++ b/packages/service-core/test/src/auth.test.ts
@@ -75,21 +75,21 @@ describe('JWT Auth', () => {
         defaultAudiences: ['other'],
         maxAge: '6m'
       })
-    ).rejects.toThrow('unexpected "aud" claim value');
+    ).rejects.toThrow('[PSYNC_S2105] Unexpected "aud" claim value: "tests"');
 
     await expect(
       store.verifyJwt(signedJwt, {
         defaultAudiences: [],
         maxAge: '6m'
       })
-    ).rejects.toThrow('unexpected "aud" claim value');
+    ).rejects.toThrow('[PSYNC_S2105] Unexpected "aud" claim value: "tests"');
 
     await expect(
       store.verifyJwt(signedJwt, {
         defaultAudiences: ['tests'],
         maxAge: '1m'
       })
-    ).rejects.toThrow('Token must expire in a maximum of');
+    ).rejects.toThrow('[PSYNC_S2104] Token must expire in a maximum of 60 seconds, got 300s');
 
     const signedJwt2 = await new jose.SignJWT({})
       .setProtectedHeader({ alg: 'HS256', kid: 'k1' })
@@ -104,7 +104,7 @@ describe('JWT Auth', () => {
         defaultAudiences: ['tests'],
         maxAge: '5m'
       })
-    ).rejects.toThrow('missing required "sub" claim');
+    ).rejects.toThrow('[PSYNC_S2101] JWT payload is missing a required claim "sub"');
   });
 
   test('Algorithm validation', async () => {
@@ -159,7 +159,7 @@ describe('JWT Auth', () => {
         maxAge: '6m'
       })
     ).rejects.toThrow(
-      'Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID'
+      '[PSYNC_S2101] Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID'
     );
 
     // Wrong kid
@@ -178,7 +178,7 @@ describe('JWT Auth', () => {
         maxAge: '6m'
       })
     ).rejects.toThrow(
-      'Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID'
+      '[PSYNC_S2101] Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID'
     );
 
     // No kid, matches sharedKey2
@@ -255,7 +255,7 @@ describe('JWT Auth', () => {
         defaultAudiences: ['tests'],
         maxAge: '6m'
       })
-    ).rejects.toThrow('unexpected "aud" claim value');
+    ).rejects.toThrow('[PSYNC_S2105] Unexpected "aud" claim value: "tests"');
 
     const signedJwt3 = await new jose.SignJWT({})
       .setProtectedHeader({ alg: 'HS256', kid: 'k1' })
@@ -345,7 +345,7 @@ describe('JWT Auth', () => {
     expect(key.kid).toEqual(publicKeyRSA.kid!);
 
     cached.addTimeForTests(301_000);
-    currentResponse = Promise.reject('refresh failed');
+    currentResponse = Promise.reject(new Error('refresh failed'));
 
     // Uses the promise, refreshes in the background
     let response = await cached.getKeys();
@@ -356,15 +356,16 @@ describe('JWT Auth', () => {
     await cached.addTimeForTests(0);
     response = await cached.getKeys();
     // Still have the cached key, but also have the error
+    console.log('e', response.errors[0]);
     expect(response.keys[0].kid).toEqual(publicKeyRSA.kid!);
-    expect(response.errors[0].message).toMatch('Failed to fetch');
+    expect(response.errors[0].message).toMatch('[PSYNC_S2201] refresh failed');
 
     await cached.addTimeForTests(3601_000);
     response = await cached.getKeys();
 
     // Now the keys have expired, and the request still fails
     expect(response.keys).toEqual([]);
-    expect(response.errors[0].message).toMatch('Failed to fetch');
+    expect(response.errors[0].message).toMatch('[PSYNC_S2201] refresh failed');
 
     currentResponse = Promise.resolve({
       errors: [],

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -313,33 +313,38 @@ export enum ErrorCode {
    * 1. Token kid is not found in the keystore.
    * 2. Signature does not match the kid in the keystore.
    */
-  PSYNC_S2111 = 'PSYNC_S2111',
+  PSYNC_S2102 = 'PSYNC_S2102',
 
   /**
    * Token has expired. Check the expiry date on the token.
    */
-  PSYNC_S2112 = 'PSYNC_S2112',
+  PSYNC_S2103 = 'PSYNC_S2103',
 
   /**
-   * Token expiration date is too long. Issue shorter-lived tokens.
+   * Token expiration period is too long. Issue shorter-lived tokens.
    */
-  PSYNC_S2113 = 'PSYNC_S2113',
+  PSYNC_S2104 = 'PSYNC_S2104',
 
   /**
    * Token audience does not match expected values.
    *
    * Check the aud value on the token, compared to the audience values allowed in the service config.
    */
-  PSYNC_S2114 = 'PSYNC_S2114',
+  PSYNC_S2105 = 'PSYNC_S2105',
 
   /**
    * No token provided. An auth token is required for every request.
    *
    * The Auhtorization header must start with "Token" or "Bearer", followed by the JWT.
    */
-  PSYNC_S2115 = 'PSYNC_S2115',
+  PSYNC_S2106 = 'PSYNC_S2106',
 
   // ## PSYNC_S22xx: Auth integration errors
+
+  /**
+   * Generic auth configuration error. See the message for details.
+   */
+  PSYNC_S2201 = 'PSYNC_S2201',
 
   /**
    * IPv6 support is not enabled for the JWKS URI.
@@ -354,6 +359,11 @@ export enum ErrorCode {
    * Make sure to use a publically-accessible JWKS URI.
    */
   PSYNC_S2203 = 'PSYNC_S2203',
+
+  /**
+   * JWKS request failed.
+   */
+  PSYNC_S2204 = 'PSYNC_S2204',
 
   // ## PSYNC_S23xx: Sync API errors
 

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -306,6 +306,39 @@ export enum ErrorCode {
    */
   PSYNC_S2101 = 'PSYNC_S2101',
 
+  /**
+   * Could not verify the auth token signature.
+   *
+   * Typical causes include:
+   * 1. Token kid is not found in the keystore.
+   * 2. Signature does not match the kid in the keystore.
+   */
+  PSYNC_S2111 = 'PSYNC_S2111',
+
+  /**
+   * Token has expired. Check the expiry date on the token.
+   */
+  PSYNC_S2112 = 'PSYNC_S2112',
+
+  /**
+   * Token expiration date is too long. Issue shorter-lived tokens.
+   */
+  PSYNC_S2113 = 'PSYNC_S2113',
+
+  /**
+   * Token audience does not match expected values.
+   *
+   * Check the aud value on the token, compared to the audience values allowed in the service config.
+   */
+  PSYNC_S2114 = 'PSYNC_S2114',
+
+  /**
+   * No token provided. An auth token is required for every request.
+   *
+   * The Auhtorization header must start with "Token" or "Bearer", followed by the JWT.
+   */
+  PSYNC_S2115 = 'PSYNC_S2115',
+
   // ## PSYNC_S22xx: Auth integration errors
 
   /**

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -160,19 +160,6 @@ export class ReplicationAbortedError extends ServiceError {
 }
 
 export class AuthorizationError extends ServiceError {
-  static readonly CODE = ErrorCode.PSYNC_S2101;
-
-  constructor(errors: any) {
-    super({
-      code: AuthorizationError.CODE,
-      status: 401,
-      description: 'Authorization failed',
-      details: errors
-    });
-  }
-}
-
-export class AuthorizationError2 extends ServiceError {
   constructor(
     code: ErrorCode,
     description: string,

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -181,7 +181,7 @@ export class AuthorizationError extends ServiceError {
       status: 401,
       description
     });
-    this.cause = this.cause;
+    this.cause = options?.cause;
     this.tokenDetails = options?.tokenDetails;
     this.configurationDetails = options?.configurationDetails;
   }

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -172,6 +172,22 @@ export class AuthorizationError extends ServiceError {
   }
 }
 
+export class AuthorizationError2 extends ServiceError {
+  constructor(
+    code: ErrorCode,
+    description: string,
+    options?: Partial<ErrorData> & { sensitiveDetails?: string; cause?: any }
+  ) {
+    super({
+      code,
+      status: 401,
+      description,
+      ...options
+    });
+    this.cause = this.cause;
+  }
+}
+
 export class InternalServerError extends ServiceError {
   static readonly CODE = ErrorCode.PSYNC_S2001;
 

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -160,18 +160,30 @@ export class ReplicationAbortedError extends ServiceError {
 }
 
 export class AuthorizationError extends ServiceError {
+  /**
+   * String describing the token. Does not contain the full token, but may help with debugging.
+   * Safe for logs.
+   */
+  tokenDetails: string | undefined;
+  /**
+   * String describing related configuration. Should never be returned to the client.
+   * Safe for logs.
+   */
+  configurationDetails: string | undefined;
+
   constructor(
     code: ErrorCode,
     description: string,
-    options?: Partial<ErrorData> & { sensitiveDetails?: string; cause?: any }
+    options?: { tokenDetails?: string; configurationDetails?: string; cause?: any }
   ) {
     super({
       code,
       status: 401,
-      description,
-      ...options
+      description
     });
     this.cause = this.cause;
+    this.tokenDetails = options?.tokenDetails;
+    this.configurationDetails = options?.configurationDetails;
   }
 }
 


### PR DESCRIPTION
This aims to provide more useful error messages when auth fails, by:
1. Using our own error codes and messages, instead of the defaults from JOSE.
2. Add additional details on the token and/or relevant configuration in the service logs (but not the error response).

## Examples

For each example, the first line is in the error response, second line is in logs only.

In most of these examples, a big gain is having the token header and payload in the logs. In some cases, the details of the key that the token is compared to may also help. The cause in the logs also help.

```js
// unknown kid
{"code":"PSYNC_S2101","status":401,"description":"Could not find an appropriate key in the keystore. The key is missing or no key matched the token KID","name":"AuthorizationError"}
"configurationDetails":"Known kid values: powersync-dev, powersync-53b1a54716","tokenDetails":"<header: {\"alg\":\"HS256\",\"typ\":\"JWT\"} payload: {\"sub\":\"1234567890\",\"name\":\"John Doe\",\"admin\":true,\"iat\":1516239022}>"

// passing a static token instead of JWT
{"code":"PSYNC_S2101","status":401,"description":"Token is not a well-formed JWT. Check the token format.","name":"AuthorizationError"}
"tokenDetails":"<token with 1 parts (needs 3), length=4>"

// Correct kid, invalid key
{"code":"PSYNC_S2101","status":401,"description":"signature verification failed","name":"AuthorizationError"}
"tokenDetails":"<header: {\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"powersync-dev\"} payload: {\"sub\":\"1234567890\",\"name\":\"John Doe\",\"admin\":true,\"iat\":1516239022}>"

// Missing exp
{"code":"PSYNC_S2101","status":401,"description":"JWT payload is missing a required claim \"exp\"","name":"AuthorizationError"}
"tokenDetails":"<header: {\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"powersync-dev\"} payload: {\"sub\":\"1234567890\",\"name\":\"John Doe\",\"admin\":true,\"iat\":1516239022}>"

// JWT expired
{"code":"PSYNC_S2103","status":401,"description":"JWT has expired","name":"AuthorizationError"}
"tokenDetails":"<header: {\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"powersync-dev\"} payload: {\"sub\":\"1234567890\",\"name\":\"John Doe\",\"admin\":true,\"iat\":1516239022,\"exp\":1516239022}>"

// Expiry too long
{"code":"PSYNC_S2104","status":401,"description":"Token must expire in a maximum of 86400 seconds, got 230387123s","name":"AuthorizationError"}
"tokenDetails":"<header: {\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"powersync-dev\"} payload: {\"sub\":\"1234567890\",\"aud\":\"powersync-dev\",\"name\":\"John Doe\",\"admin\":true,\"iat\":1516239022,\"exp\":1746626145}>"

// Missing 'aud'
{"code":"PSYNC_S2105","status":401,"description":"JWT payload is missing a required claim \"aud\"","name":"AuthorizationError"}
"configurationDetails":"Current configuration allows these audience values: [\"powersync-dev\",\"http://localhost:8000\"]","tokenDetails":"<header: {\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"powersync-dev\"} payload: {\"sub\":\"1234567890\",\"name\":\"John Doe\",\"admin\":true,\"iat\":1516239022,\"exp\":1746626145}>"

// alg mismatch for a key
{"code":"PSYNC_S2101","status":401,"description":"Unexpected token algorithm HS256","name":"AuthorizationError"}
"configurationDetails":"Key kid: powersync-dev, alg: RS256, kty: RSA","tokenDetails":"<header: {\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"powersync-dev\"} payload: {\"sub\":\"1234567890\",\"aud\":\"powersync-dev\",\"name\":\"John Doe\",\"admin\":true,\"iat\":1746626145,\"exp\":1746626145}>"

// JWKS request error
{"code":"PSYNC_S2204","status":401,"description":"JWKS request failed","name":"AuthorizationError"}
"cause":{"code":"ECONNREFUSED","message":"request to http://localhost:8000/ failed, reason: connect ECONNREFUSED 127.0.0.1:8000"},"configurationDetails":"JWKS URL: http://localhost:8000/test","tokenDetails":"<header: {\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"powersync-devz\"} payload: {\"sub\":\"1234567890\",\"aud\":\"powersync-dev\",\"name\":\"John Doe\",\"admin\":true,\"iat\":1746626145,\"exp\":1746626145}>"

// Invalid JWKS response
{"code":"PSYNC_S2204","status":401,"description":"Invalid JWKS response","name":"AuthorizationError"}
"configurationDetails":"JWKS URL: https://powersync-api.journeyapps.com/api/v1/regions. Response:\n{\n  \"data\": {\n    \"regions\": [\n      {\n        \"name...

// JWKS IP issue
{"code":"PSYNC_S2204","status":401,"description":"JWKS request failed","name":"AuthorizationError"}
"cause":{"message":"request to http://localhost:8000/ failed, reason: [PSYNC_S2203] IPs in this range are not supported: 127.0.0.1"},"configurationDetails":"JWKS URL: http://localhost:8000/"
```

