### PR TITLE
[Postgres] Add checks for RLS affecting replication

### DIFF
--- a/.changeset/eight-turtles-design.md
+++ b/.changeset/eight-turtles-design.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Add checks for RLS affecting replication.

--- a/.changeset/mean-foxes-hug.md
+++ b/.changeset/mean-foxes-hug.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-jpgwire': patch
+---
+
+Add types to pgwireRows.

--- a/.changeset/ten-readers-happen.md
+++ b/.changeset/ten-readers-happen.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-postgres': minor
+---
+
+Add checks for RLS affecting replication.

--- a/modules/module-postgres/src/replication/replication-utils.ts
+++ b/modules/module-postgres/src/replication/replication-utils.ts
@@ -1,7 +1,7 @@
 import * as pgwire from '@powersync/service-jpgwire';
 
 import * as lib_postgres from '@powersync/lib-service-postgres';
-import { ErrorCode, logger, ServiceError } from '@powersync/lib-services-framework';
+import { ErrorCode, logger, ServiceAssertionError, ServiceError } from '@powersync/lib-services-framework';
 import { PatternResult, storage } from '@powersync/service-core';
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as service_types from '@powersync/service-types';
@@ -134,6 +134,61 @@ $$ LANGUAGE plpgsql;`
       `'${publicationName}' uses publish_via_partition_root, which is not supported.`
     );
   }
+}
+
+export async function checkTableRls(
+  db: pgwire.PgClient,
+  relationId: number
+): Promise<{ canRead: boolean; message?: string }> {
+  const rs = await lib_postgres.retriedQuery(db, {
+    statement: `
+WITH user_info AS (
+    SELECT 
+        current_user as username,
+        r.rolsuper,
+        r.rolbypassrls
+    FROM pg_roles r 
+    WHERE r.rolname = current_user
+)
+SELECT
+    c.relname as tablename,
+    c.relrowsecurity as rls_enabled,
+    u.username as username,
+    u.rolsuper as is_superuser,
+    u.rolbypassrls as bypasses_rls
+FROM pg_class c
+CROSS JOIN user_info u
+WHERE c.oid = $1::oid;
+`,
+    params: [{ type: 'int4', value: relationId }]
+  });
+
+  const rows = pgwire.pgwireRows<{
+    rls_enabled: boolean;
+    tablename: string;
+    username: string;
+    is_superuser: boolean;
+    bypasses_rls: boolean;
+  }>(rs);
+  if (rows.length == 0) {
+    // Not expected, since we already got the oid
+    throw new ServiceAssertionError(`Table with OID ${relationId} does not exist.`);
+  }
+  const row = rows[0];
+  if (row.is_superuser || row.bypasses_rls) {
+    // Bypasses RLS automatically.
+    return { canRead: true };
+  }
+
+  if (row.rls_enabled) {
+    // Don't skip, since we _may_ still be able to get results.
+    return {
+      canRead: false,
+      message: `Row Level Security is enabled on table ${row.tablename}. To make sure that ${row.username} can read the table, run: 'ALTER ROLE ${row.username} BYPASSRLS'.`
+    };
+  }
+
+  return { canRead: true };
 }
 
 export interface GetDebugTablesInfoOptions {
@@ -309,6 +364,9 @@ export async function getDebugTableInfo(options: GetDebugTableInfoOptions): Prom
     };
   }
 
+  const rlsCheck = await checkTableRls(db, relationId);
+  const rlsError = rlsCheck.canRead ? null : { message: rlsCheck.message!, level: 'warning' };
+
   return {
     schema: schema,
     name: name,
@@ -316,7 +374,7 @@ export async function getDebugTableInfo(options: GetDebugTableInfoOptions): Prom
     replication_id: id_columns.map((c) => c.name),
     data_queries: syncData,
     parameter_queries: syncParameters,
-    errors: [id_columns_error, selectError, replicateError].filter(
+    errors: [id_columns_error, selectError, replicateError, rlsError].filter(
       (error) => error != null
     ) as service_types.ReplicationError[]
   };

--- a/packages/jpgwire/src/util.ts
+++ b/packages/jpgwire/src/util.ts
@@ -300,13 +300,13 @@ export function dateToSqlite(source?: string) {
  *
  * This converts it to objects.
  */
-export function pgwireRows(rs: pgwire.PgResult): Record<string, any>[] {
+export function pgwireRows<T = Record<string, any>>(rs: pgwire.PgResult): T[] {
   const columns = rs.columns;
   return rs.rows.map((row) => {
-    let r: Record<string, any> = {};
+    let r: T = {} as any;
     for (let i = 0; i < columns.length; i++) {
       const c = columns[i];
-      r[c.name] = row[i];
+      (r as any)[c.name] = row[i];
     }
     return r;
   });


### PR DESCRIPTION
## Background

Originally, Supabase only supported logical replication by using the built-in `postgres` role. In the meantime, it is possible to create a custom role with `REPLICATION`, and we recommend it in our [docs](https://docs.powersync.com/installation/database-setup#supabase).

The caveat is that using RLS is very common and encouraged on Supabase, but RLS affects every non-superuser user by default. So when switching from `postgres` to a custom role, you could easily lose access to read the tables. And worse, this does not show up as an error - we simply get 0 results. And this often does not show up immediately, since streaming replication still works - you only notice when updating sync rules and the data is suddenly missing.

## The fix

The fix is to make sure that the custom role has the `BYPASSRLS` attribute set.

## The check

This adds a check on whether RLS is enabled for every replicated table, and logs a warning if RLS is enabled and the role is not super-user or has BYPASSRLS set.

This logs a warning, and also reports the same info via the diagnostics api. We don't block replication in this case, since there are scenarios not covered by this check, for example explicitly adding a RLS policy giving access to the custom role.

