### PR TITLE
Additional log metadata on sync requests

### DIFF
--- a/.changeset/clever-months-travel.md
+++ b/.changeset/clever-months-travel.md
@@ -1,0 +1,15 @@
+---
+'@powersync/service-rsocket-router': minor
+'@powersync/service-core': minor
+'@powersync/lib-services-framework': minor
+'@powersync/service-image': minor
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-module-postgres': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-module-mysql': patch
+'@powersync/service-sync-rules': patch
+'@powersync/lib-service-postgres': patch
+---
+
+Add additional log metadata to sync requests.

--- a/libs/lib-postgres/package.json
+++ b/libs/lib-postgres/package.json
@@ -34,9 +34,7 @@
     "p-defer": "^4.0.1",
     "ts-codec": "^1.3.0",
     "uri-js": "^4.4.1",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.0"
   },
-  "devDependencies": {
-    "@types/uuid": "^9.0.4"
-  }
+  "devDependencies": {}
 }

--- a/libs/lib-services/package.json
+++ b/libs/lib-services/package.json
@@ -28,13 +28,12 @@
     "ipaddr.js": "^2.1.0",
     "lodash": "^4.17.21",
     "ts-codec": "^1.3.0",
-    "uuid": "^9.0.1",
+    "uuid": "^11.1.0",
     "winston": "^3.13.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.5",
-    "@types/uuid": "^9.0.4",
     "vitest": "^3.0.5"
   }
 }

--- a/libs/lib-services/src/index.ts
+++ b/libs/lib-services/src/index.ts
@@ -9,7 +9,7 @@ export * from './container.js';
 export * from './errors/errors-index.js';
 export * as errors from './errors/errors-index.js';
 
-export * from './logger/Logger.js';
+export * from './logger/logger-index.js';
 
 export * from './locks/locks-index.js';
 export * as locks from './locks/locks-index.js';

--- a/libs/lib-services/src/logger/Logger.ts
+++ b/libs/lib-services/src/logger/Logger.ts
@@ -1,17 +1,14 @@
 import winston from 'winston';
 
