### PR TITLE
Fix replication lag metric after initial replication

### DIFF
--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -1003,7 +1003,11 @@ WHERE  oid = $1::regclass`,
               // Big caveat: This _must not_ be used to skip individual messages, since this LSN
               // may be in the middle of the next transaction.
               // It must only be used to associate checkpoints with LSNs.
-              await batch.keepalive(chunkLastLsn);
+              const didCommit = await batch.keepalive(chunkLastLsn);
+              if (didCommit) {
+                this.oldestUncommittedChange = null;
+              }
+
               this.isStartingReplication = false;
             }
 


### PR DESCRIPTION
Replication lag metric was introduced in #272 (not released yet).

This fixes an issue where the replication lag metric could keep on growing indefinitely after initial replication, if no other changes come in at that time.

The issue is that in the case of "Commit due to keepalive", the "oldest uncommitted change" was not cleared, even though we have nothing further to write. This fixes the issue.

Sample of what happened:
![image](https://github.com/user-attachments/assets/5e3cba07-c3cd-4bd1-aa84-9b1ca0bd9a17)

The sharp increase at 16:23 is when the initial snapshot is completed, and the drop at 17:20 is when another write was made to the source db, clearing the replication lag.
