### PR TITLE
Correctly propagate auth errors for websockets

### DIFF
--- a/.changeset/witty-cougars-build.md
+++ b/.changeset/witty-cougars-build.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Fix websocket auth errors not correctly propagating the details, previously resulting in generic "[PSYNC_S2106] Authentication required" messages.

--- a/packages/service-core/src/routes/configure-rsocket.ts
+++ b/packages/service-core/src/routes/configure-rsocket.ts
@@ -38,7 +38,9 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
         const extracted_token = getTokenFromHeader(token);
         if (extracted_token != null) {
           const { context, tokenError } = await generateContext(options.service_context, extracted_token);
-          if (context?.token_payload == null) {
+          if (tokenError != null) {
+            throw tokenError;
+          } else if (context?.token_payload == null) {
             throw new errors.AuthorizationError(ErrorCode.PSYNC_S2106, 'Authentication required');
           }
 
@@ -46,7 +48,6 @@ export function configureRSocket(router: ReactiveSocketRouter<Context>, options:
             token,
             user_agent,
             ...context,
-            token_error: tokenError,
             service_context: service_context as RouterServiceContext,
             logger: connectionLogger
           };

--- a/packages/service-core/src/routes/router.ts
+++ b/packages/service-core/src/routes/router.ts
@@ -17,7 +17,6 @@ export type Context = {
   service_context: RouterServiceContext;
 
   token_payload?: JwtPayload;
-  token_error?: ServiceError;
   /**
    * Only on websocket endpoints.
    */


### PR DESCRIPTION
#258 improved auth errors in general, but it was not correctly propagated for websocket connections, resulting in a generic "[PSYNC_S2106] Authentication required" message. This fixes it to correctly propagate the token errors, same as for http streams.

