### PR TITLE
Fix custom write checkpoints

### DIFF
--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -133,7 +133,7 @@ export class MongoBucketBatch
     let result: storage.FlushedResult | null = null;
     // One flush may be split over multiple transactions.
     // Each flushInner() is one transaction.
-    while (this.batch != null) {
+    while (this.batch != null || this.write_checkpoint_batch.length > 0) {
       let r = await this.flushInner(options);
       if (r) {
         result = r;
@@ -144,17 +144,16 @@ export class MongoBucketBatch
 
   private async flushInner(options?: storage.BucketBatchCommitOptions): Promise<storage.FlushedResult | null> {
     const batch = this.batch;
-    if (batch == null) {
-      return null;
-    }
-
     let last_op: InternalOpId | null = null;
     let resumeBatch: OperationBatch | null = null;
 
-    await this.withReplicationTransaction(`Flushing ${batch.length} ops`, async (session, opSeq) => {
-      resumeBatch = await this.replicateBatch(session, batch, opSeq, options);
+    await this.withReplicationTransaction(`Flushing ${batch?.length ?? 0} ops`, async (session, opSeq) => {
+      if (batch != null) {
+        resumeBatch = await this.replicateBatch(session, batch, opSeq, options);
+      }
 
       if (this.write_checkpoint_batch.length > 0) {
+        this.logger.info(`Writing ${this.write_checkpoint_batch.length} custom write checkpoints`);
         await batchCreateCustomWriteCheckpoints(this.db, session, this.write_checkpoint_batch, opSeq.next());
         this.write_checkpoint_batch = [];
       }


### PR DESCRIPTION
Fixes a regression from #276. The bug is not any release, so not adding a changeset.

#276 refactored custom write checkpoints to be flushed together with other changes when using MongoDB storage, to make it easy to associate an op_id with it. The bug is that if there were no other changes to flush, the write checkpoints weren't flushed either. This fixes it, and adds a test to reproduce.



