### PR TITLE
Change Postgres application_name

### DIFF
--- a/.changeset/shaggy-fireants-prove.md
+++ b/.changeset/shaggy-fireants-prove.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-jpgwire': patch
+---
+
+Change application_name on postgres connections from 'PowerSync' to 'powersync/{version}'.


### PR DESCRIPTION
#293 changed the `application_name` used in postgres connections from `PowerSync` to `powersync/${version}`. This made it into the 1.13.4 release, but the changeset in the jpgwire package was missing, so this never applied the change in the released npm packages.

This just adds a changeset to allow doing that release.