### PR TITLE
Make 404 errors consistent with other error responses

### DIFF
--- a/.changeset/fifty-pens-hammer.md
+++ b/.changeset/fifty-pens-hammer.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-errors': patch
+---
+
+Report HTTP method in `RouteNotFound` error

--- a/.changeset/sharp-bees-serve.md
+++ b/.changeset/sharp-bees-serve.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Make 404 error body consistent with other error responses.

--- a/packages/service-core/src/routes/configure-fastify.ts
+++ b/packages/service-core/src/routes/configure-fastify.ts
@@ -1,7 +1,7 @@
 import type fastify from 'fastify';
 import * as uuid from 'uuid';
 
-import { registerFastifyRoutes } from './route-register.js';
+import { registerFastifyNotFoundHandler, registerFastifyRoutes } from './route-register.js';
 
 import * as system from '../system/system-index.js';
 
@@ -76,6 +76,8 @@ export function configureFastifyServer(server: fastify.FastifyInstance, options:
    */
   server.register(async function (childContext) {
     registerFastifyRoutes(childContext, generateContext, routes.api?.routes ?? DEFAULT_ROUTE_OPTIONS.api.routes);
+    registerFastifyNotFoundHandler(childContext);
+
     // Limit the active concurrent requests
     childContext.addHook(
       'onRequest',

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -218,12 +218,17 @@ export class InternalServerError extends ServiceError {
 export class RouteNotFound extends ServiceError {
   static readonly CODE = ErrorCode.PSYNC_S2002;
 
-  constructor(path: string) {
+  constructor(path: string, method?: string) {
+    let pathDescription = JSON.stringify(path);
+    if (method != null) {
+      pathDescription = `${method} ${pathDescription}`;
+    }
+
     super({
       code: RouteNotFound.CODE,
       status: 404,
       description: 'The path does not exist on this server',
-      details: `The path ${JSON.stringify(path)} does not exist on this server`,
+      details: `The path ${pathDescription} does not exist on this server`,
       severity: ErrorSeverity.INFO
     });
   }


### PR DESCRIPTION
The sync service has custom error types used to respond with error descriptions, like:

```
{"error":{"code":"PSYNC_S2106","status":401,"description":"Authentication required","name":"AuthorizationError"}}
```

When requesting an endpoint that doesn't exist, the sync service also responds with an error. That response has an incompatible structure though:

```
{"message":"Route GET:/foo/bar not found","error":"Not Found","statusCode":404}
```

That response manages to [crash the error handler](https://discord.com/channels/1138230179878154300/1396435049938944081/1396435049938944081) in the Dart SDK, leading to a confusing error message there.

This PR installs a custom 404 handler on fastify to ensure the responses are consistent.