-export namespace Logger {
-  export const development_format = winston.format.combine(
-    winston.format.colorize({ level: true }),
-    winston.format.simple()
-  );
-  export const production_format = winston.format.combine(winston.format.timestamp(), winston.format.json());
+export namespace LogFormat {
+  export const development = winston.format.combine(winston.format.colorize({ level: true }), winston.format.simple());
+  export const production = winston.format.combine(winston.format.timestamp(), winston.format.json());
 }
 
 export const logger = winston.createLogger();
 
 // Configure logging to console as the default
 logger.configure({
-  format: process.env.NODE_ENV == 'production' ? Logger.production_format : Logger.development_format,
+  format: process.env.NODE_ENV == 'production' ? LogFormat.production : LogFormat.development,
   transports: [new winston.transports.Console()]
 });

--- a/libs/lib-services/src/logger/logger-index.ts
+++ b/libs/lib-services/src/logger/logger-index.ts
@@ -1,1 +1,2 @@
 export * from './Logger.js';
+export { Logger } from 'winston';

--- a/libs/lib-services/src/router/router-response.ts
+++ b/libs/lib-services/src/router/router-response.ts
@@ -9,7 +9,7 @@ export type RouterResponseParams<T> = {
   /**
    * Hook to be called after the response has been sent
    */
-  afterSend?: () => Promise<void>;
+  afterSend?: (details: { clientClosed: boolean }) => Promise<void>;
 };
 
 /**
@@ -21,7 +21,7 @@ export class RouterResponse<T = unknown> {
   status: number;
   data: T;
   headers: Record<string, string>;
-  afterSend: () => Promise<void>;
+  afterSend: (details: { clientClosed: boolean }) => Promise<void>;
 
   __micro_router_response = true;
 

--- a/modules/module-mongodb-storage/package.json
+++ b/modules/module-mongodb-storage/package.json
@@ -28,20 +28,19 @@
     }
   },
   "dependencies": {
+    "@powersync/lib-service-mongodb": "workspace:*",
     "@powersync/lib-services-framework": "workspace:*",
     "@powersync/service-core": "workspace:*",
     "@powersync/service-jsonbig": "workspace:*",
     "@powersync/service-sync-rules": "workspace:*",
     "@powersync/service-types": "workspace:*",
-    "@powersync/lib-service-mongodb": "workspace:*",
     "bson": "^6.10.3",
-    "ts-codec": "^1.3.0",
     "ix": "^5.0.0",
     "lru-cache": "^10.2.2",
-    "uuid": "^9.0.1"
+    "ts-codec": "^1.3.0",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@types/uuid": "^9.0.4",
     "@powersync/service-core-tests": "workspace:*"
   }
 }

--- a/modules/module-mongodb/package.json
+++ b/modules/module-mongodb/package.json
@@ -28,18 +28,17 @@
     }
   },
   "dependencies": {
+    "@powersync/lib-service-mongodb": "workspace:*",
     "@powersync/lib-services-framework": "workspace:*",
     "@powersync/service-core": "workspace:*",
     "@powersync/service-jsonbig": "workspace:*",
     "@powersync/service-sync-rules": "workspace:*",
     "@powersync/service-types": "workspace:*",
-    "@powersync/lib-service-mongodb": "workspace:*",
     "bson": "^6.10.3",
     "ts-codec": "^1.3.0",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@types/uuid": "^9.0.4",
     "@powersync/service-core-tests": "workspace:*",
     "@powersync/service-module-mongodb-storage": "workspace:*",
     "@powersync/service-module-postgres-storage": "workspace:*"

--- a/modules/module-mysql/package.json
+++ b/modules/module-mysql/package.json
@@ -29,24 +29,23 @@
   },
   "dependencies": {
     "@powersync/lib-services-framework": "workspace:*",
+    "@powersync/mysql-zongji": "^0.1.0",
     "@powersync/service-core": "workspace:*",
+    "@powersync/service-jsonbig": "workspace:*",
     "@powersync/service-sync-rules": "workspace:*",
     "@powersync/service-types": "workspace:*",
-    "@powersync/service-jsonbig": "workspace:*",
-    "@powersync/mysql-zongji": "^0.1.0",
-    "semver": "^7.5.4",
     "async": "^3.2.4",
     "mysql2": "^3.11.0",
+    "semver": "^7.5.4",
     "ts-codec": "^1.3.0",
     "uri-js": "^4.4.1",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@types/semver": "^7.5.4",
-    "@types/async": "^3.2.24",
-    "@types/uuid": "^9.0.4",
     "@powersync/service-core-tests": "workspace:*",
     "@powersync/service-module-mongodb-storage": "workspace:*",
-    "@powersync/service-module-postgres-storage": "workspace:*"
+    "@powersync/service-module-postgres-storage": "workspace:*",
+    "@types/async": "^3.2.24",
+    "@types/semver": "^7.5.4"
   }
 }

--- a/modules/module-postgres-storage/package.json
+++ b/modules/module-postgres-storage/package.json
@@ -29,8 +29,8 @@
     }
   },
   "dependencies": {
-    "@powersync/lib-services-framework": "workspace:*",
     "@powersync/lib-service-postgres": "workspace:*",
+    "@powersync/lib-services-framework": "workspace:*",
     "@powersync/service-core": "workspace:*",
     "@powersync/service-core-tests": "workspace:*",
     "@powersync/service-jpgwire": "workspace:*",
@@ -41,10 +41,9 @@
     "lru-cache": "^10.2.2",
     "p-defer": "^4.0.1",
     "ts-codec": "^1.3.0",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@types/uuid": "^9.0.4",
     "typescript": "^5.7.3"
   }
 }

--- a/modules/module-postgres/package.json
+++ b/modules/module-postgres/package.json
@@ -40,13 +40,12 @@
     "semver": "^7.5.4",
     "ts-codec": "^1.3.0",
     "uri-js": "^4.4.1",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@powersync/service-core-tests": "workspace:*",
     "@powersync/service-module-mongodb-storage": "workspace:*",
     "@powersync/service-module-postgres-storage": "workspace:*",
-    "@types/semver": "^7.5.4",
-    "@types/uuid": "^9.0.4"
+    "@types/semver": "^7.5.4"
   }
 }

--- a/packages/rsocket-router/package.json
+++ b/packages/rsocket-router/package.json
@@ -21,11 +21,10 @@
     "@powersync/lib-services-framework": "workspace:*",
     "rsocket-core": "1.0.0-alpha.3",
     "ts-codec": "^1.3.0",
-    "uuid": "^9.0.1",
+    "uuid": "^11.1.0",
     "ws": "^8.17.0"
   },
   "devDependencies": {
-    "@types/uuid": "^9.0.4",
     "@types/ws": "~8.2.0",
     "bson": "^6.10.3",
     "rsocket-websocket-client": "1.0.0-alpha.3"

--- a/packages/rsocket-router/tests/src/requests.test.ts
+++ b/packages/rsocket-router/tests/src/requests.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createMockObserver, createMockResponder } from './utils/mock-responder.js';
-import { handleReactiveStream, ReactiveStreamRequest } from '../../src/router/ReactiveSocketRouter.js';
+import {
+  handleReactiveStream,
+  ReactiveStreamRequest,
+  SocketBaseContext
+} from '../../src/router/ReactiveSocketRouter.js';
 import { deserialize, serialize } from 'bson';
 import { RS_ENDPOINT_TYPE, ReactiveEndpoint, RequestMeta, SocketResponder } from '../../src/router/types.js';
-import { EndpointHandlerPayload, ErrorCode } from '@powersync/lib-services-framework';
+import { EndpointHandlerPayload, ErrorCode, logger } from '@powersync/lib-services-framework';
 
 /**
  * Mocks the process of handling reactive routes
@@ -18,8 +22,10 @@ async function handleRoute(
   responder: SocketResponder,
   request?: Partial<ReactiveStreamRequest>
 ) {
-  return handleReactiveStream<{}>(
-    {},
+  return handleReactiveStream<SocketBaseContext>(
+    {
+      logger
+    },
     {
       payload: {
         data: Buffer.from(serialize({})),
@@ -34,7 +40,7 @@ async function handleRoute(
     createMockObserver(),
     new AbortController(),
     {
-      contextProvider: async () => ({}),
+      contextProvider: async () => ({ logger }),
       endpoints,
       metaDecoder: async (buffer) => deserialize(buffer.contents) as RequestMeta,
       payloadDecoder: async (buffer) => buffer && deserialize(buffer.contents)
@@ -154,8 +160,8 @@ describe('Requests', () => {
       return undefined;
     });
 
-    await handleReactiveStream<{}>(
-      {},
+    await handleReactiveStream<SocketBaseContext>(
+      { logger },
       {
         payload: {
           data: Buffer.from(encodeJson({ hello: 'world' })),
@@ -169,7 +175,7 @@ describe('Requests', () => {
       createMockObserver(),
       new AbortController(),
       {
-        contextProvider: async () => ({}),
+        contextProvider: async () => ({ logger }),
         endpoints: [
           {
             path,

--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -40,14 +40,13 @@
     "node-fetch": "^3.3.2",
     "ts-codec": "^1.3.0",
     "uri-js": "^4.4.1",
-    "uuid": "^9.0.1",
+    "uuid": "^11.1.0",
     "winston": "^3.13.0",
     "yaml": "^2.3.2"
   },
   "devDependencies": {
     "@types/async": "^3.2.24",
     "@types/lodash": "^4.17.5",
-    "@types/uuid": "^9.0.4",
     "fastify": "4.23.2",
     "fastify-plugin": "^4.5.1"
   }

--- a/packages/service-core/src/routes/configure-fastify.ts
+++ b/packages/service-core/src/routes/configure-fastify.ts
@@ -1,4 +1,6 @@
 import type fastify from 'fastify';
+import * as uuid from 'uuid';
+
 import { registerFastifyRoutes } from './route-register.js';
 
 import * as system from '../system/system-index.js';
@@ -9,7 +11,7 @@ import { PROBES_ROUTES } from './endpoints/probes.js';
 import { SYNC_RULES_ROUTES } from './endpoints/sync-rules.js';
 import { SYNC_STREAM_ROUTES } from './endpoints/sync-stream.js';
 import { createRequestQueueHook, CreateRequestQueueParams } from './hooks.js';
-import { RouteDefinition } from './router.js';
+import { ContextProvider, RouteDefinition } from './router.js';
 
 /**
  * A list of route definitions to be registered as endpoints.
@@ -58,10 +60,11 @@ export const DEFAULT_ROUTE_OPTIONS = {
 export function configureFastifyServer(server: fastify.FastifyInstance, options: FastifyServerConfig) {
   const { service_context, routes = DEFAULT_ROUTE_OPTIONS } = options;
 
-  const generateContext = async () => {
+  const generateContext: ContextProvider = async (request, options) => {
     return {
       user_id: undefined,
-      service_context: service_context
+      service_context: service_context,
+      logger: options.logger
     };
   };
 

--- a/packages/service-core/src/routes/endpoints/socket-route.ts
+++ b/packages/service-core/src/routes/endpoints/socket-route.ts
@@ -22,6 +22,7 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
         client_id: params.client_id,
         user_agent: context.user_agent
       };
+      const streamStart = Date.now();
       let closeReason: string | undefined = undefined;
 
       // Create our own controller that we can abort directly
@@ -153,8 +154,10 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
         responder.onComplete();
         removeStopHandler();
         disposer();
-        logger.info(`Sync stream complete due to ${closeReason ?? 'unknown'}`, {
-          ...tracker.getLogMeta()
+        logger.info(`Sync stream complete`, {
+          ...tracker.getLogMeta(),
+          stream_ms: Date.now() - streamStart,
+          close_reason: closeReason ?? 'unknown'
         });
         metricsEngine.getUpDownCounter(APIMetric.CONCURRENT_CONNECTIONS).add(-1);
       }

--- a/packages/service-core/src/routes/endpoints/socket-route.ts
+++ b/packages/service-core/src/routes/endpoints/socket-route.ts
@@ -23,6 +23,10 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
         user_agent: context.user_agent
       };
       const streamStart = Date.now();
+
+      // Best effort guess on why the stream was closed.
+      // We use the `??=` operator everywhere, so that we catch the first relevant
+      // event, which is usually the most specific.
       let closeReason: string | undefined = undefined;
 
       // Create our own controller that we can abort directly
@@ -149,6 +153,7 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
         // This ensures the error can be serialized.
         const error = new errors.InternalServerError(ex);
         logger.error('Sync stream error', error);
+        closeReason ??= 'stream error';
         responder.onError(error);
       } finally {
         responder.onComplete();

--- a/packages/service-core/src/routes/endpoints/socket-route.ts
+++ b/packages/service-core/src/routes/endpoints/socket-route.ts
@@ -154,8 +154,7 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
         removeStopHandler();
         disposer();
         logger.info(`Sync stream complete due to ${closeReason ?? 'unknown'}`, {
-          operations_synced: tracker.operationsSynced,
-          data_synced_bytes: tracker.dataSyncedBytes
+          ...tracker.getLogMeta()
         });
         metricsEngine.getUpDownCounter(APIMetric.CONCURRENT_CONNECTIONS).add(-1);
       }

--- a/packages/service-core/src/routes/endpoints/sync-stream.ts
+++ b/packages/service-core/src/routes/endpoints/sync-stream.ts
@@ -20,11 +20,17 @@ export const syncStreamed = routeDefinition({
   authorize: authUser,
   validator: schema.createTsCodecValidator(util.StreamingSyncRequest, { allowAdditional: true }),
   handler: async (payload) => {
-    const { service_context } = payload.context;
+    const { service_context, logger } = payload.context;
     const { routerEngine, storageEngine, metricsEngine, syncContext } = service_context;
     const headers = payload.request.headers;
     const userAgent = headers['x-user-agent'] ?? headers['user-agent'];
     const clientId = payload.params.client_id;
+    logger.defaultMeta = {
+      ...logger.defaultMeta,
+      user_agent: userAgent,
+      client_id: clientId,
+      user_id: payload.context.user_id
+    };
 
     if (routerEngine.closed) {
       throw new errors.ServiceError({
@@ -64,7 +70,8 @@ export const syncStreamed = routeDefinition({
               syncParams,
               token: payload.context.token_payload!,
               tracker,
-              signal: controller.signal
+              signal: controller.signal,
+              logger
             })
           ),
           tracker
@@ -72,16 +79,26 @@ export const syncStreamed = routeDefinition({
         { objectMode: false, highWaterMark: 16 * 1024 }
       );
 
+      let closeReason: string | undefined = undefined;
+
       const deregister = routerEngine.addStopHandler(() => {
         // This error is not currently propagated to the client
         controller.abort();
+        closeReason ??= 'process shutdown';
         stream.destroy(new Error('Shutting down system'));
       });
+
+      stream.on('end', () => {
+        // Auth failure or switch to new sync rules
+        closeReason ??= 'service closing stream';
+      });
+
       stream.on('close', () => {
         deregister();
       });
 
       stream.on('error', (error) => {
+        closeReason ??= 'stream error';
         controller.abort();
         // Note: This appears as a 200 response in the logs.
         if (error.message != 'Shutting down system') {
@@ -95,13 +112,13 @@ export const syncStreamed = routeDefinition({
           'Content-Type': 'application/x-ndjson'
         },
         data: stream,
-        afterSend: async () => {
+        afterSend: async (details) => {
+          if (details.clientClosed) {
+            closeReason ??= 'client closing stream';
+          }
           controller.abort();
           metricsEngine.getUpDownCounter(APIMetric.CONCURRENT_CONNECTIONS).add(-1);
-          logger.info(`Sync stream complete`, {
-            user_id: syncParams.user_id,
-            client_id: clientId,
-            user_agent: userAgent,
+          logger.info(`Sync stream complete due to ${closeReason ?? 'unknown'}`, {
             operations_synced: tracker.operationsSynced,
             data_synced_bytes: tracker.dataSyncedBytes
           });

--- a/packages/service-core/src/routes/endpoints/sync-stream.ts
+++ b/packages/service-core/src/routes/endpoints/sync-stream.ts
@@ -119,8 +119,7 @@ export const syncStreamed = routeDefinition({
           controller.abort();
           metricsEngine.getUpDownCounter(APIMetric.CONCURRENT_CONNECTIONS).add(-1);
           logger.info(`Sync stream complete due to ${closeReason ?? 'unknown'}`, {
-            operations_synced: tracker.operationsSynced,
-            data_synced_bytes: tracker.dataSyncedBytes
+            ...tracker.getLogMeta()
           });
         }
       });

--- a/packages/service-core/src/routes/endpoints/sync-stream.ts
+++ b/packages/service-core/src/routes/endpoints/sync-stream.ts
@@ -81,6 +81,9 @@ export const syncStreamed = routeDefinition({
         { objectMode: false, highWaterMark: 16 * 1024 }
       );
 
+      // Best effort guess on why the stream was closed.
+      // We use the `??=` operator everywhere, so that we catch the first relevant
+      // event, which is usually the most specific.
       let closeReason: string | undefined = undefined;
 
       const deregister = routerEngine.addStopHandler(() => {

--- a/packages/service-core/src/routes/endpoints/sync-stream.ts
+++ b/packages/service-core/src/routes/endpoints/sync-stream.ts
@@ -25,6 +25,8 @@ export const syncStreamed = routeDefinition({
     const headers = payload.request.headers;
     const userAgent = headers['x-user-agent'] ?? headers['user-agent'];
     const clientId = payload.params.client_id;
+    const streamStart = Date.now();
+
     logger.defaultMeta = {
       ...logger.defaultMeta,
       user_agent: userAgent,
@@ -118,8 +120,10 @@ export const syncStreamed = routeDefinition({
           }
           controller.abort();
           metricsEngine.getUpDownCounter(APIMetric.CONCURRENT_CONNECTIONS).add(-1);
-          logger.info(`Sync stream complete due to ${closeReason ?? 'unknown'}`, {
-            ...tracker.getLogMeta()
+          logger.info(`Sync stream complete`, {
+            ...tracker.getLogMeta(),
+            stream_ms: Date.now() - streamStart,
+            close_reason: closeReason ?? 'unknown'
           });
         }
       });

--- a/packages/service-core/src/routes/route-register.ts
+++ b/packages/service-core/src/routes/route-register.ts
@@ -87,7 +87,7 @@ export function registerFastifyRoutes(
           try {
             await reply.send(response.data);
           } finally {
-            await response.afterSend?.();
+            await response.afterSend?.({ clientClosed: request.socket.closed });
             requestLogger.info(`${e.method} ${request.url}`, {
               duration_ms: Math.round(new Date().valueOf() - startTime.valueOf() + Number.EPSILON),
               status: response.status,

--- a/packages/service-core/src/routes/router.ts
+++ b/packages/service-core/src/routes/router.ts
@@ -1,4 +1,4 @@
-import { router, ServiceError } from '@powersync/lib-services-framework';
+import { router, ServiceError, Logger } from '@powersync/lib-services-framework';
 import type { JwtPayload } from '../auth/auth-index.js';
 import { ServiceContext } from '../system/ServiceContext.js';
 import { RouterEngine } from './RouterEngine.js';
@@ -22,6 +22,8 @@ export type Context = {
    * Only on websocket endpoints.
    */
   user_agent?: string;
+
+  logger: Logger;
 };
 
 export type BasicRouterRequest = {
@@ -30,7 +32,11 @@ export type BasicRouterRequest = {
   hostname: string;
 };
 
-export type ContextProvider = (request: BasicRouterRequest) => Promise<Context>;
+export type ConextProviderOptions = {
+  logger: Logger;
+};
+
+export type ContextProvider = (request: BasicRouterRequest, options: ConextProviderOptions) => Promise<Context>;
 
 export type RequestEndpoint<
   I,

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -3,7 +3,13 @@ import { BucketDescription, RequestParameters, SqlSyncRules } from '@powersync/s
 import * as storage from '../storage/storage-index.js';
 import * as util from '../util/util-index.js';
 
-import { ErrorCode, logger, ServiceAssertionError, ServiceError } from '@powersync/lib-services-framework';
+import {
+  ErrorCode,
+  Logger,
+  ServiceAssertionError,
+  ServiceError,
+  logger as defaultLogger
+} from '@powersync/lib-services-framework';
 import { JSONBig } from '@powersync/service-jsonbig';
 import { BucketParameterQuerier } from '@powersync/service-sync-rules/src/BucketParameterQuerier.js';
 import { BucketSyncState } from './sync.js';
@@ -15,6 +21,7 @@ export interface BucketChecksumStateOptions {
   bucketStorage: BucketChecksumStateStorage;
   syncRules: SqlSyncRules;
   syncParams: RequestParameters;
+  logger?: Logger;
   initialBucketPositions?: { name: string; after: util.InternalOpId }[];
 }
 
@@ -47,14 +54,18 @@ export class BucketChecksumState {
    */
   private pendingBucketDownloads = new Set<string>();
 
+  private readonly logger: Logger;
+
   constructor(options: BucketChecksumStateOptions) {
     this.context = options.syncContext;
     this.bucketStorage = options.bucketStorage;
+    this.logger = options.logger ?? defaultLogger;
     this.parameterState = new BucketParameterState(
       options.syncContext,
       options.bucketStorage,
       options.syncRules,
-      options.syncParams
+      options.syncParams,
+      this.logger
     );
     this.bucketDataPositions = new Map();
 
@@ -174,7 +185,7 @@ export class BucketChecksumState {
       message += `buckets: ${allBuckets.length} | `;
       message += `updated: ${limitedBuckets(diff.updatedBuckets, 20)} | `;
       message += `removed: ${limitedBuckets(diff.removedBuckets, 20)}`;
-      logger.info(message, {
+      this.logger.info(message, {
         checkpoint: base.checkpoint,
         user_id: user_id,
         buckets: allBuckets.length,
@@ -193,7 +204,7 @@ export class BucketChecksumState {
     } else {
       let message = `New checkpoint: ${base.checkpoint} | write: ${writeCheckpoint} | `;
       message += `buckets: ${allBuckets.length} ${limitedBuckets(allBuckets, 20)}`;
-      logger.info(message, { checkpoint: base.checkpoint, user_id: user_id, buckets: allBuckets.length });
+      this.logger.info(message, { checkpoint: base.checkpoint, user_id: user_id, buckets: allBuckets.length });
       bucketsToFetch = allBuckets;
       checkpointLine = {
         checkpoint: {
@@ -274,6 +285,7 @@ export class BucketParameterState {
   public readonly syncParams: RequestParameters;
   private readonly querier: BucketParameterQuerier;
   private readonly staticBuckets: Map<string, BucketDescription>;
+  private readonly logger: Logger;
   private cachedDynamicBuckets: BucketDescription[] | null = null;
   private cachedDynamicBucketSet: Set<string> | null = null;
 
@@ -283,12 +295,14 @@ export class BucketParameterState {
     context: SyncContext,
     bucketStorage: BucketChecksumStateStorage,
     syncRules: SqlSyncRules,
-    syncParams: RequestParameters
+    syncParams: RequestParameters,
+    logger: Logger
   ) {
     this.context = context;
     this.bucketStorage = bucketStorage;
     this.syncRules = syncRules;
     this.syncParams = syncParams;
+    this.logger = logger;
 
     this.querier = syncRules.getBucketParameterQuerier(this.syncParams);
     this.staticBuckets = new Map<string, BucketDescription>(this.querier.staticBuckets.map((b) => [b.bucket, b]));
@@ -311,7 +325,7 @@ export class BucketParameterState {
         ErrorCode.PSYNC_S2305,
         `Too many parameter query results: ${update.buckets.length} (limit of ${this.context.maxParameterQueryResults})`
       );
-      logger.error(error.message, {
+      this.logger.error(error.message, {
         checkpoint: checkpoint,
         user_id: this.syncParams.user_id,
         buckets: update.buckets.length

--- a/packages/service-core/src/sync/RequestTracker.ts
+++ b/packages/service-core/src/sync/RequestTracker.ts
@@ -1,6 +1,7 @@
 import { MetricsEngine } from '../metrics/MetricsEngine.js';
 
 import { APIMetric } from '@powersync/service-types';
+import { SyncBucketData } from '../util/protocol-types.js';
 
 /**
  * Record sync stats per request stream.
@@ -8,15 +9,24 @@ import { APIMetric } from '@powersync/service-types';
 export class RequestTracker {
   operationsSynced = 0;
   dataSyncedBytes = 0;
+  operationCounts: OperationCounts = { put: 0, remove: 0, move: 0, clear: 0 };
+  largeBuckets: Record<string, number> = {};
 
   constructor(private metrics: MetricsEngine) {
     this.metrics = metrics;
   }
 
-  addOperationsSynced(operations: number) {
-    this.operationsSynced += operations;
+  addOperationsSynced(operations: OperationsSentStats) {
+    this.operationsSynced += operations.total;
+    this.operationCounts.put += operations.operations.put;
+    this.operationCounts.remove += operations.operations.remove;
+    this.operationCounts.move += operations.operations.move;
+    this.operationCounts.clear += operations.operations.clear;
+    if (operations.total > 100 || operations.bucket in this.largeBuckets) {
+      this.largeBuckets[operations.bucket] = (this.largeBuckets[operations.bucket] ?? 0) + operations.total;
+    }
 
-    this.metrics.getCounter(APIMetric.OPERATIONS_SYNCED).add(operations);
+    this.metrics.getCounter(APIMetric.OPERATIONS_SYNCED).add(operations.total);
   }
 
   addDataSynced(bytes: number) {
@@ -24,4 +34,61 @@ export class RequestTracker {
 
     this.metrics.getCounter(APIMetric.DATA_SYNCED_BYTES).add(bytes);
   }
+
+  getLogMeta() {
+    return {
+      operations_synced: this.operationsSynced,
+      data_synced_bytes: this.dataSyncedBytes,
+      operation_counts: this.operationCounts,
+      large_buckets: this.largeBuckets
+    };
+  }
+}
+
+export interface OperationCounts {
+  put: number;
+  remove: number;
+  move: number;
+  clear: number;
+}
+
+export interface OperationsSentStats {
+  bucket: string;
+  operations: OperationCounts;
+  total: number;
+}
+
+export function statsForBatch(batch: SyncBucketData): OperationsSentStats {
+  let put = 0;
+  let remove = 0;
+  let move = 0;
+  let clear = 0;
+
+  for (const entry of batch.data) {
+    switch (entry.op) {
+      case 'PUT':
+        put++;
+        break;
+      case 'REMOVE':
+        remove++;
+        break;
+      case 'MOVE':
+        move++;
+        break;
+      case 'CLEAR':
+        clear++;
+        break;
+    }
+  }
+
+  return {
+    bucket: batch.bucket,
+    operations: {
+      put,
+      remove,
+      move,
+      clear
+    },
+    total: put + remove + move + clear
+  };
 }

--- a/packages/sync-rules/package.json
+++ b/packages/sync-rules/package.json
@@ -25,12 +25,11 @@
     "@syncpoint/wkx": "^0.5.0",
     "ajv": "^8.12.0",
     "pgsql-ast-parser": "^11.1.0",
-    "yaml": "^2.3.1",
-    "uuid": "^9.0.1"
+    "uuid": "^11.1.0",
+    "yaml": "^2.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.5.5",
-    "vitest": "^3.0.5",
-    "@types/uuid": "^9.0.4"
+    "vitest": "^3.0.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,12 +105,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
-    devDependencies:
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
+        specifier: ^11.1.0
+        version: 11.1.0
 
   libs/lib-services:
     dependencies:
@@ -139,8 +135,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       winston:
         specifier: ^3.13.0
         version: 3.13.1
@@ -151,9 +147,6 @@ importers:
       '@types/lodash':
         specifier: ^4.17.5
         version: 4.17.6
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
       vitest:
         specifier: ^3.0.5
         version: 3.0.5(@types/node@22.13.1)(yaml@2.5.0)
@@ -206,8 +199,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@powersync/service-core-tests':
         specifier: workspace:*
@@ -218,9 +211,6 @@ importers:
       '@powersync/service-module-postgres-storage':
         specifier: workspace:*
         version: link:../module-postgres-storage
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
 
   modules/module-mongodb-storage:
     dependencies:
@@ -255,15 +245,12 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@powersync/service-core-tests':
         specifier: workspace:*
         version: link:../../packages/service-core-tests
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
 
   modules/module-mysql:
     dependencies:
@@ -301,8 +288,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@powersync/service-core-tests':
         specifier: workspace:*
@@ -319,9 +306,6 @@ importers:
       '@types/semver':
         specifier: ^7.5.4
         version: 7.5.8
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
 
   modules/module-postgres:
     dependencies:
@@ -362,8 +346,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@powersync/service-core-tests':
         specifier: workspace:*
@@ -377,9 +361,6 @@ importers:
       '@types/semver':
         specifier: ^7.5.4
         version: 7.5.8
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
 
   modules/module-postgres-storage:
     dependencies:
@@ -420,12 +401,9 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -460,15 +438,12 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       ws:
         specifier: ^8.17.0
         version: 8.18.0
     devDependencies:
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
       '@types/ws':
         specifier: ~8.2.0
         version: 8.2.3
@@ -578,8 +553,8 @@ importers:
         specifier: ^4.4.1
         version: 4.4.1
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       winston:
         specifier: ^3.13.0
         version: 3.13.1
@@ -593,9 +568,6 @@ importers:
       '@types/lodash':
         specifier: ^4.17.5
         version: 4.17.6
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
       fastify:
         specifier: 4.23.2
         version: 4.23.2
@@ -645,8 +617,8 @@ importers:
         specifier: ^11.1.0
         version: 11.2.0
       uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^11.1.0
+        version: 11.1.0
       yaml:
         specifier: ^2.3.1
         version: 2.4.5
@@ -654,9 +626,6 @@ importers:
       '@types/node':
         specifier: ^22.5.5
         version: 22.5.5
-      '@types/uuid':
-        specifier: ^9.0.4
-        version: 9.0.8
       vitest:
         specifier: ^3.0.5
         version: 3.0.5(@types/node@22.5.5)(yaml@2.4.5)
@@ -1583,9 +1552,6 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -3877,8 +3843,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -5033,8 +4999,6 @@ snapshots:
   '@types/strip-json-comments@0.0.30': {}
 
   '@types/triple-beam@1.3.5': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/webidl-conversions@7.0.3': {}
 
@@ -7431,7 +7395,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@9.0.1: {}
+  uuid@11.1.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
Two general logging changes:

## 1. Child loggers

Pass a child logger instance through via the Context, so that we can configure metadata on the logger that applies to the entire request. This means that request logs will include common context, making it easier to debug:
1. user_agent
2. rid (unique request id, to correlate with other logs)
3. user_id
4. client_id

Passing the logger through the entire stack could be a pain in some cases. Right now, this is mostly limited to sync requests, so not too bad. If we start using it in many more places, [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) would be a good way to handle this automatically.

## 2. Granular sync operation tracking

For each completed stream, instead of just logging the total number of synced operations, this logs more details. Example:

```
Sync stream complete {"client_id":"2ea02120-e7d1-4adb-8e9d-b3ddaffd494d","close_reason":client closing stream ","data_synced_bytes":23475179,"large_buckets":{"global[]":51000},"operation_counts":{"clear":0,"move":0,"put":51000,"remove":0},"operations_synced":51000,"rid":"s/0196c4f6-8a5c-7253-a451-ba517f9f0ec7","stream_ms":1331,"user_agent":"powersync-js/1.30.0 powersync-web Chrome/136 linux","user_id":"112c667e-4973-45cb-ade8-40df2ad45a2a"}
```

---

This updates the `uuid` dependency to have access to `uuid.v7()`, for a timestamp-based unique request id. With this version we don't need `@types/uuid` anymore.

* close_reason: Gives an indication (best effort guess) of whether the client or the server closed the stream. Typically the server closes the stream when the auth token expired, or when switching to a new sync rules version. The client closes the stream when the application is closed / tab reloaded, or when there were checksum failures.
* operation_counts: Same as operations_synced, but split into the 4 different types of operations.
* large_buckets: operations_synced for individual buckets. Only counts buckets that synced more than 100 operations in a batch, to avoid too much noise here.
* stream_ms: Similar to duration_ms logged in the generic request handler, but added here to have the details in one place.
