### PR TITLE
Fix MongoDB replication with mixed _id types

### DIFF
--- a/.changeset/shy-pugs-teach.md
+++ b/.changeset/shy-pugs-teach.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Fix MongoDB intial replication with mixed \_id types.

--- a/.changeset/shy-pugs-teach.md
+++ b/.changeset/shy-pugs-teach.md
@@ -4,4 +4,4 @@
 '@powersync/service-image': patch
 ---
 
-Fix MongoDB intial replication with mixed \_id types.
+Fix MongoDB initial replication with mixed \_id types.

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -451,6 +451,7 @@ export class ChangeStream {
     while (true) {
       const { docs: docBatch, lastKey } = await nextChunkPromise;
       if (docBatch.length == 0) {
+        // No more data - stop iterating
         break;
       }
 

--- a/modules/module-mongodb/src/replication/MongoSnapshotQuery.ts
+++ b/modules/module-mongodb/src/replication/MongoSnapshotQuery.ts
@@ -33,6 +33,8 @@ export class ChunkedSnapshotQuery implements AsyncDisposable {
       // https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/#comparison-sort-order
       // The $literal is necessary to ensure that the lastKey is treated as a literal value, and doesn't attempt
       // any parsing as an operator.
+      // Starting in MongoDB 5.0, this filter can use the _id index. Source:
+      // https://www.mongodb.com/docs/manual/release-notes/5.0/#general-aggregation-improvements
       const filter: mongo.Filter<mongo.Document> =
         this.lastKey == null ? {} : { $expr: { $gt: ['$_id', { $literal: this.lastKey }] } };
       cursor = this.collection.find(filter, {

--- a/modules/module-mongodb/test/src/chunked_snapshot.test.ts
+++ b/modules/module-mongodb/test/src/chunked_snapshot.test.ts
@@ -59,6 +59,31 @@ function defineBatchTests(factory: TestStorageFactory) {
     });
   });
 
+  test('chunked snapshot (mixed)', async () => {
+    await testChunkedSnapshot({
+      generateId(i) {
+        // Alternatingly return a number, string or nested document.
+        // This caused issues in the past due to comparison operators only checking fields matching the same type.
+        if (i % 3 == 0) {
+          return i;
+        } else if (i % 3 == 1) {
+          return `${i}`;
+        } else {
+          return { n: i };
+        }
+      },
+      idToSqlite(id: number | string) {
+        if (typeof id == 'number') {
+          return BigInt(id);
+        } else if (typeof id == 'string') {
+          return id;
+        } else {
+          return JSON.stringify(id);
+        }
+      }
+    });
+  });
+
   async function testChunkedSnapshot(options: {
     generateId: (i: number) => any;
     idToSqlite?: (id: any) => SqliteJsonValue;


### PR DESCRIPTION
## The issue

This is a regression in v1.13.0.

In #163, we changed initial snapshot queries on MongoDB to chunk on _id, using `{_id: {$gt: ...}}` queries to filter out earlier chunks. The issue is that when the same collection uses different types for the `_id` field, the `$gt` operator only returns documents with the same type. That meant that when you have a large collection with for example both string and ObjectId _ids, only the documents with string `_id` would replicate in the initial snapshot.

This would be visible in the logs, with the collection finishing replicating with mismatching counts, such as:

```
Replicating "mydb"."mycollection" 12356/~23000
```

## The fix

This changes the snapshot query to `{ $expr: { $gt: ['$_id', { $literal: ... }] } }`. This is almost the same, but the `$expr` version respects the total ordering of BSON types (same as the sort stage), and doesn't filter out the other types. It still uses the _id index.
