### PR TITLE
Specify maxTimeMs for MongoDB storage queries

### DIFF
--- a/.changeset/dull-pumas-punch.md
+++ b/.changeset/dull-pumas-punch.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-errors': patch
+'@powersync/lib-service-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+[MongoDB Storage] Improve error messages for checksum query timeouts

--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -19,7 +19,7 @@ export const MONGO_SOCKET_TIMEOUT_MS = 60_000;
  *
  * Must be less than MONGO_SOCKET_TIMEOUT_MS to ensure proper error handling.
  */
-export const MONGO_OPERATION_TIMEOUT_MS = 30_000;
+export const MONGO_OPERATION_TIMEOUT_MS = 40_000;
 
 /**
  * Same as above, but specifically for clear operations.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -348,7 +348,10 @@ export class MongoSyncBucketStorage
         // 1. We can calculate the document size accurately without serializing again.
         // 2. We can delay parsing the results until it's needed.
         // We manually use bson.deserialize below
-        raw: true
+        raw: true,
+
+        // Limit the time for the operation to complete, to avoid getting connection timeouts
+        maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
       }
     ) as unknown as mongo.FindCursor<Buffer>;
 
@@ -486,7 +489,7 @@ export class MongoSyncBucketStorage
             }
           }
         ],
-        { session: undefined, readConcern: 'snapshot' }
+        { session: undefined, readConcern: 'snapshot', maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS }
       )
       .toArray();
 

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -428,6 +428,17 @@ export enum ErrorCode {
    */
   PSYNC_S2402 = 'PSYNC_S2402',
 
+  /**
+   * Query timed out. Could be due to a large query or a temporary load issue on the storage database.
+   * Retry the request.
+   */
+  PSYNC_S2403 = 'PSYNC_S2403',
+
+  /**
+   * Query failure on the storage database. See error details for more information.
+   */
+  PSYNC_S2404 = 'PSYNC_S2404',
+
   // ## PSYNC_S23xx: Sync API errors - Postgres Storage
 
   // ## PSYNC_S3xxx: Service configuration issues

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -243,3 +243,19 @@ export class DatabaseConnectionError extends ServiceError {
     this.cause = cause;
   }
 }
+
+export class DatabaseQueryError extends ServiceError {
+  public cause: any;
+
+  constructor(code: ErrorCode, message: string, cause?: any) {
+    super({
+      code: code,
+      status: 500,
+      description: message,
+      // Cause is always logged. Return details via the API only in development mode
+      details: process.env.NODE_ENV !== 'production' && cause != null ? `cause: ${cause.message}` : undefined,
+      stack: process.env.NODE_ENV !== 'production' ? cause.stack : undefined
+    });
+    this.cause = cause;
+  }
+}


### PR DESCRIPTION
Specify a limit of 40s for each query, instead of relying on the connection socket timeout. The most common cause is a timeout when computing checksums on buckets with millions of operations. We can often recover by retrying the query - the second attempt is faster since the data would be cached in database memory.

Before:
```
[PSYNC_2001] Something went wrong
  connection 10 to a.b.c.d:27017 timed out
```

Now:
```
[PSYNC_S2403] Query timed out while reading checksums
```