### PR TITLE
MongoDB appName & MySQL program_name

### DIFF
--- a/.changeset/slow-hounds-walk.md
+++ b/.changeset/slow-hounds-walk.md
@@ -1,0 +1,10 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-module-mysql': patch
+'@powersync/lib-service-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Add 'powersync' as the app name for MongoDB and MySQL connections.

--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -1,7 +1,6 @@
 import * as mongo from 'mongodb';
 import * as timers from 'timers/promises';
 import { BaseMongoConfigDecoded, normalizeMongoConfig } from '../types/types.js';
-import { validateIpHostname } from '@powersync/lib-services-framework';
 
 /**
  * Time for new connection to timeout.
@@ -33,6 +32,9 @@ export interface MongoConnectionOptions {
   maxPoolSize: number;
 }
 
+/**
+ * Create a MongoClient for the storage database.
+ */
 export function createMongoClient(config: BaseMongoConfigDecoded, options?: MongoConnectionOptions) {
   const normalized = normalizeMongoConfig(config);
   return new mongo.MongoClient(normalized.uri, {
@@ -46,6 +48,9 @@ export function createMongoClient(config: BaseMongoConfigDecoded, options?: Mong
     socketTimeoutMS: MONGO_SOCKET_TIMEOUT_MS,
     // How long to wait for new primary selection
     serverSelectionTimeoutMS: 30_000,
+
+    // Identify the client
+    appName: 'powersync-storage',
 
     lookup: normalized.lookup,
 

--- a/modules/module-mongodb-storage/src/storage/implementation/util.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/util.ts
@@ -107,7 +107,7 @@ export function replicaIdToSubkey(table: bson.ObjectId, id: storage.ReplicaId): 
 /**
  * Helper function for creating a MongoDB client from consumers of this package
  */
-export const createMongoClient = (url: string, options?: mongo.MongoClientOptions) => {
+const createMongoClient = (url: string, options?: mongo.MongoClientOptions) => {
   return new mongo.MongoClient(url, options);
 };
 

--- a/modules/module-mongodb/src/replication/MongoManager.ts
+++ b/modules/module-mongodb/src/replication/MongoManager.ts
@@ -3,6 +3,9 @@ import { mongo } from '@powersync/lib-service-mongodb';
 import { NormalizedMongoConnectionConfig } from '../types/types.js';
 import { BSON_DESERIALIZE_DATA_OPTIONS } from '@powersync/service-core';
 
+/**
+ * Manage a MongoDB source database connection.
+ */
 export class MongoManager {
   public readonly client: mongo.MongoClient;
   public readonly db: mongo.Db;
@@ -25,6 +28,9 @@ export class MongoManager {
       socketTimeoutMS: 60_000,
       // How long to wait for new primary selection
       serverSelectionTimeoutMS: 30_000,
+
+      // Identify the client
+      appName: 'powersync',
 
       // Avoid too many connections:
       // 1. It can overwhelm the source database.

--- a/modules/module-mysql/src/replication/BinLogReplicationJob.ts
+++ b/modules/module-mysql/src/replication/BinLogReplicationJob.ts
@@ -55,7 +55,16 @@ export class BinLogReplicationJob extends replication.AbstractReplicationJob {
     // such as caused by cached PG schemas.
     const connectionManager = this.connectionFactory.create({
       // Pool connections are only used intermittently.
-      idleTimeout: 30_000
+      idleTimeout: 30_000,
+
+      connectAttributes: {
+        // https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html
+        // These do not appear to be supported by Zongji yet, so we only specify it here.
+        // Query using `select * from performance_schema.session_connect_attrs`.
+        program_name: 'powersync'
+
+        // _client_name and _client_version is specified by the driver
+      }
     });
     try {
       await this.rateLimiter?.waitUntilAllowed({ signal: this.abortController.signal });


### PR DESCRIPTION
This includes an identifying name in database connections, which helps to distinguish database connections made by powersync from other sources.

 * MongoDB source database (direct connection and change stream): 'powersync' as `appName`.
 * MongoDB storage database: 'powersync-storage' as `appName`.
 * MySQL direct connection: 'powersync' as `program_name`.
 * MySQL replication connection: Not supported by Zongji yet.
 * Postgres connections (all): 'PowerSync' (already present before this PR)

For MongoDB, this is present in `db.currentOp()`, as well as in logs:

```
// currentOp:
       client: '127.0.0.1:40558',
      appName: 'powersync',
      clientMetadata: {
        application: { name: 'powersync' },
        driver: { name: 'nodejs', version: '6.14.2' },
        platform: 'Node.js v22.14.0, LE',
        os: {
          name: 'linux',
          architecture: 'x64',
          version: '6.15.0-061500-generic',
          type: 'Linux'
        }
      }

// logs:
{"application":{"name":"powersync"},"driver":{"name":"nodejs","version":"6.14.2"}, ...
```

In MySQL, this can be accessed via `select * from performance_schema.session_connect_attrs;`:

```
+----------------+-----------------+--------------+------------------+
| PROCESSLIST_ID | ATTR_NAME       | ATTR_VALUE   | ORDINAL_POSITION |
|             18 | _client_name    | Node-MySQL-2 |                0 |
|             18 | _client_version | 3.11.3       |                1 |
|             18 | program_name    | powersync    |                2 |
+----------------+-----------------+--------------+------------------+
```

In Postgres, use `select usename, client_addr, application_name, backend_type from pg_stat_activity;`:

```
| usename  | client_addr                          | application_name              | backend_type   |
| -------- | ------------------------------------ | ----------------------------- | -------------- |
| postgres | 54.195.180.72                        | PowerSync                     | walsender      |
```