### PR TITLE
Cleanup sync rules implementation

### DIFF
--- a/.changeset/little-beans-carry.md
+++ b/.changeset/little-beans-carry.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-sync-rules': minor
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core-tests': patch
+'@powersync/service-core': patch
+---
+
+Cleanup on internal sync rules implementation and APIs.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -895,7 +895,7 @@ export class MongoBucketBatch
    * Gets relevant {@link SqlEventDescriptor}s for the given {@link SourceTable}
    */
   protected getTableEvents(table: storage.SourceTable): SqlEventDescriptor[] {
-    return this.sync_rules.event_descriptors.filter((evt) =>
+    return this.sync_rules.eventDescriptors.filter((evt) =>
       [...evt.getSourceTables()].some((sourceTable) => sourceTable.matches(table))
     );
   }

--- a/modules/module-mongodb-storage/src/storage/implementation/PersistedBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/PersistedBatch.ts
@@ -206,7 +206,7 @@ export class PersistedBatch {
               k: sourceKey
             },
             lookup: binLookup,
-            bucket_parameters: result.bucket_parameters
+            bucket_parameters: result.bucketParameters
           }
         }
       });

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -861,7 +861,7 @@ export class PostgresBucketBatch
    * TODO maybe share this with an abstract class
    */
   protected getTableEvents(table: storage.SourceTable): sync_rules.SqlEventDescriptor[] {
-    return this.sync_rules.event_descriptors.filter((evt) =>
+    return this.sync_rules.eventDescriptors.filter((evt) =>
       [...evt.getSourceTables()].some((sourceTable) => sourceTable.matches(table))
     );
   }

--- a/modules/module-postgres-storage/src/storage/batch/PostgresPersistedBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresPersistedBatch.ts
@@ -152,7 +152,7 @@ export class PostgresPersistedBatch {
       const base64 = binLookup.toString('base64');
       remaining_lookups.delete(base64);
       const hexLookup = binLookup.toString('hex');
-      const serializedBucketParameters = JSONBig.stringify(result.bucket_parameters);
+      const serializedBucketParameters = JSONBig.stringify(result.bucketParameters);
       this.parameterDataInserts.push({
         group_id: this.group_id,
         source_table: table.id,

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -404,7 +404,7 @@ bucket_definitions:
 
     const parameters = new RequestParameters({ sub: 'u1' }, {});
 
-    const q1 = sync_rules.bucket_descriptors[0].parameter_queries[0];
+    const q1 = sync_rules.bucket_descriptors[0].parameterQueries[0];
 
     const lookups = q1.getLookups(parameters);
     expect(lookups).toEqual([ParameterLookup.normalized('by_workspace', '1', ['u1'])]);
@@ -474,7 +474,7 @@ bucket_definitions:
 
     const parameters = new RequestParameters({ sub: 'unknown' }, {});
 
-    const q1 = sync_rules.bucket_descriptors[0].parameter_queries[0];
+    const q1 = sync_rules.bucket_descriptors[0].parameterQueries[0];
 
     const lookups = q1.getLookups(parameters);
     expect(lookups).toEqual([ParameterLookup.normalized('by_public_workspace', '1', [])]);
@@ -564,7 +564,7 @@ bucket_definitions:
     const parameters = new RequestParameters({ sub: 'u1' }, {});
 
     // Test intermediate values - could be moved to sync_rules.test.ts
-    const q1 = sync_rules.bucket_descriptors[0].parameter_queries[0];
+    const q1 = sync_rules.bucket_descriptors[0].parameterQueries[0];
     const lookups1 = q1.getLookups(parameters);
     expect(lookups1).toEqual([ParameterLookup.normalized('by_workspace', '1', [])]);
 
@@ -572,7 +572,7 @@ bucket_definitions:
     parameter_sets1.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
     expect(parameter_sets1).toEqual([{ workspace_id: 'workspace1' }]);
 
-    const q2 = sync_rules.bucket_descriptors[0].parameter_queries[1];
+    const q2 = sync_rules.bucket_descriptors[0].parameterQueries[1];
     const lookups2 = q2.getLookups(parameters);
     expect(lookups2).toEqual([ParameterLookup.normalized('by_workspace', '2', ['u1'])]);
 

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -404,7 +404,7 @@ bucket_definitions:
 
     const parameters = new RequestParameters({ sub: 'u1' }, {});
 
-    const q1 = sync_rules.bucket_descriptors[0].parameterQueries[0];
+    const q1 = sync_rules.bucketDescriptors[0].parameterQueries[0];
 
     const lookups = q1.getLookups(parameters);
     expect(lookups).toEqual([ParameterLookup.normalized('by_workspace', '1', ['u1'])]);
@@ -474,7 +474,7 @@ bucket_definitions:
 
     const parameters = new RequestParameters({ sub: 'unknown' }, {});
 
-    const q1 = sync_rules.bucket_descriptors[0].parameterQueries[0];
+    const q1 = sync_rules.bucketDescriptors[0].parameterQueries[0];
 
     const lookups = q1.getLookups(parameters);
     expect(lookups).toEqual([ParameterLookup.normalized('by_public_workspace', '1', [])]);
@@ -564,7 +564,7 @@ bucket_definitions:
     const parameters = new RequestParameters({ sub: 'u1' }, {});
 
     // Test intermediate values - could be moved to sync_rules.test.ts
-    const q1 = sync_rules.bucket_descriptors[0].parameterQueries[0];
+    const q1 = sync_rules.bucketDescriptors[0].parameterQueries[0];
     const lookups1 = q1.getLookups(parameters);
     expect(lookups1).toEqual([ParameterLookup.normalized('by_workspace', '1', [])]);
 
@@ -572,7 +572,7 @@ bucket_definitions:
     parameter_sets1.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
     expect(parameter_sets1).toEqual([{ workspace_id: 'workspace1' }]);
 
-    const q2 = sync_rules.bucket_descriptors[0].parameterQueries[1];
+    const q2 = sync_rules.bucketDescriptors[0].parameterQueries[1];
     const lookups2 = q2.getLookups(parameters);
     expect(lookups2).toEqual([ParameterLookup.normalized('by_workspace', '2', ['u1'])]);
 

--- a/packages/service-core/src/routes/endpoints/sync-rules.ts
+++ b/packages/service-core/src/routes/endpoints/sync-rules.ts
@@ -202,7 +202,7 @@ async function debugSyncRules(apiHandler: RouteAPI, sync_rules: string) {
 
     return {
       valid: true,
-      bucket_definitions: rules.bucket_descriptors.map((d) => {
+      bucket_definitions: rules.bucketDescriptors.map((d) => {
         let all_parameter_queries = [...d.parameterQueries.values()].flat();
         let all_data_queries = [...d.dataQueries.values()].flat();
         return {

--- a/packages/service-core/src/routes/endpoints/sync-rules.ts
+++ b/packages/service-core/src/routes/endpoints/sync-rules.ts
@@ -203,12 +203,12 @@ async function debugSyncRules(apiHandler: RouteAPI, sync_rules: string) {
     return {
       valid: true,
       bucket_definitions: rules.bucket_descriptors.map((d) => {
-        let all_parameter_queries = [...d.parameter_queries.values()].flat();
-        let all_data_queries = [...d.data_queries.values()].flat();
+        let all_parameter_queries = [...d.parameterQueries.values()].flat();
+        let all_data_queries = [...d.dataQueries.values()].flat();
         return {
           name: d.name,
-          bucket_parameters: d.bucket_parameters,
-          global_parameter_queries: d.global_parameter_queries.map((q) => {
+          bucket_parameters: d.bucketParameters,
+          global_parameter_queries: d.globalParameterQueries.map((q) => {
             return {
               sql: q.sql
             };
@@ -217,7 +217,7 @@ async function debugSyncRules(apiHandler: RouteAPI, sync_rules: string) {
             return {
               sql: q.sql,
               table: q.sourceTable,
-              input_parameters: q.input_parameters
+              input_parameters: q.inputParameters
             };
           }),
 

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -92,7 +92,7 @@ export class BucketChecksumState {
    */
   async buildNextCheckpointLine(next: storage.StorageCheckpointUpdate): Promise<CheckpointLine | null> {
     const { writeCheckpoint, base } = next;
-    const user_id = this.parameterState.syncParams.user_id;
+    const user_id = this.parameterState.syncParams.userId;
 
     const storage = this.bucketStorage;
 
@@ -378,7 +378,7 @@ export class BucketParameterState {
       );
       this.logger.error(error.message, {
         checkpoint: checkpoint,
-        user_id: this.syncParams.user_id,
+        user_id: this.syncParams.userId,
         buckets: update.buckets.length
       });
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -93,7 +93,7 @@ async function* streamResponseInner(
 ): AsyncGenerator<util.StreamingSyncLine | string | null> {
   const { raw_data, binary_data } = params;
 
-  const checkpointUserId = util.checkpointUserId(syncParams.token_parameters.user_id as string, params.client_id);
+  const checkpointUserId = util.checkpointUserId(syncParams.tokenParameters.user_id as string, params.client_id);
 
   const checksumState = new BucketChecksumState({
     syncContext,
@@ -228,7 +228,7 @@ async function* streamResponseInner(
           onRowsSent: markOperationsSent,
           abort_connection: signal,
           abort_batch: abortCheckpointSignal,
-          user_id: syncParams.user_id,
+          user_id: syncParams.userId,
           // Passing null here will emit a full sync complete message at the end. If we pass a priority, we'll emit a partial
           // sync complete message instead.
           forPriority: !isLast ? priority : null,

--- a/packages/sync-rules/src/BaseSqlDataQuery.ts
+++ b/packages/sync-rules/src/BaseSqlDataQuery.ts
@@ -19,8 +19,8 @@ export interface BaseSqlDataQueryOptions {
   sql: string;
   columns: SelectedColumn[];
   extractors: RowValueExtractor[];
-  descriptor_name: string;
-  bucket_parameters: string[];
+  descriptorName: string;
+  bucketParameters: string[];
   tools: SqlTools;
 
   ruleId: string;
@@ -34,8 +34,8 @@ export class BaseSqlDataQuery {
   readonly sql: string;
   readonly columns: SelectedColumn[];
   readonly extractors: RowValueExtractor[] = [];
-  readonly descriptor_name: string;
-  readonly bucket_parameters: string[];
+  readonly descriptorName: string;
+  readonly bucketParameters: string[];
   readonly tools: SqlTools;
 
   readonly ruleId: string;
@@ -48,8 +48,8 @@ export class BaseSqlDataQuery {
     this.sql = options.sql;
     this.columns = options.columns;
     this.extractors = options.extractors;
-    this.descriptor_name = options.descriptor_name;
-    this.bucket_parameters = options.bucket_parameters;
+    this.descriptorName = options.descriptorName;
+    this.bucketParameters = options.bucketParameters;
     this.tools = options.tools;
     this.ruleId = options.ruleId;
     this.errors = options.errors ?? [];

--- a/packages/sync-rules/src/BaseSqlDataQuery.ts
+++ b/packages/sync-rules/src/BaseSqlDataQuery.ts
@@ -22,8 +22,6 @@ export interface BaseSqlDataQueryOptions {
   bucketParameters: string[];
   tools: SqlTools;
 
-  ruleId: string;
-
   errors?: SqlRuleError[];
 }
 
@@ -73,8 +71,6 @@ export class BaseSqlDataQuery {
    */
   private readonly tools: SqlTools;
 
-  readonly ruleId: string;
-
   readonly errors: SqlRuleError[];
 
   constructor(options: BaseSqlDataQueryOptions) {
@@ -86,7 +82,6 @@ export class BaseSqlDataQuery {
     this.descriptorName = options.descriptorName;
     this.bucketParameters = options.bucketParameters;
     this.tools = options.tools;
-    this.ruleId = options.ruleId;
     this.errors = options.errors ?? [];
   }
 

--- a/packages/sync-rules/src/BaseSqlDataQuery.ts
+++ b/packages/sync-rules/src/BaseSqlDataQuery.ts
@@ -111,7 +111,7 @@ export class BaseSqlDataQuery {
         this.getColumnOutputsFor(schemaTable, output);
       }
       result.push({
-        name: this.table!,
+        name: this.table,
         columns: Object.values(output)
       });
     }

--- a/packages/sync-rules/src/BaseSqlDataQuery.ts
+++ b/packages/sync-rules/src/BaseSqlDataQuery.ts
@@ -55,7 +55,7 @@ export class BaseSqlDataQuery {
    *
    * This may include plain column names, wildcards, and basic expressions.
    */
-  readonly extractors: RowValueExtractor[] = [];
+  readonly extractors: RowValueExtractor[];
 
   /**
    * Bucket definition name.

--- a/packages/sync-rules/src/BaseSqlDataQuery.ts
+++ b/packages/sync-rules/src/BaseSqlDataQuery.ts
@@ -6,7 +6,6 @@ import { SqlTools } from './sql_filters.js';
 import { TablePattern } from './TablePattern.js';
 import { QueryParameters, QuerySchema, SourceSchema, SourceSchemaTable, SqliteJsonRow, SqliteRow } from './types.js';
 import { filterJsonRow } from './utils.js';
-import { extendErrors } from 'ajv/dist/compile/errors.js';
 
 export interface RowValueExtractor {
   extract(tables: QueryParameters, into: SqliteRow): void;
@@ -29,14 +28,50 @@ export interface BaseSqlDataQueryOptions {
 }
 
 export class BaseSqlDataQuery {
+  /**
+   * Source table or table pattern.
+   */
   readonly sourceTable: TablePattern;
+
+  /**
+   * The table name or alias used in the query.
+   *
+   * This is used for the output table name.
+   */
   readonly table: string;
+
+  /**
+   * The source SQL query, for debugging purposes.
+   */
   readonly sql: string;
+
+  /**
+   * Query columns, for debugging purposes.
+   */
   readonly columns: SelectedColumn[];
+
+  /**
+   * Extracts input row into output row. This is the column list in the SELECT part of the query.
+   *
+   * This may include plain column names, wildcards, and basic expressions.
+   */
   readonly extractors: RowValueExtractor[] = [];
+
+  /**
+   * Bucket definition name.
+   */
   readonly descriptorName: string;
+  /**
+   * Bucket parameter names, without the `bucket.` prefix.
+   *
+   * These are received from the associated parameter query (if any), and must match the filters
+   * used in the data query.
+   */
   readonly bucketParameters: string[];
-  readonly tools: SqlTools;
+  /**
+   * Used to generate debugging info.
+   */
+  private readonly tools: SqlTools;
 
   readonly ruleId: string;
 

--- a/packages/sync-rules/src/BucketDescription.ts
+++ b/packages/sync-rules/src/BucketDescription.ts
@@ -13,7 +13,7 @@
  */
 export type BucketPriority = 0 | 1 | 2 | 3;
 
-export const defaultBucketPriority: BucketPriority = 3;
+export const DEFAULT_BUCKET_PRIORITY: BucketPriority = 3;
 
 export const isValidPriority = (i: number): i is BucketPriority => {
   return Number.isInteger(i) && i >= 0 && i <= 3;

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -50,9 +50,7 @@ export class SqlBucketDescriptor {
     if (this.bucket_parameters == null) {
       throw new Error('Bucket parameters must be defined');
     }
-    const dataRows = SqlDataQuery.fromSql(this.name, this.bucket_parameters, sql, options);
-
-    dataRows.ruleId = this.idSequence.nextId();
+    const dataRows = SqlDataQuery.fromSql(this.name, this.bucket_parameters, sql, options, this.idSequence.nextId());
 
     this.data_queries.push(dataRows);
 

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -61,7 +61,7 @@ export class SqlBucketDescriptor {
   }
 
   addParameterQuery(sql: string, options: QueryParseOptions): QueryParseResult {
-    const parameterQuery = SqlParameterQuery.fromSql(this.name, sql, options);
+    const parameterQuery = SqlParameterQuery.fromSql(this.name, sql, options, this.parameterIdSequence.nextId());
     if (this.bucket_parameters == null) {
       this.bucket_parameters = parameterQuery.bucket_parameters;
     } else {
@@ -71,7 +71,6 @@ export class SqlBucketDescriptor {
         throw new Error('Bucket parameters must match for each parameter query within a bucket');
       }
     }
-    parameterQuery.id = this.parameterIdSequence.nextId();
     if (parameterQuery instanceof SqlParameterQuery) {
       this.parameter_queries.push(parameterQuery);
     } else {

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -31,10 +31,7 @@ export class SqlBucketDescriptor {
   name: string;
   bucketParameters?: string[];
 
-  constructor(
-    name: string,
-    public idSequence: IdSequence
-  ) {
+  constructor(name: string) {
     this.name = name;
   }
 
@@ -51,7 +48,7 @@ export class SqlBucketDescriptor {
     if (this.bucketParameters == null) {
       throw new Error('Bucket parameters must be defined');
     }
-    const dataRows = SqlDataQuery.fromSql(this.name, this.bucketParameters, sql, options, this.idSequence.nextId());
+    const dataRows = SqlDataQuery.fromSql(this.name, this.bucketParameters, sql, options);
 
     this.dataQueries.push(dataRows);
 

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -7,6 +7,7 @@ import { SqlParameterQuery } from './SqlParameterQuery.js';
 import { SyncRulesOptions } from './SqlSyncRules.js';
 import { StaticSqlParameterQuery } from './StaticSqlParameterQuery.js';
 import { TablePattern } from './TablePattern.js';
+import { TableValuedFunctionSqlParameterQuery } from './TableValuedFunctionSqlParameterQuery.js';
 import { SqlRuleError } from './errors.js';
 import {
   EvaluatedParametersResult,
@@ -42,7 +43,7 @@ export class SqlBucketDescriptor {
    */
   data_queries: SqlDataQuery[] = [];
   parameter_queries: SqlParameterQuery[] = [];
-  global_parameter_queries: StaticSqlParameterQuery[] = [];
+  global_parameter_queries: (StaticSqlParameterQuery | TableValuedFunctionSqlParameterQuery)[] = [];
 
   parameterIdSequence = new IdSequence();
 

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -18,13 +18,7 @@ export interface SqlDataQueryOptions extends BaseSqlDataQueryOptions {
 }
 
 export class SqlDataQuery extends BaseSqlDataQuery {
-  static fromSql(
-    descriptorName: string,
-    bucketParameters: string[],
-    sql: string,
-    options: SyncRulesOptions,
-    ruleId?: string
-  ) {
+  static fromSql(descriptorName: string, bucketParameters: string[], sql: string, options: SyncRulesOptions) {
     const parsed = parse(sql, { locationTracking: true });
     const schema = options.schema;
 
@@ -172,7 +166,6 @@ export class SqlDataQuery extends BaseSqlDataQuery {
       descriptorName,
       bucketParameters,
       tools,
-      ruleId: ruleId ?? '',
       errors,
       extractors
     });
@@ -218,8 +211,7 @@ export class SqlDataQuery extends BaseSqlDataQuery {
           bucket: bucketId,
           table: outputTable,
           id: id,
-          data,
-          ruleId: this.ruleId
+          data
         } as EvaluationResult;
       });
     } catch (e) {

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -18,8 +18,6 @@ export interface SqlDataQueryOptions extends BaseSqlDataQueryOptions {
 }
 
 export class SqlDataQuery extends BaseSqlDataQuery {
-  readonly filter: ParameterMatchClause;
-
   static fromSql(
     descriptorName: string,
     bucketParameters: string[],
@@ -179,6 +177,15 @@ export class SqlDataQuery extends BaseSqlDataQuery {
       extractors
     });
   }
+
+  /**
+   * The query WHERE clause.
+   *
+   * For a given row, this returns a set of bucket parameter values that could cause the filter to match.
+   *
+   * We use this to determine the buckets that a data row belong to.
+   */
+  readonly filter: ParameterMatchClause;
 
   constructor(options: SqlDataQueryOptions) {
     super(options);

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -21,8 +21,8 @@ export class SqlDataQuery extends BaseSqlDataQuery {
   readonly filter: ParameterMatchClause;
 
   static fromSql(
-    descriptor_name: string,
-    bucket_parameters: string[],
+    descriptorName: string,
+    bucketParameters: string[],
     sql: string,
     options: SyncRulesOptions,
     ruleId?: string
@@ -73,8 +73,8 @@ export class SqlDataQuery extends BaseSqlDataQuery {
     const where = q.where;
     const tools = new SqlTools({
       table: alias,
-      parameter_tables: ['bucket'],
-      value_tables: [alias],
+      parameterTables: ['bucket'],
+      valueTables: [alias],
       sql,
       schema: querySchema
     });
@@ -82,11 +82,11 @@ export class SqlDataQuery extends BaseSqlDataQuery {
     const filter = tools.compileWhereClause(where);
 
     const inputParameterNames = filter.inputParameters.map((p) => p.key);
-    const bucketParameterNames = bucket_parameters.map((p) => `bucket.${p}`);
+    const bucketParameterNames = bucketParameters.map((p) => `bucket.${p}`);
     const allParams = new Set<string>([...inputParameterNames, ...bucketParameterNames]);
     if (
       (!filter.error && allParams.size != filter.inputParameters.length) ||
-      allParams.size != bucket_parameters.length
+      allParams.size != bucketParameters.length
     ) {
       errors.push(
         new SqlRuleError(
@@ -171,8 +171,8 @@ export class SqlDataQuery extends BaseSqlDataQuery {
       sql,
       filter,
       columns: q.columns ?? [],
-      descriptor_name,
-      bucket_parameters,
+      descriptorName,
+      bucketParameters,
       tools,
       ruleId: ruleId ?? '',
       errors,
@@ -190,7 +190,7 @@ export class SqlDataQuery extends BaseSqlDataQuery {
       const tables = { [this.table]: this.addSpecialParameters(table, row) };
       const bucketParameters = this.filter.filterRow(tables);
       const bucketIds = bucketParameters.map((params) =>
-        getBucketId(this.descriptor_name, this.bucket_parameters, params)
+        getBucketId(this.descriptorName, this.bucketParameters, params)
       );
 
       const data = this.transformRow(tables);

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -187,7 +187,7 @@ export class SqlDataQuery extends BaseSqlDataQuery {
 
   evaluateRow(table: SourceTableInterface, row: SqliteRow): EvaluationResult[] {
     try {
-      const tables = { [this.table!]: this.addSpecialParameters(table, row) };
+      const tables = { [this.table]: this.addSpecialParameters(table, row) };
       const bucketParameters = this.filter.filterRow(tables);
       const bucketIds = bucketParameters.map((params) =>
         getBucketId(this.descriptor_name, this.bucket_parameters, params)

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -1,6 +1,6 @@
 import { JSONBig } from '@powersync/service-jsonbig';
 import { parse } from 'pgsql-ast-parser';
-import { BaseSqlDataQuery } from './BaseSqlDataQuery.js';
+import { BaseSqlDataQuery, BaseSqlDataQueryOptions, RowValueExtractor } from './BaseSqlDataQuery.js';
 import { SqlRuleError } from './errors.js';
 import { ExpressionType } from './ExpressionType.js';
 import { SourceTableInterface } from './SourceTableInterface.js';
@@ -13,13 +13,24 @@ import { TableQuerySchema } from './TableQuerySchema.js';
 import { EvaluationResult, ParameterMatchClause, QuerySchema, SqliteRow } from './types.js';
 import { getBucketId, isSelectStatement } from './utils.js';
 
-export class SqlDataQuery extends BaseSqlDataQuery {
-  filter?: ParameterMatchClause;
+export interface SqlDataQueryOptions extends BaseSqlDataQueryOptions {
+  filter: ParameterMatchClause;
+}
 
-  static fromSql(descriptor_name: string, bucket_parameters: string[], sql: string, options: SyncRulesOptions) {
+export class SqlDataQuery extends BaseSqlDataQuery {
+  readonly filter: ParameterMatchClause;
+
+  static fromSql(
+    descriptor_name: string,
+    bucket_parameters: string[],
+    sql: string,
+    options: SyncRulesOptions,
+    ruleId?: string
+  ) {
     const parsed = parse(sql, { locationTracking: true });
-    const rows = new SqlDataQuery();
     const schema = options.schema;
+
+    let errors: SqlRuleError[] = [];
 
     if (parsed.length > 1) {
       throw new SqlRuleError('Only a single SELECT statement is supported', sql, parsed[1]?._location);
@@ -29,7 +40,7 @@ export class SqlDataQuery extends BaseSqlDataQuery {
       throw new SqlRuleError('Only SELECT statements are supported', sql, q._location);
     }
 
-    rows.errors.push(...checkUnsupportedFeatures(sql, q));
+    errors.push(...checkUnsupportedFeatures(sql, q));
 
     if (q.from == null || q.from.length != 1 || q.from[0].type != 'table') {
       throw new SqlRuleError('Must SELECT from a single table', sql, q.from?.[0]._location);
@@ -53,7 +64,7 @@ export class SqlDataQuery extends BaseSqlDataQuery {
         );
         e.type = 'warning';
 
-        rows.errors.push(e);
+        errors.push(e);
       } else {
         querySchema = new TableQuerySchema(tables, alias);
       }
@@ -70,14 +81,14 @@ export class SqlDataQuery extends BaseSqlDataQuery {
     tools.checkSpecificNameCase(tableRef);
     const filter = tools.compileWhereClause(where);
 
-    const inputParameterNames = filter.inputParameters!.map((p) => p.key);
+    const inputParameterNames = filter.inputParameters.map((p) => p.key);
     const bucketParameterNames = bucket_parameters.map((p) => `bucket.${p}`);
     const allParams = new Set<string>([...inputParameterNames, ...bucketParameterNames]);
     if (
-      (!filter.error && allParams.size != filter.inputParameters!.length) ||
+      (!filter.error && allParams.size != filter.inputParameters.length) ||
       allParams.size != bucket_parameters.length
     ) {
-      rows.errors.push(
+      errors.push(
         new SqlRuleError(
           `Query must cover all bucket parameters. Expected: ${JSONBig.stringify(
             bucketParameterNames
@@ -88,17 +99,9 @@ export class SqlDataQuery extends BaseSqlDataQuery {
       );
     }
 
-    rows.sourceTable = sourceTable;
-    rows.table = alias;
-    rows.sql = sql;
-    rows.filter = filter;
-    rows.descriptor_name = descriptor_name;
-    rows.bucket_parameters = bucket_parameters;
-    rows.columns = q.columns ?? [];
-    rows.tools = tools;
-
     let hasId = false;
     let hasWildcard = false;
+    let extractors: RowValueExtractor[] = [];
 
     for (let column of q.columns ?? []) {
       const name = tools.getOutputName(column);
@@ -108,7 +111,7 @@ export class SqlDataQuery extends BaseSqlDataQuery {
           // Error logged already
           continue;
         }
-        rows.extractors.push({
+        extractors.push({
           extract: (tables, output) => {
             output[name] = clause.evaluate(tables);
           },
@@ -119,7 +122,7 @@ export class SqlDataQuery extends BaseSqlDataQuery {
           }
         });
       } else {
-        rows.extractors.push({
+        extractors.push({
           extract: (tables, output) => {
             const row = tables[alias];
             for (let key in row) {
@@ -157,18 +160,37 @@ export class SqlDataQuery extends BaseSqlDataQuery {
         // Schema-based validations are always warnings
         error.type = 'warning';
       }
-      rows.errors.push(error);
+      errors.push(error);
     }
-    rows.errors.push(...tools.errors);
-    return rows;
+
+    errors.push(...tools.errors);
+
+    return new SqlDataQuery({
+      sourceTable,
+      table: alias,
+      sql,
+      filter,
+      columns: q.columns ?? [],
+      descriptor_name,
+      bucket_parameters,
+      tools,
+      ruleId: ruleId ?? '',
+      errors,
+      extractors
+    });
+  }
+
+  constructor(options: SqlDataQueryOptions) {
+    super(options);
+    this.filter = options.filter;
   }
 
   evaluateRow(table: SourceTableInterface, row: SqliteRow): EvaluationResult[] {
     try {
       const tables = { [this.table!]: this.addSpecialParameters(table, row) };
-      const bucketParameters = this.filter!.filterRow(tables);
+      const bucketParameters = this.filter.filterRow(tables);
       const bucketIds = bucketParameters.map((params) =>
-        getBucketId(this.descriptor_name!, this.bucket_parameters!, params)
+        getBucketId(this.descriptor_name, this.bucket_parameters, params)
       );
 
       const data = this.transformRow(tables);

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -257,7 +257,7 @@ export class SqlParameterQuery {
   readonly expandedInputParameter: InputParameter | undefined;
 
   /**
-   * _Output_ bucket parameters.
+   * _Output_ bucket parameters, excluding the `bucket.` prefix.
    *
    * Each one of these will be present in either lookupExtractors or parameterExtractors.
    */

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -82,7 +82,7 @@ export class SqlParameterQuery {
     sql: string,
     options: QueryParseOptions,
     queryId: string
-  ): SqlParameterQuery | StaticSqlParameterQuery {
+  ): SqlParameterQuery | StaticSqlParameterQuery | TableValuedFunctionSqlParameterQuery {
     const parsed = parse(sql, { locationTracking: true });
     const schema = options?.schema;
 
@@ -97,7 +97,7 @@ export class SqlParameterQuery {
 
     if (q.from == null) {
       // E.g. SELECT token_parameters.user_id as user_id WHERE token_parameters.is_admin
-      return StaticSqlParameterQuery.fromSql(descriptor_name, sql, q, options);
+      return StaticSqlParameterQuery.fromSql(descriptor_name, sql, q, options, queryId);
     }
 
     let errors: SqlRuleError[] = [];

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -37,7 +37,7 @@ export interface SqlParameterQueryOptions {
   inputParameters: InputParameter[];
   expandedInputParameter: InputParameter | undefined;
   bucketParameters: string[];
-  id: string;
+  queryId: string;
   tools: SqlTools;
   errors?: SqlRuleError[];
 }
@@ -178,7 +178,7 @@ export class SqlParameterQuery {
       inputParameters: filter.inputParameters,
       expandedInputParameter: expandedParams[0],
       bucketParameters,
-      id: queryId,
+      queryId,
       tools,
       errors
     });
@@ -263,7 +263,14 @@ export class SqlParameterQuery {
    */
   readonly bucketParameters: string[];
 
-  readonly id: string;
+  /**
+   * Unique identifier for this query within a bucket definition.
+   *
+   * Typically auto-generated based on query order.
+   *
+   * This is used when persisting lookup values.
+   */
+  readonly queryId: string;
   readonly tools: SqlTools;
 
   readonly errors: SqlRuleError[];
@@ -280,7 +287,7 @@ export class SqlParameterQuery {
     this.inputParameters = options.inputParameters;
     this.expandedInputParameter = options.expandedInputParameter;
     this.bucketParameters = options.bucketParameters;
-    this.id = options.id;
+    this.queryId = options.queryId;
     this.tools = options.tools;
     this.errors = options.errors ?? [];
   }
@@ -300,7 +307,7 @@ export class SqlParameterQuery {
       const filterParameters = this.filter.filterRow(tables);
       let result: EvaluatedParametersResult[] = [];
       for (let filterParamSet of filterParameters) {
-        let lookup: SqliteJsonValue[] = [this.descriptorName, this.id];
+        let lookup: SqliteJsonValue[] = [this.descriptorName, this.queryId];
         lookup.push(
           ...this.inputParameters.map((param) => {
             return normalizeParameterValue(param.filteredRowToLookupValue(filterParamSet));
@@ -374,7 +381,7 @@ export class SqlParameterQuery {
    */
   getLookups(parameters: RequestParameters): ParameterLookup[] {
     if (!this.expandedInputParameter) {
-      let lookup: SqliteJsonValue[] = [this.descriptorName, this.id];
+      let lookup: SqliteJsonValue[] = [this.descriptorName, this.queryId];
 
       let valid = true;
       lookup.push(
@@ -412,7 +419,7 @@ export class SqlParameterQuery {
 
       return values
         .map((expandedValue) => {
-          let lookup: SqliteJsonValue[] = [this.descriptorName, this.id];
+          let lookup: SqliteJsonValue[] = [this.descriptorName, this.queryId];
           let valid = true;
           const normalizedExpandedValue = normalizeParameterValue(expandedValue);
           lookup.push(

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -314,7 +314,7 @@ export class SqlParameterQuery {
         const data = this.transformRows(row);
 
         const role: EvaluatedParameters = {
-          bucket_parameters: data.map((row) => filterJsonRow(row)),
+          bucketParameters: data.map((row) => filterJsonRow(row)),
           lookup: new ParameterLookup(lookup)
         };
         result.push(role);

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -293,20 +293,20 @@ export class SqlParameterQuery {
   }
 
   applies(table: SourceTableInterface) {
-    return this.sourceTable!.matches(table);
+    return this.sourceTable.matches(table);
   }
 
   evaluateParameterRow(row: SqliteRow): EvaluatedParametersResult[] {
     const tables = {
-      [this.table!]: row
+      [this.table]: row
     };
     try {
-      const filterParameters = this.filter!.filterRow(tables);
+      const filterParameters = this.filter.filterRow(tables);
       let result: EvaluatedParametersResult[] = [];
       for (let filterParamSet of filterParameters) {
-        let lookup: SqliteJsonValue[] = [this.descriptor_name!, this.id!];
+        let lookup: SqliteJsonValue[] = [this.descriptor_name, this.id];
         lookup.push(
-          ...this.input_parameters!.map((param) => {
+          ...this.input_parameters.map((param) => {
             return normalizeParameterValue(param.filteredRowToLookupValue(filterParamSet));
           })
         );
@@ -326,7 +326,7 @@ export class SqlParameterQuery {
   }
 
   transformRows(row: SqliteRow): SqliteRow[] {
-    const tables = { [this.table!]: row };
+    const tables = { [this.table]: row };
     let result: SqliteRow = {};
     for (let key in this.lookup_extractors) {
       const extractor = this.lookup_extractors[key];
@@ -346,7 +346,7 @@ export class SqlParameterQuery {
     return bucketParameters
       .map((lookup) => {
         let result: Record<string, SqliteJsonValue> = {};
-        for (let name of this.bucket_parameters!) {
+        for (let name of this.bucket_parameters) {
           if (name in this.lookup_extractors) {
             result[`bucket.${name}`] = lookup[name];
           } else {
@@ -362,7 +362,7 @@ export class SqlParameterQuery {
         }
 
         return {
-          bucket: getBucketId(this.descriptor_name!, this.bucket_parameters!, result),
+          bucket: getBucketId(this.descriptor_name, this.bucket_parameters, result),
           priority: this.priority
         };
       })
@@ -376,11 +376,11 @@ export class SqlParameterQuery {
    */
   getLookups(parameters: RequestParameters): ParameterLookup[] {
     if (!this.expanded_input_parameter) {
-      let lookup: SqliteJsonValue[] = [this.descriptor_name!, this.id!];
+      let lookup: SqliteJsonValue[] = [this.descriptor_name, this.id];
 
       let valid = true;
       lookup.push(
-        ...this.input_parameters!.map((param): SqliteJsonValue => {
+        ...this.input_parameters.map((param): SqliteJsonValue => {
           // Scalar value
           const value = param.parametersToLookupValue(parameters);
 
@@ -414,11 +414,11 @@ export class SqlParameterQuery {
 
       return values
         .map((expandedValue) => {
-          let lookup: SqliteJsonValue[] = [this.descriptor_name!, this.id!];
+          let lookup: SqliteJsonValue[] = [this.descriptor_name, this.id];
           let valid = true;
           const normalizedExpandedValue = normalizeParameterValue(expandedValue);
           lookup.push(
-            ...this.input_parameters!.map((param): SqliteJsonValue => {
+            ...this.input_parameters.map((param): SqliteJsonValue => {
               if (param == this.expanded_input_parameter) {
                 // Expand array value
                 return normalizedExpandedValue;
@@ -480,14 +480,13 @@ export class SqlParameterQuery {
 
   get hasAuthenticatedMatchClause(): boolean {
     // select ... where user_id = request.user_id()
-    this.filter?.inputParameters.find;
-    const authenticatedInputParameter = this.filter!.usesAuthenticatedRequestParameters;
+    const authenticatedInputParameter = this.filter.usesAuthenticatedRequestParameters;
     return authenticatedInputParameter;
   }
 
   get usesUnauthenticatedRequestParameters(): boolean {
     // select ... where request.parameters() ->> 'include_comments'
-    const unauthenticatedInputParameter = this.filter!.usesUnauthenticatedRequestParameters;
+    const unauthenticatedInputParameter = this.filter.usesUnauthenticatedRequestParameters;
 
     // select request.parameters() ->> 'project_id'
     const unauthenticatedExtractor =

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -108,7 +108,7 @@ export class SqlParameterQuery {
       throw new SqlRuleError('Must SELECT from a single table', sql, q.from?.[0]._location);
     } else if (q.from[0].type == 'call') {
       const from = q.from[0];
-      return TableValuedFunctionSqlParameterQuery.fromSql(descriptor_name, sql, from, q, options);
+      return TableValuedFunctionSqlParameterQuery.fromSql(descriptor_name, sql, from, q, options, queryId);
     } else if (q.from[0].type == 'statement') {
       throw new SqlRuleError('Subqueries are not supported yet', sql, q.from?.[0]._location);
     }

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -386,7 +386,7 @@ export class SqlSyncRules implements SyncRules {
   debugGetOutputTables() {
     let result: Record<string, any[]> = {};
     for (let bucket of this.bucket_descriptors) {
-      for (let q of bucket.data_queries) {
+      for (let q of bucket.dataQueries) {
         result[q.table!] ??= [];
         const r = {
           query: q.sql

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -42,7 +42,6 @@ export interface SyncRulesOptions {
 export class SqlSyncRules implements SyncRules {
   bucketDescriptors: SqlBucketDescriptor[] = [];
   eventDescriptors: SqlEventDescriptor[] = [];
-  idSequence = new IdSequence();
 
   content: string;
 
@@ -137,7 +136,7 @@ export class SqlSyncRules implements SyncRules {
       const parameters = value.get('parameters', true) as unknown;
       const dataQueries = value.get('data', true) as unknown;
 
-      const descriptor = new SqlBucketDescriptor(key, rules.idSequence);
+      const descriptor = new SqlBucketDescriptor(key);
 
       if (parameters instanceof Scalar) {
         rules.withScalar(parameters, (q) => {
@@ -180,7 +179,7 @@ export class SqlSyncRules implements SyncRules {
         continue;
       }
 
-      const eventDescriptor = new SqlEventDescriptor(key.toString(), rules.idSequence);
+      const eventDescriptor = new SqlEventDescriptor(key.toString());
       for (let item of payloads.items) {
         if (!isScalar(item)) {
           rules.errors.push(new YamlError(new Error(`Payload queries for events must be scalar.`)));

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -143,7 +143,7 @@ export class StaticSqlParameterQuery {
     }
 
     let result: Record<string, SqliteJsonValue> = {};
-    for (let name of this.bucket_parameters!) {
+    for (let name of this.bucket_parameters) {
       const value = this.parameter_extractors[name].lookupParameterValue(parameters);
       if (isJsonValue(value)) {
         result[`bucket.${name}`] = value;
@@ -156,7 +156,7 @@ export class StaticSqlParameterQuery {
 
     return [
       {
-        bucket: getBucketId(this.descriptor_name!, this.bucket_parameters!, result),
+        bucket: getBucketId(this.descriptor_name, this.bucket_parameters, result),
         priority: this.priority
       }
     ];
@@ -165,7 +165,7 @@ export class StaticSqlParameterQuery {
   get hasAuthenticatedBucketParameters(): boolean {
     // select where request.jwt() ->> 'role' == 'authorized'
     // we do not count this as a sufficient check
-    // const authenticatedFilter = this.filter!.usesAuthenticatedRequestParameters;
+    // const authenticatedFilter = this.filter.usesAuthenticatedRequestParameters;
 
     // select request.user_id() as user_id
     const authenticatedExtractor =

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -12,7 +12,7 @@ export interface StaticSqlParameterQueryOptions {
   priority: BucketPriority;
   descriptorName: string;
   bucketParameters: string[];
-  id: string;
+  queryId: string;
   filter: ParameterValueClause | undefined;
   errors?: SqlRuleError[];
 }
@@ -84,7 +84,7 @@ export class StaticSqlParameterQuery {
       parameterExtractors,
       priority: priority ?? DEFAULT_BUCKET_PRIORITY,
       filter: isClauseError(filter) ? undefined : filter,
-      id: queryId,
+      queryId,
       errors
     });
     if (query.usesDangerousRequestParameters && !options?.accept_potentially_dangerous_queries) {
@@ -124,7 +124,14 @@ export class StaticSqlParameterQuery {
    */
   readonly bucketParameters: string[];
 
-  readonly id: string;
+  /**
+   * Unique identifier for this query within a bucket definition.
+   *
+   * Typically auto-generated based on query order.
+   *
+   * This is not used directly, but we keep this to match behavior of other parameter queries.
+   */
+  readonly queryId: string;
 
   /**
    * The query filter (WHERE clause). Given request parameters, the filter will determine whether or not this query returns a row.
@@ -141,7 +148,7 @@ export class StaticSqlParameterQuery {
     this.priority = options.priority;
     this.descriptorName = options.descriptorName;
     this.bucketParameters = options.bucketParameters;
-    this.id = options.id;
+    this.queryId = options.queryId;
     this.filter = options.filter;
     this.errors = options.errors ?? [];
   }

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -4,7 +4,7 @@ import { SqlTools } from './sql_filters.js';
 import { checkUnsupportedFeatures, isClauseError, isParameterValueClause, sqliteBool } from './sql_support.js';
 import { ParameterValueClause, QueryParseOptions, RequestParameters, SqliteJsonValue } from './types.js';
 import { getBucketId, isJsonValue } from './utils.js';
-import { BucketDescription, BucketPriority, defaultBucketPriority } from './BucketDescription.js';
+import { BucketDescription, BucketPriority, DEFAULT_BUCKET_PRIORITY } from './BucketDescription.js';
 
 /**
  * Represents a bucket parameter query without any tables, e.g.:
@@ -117,7 +117,7 @@ export class StaticSqlParameterQuery {
     return [
       {
         bucket: getBucketId(this.descriptor_name!, this.bucket_parameters!, result),
-        priority: this.priority ?? defaultBucketPriority
+        priority: this.priority ?? DEFAULT_BUCKET_PRIORITY
       }
     ];
   }

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -8,17 +8,12 @@ import { getBucketId, isJsonValue } from './utils.js';
 
 export interface StaticSqlParameterQueryOptions {
   sql: string;
-  columns: SelectedColumn[];
   parameterExtractors: Record<string, ParameterValueClause>;
   priority: BucketPriority;
   descriptorName: string;
-  /** _Output_ bucket parameters */
   bucketParameters: string[];
   id: string;
-  tools: SqlTools;
-
   filter: ParameterValueClause | undefined;
-
   errors?: SqlRuleError[];
 }
 
@@ -86,9 +81,7 @@ export class StaticSqlParameterQuery {
       sql,
       descriptorName,
       bucketParameters,
-      columns,
       parameterExtractors,
-      tools,
       priority: priority ?? DEFAULT_BUCKET_PRIORITY,
       filter: isClauseError(filter) ? undefined : filter,
       id: queryId,
@@ -105,29 +98,50 @@ export class StaticSqlParameterQuery {
     return query;
   }
 
+  /**
+   * Raw source sql query, for debugging purposes.
+   */
   readonly sql: string;
-  readonly columns: SelectedColumn[];
-  readonly parameterExtractors: Record<string, ParameterValueClause>;
-  readonly priority: BucketPriority;
-  readonly descriptorName: string;
-  /** _Output_ bucket parameters */
-  readonly bucketParameters: string[];
-  readonly id: string;
-  readonly tools: SqlTools;
 
+  /**
+   * Matches the keys in `bucketParameters`.
+   *
+   * This is used to map request parameters -> bucket parameters.
+   */
+  readonly parameterExtractors: Record<string, ParameterValueClause>;
+
+  readonly priority: BucketPriority;
+
+  /**
+   * Bucket definition name.
+   */
+  readonly descriptorName: string;
+
+  /**
+   * _Output_ bucket parameters, excluding the `bucket.` prefix.
+   *
+   * Each one will be present in the `parameterExtractors` map.
+   */
+  readonly bucketParameters: string[];
+
+  readonly id: string;
+
+  /**
+   * The query filter (WHERE clause). Given request parameters, the filter will determine whether or not this query returns a row.
+   *
+   * undefined if the clause is not valid.
+   */
   readonly filter: ParameterValueClause | undefined;
 
   readonly errors: SqlRuleError[];
 
   constructor(options: StaticSqlParameterQueryOptions) {
     this.sql = options.sql;
-    this.columns = options.columns;
     this.parameterExtractors = options.parameterExtractors;
     this.priority = options.priority;
     this.descriptorName = options.descriptorName;
     this.bucketParameters = options.bucketParameters;
     this.id = options.id;
-    this.tools = options.tools;
     this.filter = options.filter;
     this.errors = options.errors ?? [];
   }

--- a/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
+++ b/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
@@ -168,7 +168,7 @@ export class TableValuedFunctionSqlParameterQuery {
     }
 
     const valueString = this.callClause.lookupParameterValue(parameters);
-    const rows = this.function!.call([valueString]);
+    const rows = this.function.call([valueString]);
     let total: BucketDescription[] = [];
     for (let row of rows) {
       const description = this.getIndividualBucketDescription(row, parameters);
@@ -216,7 +216,7 @@ export class TableValuedFunctionSqlParameterQuery {
   get hasAuthenticatedBucketParameters(): boolean {
     // select where request.jwt() ->> 'role' == 'authorized'
     // we do not count this as a sufficient check
-    // const authenticatedFilter = this.filter!.usesAuthenticatedRequestParameters;
+    // const authenticatedFilter = this.filter.usesAuthenticatedRequestParameters;
 
     // select request.user_id() as user_id
     const authenticatedExtractor =

--- a/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
+++ b/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
@@ -12,7 +12,7 @@ import {
   SqliteRow
 } from './types.js';
 import { getBucketId, isJsonValue } from './utils.js';
-import { BucketDescription, BucketPriority, defaultBucketPriority } from './BucketDescription.js';
+import { BucketDescription, BucketPriority, DEFAULT_BUCKET_PRIORITY } from './BucketDescription.js';
 
 /**
  * Represents a parameter query using a table-valued function.
@@ -166,7 +166,7 @@ export class TableValuedFunctionSqlParameterQuery {
 
     return {
       bucket: getBucketId(this.descriptor_name!, this.bucket_parameters!, result),
-      priority: this.priority ?? defaultBucketPriority
+      priority: this.priority ?? DEFAULT_BUCKET_PRIORITY
     };
   }
 

--- a/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
+++ b/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
@@ -19,9 +19,8 @@ export interface TableValuedFunctionSqlParameterQueryOptions {
   parameterExtractors: Record<string, ParameterValueClause>;
   priority: BucketPriority;
   descriptorName: string;
-  /** _Output_ bucket parameters */
   bucketParameters: string[];
-  id: string;
+  queryId: string;
 
   filter: ParameterValueClause | undefined;
   callClause: ParameterValueClause | undefined;
@@ -107,7 +106,7 @@ export class TableValuedFunctionSqlParameterQuery {
       function: functionImpl,
       callTableName: callTable,
       priority: priority ?? DEFAULT_BUCKET_PRIORITY,
-      id: queryId,
+      queryId,
       errors
     });
 
@@ -148,7 +147,14 @@ export class TableValuedFunctionSqlParameterQuery {
    */
   readonly bucketParameters: string[];
 
-  readonly id: string;
+  /**
+   * Unique identifier for this query within a bucket definition.
+   *
+   * Typically auto-generated based on query order.
+   *
+   * This is not used directly, but we keep this to match behavior of other parameter queries.
+   */
+  readonly queryId: string;
 
   /**
    * The WHERE clause. This is applied on (request parameters + individual function call result row).
@@ -186,7 +192,7 @@ export class TableValuedFunctionSqlParameterQuery {
     this.priority = options.priority;
     this.descriptorName = options.descriptorName;
     this.bucketParameters = options.bucketParameters;
-    this.id = options.id;
+    this.queryId = options.queryId;
 
     this.filter = options.filter;
     this.callClause = options.callClause;

--- a/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
+++ b/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
@@ -181,9 +181,9 @@ export class TableValuedFunctionSqlParameterQuery {
 
   private getIndividualBucketDescription(row: SqliteRow, parameters: RequestParameters): BucketDescription | null {
     const mergedParams: ParameterValueSet = {
-      raw_token_payload: parameters.raw_token_payload,
-      raw_user_parameters: parameters.raw_user_parameters,
-      user_id: parameters.user_id,
+      rawTokenPayload: parameters.rawTokenPayload,
+      rawUserParameters: parameters.rawUserParameters,
+      userId: parameters.userId,
       lookup: (table, column) => {
         if (table == this.callTableName) {
           return row[column]!;

--- a/packages/sync-rules/src/events/SqlEventDescriptor.ts
+++ b/packages/sync-rules/src/events/SqlEventDescriptor.ts
@@ -22,7 +22,7 @@ export class SqlEventDescriptor {
   }
 
   addSourceQuery(sql: string, options: SyncRulesOptions): QueryParseResult {
-    const source = SqlEventSourceQuery.fromSql(this.name, sql, options);
+    const source = SqlEventSourceQuery.fromSql(this.name, sql, options, this.idSequence.nextId());
 
     // Each source query should be for a unique table
     const existingSourceQuery = this.source_queries.find((q) => q.table == source.table);
@@ -33,7 +33,6 @@ export class SqlEventDescriptor {
       };
     }
 
-    source.ruleId = this.idSequence.nextId();
     this.source_queries.push(source);
 
     return {

--- a/packages/sync-rules/src/events/SqlEventDescriptor.ts
+++ b/packages/sync-rules/src/events/SqlEventDescriptor.ts
@@ -14,15 +14,12 @@ export class SqlEventDescriptor {
   name: string;
   sourceQueries: SqlEventSourceQuery[] = [];
 
-  constructor(
-    name: string,
-    public idSequence: IdSequence
-  ) {
+  constructor(name: string) {
     this.name = name;
   }
 
   addSourceQuery(sql: string, options: SyncRulesOptions): QueryParseResult {
-    const source = SqlEventSourceQuery.fromSql(this.name, sql, options, this.idSequence.nextId());
+    const source = SqlEventSourceQuery.fromSql(this.name, sql, options);
 
     // Each source query should be for a unique table
     const existingSourceQuery = this.sourceQueries.find((q) => q.table == source.table);

--- a/packages/sync-rules/src/events/SqlEventDescriptor.ts
+++ b/packages/sync-rules/src/events/SqlEventDescriptor.ts
@@ -12,7 +12,7 @@ import { EvaluatedEventRowWithErrors, SqlEventSourceQuery } from './SqlEventSour
  */
 export class SqlEventDescriptor {
   name: string;
-  source_queries: SqlEventSourceQuery[] = [];
+  sourceQueries: SqlEventSourceQuery[] = [];
 
   constructor(
     name: string,
@@ -25,7 +25,7 @@ export class SqlEventDescriptor {
     const source = SqlEventSourceQuery.fromSql(this.name, sql, options, this.idSequence.nextId());
 
     // Each source query should be for a unique table
-    const existingSourceQuery = this.source_queries.find((q) => q.table == source.table);
+    const existingSourceQuery = this.sourceQueries.find((q) => q.table == source.table);
     if (existingSourceQuery) {
       return {
         parsed: false,
@@ -33,7 +33,7 @@ export class SqlEventDescriptor {
       };
     }
 
-    this.source_queries.push(source);
+    this.sourceQueries.push(source);
 
     return {
       parsed: true,
@@ -43,7 +43,7 @@ export class SqlEventDescriptor {
 
   evaluateRowWithErrors(options: EvaluateRowOptions): EvaluatedEventRowWithErrors {
     // There should only be 1 payload result per source query
-    const matchingQuery = this.source_queries.find((q) => q.applies(options.sourceTable));
+    const matchingQuery = this.sourceQueries.find((q) => q.applies(options.sourceTable));
     if (!matchingQuery) {
       return {
         errors: [{ error: `No marching source query found for table ${options.sourceTable.table}` }]
@@ -55,13 +55,13 @@ export class SqlEventDescriptor {
 
   getSourceTables(): Set<TablePattern> {
     let result = new Set<TablePattern>();
-    for (let query of this.source_queries) {
+    for (let query of this.sourceQueries) {
       result.add(query.sourceTable!);
     }
     return result;
   }
 
   tableTriggersEvent(table: SourceTableInterface): boolean {
-    return this.source_queries.some((query) => query.applies(table));
+    return this.sourceQueries.some((query) => query.applies(table));
   }
 }

--- a/packages/sync-rules/src/events/SqlEventSourceQuery.ts
+++ b/packages/sync-rules/src/events/SqlEventSourceQuery.ts
@@ -1,5 +1,5 @@
 import { parse } from 'pgsql-ast-parser';
-import { BaseSqlDataQuery } from '../BaseSqlDataQuery.js';
+import { BaseSqlDataQuery, BaseSqlDataQueryOptions, RowValueExtractor } from '../BaseSqlDataQuery.js';
 import { SqlRuleError } from '../errors.js';
 import { ExpressionType } from '../ExpressionType.js';
 import { SourceTableInterface } from '../SourceTableInterface.js';
@@ -25,9 +25,8 @@ export type EvaluatedEventRowWithErrors = {
  * Defines how a Replicated Row is mapped to source parameters for events.
  */
 export class SqlEventSourceQuery extends BaseSqlDataQuery {
-  static fromSql(descriptor_name: string, sql: string, options: SyncRulesOptions) {
+  static fromSql(descriptor_name: string, sql: string, options: SyncRulesOptions, ruleId: string) {
     const parsed = parse(sql, { locationTracking: true });
-    const rows = new SqlEventSourceQuery();
     const schema = options.schema;
 
     if (parsed.length > 1) {
@@ -38,7 +37,9 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
       throw new SqlRuleError('Only SELECT statements are supported', sql, q._location);
     }
 
-    rows.errors.push(...checkUnsupportedFeatures(sql, q));
+    let errors: SqlRuleError[] = [];
+
+    errors.push(...checkUnsupportedFeatures(sql, q));
 
     if (q.from == null || q.from.length != 1 || q.from[0].type != 'table') {
       throw new SqlRuleError('Must SELECT from a single table', sql, q.from?.[0]._location);
@@ -62,7 +63,7 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
         );
         e.type = 'warning';
 
-        rows.errors.push(e);
+        errors.push(e);
       } else {
         querySchema = new TableQuerySchema(tables, alias);
       }
@@ -76,13 +77,7 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
       schema: querySchema
     });
 
-    rows.sourceTable = sourceTable;
-    rows.table = alias;
-    rows.sql = sql;
-    rows.descriptor_name = descriptor_name;
-    rows.columns = q.columns ?? [];
-    rows.tools = tools;
-
+    let extractors: RowValueExtractor[] = [];
     for (let column of q.columns ?? []) {
       const name = tools.getOutputName(column);
       if (name != '*') {
@@ -91,7 +86,7 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
           // Error logged already
           continue;
         }
-        rows.extractors.push({
+        extractors.push({
           extract: (tables, output) => {
             output[name] = clause.evaluate(tables);
           },
@@ -101,7 +96,7 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
           }
         });
       } else {
-        rows.extractors.push({
+        extractors.push({
           extract: (tables, output) => {
             const row = tables[alias];
             for (let key in row) {
@@ -119,8 +114,24 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
         });
       }
     }
-    rows.errors.push(...tools.errors);
-    return rows;
+    errors.push(...tools.errors);
+
+    return new SqlEventSourceQuery({
+      sourceTable,
+      table: alias,
+      sql,
+      descriptor_name,
+      columns: q.columns ?? [],
+      extractors: extractors,
+      tools,
+      bucket_parameters: [],
+      ruleId: ruleId,
+      errors: errors
+    });
+  }
+
+  constructor(options: BaseSqlDataQueryOptions) {
+    super(options);
   }
 
   evaluateRowWithErrors(table: SourceTableInterface, row: SqliteRow): EvaluatedEventRowWithErrors {

--- a/packages/sync-rules/src/events/SqlEventSourceQuery.ts
+++ b/packages/sync-rules/src/events/SqlEventSourceQuery.ts
@@ -13,7 +13,6 @@ import { isSelectStatement } from '../utils.js';
 
 export type EvaluatedEventSourceRow = {
   data: SqliteJsonRow;
-  ruleId?: string;
 };
 
 export type EvaluatedEventRowWithErrors = {
@@ -25,7 +24,7 @@ export type EvaluatedEventRowWithErrors = {
  * Defines how a Replicated Row is mapped to source parameters for events.
  */
 export class SqlEventSourceQuery extends BaseSqlDataQuery {
-  static fromSql(descriptor_name: string, sql: string, options: SyncRulesOptions, ruleId: string) {
+  static fromSql(descriptor_name: string, sql: string, options: SyncRulesOptions) {
     const parsed = parse(sql, { locationTracking: true });
     const schema = options.schema;
 
@@ -125,7 +124,6 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
       extractors: extractors,
       tools,
       bucketParameters: [],
-      ruleId: ruleId,
       errors: errors
     });
   }
@@ -141,8 +139,7 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
       const data = this.transformRow(tables);
       return {
         result: {
-          data,
-          ruleId: this.ruleId
+          data
         },
         errors: []
       };

--- a/packages/sync-rules/src/events/SqlEventSourceQuery.ts
+++ b/packages/sync-rules/src/events/SqlEventSourceQuery.ts
@@ -71,8 +71,8 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
 
     const tools = new SqlTools({
       table: alias,
-      parameter_tables: [],
-      value_tables: [alias],
+      parameterTables: [],
+      valueTables: [alias],
       sql,
       schema: querySchema
     });
@@ -120,11 +120,11 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
       sourceTable,
       table: alias,
       sql,
-      descriptor_name,
+      descriptorName: descriptor_name,
       columns: q.columns ?? [],
       extractors: extractors,
       tools,
-      bucket_parameters: [],
+      bucketParameters: [],
       ruleId: ruleId,
       errors: errors
     });

--- a/packages/sync-rules/src/request_functions.ts
+++ b/packages/sync-rules/src/request_functions.ts
@@ -16,7 +16,7 @@ export interface SqlParameterFunction {
 const request_parameters: SqlParameterFunction = {
   debugName: 'request.parameters',
   call(parameters: ParameterValueSet) {
-    return parameters.raw_user_parameters;
+    return parameters.rawUserParameters;
   },
   getReturnType() {
     return ExpressionType.TEXT;
@@ -31,7 +31,7 @@ const request_parameters: SqlParameterFunction = {
 const request_jwt: SqlParameterFunction = {
   debugName: 'request.jwt',
   call(parameters: ParameterValueSet) {
-    return parameters.raw_token_payload;
+    return parameters.rawTokenPayload;
   },
   getReturnType() {
     return ExpressionType.TEXT;
@@ -45,7 +45,7 @@ const request_jwt: SqlParameterFunction = {
 const request_user_id: SqlParameterFunction = {
   debugName: 'request.user_id',
   call(parameters: ParameterValueSet) {
-    return parameters.user_id;
+    return parameters.userId;
   },
   getReturnType() {
     return ExpressionType.TEXT;

--- a/packages/sync-rules/src/schema-generators/SchemaGenerator.ts
+++ b/packages/sync-rules/src/schema-generators/SchemaGenerator.ts
@@ -10,7 +10,7 @@ export abstract class SchemaGenerator {
   protected getAllTables(source: SqlSyncRules, schema: SourceSchema) {
     let tables: Record<string, Record<string, ColumnDefinition>> = {};
 
-    for (let descriptor of source.bucket_descriptors) {
+    for (let descriptor of source.bucketDescriptors) {
       for (let query of descriptor.dataQueries) {
         const outTables = query.getColumnOutputs(schema);
         for (let table of outTables) {

--- a/packages/sync-rules/src/schema-generators/SchemaGenerator.ts
+++ b/packages/sync-rules/src/schema-generators/SchemaGenerator.ts
@@ -11,7 +11,7 @@ export abstract class SchemaGenerator {
     let tables: Record<string, Record<string, ColumnDefinition>> = {};
 
     for (let descriptor of source.bucket_descriptors) {
-      for (let query of descriptor.data_queries) {
+      for (let query of descriptor.dataQueries) {
         const outTables = query.getColumnOutputs(schema);
         for (let table of outTables) {
           tables[table.name] ??= {};

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -1,6 +1,7 @@
 import { JSONBig } from '@powersync/service-jsonbig';
 import { Expr, ExprRef, Name, NodeLocation, QName, QNameAliased, SelectedColumn } from 'pgsql-ast-parser';
 import { nil } from 'pgsql-ast-parser/src/utils.js';
+import { BucketPriority, isValidPriority } from './BucketDescription.js';
 import { ExpressionType } from './ExpressionType.js';
 import { SqlRuleError } from './errors.js';
 import { REQUEST_FUNCTIONS } from './request_functions.js';
@@ -40,13 +41,11 @@ import {
   QueryParameters,
   QuerySchema,
   RowValueClause,
-  SqliteJsonRow,
   SqliteValue,
   StaticValueClause,
   TrueIfParametersMatch
 } from './types.js';
 import { isJsonValue } from './utils.js';
-import { BucketPriority, isValidPriority } from './BucketDescription.js';
 
 export const MATCH_CONST_FALSE: TrueIfParametersMatch = [];
 export const MATCH_CONST_TRUE: TrueIfParametersMatch = [{}];

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -69,14 +69,14 @@ export interface SqlToolsOptions {
    *   "bucket" (bucket parameters for data query)
    *   "token_parameters" (token parameters for parameter query)
    */
-  parameter_tables?: string[];
+  parameterTables?: string[];
 
   /**
    * Set of tables used in QueryParameters.
    *
    * If not specified, defaults to [table].
    */
-  value_tables?: string[];
+  valueTables?: string[];
 
   /**
    * For debugging / error messages.
@@ -88,12 +88,12 @@ export interface SqlToolsOptions {
    *
    * Only one parameter may be expanded.
    */
-  supports_expanding_parameters?: boolean;
+  supportsExpandingParameters?: boolean;
 
   /**
    * true if expressions on parameters are supported, e.g. upper(token_parameters.user_id)
    */
-  supports_parameter_expressions?: boolean;
+  supportsParameterExpressions?: boolean;
 
   /**
    * Schema for validations.
@@ -102,36 +102,36 @@ export interface SqlToolsOptions {
 }
 
 export class SqlTools {
-  default_table?: string;
-  value_tables: string[];
+  readonly defaultTable?: string;
+  readonly valueTables: string[];
   /**
    * ['bucket'] for data queries
    * ['token_parameters', 'user_parameters'] for parameter queries
    */
-  parameter_tables: string[];
-  sql: string;
-  errors: SqlRuleError[] = [];
+  readonly parameterTables: string[];
+  readonly sql: string;
+  readonly errors: SqlRuleError[] = [];
 
-  supports_expanding_parameters: boolean;
-  supports_parameter_expressions: boolean;
+  readonly supportsExpandingParameters: boolean;
+  readonly supportsParameterExpressions: boolean;
 
   schema?: QuerySchema;
 
   constructor(options: SqlToolsOptions) {
-    this.default_table = options.table;
+    this.defaultTable = options.table;
     this.schema = options.schema;
 
-    if (options.value_tables) {
-      this.value_tables = options.value_tables;
-    } else if (this.default_table) {
-      this.value_tables = [this.default_table];
+    if (options.valueTables) {
+      this.valueTables = options.valueTables;
+    } else if (this.defaultTable) {
+      this.valueTables = [this.defaultTable];
     } else {
-      this.value_tables = [];
+      this.valueTables = [];
     }
-    this.parameter_tables = options.parameter_tables ?? [];
+    this.parameterTables = options.parameterTables ?? [];
     this.sql = options.sql;
-    this.supports_expanding_parameters = options.supports_expanding_parameters ?? false;
-    this.supports_parameter_expressions = options.supports_parameter_expressions ?? false;
+    this.supportsExpandingParameters = options.supportsExpandingParameters ?? false;
+    this.supportsParameterExpressions = options.supportsParameterExpressions ?? false;
   }
 
   error(message: string, expr: NodeLocation | Expr | undefined): ClauseError {
@@ -242,7 +242,7 @@ export class SqlTools {
         let otherFilter1: CompiledClause;
 
         if (
-          this.supports_parameter_expressions &&
+          this.supportsParameterExpressions &&
           isParameterValueClause(leftFilter) &&
           isParameterValueClause(rightFilter)
         ) {
@@ -342,7 +342,7 @@ export class SqlTools {
             usesUnauthenticatedRequestParameters: leftFilter.usesUnauthenticatedRequestParameters
           } satisfies ParameterMatchClause;
         } else if (
-          this.supports_expanding_parameters &&
+          this.supportsExpandingParameters &&
           isRowValueClause(leftFilter) &&
           isParameterValueClause(rightFilter)
         ) {
@@ -415,7 +415,7 @@ export class SqlTools {
         return composed;
       } else if (schema == 'request') {
         // Special function
-        if (!this.supports_parameter_expressions) {
+        if (!this.supportsParameterExpressions) {
           return this.error(`${schema} schema is not available in data queries`, expr);
         }
 
@@ -501,8 +501,8 @@ export class SqlTools {
     if (expr.type != 'ref') {
       return false;
     }
-    const tableName = expr.table?.name ?? this.default_table;
-    return this.parameter_tables.includes(tableName ?? '');
+    const tableName = expr.table?.name ?? this.defaultTable;
+    return this.parameterTables.includes(tableName ?? '');
   }
 
   /**
@@ -587,7 +587,7 @@ export class SqlTools {
   }
 
   getParameterRefClause(expr: ExprRef): ParameterValueClause {
-    const table = (expr.table?.name ?? this.default_table)!;
+    const table = (expr.table?.name ?? this.defaultTable)!;
     const column = expr.name;
     return {
       key: `${table}.${column}`,
@@ -612,8 +612,8 @@ export class SqlTools {
     if (this.refHasSchema(ref)) {
       throw new SqlRuleError(`Specifying schema in column references is not supported`, this.sql, ref);
     }
-    const tableName = ref.table?.name ?? this.default_table;
-    if (this.value_tables.includes(tableName ?? '')) {
+    const tableName = ref.table?.name ?? this.defaultTable;
+    if (this.valueTables.includes(tableName ?? '')) {
       return tableName!;
     } else if (ref.table?.name == null) {
       throw new SqlRuleError(`Table name required`, this.sql, ref);
@@ -712,7 +712,7 @@ export class SqlTools {
       } else if (isStaticValueClause(clause)) {
         // argsType unchanged
       } else if (isParameterValueClause(clause)) {
-        if (!this.supports_parameter_expressions) {
+        if (!this.supportsParameterExpressions) {
           if (fnImpl.debugName == 'operatorIN') {
             // Special-case error message to be more descriptive
             return { error: `Cannot use bucket parameters on the right side of IN operators`, errorExpr: debugArg };

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -26,7 +26,7 @@ export interface EvaluatedParameters {
    *
    * JSON-serializable.
    */
-  bucket_parameters: Record<string, SqliteJsonValue>[];
+  bucketParameters: Record<string, SqliteJsonValue>[];
 }
 
 export type EvaluatedParametersResult = EvaluatedParameters | EvaluationError;
@@ -82,55 +82,55 @@ export interface ParameterValueSet {
   /**
    * JSON string of raw request parameters.
    */
-  raw_user_parameters: string;
+  rawUserParameters: string;
 
   /**
    * JSON string of raw request parameters.
    */
-  raw_token_payload: string;
+  rawTokenPayload: string;
 
-  user_id: string;
+  userId: string;
 }
 
 export class RequestParameters implements ParameterValueSet {
-  token_parameters: SqliteJsonRow;
-  user_parameters: SqliteJsonRow;
+  tokenParameters: SqliteJsonRow;
+  userParameters: SqliteJsonRow;
 
   /**
    * JSON string of raw request parameters.
    */
-  raw_user_parameters: string;
+  rawUserParameters: string;
 
   /**
    * JSON string of raw request parameters.
    */
-  raw_token_payload: string;
+  rawTokenPayload: string;
 
-  user_id: string;
+  userId: string;
 
   constructor(tokenPayload: RequestJwtPayload, clientParameters: Record<string, any>) {
     // This type is verified when we verify the token
     const legacyParameters = tokenPayload.parameters as Record<string, any> | undefined;
 
-    const token_parameters = {
+    const tokenParameters = {
       ...legacyParameters,
       // sub takes presedence over any embedded parameters
       user_id: tokenPayload.sub
     };
 
-    this.token_parameters = toSyncRulesParameters(token_parameters);
-    this.user_id = tokenPayload.sub;
-    this.raw_token_payload = JSONBig.stringify(tokenPayload);
+    this.tokenParameters = toSyncRulesParameters(tokenParameters);
+    this.userId = tokenPayload.sub;
+    this.rawTokenPayload = JSONBig.stringify(tokenPayload);
 
-    this.raw_user_parameters = JSONBig.stringify(clientParameters);
-    this.user_parameters = toSyncRulesParameters(clientParameters);
+    this.rawUserParameters = JSONBig.stringify(clientParameters);
+    this.userParameters = toSyncRulesParameters(clientParameters);
   }
 
   lookup(table: string, column: string): SqliteJsonValue {
     if (table == 'token_parameters') {
-      return this.token_parameters[column];
+      return this.tokenParameters[column];
     } else if (table == 'user_parameters') {
-      return this.user_parameters[column];
+      return this.userParameters[column];
     }
     throw new Error(`Unknown table: ${table}`);
   }

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -44,9 +44,6 @@ export interface EvaluatedRow {
 
   /** Must be JSON-serializable. */
   data: SqliteJsonRow;
-
-  /** For debugging purposes only. */
-  ruleId?: string;
 }
 
 export interface EvaluationError {

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -13,7 +13,8 @@ describe('data queries', () => {
         bucket: 'mybucket["org1"]',
         table: 'assets',
         id: 'asset1',
-        data: { id: 'asset1', org_id: 'org1' }
+        data: { id: 'asset1', org_id: 'org1' },
+        ruleId: ''
       }
     ]);
 
@@ -83,7 +84,8 @@ describe('data queries', () => {
         bucket: 'mybucket["org1"]',
         table: 'others',
         id: 'asset1',
-        data: { id: 'asset1', org_id: 'org1' }
+        data: { id: 'asset1', org_id: 'org1' },
+        ruleId: ''
       }
     ]);
   });

--- a/packages/sync-rules/test/src/data_queries.test.ts
+++ b/packages/sync-rules/test/src/data_queries.test.ts
@@ -13,8 +13,7 @@ describe('data queries', () => {
         bucket: 'mybucket["org1"]',
         table: 'assets',
         id: 'asset1',
-        data: { id: 'asset1', org_id: 'org1' },
-        ruleId: ''
+        data: { id: 'asset1', org_id: 'org1' }
       }
     ]);
 
@@ -84,8 +83,7 @@ describe('data queries', () => {
         bucket: 'mybucket["org1"]',
         table: 'others',
         id: 'asset1',
-        data: { id: 'asset1', org_id: 'org1' },
-        ruleId: ''
+        data: { id: 'asset1', org_id: 'org1' }
       }
     ]);
   });

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -11,7 +11,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'group1', user_ids: JSON.stringify(['user1', 'user2']) })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1']),
-        bucket_parameters: [
+        bucketParameters: [
           {
             group_id: 'group1'
           }
@@ -19,7 +19,7 @@ describe('parameter queries', () => {
       },
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user2']),
-        bucket_parameters: [
+        bucketParameters: [
           {
             group_id: 'group1'
           }
@@ -42,7 +42,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'region1', name: 'colorado' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['colorado']),
-        bucket_parameters: [
+        bucketParameters: [
           {
             region_id: 'region1'
           }
@@ -71,7 +71,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', [314n, 3.14, 314]),
 
-        bucket_parameters: [{ int1: 314n, float1: 3.14, float2: 314 }]
+        bucketParameters: [{ int1: 314n, float1: 3.14, float2: 314 }]
       }
     ]);
 
@@ -100,7 +100,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['test_param']),
 
-        bucket_parameters: [{ id: 'test_id' }]
+        bucketParameters: [{ id: 'test_id' }]
       }
     ]);
 
@@ -118,7 +118,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['test_param']),
 
-        bucket_parameters: [{ id: 'test_id' }]
+        bucketParameters: [{ id: 'test_id' }]
       }
     ]);
 
@@ -136,7 +136,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['test_param']),
 
-        bucket_parameters: [{ id: 'test_id' }]
+        bucketParameters: [{ id: 'test_id' }]
       }
     ]);
 
@@ -176,7 +176,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', [1n]),
-        bucket_parameters: [{}]
+        bucketParameters: [{}]
       }
     ]);
 
@@ -196,7 +196,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', [1n]),
-        bucket_parameters: [{}]
+        bucketParameters: [{}]
       }
     ]);
 
@@ -216,7 +216,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', [1n]),
-        bucket_parameters: [{}]
+        bucketParameters: [{}]
       }
     ]);
 
@@ -236,7 +236,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', [1n]),
-        bucket_parameters: [{}]
+        bucketParameters: [{}]
       }
     ]);
 
@@ -256,7 +256,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1', 1n]),
-        bucket_parameters: [{}]
+        bucketParameters: [{}]
       }
     ]);
 
@@ -276,7 +276,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1', 1n]),
-        bucket_parameters: [{}]
+        bucketParameters: [{}]
       }
     ]);
 
@@ -309,7 +309,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1', role: null })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', []),
-        bucket_parameters: [{ id: 'user1' }]
+        bucketParameters: [{ id: 'user1' }]
       }
     ]);
 
@@ -329,7 +329,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1', 1n]),
-        bucket_parameters: [{}]
+        bucketParameters: [{}]
       }
     ]);
 
@@ -352,7 +352,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1', 1n]),
 
-        bucket_parameters: [{ user_id: 'user1' }]
+        bucketParameters: [{ user_id: 'user1' }]
       }
     ]);
 
@@ -377,7 +377,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1']),
 
-        bucket_parameters: [{ user_id: 'user1' }]
+        bucketParameters: [{ user_id: 'user1' }]
       }
     ]);
   });
@@ -398,7 +398,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1']),
 
-        bucket_parameters: [{ user_id: 'user1' }]
+        bucketParameters: [{ user_id: 'user1' }]
       }
     ]);
   });
@@ -452,7 +452,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', []),
 
-        bucket_parameters: [{ workspace_id: 'workspace1' }]
+        bucketParameters: [{ workspace_id: 'workspace1' }]
       }
     ]);
 
@@ -470,7 +470,7 @@ describe('parameter queries', () => {
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['test_param', 'test_param']),
 
-        bucket_parameters: [{ id: 'test_id' }]
+        bucketParameters: [{ id: 'test_id' }]
       }
     ]);
 
@@ -489,11 +489,11 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param1: 'test1', filter_param2: 'test2' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['test1']),
-        bucket_parameters: [{ id: 'test_id' }]
+        bucketParameters: [{ id: 'test_id' }]
       },
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['test2']),
-        bucket_parameters: [{ id: 'test_id' }]
+        bucketParameters: [{ id: 'test_id' }]
       }
     ]);
 
@@ -517,7 +517,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'group1', category: 'red' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['red']),
-        bucket_parameters: [{}]
+        bucketParameters: [{}]
       }
     ]);
     expect(query.getLookups(normalizeTokenParameters({}, { category_id: 'red' }))).toEqual([
@@ -575,7 +575,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'region1', name: 'colorado' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['colorado']),
-        bucket_parameters: [
+        bucketParameters: [
           {
             region_id: 'region1'
           }
@@ -604,7 +604,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1']),
-        bucket_parameters: [{ id: 'user1' }]
+        bucketParameters: [{ id: 'user1' }]
       }
     ]);
     const requestParams = normalizeTokenParameters({ user_id: 'user1' }, { other_id: 'red' });
@@ -619,7 +619,7 @@ describe('parameter queries', () => {
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1']),
-        bucket_parameters: [{ id: 'user1' }]
+        bucketParameters: [{ id: 'user1' }]
       }
     ]);
     const requestParams = normalizeTokenParameters({ user_id: 'user1' }, { other_id: 'red' });

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -6,9 +6,8 @@ import { StaticSqlParameterQuery } from '../../src/StaticSqlParameterQuery.js';
 describe('parameter queries', () => {
   test('token_parameters IN query', function () {
     const sql = 'SELECT id as group_id FROM groups WHERE token_parameters.user_id IN groups.user_ids';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     expect(query.evaluateParameterRow({ id: 'group1', user_ids: JSON.stringify(['user1', 'user2']) })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1']),
@@ -38,9 +37,8 @@ describe('parameter queries', () => {
 
   test('IN token_parameters query', function () {
     const sql = 'SELECT id as region_id FROM regions WHERE name IN token_parameters.region_names';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     expect(query.evaluateParameterRow({ id: 'region1', name: 'colorado' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['colorado']),
@@ -66,9 +64,8 @@ describe('parameter queries', () => {
   test('queried numeric parameters', () => {
     const sql =
       'SELECT users.int1, users.float1, users.float2 FROM users WHERE users.int1 = token_parameters.int1 AND users.float1 = token_parameters.float1 AND users.float2 = token_parameters.float2';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     // Note: We don't need to worry about numeric vs decimal types in the lookup - JSONB handles normalization for us.
     expect(query.evaluateParameterRow({ int1: 314n, float1: 3.14, float2: 314 })).toEqual([
       {
@@ -96,9 +93,8 @@ describe('parameter queries', () => {
 
   test('plain token_parameter (baseline)', () => {
     const sql = 'SELECT id from users WHERE filter_param = token_parameters.user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
       {
@@ -115,9 +111,8 @@ describe('parameter queries', () => {
 
   test('function on token_parameter', () => {
     const sql = 'SELECT id from users WHERE filter_param = upper(token_parameters.user_id)';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
       {
@@ -134,9 +129,8 @@ describe('parameter queries', () => {
 
   test('token parameter member operator', () => {
     const sql = "SELECT id from users WHERE filter_param = token_parameters.some_param ->> 'description'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
       {
@@ -153,9 +147,8 @@ describe('parameter queries', () => {
 
   test('token parameter and binary operator', () => {
     const sql = 'SELECT id from users WHERE filter_param = token_parameters.some_param + 2';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.getLookups(normalizeTokenParameters({ some_param: 3 }))).toEqual([
       ParameterLookup.normalized('mybucket', '1', [5n])
@@ -164,9 +157,8 @@ describe('parameter queries', () => {
 
   test('token parameter IS NULL as filter', () => {
     const sql = 'SELECT id from users WHERE filter_param = (token_parameters.some_param IS NULL)';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.getLookups(normalizeTokenParameters({ some_param: null }))).toEqual([
       ParameterLookup.normalized('mybucket', '1', [1n])
@@ -178,9 +170,8 @@ describe('parameter queries', () => {
 
   test('direct token parameter', () => {
     const sql = 'SELECT FROM users WHERE token_parameters.some_param';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
@@ -199,9 +190,8 @@ describe('parameter queries', () => {
 
   test('token parameter IS NULL', () => {
     const sql = 'SELECT FROM users WHERE token_parameters.some_param IS NULL';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
@@ -220,9 +210,8 @@ describe('parameter queries', () => {
 
   test('token parameter IS NOT NULL', () => {
     const sql = 'SELECT FROM users WHERE token_parameters.some_param IS NOT NULL';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
@@ -241,9 +230,8 @@ describe('parameter queries', () => {
 
   test('token parameter NOT', () => {
     const sql = 'SELECT FROM users WHERE NOT token_parameters.is_admin';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
@@ -262,9 +250,8 @@ describe('parameter queries', () => {
 
   test('row filter and token parameter IS NULL', () => {
     const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.some_param IS NULL';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
@@ -283,9 +270,8 @@ describe('parameter queries', () => {
 
   test('row filter and direct token parameter', () => {
     const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.some_param';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
@@ -304,9 +290,8 @@ describe('parameter queries', () => {
 
   test('cast', () => {
     const sql = 'SELECT FROM users WHERE users.id = cast(token_parameters.user_id as text)';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.getLookups(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
       ParameterLookup.normalized('mybucket', '1', ['user1'])
@@ -318,9 +303,8 @@ describe('parameter queries', () => {
 
   test('IS NULL row filter', () => {
     const sql = 'SELECT id FROM users WHERE role IS NULL';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1', role: null })).toEqual([
       {
@@ -339,9 +323,8 @@ describe('parameter queries', () => {
     // Not supported: token_parameters.is_admin != false
     // Support could be added later.
     const sql = 'SELECT FROM users WHERE users.id = token_parameters.user_id AND token_parameters.is_admin';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
@@ -362,9 +345,8 @@ describe('parameter queries', () => {
   test('token filter (2)', () => {
     const sql =
       'SELECT users.id AS user_id, token_parameters.is_admin as is_admin FROM users WHERE users.id = token_parameters.user_id AND token_parameters.is_admin';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
@@ -388,9 +370,8 @@ describe('parameter queries', () => {
 
   test('case-sensitive parameter queries (1)', () => {
     const sql = 'SELECT users."userId" AS user_id FROM users WHERE users."userId" = token_parameters.user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ userId: 'user1' })).toEqual([
       {
@@ -406,12 +387,11 @@ describe('parameter queries', () => {
     // This may change in the future - we should check against expected behavior for
     // Postgres and/or SQLite.
     const sql = 'SELECT users.userId AS user_id FROM users WHERE users.userId = token_parameters.user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toMatchObject([
       { message: `Unquoted identifiers are converted to lower-case. Use "userId" instead.` },
       { message: `Unquoted identifiers are converted to lower-case. Use "userId" instead.` }
     ]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ userId: 'user1' })).toEqual([]);
     expect(query.evaluateParameterRow({ userid: 'user1' })).toEqual([
@@ -425,7 +405,7 @@ describe('parameter queries', () => {
 
   test('case-sensitive parameter queries (3)', () => {
     const sql = 'SELECT user_id FROM users WHERE Users.user_id = token_parameters.user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toMatchObject([
       { message: `Unquoted identifiers are converted to lower-case. Use "Users" instead.` }
     ]);
@@ -433,7 +413,7 @@ describe('parameter queries', () => {
 
   test('case-sensitive parameter queries (4)', () => {
     const sql = 'SELECT Users.user_id FROM users WHERE user_id = token_parameters.user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toMatchObject([
       { message: `Unquoted identifiers are converted to lower-case. Use "Users" instead.` }
     ]);
@@ -441,7 +421,7 @@ describe('parameter queries', () => {
 
   test('case-sensitive parameter queries (5)', () => {
     const sql = 'SELECT user_id FROM Users WHERE user_id = token_parameters.user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toMatchObject([
       { message: `Unquoted identifiers are converted to lower-case. Use "Users" instead.` }
     ]);
@@ -449,7 +429,7 @@ describe('parameter queries', () => {
 
   test('case-sensitive parameter queries (6)', () => {
     const sql = 'SELECT userId FROM users';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toMatchObject([
       { message: `Unquoted identifiers are converted to lower-case. Use "userId" instead.` }
     ]);
@@ -457,7 +437,7 @@ describe('parameter queries', () => {
 
   test('case-sensitive parameter queries (7)', () => {
     const sql = 'SELECT user_id as userId FROM users';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toMatchObject([
       { message: `Unquoted identifiers are converted to lower-case. Use "userId" instead.` }
     ]);
@@ -465,9 +445,8 @@ describe('parameter queries', () => {
 
   test('dynamic global parameter query', () => {
     const sql = "SELECT workspaces.id AS workspace_id FROM workspaces WHERE visibility = 'public'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'workspace1', visibility: 'public' })).toEqual([
       {
@@ -484,9 +463,8 @@ describe('parameter queries', () => {
     // This is treated as two separate lookup index values
     const sql =
       'SELECT id from users WHERE filter_param = upper(token_parameters.user_id) AND filter_param = lower(token_parameters.user_id)';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param: 'test_param' })).toEqual([
       {
@@ -505,9 +483,8 @@ describe('parameter queries', () => {
     // This is treated as the same index lookup value, can use OR with the two clauses
     const sql =
       'SELECT id from users WHERE filter_param1 = upper(token_parameters.user_id) OR filter_param2 = upper(token_parameters.user_id)';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     expect(query.evaluateParameterRow({ id: 'test_id', filter_param1: 'test1', filter_param2: 'test2' })).toEqual([
       {
@@ -527,12 +504,16 @@ describe('parameter queries', () => {
 
   test('request.parameters()', function () {
     const sql = "SELECT FROM posts WHERE category = request.parameters() ->> 'category_id'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      accept_potentially_dangerous_queries: true,
-      ...PARSE_OPTIONS
-    }) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        accept_potentially_dangerous_queries: true,
+        ...PARSE_OPTIONS
+      },
+      '1'
+    ) as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     expect(query.evaluateParameterRow({ id: 'group1', category: 'red' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['red']),
@@ -546,12 +527,16 @@ describe('parameter queries', () => {
 
   test('nested request.parameters() (1)', function () {
     const sql = "SELECT FROM posts WHERE category = request.parameters() -> 'details' ->> 'category'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      accept_potentially_dangerous_queries: true,
-      ...PARSE_OPTIONS
-    }) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        accept_potentially_dangerous_queries: true,
+        ...PARSE_OPTIONS
+      },
+      '1'
+    ) as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     expect(query.getLookups(normalizeTokenParameters({}, { details: { category: 'red' } }))).toEqual([
       ParameterLookup.normalized('mybucket', '1', ['red'])
     ]);
@@ -559,12 +544,16 @@ describe('parameter queries', () => {
 
   test('nested request.parameters() (2)', function () {
     const sql = "SELECT FROM posts WHERE category = request.parameters() ->> 'details.category'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      accept_potentially_dangerous_queries: true,
-      ...PARSE_OPTIONS
-    }) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        accept_potentially_dangerous_queries: true,
+        ...PARSE_OPTIONS
+      },
+      '1'
+    ) as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     expect(query.getLookups(normalizeTokenParameters({}, { details: { category: 'red' } }))).toEqual([
       ParameterLookup.normalized('mybucket', '1', ['red'])
     ]);
@@ -573,12 +562,16 @@ describe('parameter queries', () => {
   test('IN request.parameters()', function () {
     // Can use -> or ->> here
     const sql = "SELECT id as region_id FROM regions WHERE name IN request.parameters() -> 'region_names'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      accept_potentially_dangerous_queries: true,
-      ...PARSE_OPTIONS
-    }) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        accept_potentially_dangerous_queries: true,
+        ...PARSE_OPTIONS
+      },
+      '1'
+    ) as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     expect(query.evaluateParameterRow({ id: 'region1', name: 'colorado' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['colorado']),
@@ -606,9 +599,8 @@ describe('parameter queries', () => {
 
   test('user_parameters in SELECT', function () {
     const sql = 'SELECT id, user_parameters.other_id as other_id FROM users WHERE id = token_parameters.user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1']),
@@ -622,9 +614,8 @@ describe('parameter queries', () => {
   test('request.parameters() in SELECT', function () {
     const sql =
       "SELECT id, request.parameters() ->> 'other_id' as other_id FROM users WHERE id = token_parameters.user_id";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
     expect(query.evaluateParameterRow({ id: 'user1' })).toEqual([
       {
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1']),
@@ -637,9 +628,8 @@ describe('parameter queries', () => {
 
   test('request.jwt()', function () {
     const sql = "SELECT FROM users WHERE id = request.jwt() ->> 'sub'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     const requestParams = normalizeTokenParameters({ user_id: 'user1' });
     expect(query.getLookups(requestParams)).toEqual([ParameterLookup.normalized('mybucket', '1', ['user1'])]);
@@ -647,9 +637,8 @@ describe('parameter queries', () => {
 
   test('request.user_id()', function () {
     const sql = 'SELECT FROM users WHERE id = request.user_id()';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toEqual([]);
-    query.id = '1';
 
     const requestParams = normalizeTokenParameters({ user_id: 'user1' });
     expect(query.getLookups(requestParams)).toEqual([ParameterLookup.normalized('mybucket', '1', ['user1'])]);
@@ -660,67 +649,73 @@ describe('parameter queries', () => {
     // into separate queries, but it's a significant change. For now, developers should do that manually.
     const sql =
       "SELECT workspaces.id AS workspace_id FROM workspaces WHERE workspaces.user_id = token_parameters.user_id OR visibility = 'public'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/must use the same parameters/);
   });
 
   test('invalid OR in parameter queries (2)', () => {
     const sql =
       'SELECT id from users WHERE filter_param = upper(token_parameters.user_id) OR filter_param = lower(token_parameters.user_id)';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/must use the same parameters/);
   });
 
   test('invalid parameter match clause (1)', () => {
     const sql = 'SELECT FROM users WHERE (id = token_parameters.user_id) = false';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/Parameter match clauses cannot be used here/);
   });
 
   test('invalid parameter match clause (2)', () => {
     const sql = 'SELECT FROM users WHERE NOT (id = token_parameters.user_id)';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/Parameter match clauses cannot be used here/);
   });
 
   test('invalid parameter match clause (3)', () => {
     // May be supported in the future
     const sql = 'SELECT FROM users WHERE token_parameters.start_at < users.created_at';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/Cannot use table values and parameters in the same clauses/);
   });
 
   test('invalid parameter match clause (4)', () => {
     const sql = 'SELECT FROM users WHERE json_extract(users.description, token_parameters.path)';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/Cannot use table values and parameters in the same clauses/);
   });
 
   test('invalid parameter match clause (5)', () => {
     const sql = 'SELECT (user_parameters.role = posts.roles) as r FROM posts';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/Parameter match expression is not allowed here/);
   });
 
   test('invalid function schema', () => {
     const sql = 'SELECT FROM users WHERE something.length(users.id) = 0';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors[0].message).toMatch(/Function 'something.length' is not defined/);
   });
 
   test('validate columns', () => {
     const schema = BASIC_SCHEMA;
 
-    const q1 = SqlParameterQuery.fromSql('q4', 'SELECT id FROM assets WHERE owner_id = token_parameters.user_id', {
-      ...PARSE_OPTIONS,
-      schema
-    });
+    const q1 = SqlParameterQuery.fromSql(
+      'q4',
+      'SELECT id FROM assets WHERE owner_id = token_parameters.user_id',
+      {
+        ...PARSE_OPTIONS,
+        schema
+      },
+      '1'
+    );
     expect(q1.errors).toMatchObject([]);
 
     const q2 = SqlParameterQuery.fromSql(
       'q5',
       'SELECT id as asset_id FROM assets WHERE other_id = token_parameters.user_id',
-      { ...PARSE_OPTIONS, schema }
+      { ...PARSE_OPTIONS, schema },
+      '1'
     );
 
     expect(q2.errors).toMatchObject([
@@ -734,7 +729,7 @@ describe('parameter queries', () => {
   describe('dangerous queries', function () {
     function testDangerousQuery(sql: string) {
       test(sql, function () {
-        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
         expect(query.errors).toMatchObject([
           {
             message:
@@ -746,7 +741,7 @@ describe('parameter queries', () => {
     }
     function testSafeQuery(sql: string) {
       test(sql, function () {
-        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
         expect(query.errors).toEqual([]);
         expect(query.usesDangerousRequestParameters).toEqual(false);
       });
@@ -775,7 +770,7 @@ describe('parameter queries', () => {
   describe('bucket priorities', () => {
     test('valid definition', function () {
       const sql = 'SELECT id as group_id, 1 AS _priority FROM groups WHERE token_parameters.user_id IN groups.user_ids';
-      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
       expect(query.errors).toEqual([]);
       expect(Object.entries(query.lookup_extractors)).toHaveLength(1);
       expect(Object.entries(query.parameter_extractors)).toHaveLength(0);
@@ -785,7 +780,7 @@ describe('parameter queries', () => {
 
     test('valid definition, static query', function () {
       const sql = 'SELECT token_parameters.user_id, 0 AS _priority';
-      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
       expect(query.errors).toEqual([]);
       expect(Object.entries(query.parameter_extractors)).toHaveLength(1);
       expect(query.bucket_parameters).toEqual(['user_id']);
@@ -794,21 +789,21 @@ describe('parameter queries', () => {
 
     test('invalid dynamic query', function () {
       const sql = 'SELECT LENGTH(assets.name) AS _priority FROM assets';
-      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
 
       expect(query.errors).toMatchObject([{ message: 'Priority must be a simple integer literal' }]);
     });
 
     test('invalid literal type', function () {
       const sql = "SELECT 'very fast please' AS _priority";
-      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
 
       expect(query.errors).toMatchObject([{ message: 'Priority must be a simple integer literal' }]);
     });
 
     test('invalid literal value', function () {
       const sql = 'SELECT 15 AS _priority';
-      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+      const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
 
       expect(query.errors).toMatchObject([
         { message: 'Invalid value for priority, must be between 0 and 3 (inclusive).' }

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -772,9 +772,9 @@ describe('parameter queries', () => {
       const sql = 'SELECT id as group_id, 1 AS _priority FROM groups WHERE token_parameters.user_id IN groups.user_ids';
       const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
       expect(query.errors).toEqual([]);
-      expect(Object.entries(query.lookup_extractors)).toHaveLength(1);
-      expect(Object.entries(query.parameter_extractors)).toHaveLength(0);
-      expect(query.bucket_parameters).toEqual(['group_id']);
+      expect(Object.entries(query.lookupExtractors)).toHaveLength(1);
+      expect(Object.entries(query.parameterExtractors)).toHaveLength(0);
+      expect(query.bucketParameters).toEqual(['group_id']);
       expect(query.priority).toBe(1);
     });
 
@@ -782,8 +782,8 @@ describe('parameter queries', () => {
       const sql = 'SELECT token_parameters.user_id, 0 AS _priority';
       const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
       expect(query.errors).toEqual([]);
-      expect(Object.entries(query.parameter_extractors)).toHaveLength(1);
-      expect(query.bucket_parameters).toEqual(['user_id']);
+      expect(Object.entries(query.parameterExtractors)).toHaveLength(1);
+      expect(query.bucketParameters).toEqual(['user_id']);
       expect(query.priority).toBe(0);
     });
 

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -6,7 +6,7 @@ import { normalizeTokenParameters, PARSE_OPTIONS } from './util.js';
 describe('static parameter queries', () => {
   test('basic query', function () {
     const sql = 'SELECT token_parameters.user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters!).toEqual(['user_id']);
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
@@ -16,7 +16,7 @@ describe('static parameter queries', () => {
 
   test('global query', function () {
     const sql = 'SELECT';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters!).toEqual([]);
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
@@ -26,7 +26,7 @@ describe('static parameter queries', () => {
 
   test('query with filter', function () {
     const sql = 'SELECT token_parameters.user_id WHERE token_parameters.is_admin';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1', is_admin: true }))).toEqual([
       { bucket: 'mybucket["user1"]', priority: 3 }
@@ -38,7 +38,7 @@ describe('static parameter queries', () => {
 
   test('function in select clause', function () {
     const sql = 'SELECT upper(token_parameters.user_id) as upper_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
       { bucket: 'mybucket["USER1"]', priority: 3 }
@@ -48,7 +48,7 @@ describe('static parameter queries', () => {
 
   test('function in filter clause', function () {
     const sql = "SELECT WHERE upper(token_parameters.role) = 'ADMIN'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ role: 'admin' }))).toEqual([
       { bucket: 'mybucket[]', priority: 3 }
@@ -58,7 +58,7 @@ describe('static parameter queries', () => {
 
   test('comparison in filter clause', function () {
     const sql = 'SELECT WHERE token_parameters.id1 = token_parameters.id2';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ id1: 't1', id2: 't1' }))).toEqual([
       { bucket: 'mybucket[]', priority: 3 }
@@ -68,10 +68,15 @@ describe('static parameter queries', () => {
 
   test('request.parameters()', function () {
     const sql = "SELECT request.parameters() ->> 'org_id' as org_id";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      ...PARSE_OPTIONS,
-      accept_potentially_dangerous_queries: true
-    }) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        ...PARSE_OPTIONS,
+        accept_potentially_dangerous_queries: true
+      },
+      '1'
+    ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
 
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({}, { org_id: 'test' }))).toEqual([
@@ -81,7 +86,7 @@ describe('static parameter queries', () => {
 
   test('request.jwt()', function () {
     const sql = "SELECT request.jwt() ->> 'sub' as user_id";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['user_id']);
 
@@ -92,7 +97,7 @@ describe('static parameter queries', () => {
 
   test('request.user_id()', function () {
     const sql = 'SELECT request.user_id() as user_id';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['user_id']);
 
@@ -103,7 +108,7 @@ describe('static parameter queries', () => {
 
   test('static value', function () {
     const sql = `SELECT WHERE 1`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([
       { bucket: 'mybucket[]', priority: 3 }
@@ -112,7 +117,7 @@ describe('static parameter queries', () => {
 
   test('static expression (1)', function () {
     const sql = `SELECT WHERE 1 = 1`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([
       { bucket: 'mybucket[]', priority: 3 }
@@ -121,14 +126,14 @@ describe('static parameter queries', () => {
 
   test('static expression (2)', function () {
     const sql = `SELECT WHERE 1 != 1`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([]);
   });
 
   test('static IN expression', function () {
     const sql = `SELECT WHERE 'admin' IN '["admin", "superuser"]'`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([
       { bucket: 'mybucket[]', priority: 3 }
@@ -138,7 +143,7 @@ describe('static parameter queries', () => {
   test('IN for permissions in request.jwt() (1)', function () {
     // Can use -> or ->> here
     const sql = `SELECT 'read:users' IN (request.jwt() ->> 'permissions') as access_granted`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(
       query.getStaticBucketDescriptions(new RequestParameters({ sub: '', permissions: ['write', 'read:users'] }, {}))
@@ -151,7 +156,7 @@ describe('static parameter queries', () => {
   test('IN for permissions in request.jwt() (2)', function () {
     // Can use -> or ->> here
     const sql = `SELECT WHERE 'read:users' IN (request.jwt() ->> 'permissions')`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(
       query.getStaticBucketDescriptions(new RequestParameters({ sub: '', permissions: ['write', 'read:users'] }, {}))
@@ -163,7 +168,7 @@ describe('static parameter queries', () => {
 
   test('IN for permissions in request.jwt() (3)', function () {
     const sql = `SELECT WHERE request.jwt() ->> 'role' IN '["admin", "superuser"]'`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '', role: 'superuser' }, {}))).toEqual([
       { bucket: 'mybucket[]', priority: 3 }
@@ -173,7 +178,7 @@ describe('static parameter queries', () => {
 
   test('case-sensitive queries (1)', () => {
     const sql = 'SELECT request.user_id() as USER_ID';
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
     expect(query.errors).toMatchObject([
       { message: `Unquoted identifiers are converted to lower-case. Use "USER_ID" instead.` }
     ]);
@@ -182,7 +187,7 @@ describe('static parameter queries', () => {
   describe('dangerous queries', function () {
     function testDangerousQuery(sql: string) {
       test(sql, function () {
-        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
         expect(query.errors).toMatchObject([
           {
             message:
@@ -194,7 +199,7 @@ describe('static parameter queries', () => {
     }
     function testSafeQuery(sql: string) {
       test(sql, function () {
-        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
         expect(query.errors).toEqual([]);
         expect(query.usesDangerousRequestParameters).toEqual(false);
       });

--- a/packages/sync-rules/test/src/static_parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/static_parameter_queries.test.ts
@@ -8,7 +8,7 @@ describe('static parameter queries', () => {
     const sql = 'SELECT token_parameters.user_id';
     const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters!).toEqual(['user_id']);
+    expect(query.bucketParameters!).toEqual(['user_id']);
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
       { bucket: 'mybucket["user1"]', priority: 3 }
     ]);
@@ -18,7 +18,7 @@ describe('static parameter queries', () => {
     const sql = 'SELECT';
     const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters!).toEqual([]);
+    expect(query.bucketParameters!).toEqual([]);
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
       { bucket: 'mybucket[]', priority: 3 }
     ]);
@@ -43,7 +43,7 @@ describe('static parameter queries', () => {
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
       { bucket: 'mybucket["USER1"]', priority: 3 }
     ]);
-    expect(query.bucket_parameters!).toEqual(['upper_id']);
+    expect(query.bucketParameters!).toEqual(['upper_id']);
   });
 
   test('function in filter clause', function () {
@@ -88,7 +88,7 @@ describe('static parameter queries', () => {
     const sql = "SELECT request.jwt() ->> 'sub' as user_id";
     const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['user_id']);
+    expect(query.bucketParameters).toEqual(['user_id']);
 
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
       { bucket: 'mybucket["user1"]', priority: 3 }
@@ -99,7 +99,7 @@ describe('static parameter queries', () => {
     const sql = 'SELECT request.user_id() as user_id';
     const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['user_id']);
+    expect(query.bucketParameters).toEqual(['user_id']);
 
     expect(query.getStaticBucketDescriptions(normalizeTokenParameters({ user_id: 'user1' }))).toEqual([
       { bucket: 'mybucket["user1"]', priority: 3 }

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -27,7 +27,6 @@ bucket_definitions:
     expect(dataQuery.columnOutputNames()).toEqual(['id', 'description']);
     expect(rules.evaluateRow({ sourceTable: ASSETS, record: { id: 'asset1', description: 'test' } })).toEqual([
       {
-        ruleId: '1',
         table: 'assets',
         id: 'asset1',
         data: {
@@ -128,7 +127,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket["user1","device1"]',
         id: 'asset1',
         data: {
@@ -174,7 +172,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket["user1"]',
         id: 'asset1',
         data: {
@@ -191,7 +188,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket["user1"]',
         id: 'asset1',
         data: {
@@ -317,7 +313,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket["USER1"]',
         id: 'asset1',
         data: {
@@ -355,7 +350,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket["USER1"]',
         id: 'asset1',
         data: {
@@ -384,7 +378,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[]',
         id: 'asset1',
         data: {
@@ -423,7 +416,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket["region1"]',
         id: 'asset1',
         data: {
@@ -433,7 +425,6 @@ bucket_definitions:
         table: 'assets'
       },
       {
-        ruleId: '1',
         bucket: 'mybucket["region2"]',
         id: 'asset1',
         data: {
@@ -462,7 +453,6 @@ bucket_definitions:
       rules.evaluateRow({ sourceTable: ASSETS, record: { id: 'asset1', description: 'test', role: 'admin' } })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[1]',
         id: 'asset1',
         data: {
@@ -479,7 +469,6 @@ bucket_definitions:
       rules.evaluateRow({ sourceTable: ASSETS, record: { id: 'asset2', description: 'test', role: 'normal' } })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[1]',
         id: 'asset2',
         data: {
@@ -491,7 +480,6 @@ bucket_definitions:
         table: 'assets'
       },
       {
-        ruleId: '2',
         bucket: 'mybucket[1]',
         id: 'asset2',
         data: {
@@ -503,7 +491,6 @@ bucket_definitions:
         table: 'assets'
       },
       {
-        ruleId: '2',
         bucket: 'mybucket[0]',
         id: 'asset2',
         data: {
@@ -534,7 +521,6 @@ bucket_definitions:
 
     expect(rules.evaluateRow({ sourceTable: ASSETS, record: { id: 'asset1' } })).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[]',
         id: 'asset1',
         data: {
@@ -567,7 +553,6 @@ bucket_definitions:
       rules.evaluateRow({ sourceTable: ASSETS, record: { id: 'asset1', int1: 314n, float1: 3.14, float2: 314 } })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[314,3.14,314]',
         id: 'asset1',
         data: {
@@ -601,8 +586,8 @@ bucket_definitions:
 bucket_definitions:
   mybucket:
     data:
-      - SELECT client_id AS id, description FROM assets_123 as assets WHERE assets.archived = false
-      - SELECT other_id AS id, description FROM assets_123 as assets
+      - SELECT client_id AS id, description, '1' as rule FROM assets_123 as assets WHERE assets.archived = false
+      - SELECT other_id AS id, description, '2' as rule FROM assets_123 as assets
     `,
       PARSE_OPTIONS
     );
@@ -614,22 +599,22 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[]',
         id: 'asset1',
         data: {
           id: 'asset1',
-          description: 'test'
+          description: 'test',
+          rule: '1'
         },
         table: 'assets'
       },
       {
-        ruleId: '2',
         bucket: 'mybucket[]',
         id: 'other1',
         data: {
           id: 'other1',
-          description: 'test'
+          description: 'test',
+          rule: '2'
         },
         table: 'assets'
       }
@@ -654,7 +639,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[]',
         id: 'asset1',
         data: {
@@ -688,7 +672,6 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[]',
         id: 'asset1',
         data: {
@@ -708,11 +691,11 @@ bucket_definitions:
 bucket_definitions:
   mybucket:
     data:
-      - SELECT id FROM "assets" # Yes
-      - SELECT id FROM "test_schema"."assets" # yes
-      - SELECT id FROM "default.test_schema"."assets" # yes
-      - SELECT id FROM "other"."assets" # no
-      - SELECT id FROM "other.test_schema"."assets" # no
+      - SELECT id FROM "assets" as assets1 # Yes
+      - SELECT id FROM "test_schema"."assets" as assets2 # yes
+      - SELECT id FROM "default.test_schema"."assets" as assets3 # yes
+      - SELECT id FROM "other"."assets" as assets4 # no
+      - SELECT id FROM "other.test_schema"."assets" as assets5 # no
     `,
       PARSE_OPTIONS
     );
@@ -724,31 +707,28 @@ bucket_definitions:
       })
     ).toEqual([
       {
-        ruleId: '1',
         bucket: 'mybucket[]',
         id: 'asset1',
         data: {
           id: 'asset1'
         },
-        table: 'assets'
+        table: 'assets1'
       },
       {
-        ruleId: '2',
         bucket: 'mybucket[]',
         id: 'asset1',
         data: {
           id: 'asset1'
         },
-        table: 'assets'
+        table: 'assets2'
       },
       {
-        ruleId: '3',
         bucket: 'mybucket[]',
         id: 'asset1',
         data: {
           id: 'asset1'
         },
-        table: 'assets'
+        table: 'assets3'
       }
     ]);
   });

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -6,7 +6,7 @@ import { ASSETS, BASIC_SCHEMA, PARSE_OPTIONS, TestSourceTable, USERS, normalizeT
 describe('sync rules', () => {
   test('parse empty sync rules', () => {
     const rules = SqlSyncRules.fromYaml('bucket_definitions: {}', PARSE_OPTIONS);
-    expect(rules.bucket_descriptors).toEqual([]);
+    expect(rules.bucketDescriptors).toEqual([]);
   });
 
   test('parse global sync rules', () => {
@@ -19,7 +19,7 @@ bucket_definitions:
     `,
       PARSE_OPTIONS
     );
-    const bucket = rules.bucket_descriptors[0];
+    const bucket = rules.bucketDescriptors[0];
     expect(bucket.name).toEqual('mybucket');
     expect(bucket.bucketParameters).toEqual([]);
     const dataQuery = bucket.dataQueries[0];
@@ -54,7 +54,7 @@ bucket_definitions:
     `,
       PARSE_OPTIONS
     );
-    const bucket = rules.bucket_descriptors[0];
+    const bucket = rules.bucketDescriptors[0];
     expect(bucket.bucketParameters).toEqual([]);
     const param_query = bucket.globalParameterQueries[0];
 
@@ -86,13 +86,13 @@ bucket_definitions:
     `,
       PARSE_OPTIONS
     );
-    const bucket = rules.bucket_descriptors[0];
+    const bucket = rules.bucketDescriptors[0];
     expect(bucket.bucketParameters).toEqual([]);
     const param_query = bucket.parameterQueries[0];
     expect(param_query.bucketParameters).toEqual([]);
     expect(rules.evaluateParameterRow(USERS, { id: 'user1', is_admin: 1 })).toEqual([
       {
-        bucket_parameters: [{}],
+        bucketParameters: [{}],
         lookup: ParameterLookup.normalized('mybucket', '1', ['user1'])
       }
     ]);
@@ -110,7 +110,7 @@ bucket_definitions:
     `,
       PARSE_OPTIONS
     );
-    const bucket = rules.bucket_descriptors[0];
+    const bucket = rules.bucketDescriptors[0];
     expect(bucket.bucketParameters).toEqual(['user_id', 'device_id']);
     const param_query = bucket.globalParameterQueries[0];
     expect(param_query.bucketParameters).toEqual(['user_id', 'device_id']);
@@ -157,7 +157,7 @@ bucket_definitions:
     `,
       PARSE_OPTIONS
     );
-    const bucket = rules.bucket_descriptors[0];
+    const bucket = rules.bucketDescriptors[0];
     expect(bucket.bucketParameters).toEqual(['user_id']);
     const param_query = bucket.globalParameterQueries[0];
     expect(param_query.bucketParameters).toEqual(['user_id']);
@@ -303,7 +303,7 @@ bucket_definitions:
     `,
       PARSE_OPTIONS
     );
-    const bucket = rules.bucket_descriptors[0];
+    const bucket = rules.bucketDescriptors[0];
     expect(bucket.bucketParameters).toEqual(['user_id']);
     expect(rules.getBucketParameterQuerier(normalizeTokenParameters({ user_id: 'user1' }))).toMatchObject({
       staticBuckets: [{ bucket: 'mybucket["USER1"]', priority: 3 }],
@@ -341,7 +341,7 @@ bucket_definitions:
     `,
       PARSE_OPTIONS
     );
-    const bucket = rules.bucket_descriptors[0];
+    const bucket = rules.bucketDescriptors[0];
     expect(bucket.bucketParameters).toEqual(['user_id']);
     expect(rules.getBucketParameterQuerier(normalizeTokenParameters({ user_id: 'user1' }))).toMatchObject({
       staticBuckets: [{ bucket: 'mybucket["USER1"]', priority: 3 }],
@@ -933,7 +933,7 @@ bucket_definitions:
     `,
       PARSE_OPTIONS
     );
-    const bucket = rules.bucket_descriptors[0];
+    const bucket = rules.bucketDescriptors[0];
     expect(bucket.bucketParameters).toEqual(['user_id']);
     expect(rules.hasDynamicBucketQueries()).toBe(true);
 

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -21,9 +21,9 @@ bucket_definitions:
     );
     const bucket = rules.bucket_descriptors[0];
     expect(bucket.name).toEqual('mybucket');
-    expect(bucket.bucket_parameters).toEqual([]);
-    const dataQuery = bucket.data_queries[0];
-    expect(dataQuery.bucket_parameters).toEqual([]);
+    expect(bucket.bucketParameters).toEqual([]);
+    const dataQuery = bucket.dataQueries[0];
+    expect(dataQuery.bucketParameters).toEqual([]);
     expect(dataQuery.columnOutputNames()).toEqual(['id', 'description']);
     expect(rules.evaluateRow({ sourceTable: ASSETS, record: { id: 'asset1', description: 'test' } })).toEqual([
       {
@@ -55,8 +55,8 @@ bucket_definitions:
       PARSE_OPTIONS
     );
     const bucket = rules.bucket_descriptors[0];
-    expect(bucket.bucket_parameters).toEqual([]);
-    const param_query = bucket.global_parameter_queries[0];
+    expect(bucket.bucketParameters).toEqual([]);
+    const param_query = bucket.globalParameterQueries[0];
 
     // Internal API, subject to change
     expect(param_query.filter!.lookupParameterValue(normalizeTokenParameters({ is_admin: 1n }))).toEqual(1n);
@@ -87,9 +87,9 @@ bucket_definitions:
       PARSE_OPTIONS
     );
     const bucket = rules.bucket_descriptors[0];
-    expect(bucket.bucket_parameters).toEqual([]);
-    const param_query = bucket.parameter_queries[0];
-    expect(param_query.bucket_parameters).toEqual([]);
+    expect(bucket.bucketParameters).toEqual([]);
+    const param_query = bucket.parameterQueries[0];
+    expect(param_query.bucketParameters).toEqual([]);
     expect(rules.evaluateParameterRow(USERS, { id: 'user1', is_admin: 1 })).toEqual([
       {
         bucket_parameters: [{}],
@@ -111,16 +111,16 @@ bucket_definitions:
       PARSE_OPTIONS
     );
     const bucket = rules.bucket_descriptors[0];
-    expect(bucket.bucket_parameters).toEqual(['user_id', 'device_id']);
-    const param_query = bucket.global_parameter_queries[0];
-    expect(param_query.bucket_parameters).toEqual(['user_id', 'device_id']);
+    expect(bucket.bucketParameters).toEqual(['user_id', 'device_id']);
+    const param_query = bucket.globalParameterQueries[0];
+    expect(param_query.bucketParameters).toEqual(['user_id', 'device_id']);
     expect(
       rules.getBucketParameterQuerier(normalizeTokenParameters({ user_id: 'user1' }, { device_id: 'device1' }))
         .staticBuckets
     ).toEqual([{ bucket: 'mybucket["user1","device1"]', priority: 3 }]);
 
-    const data_query = bucket.data_queries[0];
-    expect(data_query.bucket_parameters).toEqual(['user_id', 'device_id']);
+    const data_query = bucket.dataQueries[0];
+    expect(data_query.bucketParameters).toEqual(['user_id', 'device_id']);
     expect(
       rules.evaluateRow({
         sourceTable: ASSETS,
@@ -158,15 +158,15 @@ bucket_definitions:
       PARSE_OPTIONS
     );
     const bucket = rules.bucket_descriptors[0];
-    expect(bucket.bucket_parameters).toEqual(['user_id']);
-    const param_query = bucket.global_parameter_queries[0];
-    expect(param_query.bucket_parameters).toEqual(['user_id']);
+    expect(bucket.bucketParameters).toEqual(['user_id']);
+    const param_query = bucket.globalParameterQueries[0];
+    expect(param_query.bucketParameters).toEqual(['user_id']);
     expect(rules.getBucketParameterQuerier(normalizeTokenParameters({ user_id: 'user1' })).staticBuckets).toEqual([
       { bucket: 'mybucket["user1"]', priority: 3 }
     ]);
 
-    const data_query = bucket.data_queries[0];
-    expect(data_query.bucket_parameters).toEqual(['user_id']);
+    const data_query = bucket.dataQueries[0];
+    expect(data_query.bucketParameters).toEqual(['user_id']);
     expect(
       rules.evaluateRow({
         sourceTable: ASSETS,
@@ -304,7 +304,7 @@ bucket_definitions:
       PARSE_OPTIONS
     );
     const bucket = rules.bucket_descriptors[0];
-    expect(bucket.bucket_parameters).toEqual(['user_id']);
+    expect(bucket.bucketParameters).toEqual(['user_id']);
     expect(rules.getBucketParameterQuerier(normalizeTokenParameters({ user_id: 'user1' }))).toMatchObject({
       staticBuckets: [{ bucket: 'mybucket["USER1"]', priority: 3 }],
       hasDynamicBuckets: false
@@ -342,7 +342,7 @@ bucket_definitions:
       PARSE_OPTIONS
     );
     const bucket = rules.bucket_descriptors[0];
-    expect(bucket.bucket_parameters).toEqual(['user_id']);
+    expect(bucket.bucketParameters).toEqual(['user_id']);
     expect(rules.getBucketParameterQuerier(normalizeTokenParameters({ user_id: 'user1' }))).toMatchObject({
       staticBuckets: [{ bucket: 'mybucket["USER1"]', priority: 3 }],
       hasDynamicBuckets: false
@@ -934,7 +934,7 @@ bucket_definitions:
       PARSE_OPTIONS
     );
     const bucket = rules.bucket_descriptors[0];
-    expect(bucket.bucket_parameters).toEqual(['user_id']);
+    expect(bucket.bucketParameters).toEqual(['user_id']);
     expect(rules.hasDynamicBucketQueries()).toBe(true);
 
     expect(rules.getBucketParameterQuerier(normalizeTokenParameters({ user_id: 'user1' }))).toMatchObject({

--- a/packages/sync-rules/test/src/table_valued_function_queries.test.ts
+++ b/packages/sync-rules/test/src/table_valued_function_queries.test.ts
@@ -6,10 +6,15 @@ import { PARSE_OPTIONS } from './util.js';
 describe('table-valued function queries', () => {
   test('json_each(array param)', function () {
     const sql = "SELECT json_each.value as v FROM json_each(request.parameters() -> 'array')";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      ...PARSE_OPTIONS,
-      accept_potentially_dangerous_queries: true
-    }) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        ...PARSE_OPTIONS,
+        accept_potentially_dangerous_queries: true
+      },
+      '1'
+    ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['v']);
 
@@ -22,7 +27,7 @@ describe('table-valued function queries', () => {
 
   test('json_each(static string)', function () {
     const sql = `SELECT json_each.value as v FROM json_each('[1,2,3]')`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['v']);
 
@@ -35,7 +40,7 @@ describe('table-valued function queries', () => {
 
   test('json_each(null)', function () {
     const sql = `SELECT json_each.value as v FROM json_each(null)`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['v']);
 
@@ -44,10 +49,15 @@ describe('table-valued function queries', () => {
 
   test('json_each(array param not present)', function () {
     const sql = "SELECT json_each.value as v FROM json_each(request.parameters() -> 'array_not_present')";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      ...PARSE_OPTIONS,
-      accept_potentially_dangerous_queries: true
-    }) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        ...PARSE_OPTIONS,
+        accept_potentially_dangerous_queries: true
+      },
+      '1'
+    ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['v']);
 
@@ -56,10 +66,15 @@ describe('table-valued function queries', () => {
 
   test('json_each(array param not present, ifnull)', function () {
     const sql = "SELECT json_each.value as v FROM json_each(ifnull(request.parameters() -> 'array_not_present', '[]'))";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      ...PARSE_OPTIONS,
-      accept_potentially_dangerous_queries: true
-    }) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        ...PARSE_OPTIONS,
+        accept_potentially_dangerous_queries: true
+      },
+      '1'
+    ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['v']);
 
@@ -68,7 +83,7 @@ describe('table-valued function queries', () => {
 
   test('json_each on json_keys', function () {
     const sql = `SELECT value FROM json_each(json_keys('{"a": [], "b": 2, "c": null}'))`;
-    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['value']);
 
@@ -81,10 +96,15 @@ describe('table-valued function queries', () => {
 
   test('json_each with fn alias', function () {
     const sql = "SELECT e.value FROM json_each(request.parameters() -> 'array') e";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      ...PARSE_OPTIONS,
-      accept_potentially_dangerous_queries: true
-    }) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        ...PARSE_OPTIONS,
+        accept_potentially_dangerous_queries: true
+      },
+      '1'
+    ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['value']);
 
@@ -97,10 +117,15 @@ describe('table-valued function queries', () => {
 
   test('json_each with direct value', function () {
     const sql = "SELECT value FROM json_each(request.parameters() -> 'array')";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      ...PARSE_OPTIONS,
-      accept_potentially_dangerous_queries: true
-    }) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        ...PARSE_OPTIONS,
+        accept_potentially_dangerous_queries: true
+      },
+      '1'
+    ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['value']);
 
@@ -113,10 +138,15 @@ describe('table-valued function queries', () => {
 
   test('json_each in filters (1)', function () {
     const sql = "SELECT value as v FROM json_each(request.parameters() -> 'array') e WHERE e.value >= 2";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      ...PARSE_OPTIONS,
-      accept_potentially_dangerous_queries: true
-    }) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        ...PARSE_OPTIONS,
+        accept_potentially_dangerous_queries: true
+      },
+      '1'
+    ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['v']);
 
@@ -129,10 +159,15 @@ describe('table-valued function queries', () => {
   test('json_each with nested json', function () {
     const sql =
       "SELECT value ->> 'id' as project_id FROM json_each(request.jwt() -> 'projects') WHERE (value ->> 'role') = 'admin'";
-    const query = SqlParameterQuery.fromSql('mybucket', sql, {
-      ...PARSE_OPTIONS,
-      accept_potentially_dangerous_queries: true
-    }) as StaticSqlParameterQuery;
+    const query = SqlParameterQuery.fromSql(
+      'mybucket',
+      sql,
+      {
+        ...PARSE_OPTIONS,
+        accept_potentially_dangerous_queries: true
+      },
+      '1'
+    ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
     expect(query.bucket_parameters).toEqual(['project_id']);
 
@@ -155,7 +190,7 @@ describe('table-valued function queries', () => {
   describe('dangerous queries', function () {
     function testDangerousQuery(sql: string) {
       test(sql, function () {
-        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
         expect(query.errors).toMatchObject([
           {
             message:
@@ -167,7 +202,7 @@ describe('table-valued function queries', () => {
     }
     function testSafeQuery(sql: string) {
       test(sql, function () {
-        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS) as SqlParameterQuery;
+        const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as SqlParameterQuery;
         expect(query.errors).toEqual([]);
         expect(query.usesDangerousRequestParameters).toEqual(false);
       });

--- a/packages/sync-rules/test/src/table_valued_function_queries.test.ts
+++ b/packages/sync-rules/test/src/table_valued_function_queries.test.ts
@@ -16,7 +16,7 @@ describe('table-valued function queries', () => {
       '1'
     ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['v']);
+    expect(query.bucketParameters).toEqual(['v']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, { array: [1, 2, 3] }))).toEqual([
       { bucket: 'mybucket[1]', priority: 3 },
@@ -29,7 +29,7 @@ describe('table-valued function queries', () => {
     const sql = `SELECT json_each.value as v FROM json_each('[1,2,3]')`;
     const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['v']);
+    expect(query.bucketParameters).toEqual(['v']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([
       { bucket: 'mybucket[1]', priority: 3 },
@@ -42,7 +42,7 @@ describe('table-valued function queries', () => {
     const sql = `SELECT json_each.value as v FROM json_each(null)`;
     const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['v']);
+    expect(query.bucketParameters).toEqual(['v']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([]);
   });
@@ -59,7 +59,7 @@ describe('table-valued function queries', () => {
       '1'
     ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['v']);
+    expect(query.bucketParameters).toEqual(['v']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([]);
   });
@@ -76,7 +76,7 @@ describe('table-valued function queries', () => {
       '1'
     ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['v']);
+    expect(query.bucketParameters).toEqual(['v']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([]);
   });
@@ -85,7 +85,7 @@ describe('table-valued function queries', () => {
     const sql = `SELECT value FROM json_each(json_keys('{"a": [], "b": 2, "c": null}'))`;
     const query = SqlParameterQuery.fromSql('mybucket', sql, PARSE_OPTIONS, '1') as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['value']);
+    expect(query.bucketParameters).toEqual(['value']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, {}))).toEqual([
       { bucket: 'mybucket["a"]', priority: 3 },
@@ -106,7 +106,7 @@ describe('table-valued function queries', () => {
       '1'
     ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['value']);
+    expect(query.bucketParameters).toEqual(['value']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, { array: [1, 2, 3] }))).toEqual([
       { bucket: 'mybucket[1]', priority: 3 },
@@ -127,7 +127,7 @@ describe('table-valued function queries', () => {
       '1'
     ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['value']);
+    expect(query.bucketParameters).toEqual(['value']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, { array: [1, 2, 3] }))).toEqual([
       { bucket: 'mybucket[1]', priority: 3 },
@@ -148,7 +148,7 @@ describe('table-valued function queries', () => {
       '1'
     ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['v']);
+    expect(query.bucketParameters).toEqual(['v']);
 
     expect(query.getStaticBucketDescriptions(new RequestParameters({ sub: '' }, { array: [1, 2, 3] }))).toEqual([
       { bucket: 'mybucket[2]', priority: 3 },
@@ -169,7 +169,7 @@ describe('table-valued function queries', () => {
       '1'
     ) as StaticSqlParameterQuery;
     expect(query.errors).toEqual([]);
-    expect(query.bucket_parameters).toEqual(['project_id']);
+    expect(query.bucketParameters).toEqual(['project_id']);
 
     expect(
       query.getStaticBucketDescriptions(


### PR DESCRIPTION
This contains no functional changes, but does contain some breaking "api" changes for the `@powersync/service-sync-rules` package. This is primarily to clean up the code to make it easier to make larger changes that I'll be working on soon.

Main changes:
1. Make individual query classes "immutable" for the most part. This removes the need for nullable fields while building the instances, making it clear which fields may actually be undefined.
2. Change field names to camelCase for consistency.
3. Remove some unused fields, and document the others.



