### PR TITLE
Minor fixes

### DIFF
--- a/.changeset/long-dolphins-judge.md
+++ b/.changeset/long-dolphins-judge.md
@@ -1,0 +1,10 @@
+---
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-module-postgres': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-module-mysql': patch
+---
+
+Cleanly interrupt clearing of storage when the process is stopped/restarted.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -129,7 +129,7 @@ export class MongoBucketBatch
     return this.last_checkpoint_lsn;
   }
 
-  async flush(options?: storage.BucketBatchCommitOptions): Promise<storage.FlushedResult | null> {
+  async flush(options?: storage.BatchBucketFlushOptions): Promise<storage.FlushedResult | null> {
     let result: storage.FlushedResult | null = null;
     // One flush may be split over multiple transactions.
     // Each flushInner() is one transaction.
@@ -142,7 +142,7 @@ export class MongoBucketBatch
     return result;
   }
 
-  private async flushInner(options?: storage.BucketBatchCommitOptions): Promise<storage.FlushedResult | null> {
+  private async flushInner(options?: storage.BatchBucketFlushOptions): Promise<storage.FlushedResult | null> {
     const batch = this.batch;
     if (batch == null) {
       return null;

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -670,7 +670,7 @@ export class ChangeStream {
     if (result.needsInitialSync) {
       if (result.snapshotLsn == null) {
         // Snapshot LSN is not present, so we need to start replication from scratch.
-        await this.storage.clear();
+        await this.storage.clear({ signal: this.abort_signal });
       }
       await this.initialReplication(result.snapshotLsn);
     }

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -288,7 +288,7 @@ AND table_type = 'BASE TABLE';`,
    * and starts again from scratch.
    */
   async startInitialReplication() {
-    await this.storage.clear();
+    await this.storage.clear({ signal: this.abortSignal });
     // Replication will be performed in a single transaction on this connection
     const connection = await this.connections.getStreamingConnection();
     const promiseConnection = (connection as mysql.Connection).promise();

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -567,7 +567,7 @@ export class PostgresSyncRulesStorage
 
   async terminate(options?: storage.TerminateOptions) {
     if (!options || options?.clearStorage) {
-      await this.clear();
+      await this.clear(options);
     }
     await this.db.sql`
       UPDATE sync_rules
@@ -606,7 +606,8 @@ export class PostgresSyncRulesStorage
     };
   }
 
-  async clear(): Promise<void> {
+  async clear(options?: storage.ClearStorageOptions): Promise<void> {
+    // TODO: Cleanly abort the cleanup when the provided signal is aborted.
     await this.db.sql`
       UPDATE sync_rules
       SET

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -431,7 +431,7 @@ WHERE  oid = $1::regclass`,
       // In those cases, we have to start replication from scratch.
       // If there is an existing healthy slot, we can skip this and continue
       // initial replication where we left off.
-      await this.storage.clear();
+      await this.storage.clear({ signal: this.abort_signal });
 
       await db.query({
         statement: 'SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = $1',

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -948,7 +948,7 @@ WHERE  oid = $1::regclass`,
                 skipKeepalive = false;
                 // flush() must be before the resnapshot check - that is
                 // typically what reports the resnapshot records.
-                await batch.flush();
+                await batch.flush({ oldestUncommittedChange: this.oldestUncommittedChange });
                 // This _must_ be checked after the flush(), and before
                 // commit() or ack(). We never persist the resnapshot list,
                 // so we have to process it before marking our progress.

--- a/packages/service-core/src/storage/BucketStorageBatch.ts
+++ b/packages/service-core/src/storage/BucketStorageBatch.ts
@@ -39,7 +39,7 @@ export interface BucketStorageBatch extends ObserverClient<BucketBatchStorageLis
    *
    * @returns null if there are no changes to flush.
    */
-  flush(): Promise<FlushedResult | null>;
+  flush(options?: BatchBucketFlushOptions): Promise<FlushedResult | null>;
 
   /**
    * Flush and commit any saved ops. This creates a new checkpoint by default.
@@ -161,19 +161,21 @@ export interface FlushedResult {
   flushed_op: InternalOpId;
 }
 
-export interface BucketBatchCommitOptions {
-  /**
-   * Creates a new checkpoint even if there were no persisted operations.
-   * Defaults to true.
-   */
-  createEmptyCheckpoints?: boolean;
-
+export interface BatchBucketFlushOptions {
   /**
    * The timestamp of the first change in this batch, according to the source database.
    *
    * Used to estimate replication lag.
    */
   oldestUncommittedChange?: Date | null;
+}
+
+export interface BucketBatchCommitOptions extends BatchBucketFlushOptions {
+  /**
+   * Creates a new checkpoint even if there were no persisted operations.
+   * Defaults to true.
+   */
+  createEmptyCheckpoints?: boolean;
 }
 
 export type ResolvedBucketBatchCommitOptions = Required<BucketBatchCommitOptions>;

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -48,7 +48,7 @@ export interface SyncRulesBucketStorage
   /**
    * Clear the storage, without changing state.
    */
-  clear(): Promise<void>;
+  clear(options?: ClearStorageOptions): Promise<void>;
 
   autoActivate(): Promise<void>;
 
@@ -210,7 +210,11 @@ export interface CompactOptions {
   moveBatchQueryLimit?: number;
 }
 
-export interface TerminateOptions {
+export interface ClearStorageOptions {
+  signal?: AbortSignal;
+}
+
+export interface TerminateOptions extends ClearStorageOptions {
   /**
    * If true, also clear the storage before terminating.
    */


### PR DESCRIPTION
1. Follow-up to #272 - fix replication lag not being logged when replicating from Postgres (regression from #163).
2. Cleanly interrupt clearing of storage if the process is stopped / restarted, instead of relying on a hard exit (currently implemented on MongoDB storage only).

