### PR TITLE
Sync streams

### DIFF
--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -388,8 +388,8 @@ export class BucketParameterState {
 
     this.querier = syncRules.getBucketParameterQuerier({
       globalParameters: this.syncParams,
-      hasDefaultSubscriptions: this.includeDefaultStreams,
-      resolveSubscription(name) {
+      hasDefaultStreams: this.includeDefaultStreams,
+      resolveOpenedStream(name) {
         const subscription = explicitlyOpenedStreams[name];
         if (subscription) {
           return subscription.parameters ?? {};

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -100,6 +100,7 @@ async function* streamResponseInner(
     bucketStorage,
     syncRules,
     syncParams,
+    syncRequest: params,
     initialBucketPositions: params.buckets?.map((bucket) => ({
       name: bucket.name,
       after: BigInt(bucket.after)

--- a/packages/service-core/src/util/protocol-types.ts
+++ b/packages/service-core/src/util/protocol-types.ts
@@ -14,11 +14,11 @@ export const BucketRequest = t.object({
 export type BucketRequest = t.Decoded<typeof BucketRequest>;
 
 /**
- * An explicit subscription to a defined sync stream made by the client.
+ * A sync steam that a client has expressed interest in by explicitly opening it on the client side.
  */
-export const StreamSubscription = t.object({
+export const OpenedStream = t.object({
   /**
-   * The defined name of the stream as it appears in sync rules.
+   * The defined name of the stream as it appears in sync stream definitions.
    */
   stream: t.string,
   /**
@@ -26,7 +26,7 @@ export const StreamSubscription = t.object({
    */
   parameters: t.record(t.any).optional(),
   /**
-   * Set when the client wishes to re-assign a different priority to this subscription.
+   * Set when the client wishes to re-assign a different priority to this stream.
    *
    * Streams and sync rules can also assign a default priority, but clients are allowed to override those. This can be
    * useful when the priority for partial syncs depends on e.g. the current page opened in a client.
@@ -34,12 +34,12 @@ export const StreamSubscription = t.object({
   override_priority: t.number.optional()
 });
 
-export type StreamSubscription = t.Decoded<typeof StreamSubscription>;
+export type OpenedStream = t.Decoded<typeof OpenedStream>;
 
 /**
- * An overview of all subscriptions as part of a streaming sync request.
+ * An overview of all opened streams as part of a streaming sync request.
  */
-export const StreamSubscriptions = t.object({
+export const OpenedStreams = t.object({
   /**
    * Whether to sync default streams.
    *
@@ -48,12 +48,12 @@ export const StreamSubscriptions = t.object({
   include_defaults: t.boolean.optional(),
 
   /**
-   * An array of streams the client has subscribed to.
+   * An array of sync streams the client has opened explicitly.
    */
-  subscriptions: t.array(StreamSubscription)
+  opened: t.array(OpenedStream)
 });
 
-export type StreamSubscriptions = t.Decoded<typeof StreamSubscriptions>;
+export type StreamSubscriptions = t.Decoded<typeof OpenedStreams>;
 
 export const StreamingSyncRequest = t.object({
   /**
@@ -92,9 +92,9 @@ export const StreamingSyncRequest = t.object({
   client_id: t.string.optional(),
 
   /**
-   * If the client is aware of stream subscriptions, an array of streams the client is subscribing to.
+   * If the client is aware of streams, an array of streams the client has opened.
    */
-  subscriptions: StreamSubscriptions.optional()
+  subscriptions: OpenedStreams.optional()
 });
 
 export type StreamingSyncRequest = t.Decoded<typeof StreamingSyncRequest>;
@@ -146,7 +146,7 @@ export type StreamingSyncLine =
  */
 export type ProtocolOpId = string;
 
-export interface SubscribedStream {
+export interface StreamDescription {
   name: string;
   is_default: boolean;
 }
@@ -155,7 +155,7 @@ export interface Checkpoint {
   last_op_id: ProtocolOpId;
   write_checkpoint?: ProtocolOpId;
   buckets: BucketChecksumWithDescription[];
-  included_subscriptions: SubscribedStream[];
+  streams: StreamDescription[];
 }
 
 export interface BucketState {

--- a/packages/service-core/src/util/protocol-types.ts
+++ b/packages/service-core/src/util/protocol-types.ts
@@ -13,9 +13,51 @@ export const BucketRequest = t.object({
 
 export type BucketRequest = t.Decoded<typeof BucketRequest>;
 
+/**
+ * An explicit subscription to a defined sync stream made by the client.
+ */
+export const StreamSubscription = t.object({
+  /**
+   * The defined name of the stream as it appears in sync rules.
+   */
+  stream: t.string,
+  /**
+   * An optional dictionary of parameters to pass to this specific stream.
+   */
+  parameters: t.record(t.any).optional(),
+  /**
+   * Set when the client wishes to re-assign a different priority to this subscription.
+   *
+   * Streams and sync rules can also assign a default priority, but clients are allowed to override those. This can be
+   * useful when the priority for partial syncs depends on e.g. the current page opened in a client.
+   */
+  override_priority: t.number.optional()
+});
+
+export type StreamSubscription = t.Decoded<typeof StreamSubscription>;
+
+/**
+ * An overview of all subscriptions as part of a streaming sync request.
+ */
+export const StreamSubscriptions = t.object({
+  /**
+   * Whether to sync default streams.
+   *
+   * When disabled,only
+   */
+  include_defaults: t.boolean.optional(),
+
+  /**
+   * An array of streams the client has subscribed to.
+   */
+  subscriptions: t.array(StreamSubscription)
+});
+
+export type StreamSubscriptions = t.Decoded<typeof StreamSubscriptions>;
+
 export const StreamingSyncRequest = t.object({
   /**
-   * Existing bucket states.
+   * Existing client-side bucket states.
    */
   buckets: t.array(BucketRequest).optional(),
 
@@ -47,7 +89,12 @@ export const StreamingSyncRequest = t.object({
   /**
    * Unique client id.
    */
-  client_id: t.string.optional()
+  client_id: t.string.optional(),
+
+  /**
+   * If the client is aware of stream subscriptions, an array of streams the client is subscribing to.
+   */
+  subscriptions: StreamSubscriptions.optional()
 });
 
 export type StreamingSyncRequest = t.Decoded<typeof StreamingSyncRequest>;

--- a/packages/service-core/src/util/protocol-types.ts
+++ b/packages/service-core/src/util/protocol-types.ts
@@ -146,10 +146,16 @@ export type StreamingSyncLine =
  */
 export type ProtocolOpId = string;
 
+export interface SubscribedStream {
+  name: string;
+  is_default: boolean;
+}
+
 export interface Checkpoint {
   last_op_id: ProtocolOpId;
   write_checkpoint?: ProtocolOpId;
   buckets: BucketChecksumWithDescription[];
+  included_subscriptions: SubscribedStream[];
 }
 
 export interface BucketState {

--- a/packages/sync-rules/src/BucketDescription.ts
+++ b/packages/sync-rules/src/BucketDescription.ts
@@ -24,6 +24,7 @@ export interface BucketDescription {
    * The name of the sync rule or stream definition from which the bucket is derived.
    */
   definition: string;
+
   /**
    * The id of the bucket, which is derived from the name of the bucket's definition
    * in the sync rules as well as the values returned by the parameter queries.
@@ -34,3 +35,15 @@ export interface BucketDescription {
    */
   priority: BucketPriority;
 }
+
+/**
+ * A bucket that was resolved to a specific request including stream subscriptions.
+ *
+ * This includes information on why the bucket has been included in a checkpoint subset
+ * shown to clients.
+ */
+export interface ResolvedBucket extends BucketDescription {
+  inclusion_reasons: BucketInclusionReason[];
+}
+
+export type BucketInclusionReason = 'default' | { subscription: string };

--- a/packages/sync-rules/src/BucketDescription.ts
+++ b/packages/sync-rules/src/BucketDescription.ts
@@ -21,6 +21,10 @@ export const isValidPriority = (i: number): i is BucketPriority => {
 
 export interface BucketDescription {
   /**
+   * The name of the sync rule or stream definition from which the bucket is derived.
+   */
+  definition: string;
+  /**
    * The id of the bucket, which is derived from the name of the bucket's definition
    * in the sync rules as well as the values returned by the parameter queries.
    */

--- a/packages/sync-rules/src/BucketParameterQuerier.ts
+++ b/packages/sync-rules/src/BucketParameterQuerier.ts
@@ -1,4 +1,4 @@
-import { BucketDescription } from './BucketDescription.js';
+import { BucketDescription, ResolvedBucket } from './BucketDescription.js';
 import { RequestParameters, SqliteJsonRow, SqliteJsonValue } from './types.js';
 import { normalizeParameterValue } from './utils.js';
 
@@ -14,7 +14,7 @@ export interface BucketParameterQuerier {
    *     select request.user_id() as user_id()
    *     select value as project_id from json_each(request.jwt() -> 'project_ids')
    */
-  readonly staticBuckets: BucketDescription[];
+  readonly staticBuckets: ResolvedBucket[];
 
   /**
    * True if there are dynamic buckets, meaning queryDynamicBucketDescriptions() should be used.
@@ -36,7 +36,7 @@ export interface BucketParameterQuerier {
    *
    *     select id as user_id from users where users.id = request.user_id()
    */
-  queryDynamicBucketDescriptions(source: ParameterLookupSource): Promise<BucketDescription[]>;
+  queryDynamicBucketDescriptions(source: ParameterLookupSource): Promise<ResolvedBucket[]>;
 }
 
 export interface ParameterLookupSource {
@@ -54,7 +54,7 @@ export function mergeBucketParameterQueriers(queriers: BucketParameterQuerier[])
     hasDynamicBuckets: parameterQueryLookups.length > 0,
     parameterQueryLookups: parameterQueryLookups,
     async queryDynamicBucketDescriptions(source: ParameterLookupSource) {
-      let results: BucketDescription[] = [];
+      let results: ResolvedBucket[] = [];
       for (let q of queriers) {
         if (q.hasDynamicBuckets) {
           results.push(...(await q.queryDynamicBucketDescriptions(source)));

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -29,12 +29,23 @@ export interface QueryParseResult {
   errors: SqlRuleError[];
 }
 
+export enum SqlBucketDescriptorType {
+  SYNC_RULE,
+  STREAM
+}
+
 export class SqlBucketDescriptor {
   name: string;
   bucketParameters?: string[];
+  type: SqlBucketDescriptorType;
+  subscribedToByDefault: boolean;
 
-  constructor(name: string) {
+  constructor(name: string, type: SqlBucketDescriptorType) {
     this.name = name;
+    this.type = type;
+
+    // Sync-rule style buckets are subscribed to by default, streams are opt-in unless their definition says otherwise.
+    this.subscribedToByDefault = type == SqlBucketDescriptorType.SYNC_RULE;
   }
 
   /**
@@ -93,6 +104,7 @@ export class SqlBucketDescriptor {
       }
     }
     this.dataQueries.push(query.data);
+    this.subscribedToByDefault = options.default ?? false;
 
     return {
       parsed: true,

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -1,5 +1,10 @@
 import { parse, SelectedColumn } from 'pgsql-ast-parser';
-import { BucketDescription, BucketPriority, DEFAULT_BUCKET_PRIORITY } from './BucketDescription.js';
+import {
+  BucketDescription,
+  BucketInclusionReason,
+  BucketPriority,
+  DEFAULT_BUCKET_PRIORITY
+} from './BucketDescription.js';
 import { BucketParameterQuerier, ParameterLookup, ParameterLookupSource } from './BucketParameterQuerier.js';
 import { SqlRuleError } from './errors.js';
 import { SourceTableInterface } from './SourceTableInterface.js';
@@ -451,7 +456,10 @@ export class SqlParameterQuery {
     }
   }
 
-  getBucketParameterQuerier(requestParameters: RequestParameters): BucketParameterQuerier {
+  getBucketParameterQuerier(
+    requestParameters: RequestParameters,
+    reasons: BucketInclusionReason[]
+  ): BucketParameterQuerier {
     const lookups = this.getLookups(requestParameters);
     if (lookups.length == 0) {
       // This typically happens when the query is pre-filtered using a where clause
@@ -470,7 +478,10 @@ export class SqlParameterQuery {
       parameterQueryLookups: lookups,
       queryDynamicBucketDescriptions: async (source: ParameterLookupSource) => {
         const bucketParameters = await source.getParameterSets(lookups);
-        return this.resolveBucketDescriptions(bucketParameters, requestParameters);
+        return this.resolveBucketDescriptions(bucketParameters, requestParameters).map((bucket) => ({
+          ...bucket,
+          inclusion_reasons: reasons
+        }));
       }
     };
   }

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -367,6 +367,7 @@ export class SqlParameterQuery {
         }
 
         return {
+          definition: this.descriptorName,
           bucket: getBucketId(this.descriptorName, this.bucketParameters, result),
           priority: this.priority
         };

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -411,16 +411,16 @@ export class SqlSyncRules implements SyncRules {
             hasExplicitDefaultSubscription = true;
           }
 
-          queriers.push(descriptor.getBucketParameterQuerier(subscriptionParams));
+          descriptor.pushBucketParameterQueriers(queriers, options, subscriptionParams);
         }
 
         // If the stream is subscribed to by default and there is no explicit subscription that would match the default
         // subscription, also include the default querier.
         if (descriptor.subscribedToByDefault && !hasExplicitDefaultSubscription) {
-          queriers.push(descriptor.getBucketParameterQuerier(params));
+          descriptor.pushBucketParameterQueriers(queriers, options, params);
         }
       } else {
-        queriers.push(descriptor.getBucketParameterQuerier(params));
+        descriptor.pushBucketParameterQueriers(queriers, options, params);
       }
     }
 

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -177,6 +177,7 @@ export class StaticSqlParameterQuery {
 
     return [
       {
+        definition: this.descriptorName,
         bucket: getBucketId(this.descriptorName, this.bucketParameters, result),
         priority: this.priority
       }

--- a/packages/sync-rules/src/StreamQuery.ts
+++ b/packages/sync-rules/src/StreamQuery.ts
@@ -1,0 +1,191 @@
+import { parse } from 'pgsql-ast-parser';
+import { ParameterValueClause, QuerySchema, StreamParseOptions } from './types.js';
+import { SqlRuleError } from './errors.js';
+import { isSelectStatement } from './utils.js';
+import { checkUnsupportedFeatures, isClauseError } from './sql_support.js';
+import { SqlDataQuery, SqlDataQueryOptions } from './SqlDataQuery.js';
+import { RowValueExtractor } from './BaseSqlDataQuery.js';
+import { TablePattern } from './TablePattern.js';
+import { TableQuerySchema } from './TableQuerySchema.js';
+import { SqlTools } from './sql_filters.js';
+import { ExpressionType } from './ExpressionType.js';
+import { SqlParameterQuery } from './SqlParameterQuery.js';
+import { StaticSqlParameterQuery } from './StaticSqlParameterQuery.js';
+import { DEFAULT_BUCKET_PRIORITY } from './BucketDescription.js';
+
+/**
+ * Represents a query backing a stream definition.
+ *
+ * Streams are a new way to define sync rules that don't require separate data and
+ * parameter queries. However, since most of the sync service is built around that
+ * distiction at the moment, stream queries are implemented by desugaring a unified
+ * query into its individual components.
+ */
+export class StreamQuery {
+  inferredParameters: (SqlParameterQuery | StaticSqlParameterQuery)[];
+  data: SqlDataQuery;
+
+  static fromSql(descriptorName: string, sql: string, options: StreamParseOptions): [StreamQuery, SqlRuleError[]] {
+    const [query, ...illegalRest] = parse(sql, { locationTracking: true });
+    const schema = options.schema;
+    const parameters: (SqlParameterQuery | StaticSqlParameterQuery)[] = [];
+    const errors: SqlRuleError[] = [];
+
+    // TODO: Share more of this code with SqlDataQuery
+    if (illegalRest.length > 0) {
+      throw new SqlRuleError('Only a single SELECT statement is supported', sql, illegalRest[0]?._location);
+    }
+
+    if (!isSelectStatement(query)) {
+      throw new SqlRuleError('Only SELECT statements are supported', sql, query._location);
+    }
+
+    if (query.from == null || query.from.length != 1 || query.from[0].type != 'table') {
+      throw new SqlRuleError('Must SELECT from a single table', sql, query.from?.[0]._location);
+    }
+
+    errors.push(...checkUnsupportedFeatures(sql, query));
+
+    const tableRef = query.from?.[0].name;
+    if (tableRef?.name == null) {
+      throw new SqlRuleError('Must SELECT from a single table', sql, query.from?.[0]._location);
+    }
+    const alias: string = tableRef.alias ?? tableRef.name;
+
+    const sourceTable = new TablePattern(tableRef.schema ?? options.defaultSchema, tableRef.name);
+    let querySchema: QuerySchema | undefined = undefined;
+    if (schema) {
+      const tables = schema.getTables(sourceTable);
+      if (tables.length == 0) {
+        const e = new SqlRuleError(
+          `Table ${sourceTable.schema}.${sourceTable.tablePattern} not found`,
+          sql,
+          query.from?.[0]?._location
+        );
+        e.type = 'warning';
+
+        errors.push(e);
+      } else {
+        querySchema = new TableQuerySchema(tables, alias);
+      }
+    }
+
+    const where = query.where;
+    const tools = new SqlTools({
+      table: alias,
+      parameterTables: [],
+      valueTables: [alias],
+      sql,
+      schema: querySchema,
+      supportsStreamInputs: true,
+      supportsParameterExpressions: true
+    });
+    tools.checkSpecificNameCase(tableRef);
+    const filter = tools.compileWhereClause(where);
+    const inputParameterNames = filter.inputParameters.map((p) => `bucket.${p.key}`);
+
+    // Build parameter queries based on inferred bucket parameters
+    if (tools.inferredParameters.length) {
+      const extractors: Record<string, ParameterValueClause> = {};
+      for (const inferred of tools.inferredParameters) {
+        extractors[inferred.name] = inferred.clause;
+      }
+
+      parameters.push(
+        new StaticSqlParameterQuery({
+          sql,
+          queryId: 'static',
+          descriptorName,
+          parameterExtractors: extractors,
+          bucketParameters: tools.inferredParameters.map((p) => p.name),
+          filter: undefined, // TODO
+          priority: DEFAULT_BUCKET_PRIORITY // Ignored here
+        })
+      );
+    }
+
+    let hasId = false;
+    let hasWildcard = false;
+    let extractors: RowValueExtractor[] = [];
+
+    for (let column of query.columns ?? []) {
+      const name = tools.getOutputName(column);
+      if (name != '*') {
+        const clause = tools.compileRowValueExtractor(column.expr);
+        if (isClauseError(clause)) {
+          // Error logged already
+          continue;
+        }
+        extractors.push({
+          extract: (tables, output) => {
+            output[name] = clause.evaluate(tables);
+          },
+          getTypes(schema, into) {
+            const def = clause.getColumnDefinition(schema);
+
+            into[name] = { name, type: def?.type ?? ExpressionType.NONE, originalType: def?.originalType };
+          }
+        });
+      } else {
+        extractors.push({
+          extract: (tables, output) => {
+            const row = tables[alias];
+            for (let key in row) {
+              if (key.startsWith('_')) {
+                continue;
+              }
+              output[key] ??= row[key];
+            }
+          },
+          getTypes(schema, into) {
+            for (let column of schema.getColumns(alias)) {
+              into[column.name] ??= column;
+            }
+          }
+        });
+      }
+      if (name == 'id') {
+        hasId = true;
+      } else if (name == '*') {
+        hasWildcard = true;
+        if (querySchema == null) {
+          // Not performing schema-based validation - assume there is an id
+          hasId = true;
+        } else {
+          const idType = querySchema.getColumn(alias, 'id')?.type ?? ExpressionType.NONE;
+          if (!idType.isNone()) {
+            hasId = true;
+          }
+        }
+      }
+    }
+    if (!hasId) {
+      const error = new SqlRuleError(`Query must return an "id" column`, sql, query.columns?.[0]._location);
+      if (hasWildcard) {
+        // Schema-based validations are always warnings
+        error.type = 'warning';
+      }
+      errors.push(error);
+    }
+
+    errors.push(...tools.errors);
+
+    const data: SqlDataQueryOptions = {
+      sourceTable,
+      table: alias,
+      sql,
+      filter,
+      columns: query.columns ?? [],
+      descriptorName,
+      bucketParameters: inputParameterNames,
+      tools,
+      extractors
+    };
+    return [new StreamQuery(parameters, data), errors];
+  }
+
+  private constructor(parameters: (SqlParameterQuery | StaticSqlParameterQuery)[], data: SqlDataQueryOptions) {
+    this.inferredParameters = parameters;
+    this.data = new SqlDataQuery(data);
+  }
+}

--- a/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
+++ b/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
@@ -222,9 +222,7 @@ export class TableValuedFunctionSqlParameterQuery {
 
   private getIndividualBucketDescription(row: SqliteRow, parameters: RequestParameters): BucketDescription | null {
     const mergedParams: ParameterValueSet = {
-      rawTokenPayload: parameters.rawTokenPayload,
-      rawUserParameters: parameters.rawUserParameters,
-      userId: parameters.userId,
+      ...parameters,
       lookup: (table, column) => {
         if (table == this.callTableName) {
           return row[column]!;

--- a/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
+++ b/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
@@ -249,6 +249,7 @@ export class TableValuedFunctionSqlParameterQuery {
     }
 
     return {
+      definition: this.descriptorName,
       bucket: getBucketId(this.descriptorName, this.bucketParameters, result),
       priority: this.priority
     };

--- a/packages/sync-rules/src/json_schema.ts
+++ b/packages/sync-rules/src/json_schema.ts
@@ -49,6 +49,37 @@ export const syncRulesSchema: ajvModule.Schema = {
         }
       }
     },
+    streams: {
+      type: 'object',
+      description: 'Stream definitions',
+      patternProperties: {
+        '.*': {
+          type: 'object',
+          required: ['query'],
+          examples: [{ query: ['select * from mytable'] }],
+          properties: {
+            accept_potentially_dangerous_queries: {
+              description: 'If true, disables warnings on potentially dangerous queries',
+              type: 'boolean'
+            },
+            priority: {
+              description:
+                'Default priority for the stream (lower values indicate higher priority). Clients can override the priority when subscribing.',
+              type: 'integer'
+            },
+            default: {
+              type: 'boolean',
+              description: 'Whether the stream should be subscribed to by default.'
+            },
+            query: {
+              description: 'The SQL query to sync to clients.',
+              type: 'string'
+            }
+          },
+          additionalProperties: false
+        }
+      }
+    },
     event_definitions: {
       type: 'object',
       description: 'Record of sync replication event definitions',
@@ -79,7 +110,7 @@ export const syncRulesSchema: ajvModule.Schema = {
       }
     }
   },
-  required: ['bucket_definitions'],
+  //  required: ['bucket_definitions'],
   additionalProperties: false
 } as const;
 

--- a/packages/sync-rules/src/request_functions.ts
+++ b/packages/sync-rules/src/request_functions.ts
@@ -13,19 +13,21 @@ export interface SqlParameterFunction {
   documentation: string;
 }
 
-const request_parameters: SqlParameterFunction = {
-  debugName: 'request.parameters',
-  call(parameters: ParameterValueSet) {
-    return parameters.rawUserParameters;
-  },
-  getReturnType() {
-    return ExpressionType.TEXT;
-  },
-  detail: 'Unauthenticated request parameters as JSON',
-  documentation:
-    'Returns parameters passed by the client as a JSON string. These parameters are not authenticated - any value can be passed in by the client.',
-  usesAuthenticatedRequestParameters: false,
-  usesUnauthenticatedRequestParameters: true
+const parametersFunction = (name: string): SqlParameterFunction => {
+  return {
+    debugName: name,
+    call(parameters: ParameterValueSet) {
+      return parameters.rawUserParameters;
+    },
+    getReturnType() {
+      return ExpressionType.TEXT;
+    },
+    detail: 'Unauthenticated request parameters as JSON',
+    documentation:
+      'Returns parameters passed by the client as a JSON string. These parameters are not authenticated - any value can be passed in by the client.',
+    usesAuthenticatedRequestParameters: false,
+    usesUnauthenticatedRequestParameters: true
+  };
 };
 
 const request_jwt: SqlParameterFunction = {
@@ -56,10 +58,16 @@ const request_user_id: SqlParameterFunction = {
   usesUnauthenticatedRequestParameters: false
 };
 
-export const REQUEST_FUNCTIONS_NAMED = {
-  parameters: request_parameters,
+export const REQUEST_FUNCTIONS_WITHOUT_PARAMETERS: Record<string, SqlParameterFunction> = {
   jwt: request_jwt,
   user_id: request_user_id
 };
 
-export const REQUEST_FUNCTIONS: Record<string, SqlParameterFunction> = REQUEST_FUNCTIONS_NAMED;
+export const REQUEST_FUNCTIONS: Record<string, SqlParameterFunction> = {
+  parameters: parametersFunction('request.parameters'),
+  ...REQUEST_FUNCTIONS_WITHOUT_PARAMETERS
+};
+
+export const QUERY_FUNCTIONS: Record<string, SqlParameterFunction> = {
+  params: parametersFunction('query.params')
+};

--- a/packages/sync-rules/src/request_functions.ts
+++ b/packages/sync-rules/src/request_functions.ts
@@ -13,21 +13,19 @@ export interface SqlParameterFunction {
   documentation: string;
 }
 
-const parametersFunction = (name: string): SqlParameterFunction => {
-  return {
-    debugName: name,
-    call(parameters: ParameterValueSet) {
-      return parameters.rawUserParameters;
-    },
-    getReturnType() {
-      return ExpressionType.TEXT;
-    },
-    detail: 'Unauthenticated request parameters as JSON',
-    documentation:
-      'Returns parameters passed by the client as a JSON string. These parameters are not authenticated - any value can be passed in by the client.',
-    usesAuthenticatedRequestParameters: false,
-    usesUnauthenticatedRequestParameters: true
-  };
+const request_parameters: SqlParameterFunction = {
+  debugName: 'request.parameters',
+  call(parameters: ParameterValueSet) {
+    return parameters.rawUserParameters;
+  },
+  getReturnType() {
+    return ExpressionType.TEXT;
+  },
+  detail: 'Unauthenticated request parameters as JSON',
+  documentation:
+    'Returns parameters passed by the client as a JSON string. These parameters are not authenticated - any value can be passed in by the client.',
+  usesAuthenticatedRequestParameters: false,
+  usesUnauthenticatedRequestParameters: true
 };
 
 const request_jwt: SqlParameterFunction = {
@@ -58,16 +56,25 @@ const request_user_id: SqlParameterFunction = {
   usesUnauthenticatedRequestParameters: false
 };
 
-export const REQUEST_FUNCTIONS_WITHOUT_PARAMETERS: Record<string, SqlParameterFunction> = {
+export const REQUEST_FUNCTIONS: Record<string, SqlParameterFunction> = {
+  parameters: request_parameters,
   jwt: request_jwt,
   user_id: request_user_id
 };
 
-export const REQUEST_FUNCTIONS: Record<string, SqlParameterFunction> = {
-  parameters: parametersFunction('request.parameters'),
-  ...REQUEST_FUNCTIONS_WITHOUT_PARAMETERS
-};
-
 export const QUERY_FUNCTIONS: Record<string, SqlParameterFunction> = {
-  params: parametersFunction('query.params')
+  params: {
+    debugName: 'stream.params',
+    call(parameters: ParameterValueSet) {
+      return parameters.rawUserParameters;
+    },
+    getReturnType() {
+      return ExpressionType.TEXT;
+    },
+    detail: 'Unauthenticated stream parameters as JSON',
+    documentation:
+      'Returns stream passed by the client when opening the stream. These parameters are not authenticated - any value can be passed in by the client.',
+    usesAuthenticatedRequestParameters: false,
+    usesUnauthenticatedRequestParameters: true
+  }
 };

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -4,7 +4,7 @@ import { nil } from 'pgsql-ast-parser/src/utils.js';
 import { BucketPriority, isValidPriority } from './BucketDescription.js';
 import { ExpressionType } from './ExpressionType.js';
 import { SqlRuleError } from './errors.js';
-import { REQUEST_FUNCTIONS } from './request_functions.js';
+import { QUERY_FUNCTIONS, REQUEST_FUNCTIONS } from './request_functions.js';
 import {
   BASIC_OPERATORS,
   OPERATOR_IN,
@@ -95,6 +95,11 @@ export interface SqlToolsOptions {
   supportsParameterExpressions?: boolean;
 
   /**
+   * true if expressions on stream parameters are supported.
+   */
+  supportsStreamInputs?: boolean;
+
+  /**
    * Schema for validations.
    */
   schema?: QuerySchema;
@@ -113,6 +118,9 @@ export class SqlTools {
 
   readonly supportsExpandingParameters: boolean;
   readonly supportsParameterExpressions: boolean;
+  readonly supportsStreamInputs: boolean;
+
+  private inferredStaticParameters: Map<string, InferredBucketParameter> = new Map();
 
   schema?: QuerySchema;
 
@@ -131,6 +139,7 @@ export class SqlTools {
     this.sql = options.sql;
     this.supportsExpandingParameters = options.supportsExpandingParameters ?? false;
     this.supportsParameterExpressions = options.supportsParameterExpressions ?? false;
+    this.supportsStreamInputs = options.supportsStreamInputs ?? false;
   }
 
   error(message: string, expr: NodeLocation | Expr | undefined): ClauseError {
@@ -271,7 +280,7 @@ export class SqlTools {
           return compileStaticOperator(op, leftFilter as RowValueClause, rightFilter as RowValueClause);
         } else if (isParameterValueClause(otherFilter)) {
           // 2. row value = parameter value
-          const inputParam = basicInputParameter(otherFilter);
+          const inputParam = this.basicInputParameter(otherFilter);
 
           return {
             error: false,
@@ -318,7 +327,7 @@ export class SqlTools {
         } else if (isParameterValueClause(leftFilter) && isRowValueClause(rightFilter)) {
           // token_parameters.value IN table.some_array
           // bucket.param IN table.some_array
-          const inputParam = basicInputParameter(leftFilter);
+          const inputParam = this.basicInputParameter(leftFilter);
 
           return {
             error: false,
@@ -418,6 +427,10 @@ export class SqlTools {
           return this.error(`${schema} schema is not available in data queries`, expr);
         }
 
+        if (fn == 'parameters' && this.supportsStreamInputs) {
+          return this.error(`'request.parameters()' is unavailable on streams - use 'stream.params()' instead.`, expr);
+        }
+
         if (expr.args.length > 0) {
           return this.error(`Function '${schema}.${fn}' does not take arguments`, expr);
         }
@@ -426,6 +439,24 @@ export class SqlTools {
           const fnImpl = REQUEST_FUNCTIONS[fn];
           return {
             key: 'request.parameters()',
+            lookupParameterValue(parameters) {
+              return fnImpl.call(parameters);
+            },
+            usesAuthenticatedRequestParameters: fnImpl.usesAuthenticatedRequestParameters,
+            usesUnauthenticatedRequestParameters: fnImpl.usesUnauthenticatedRequestParameters
+          } satisfies ParameterValueClause;
+        } else {
+          return this.error(`Function '${schema}.${fn}' is not defined`, expr);
+        }
+      } else if (schema == 'stream') {
+        if (!this.supportsStreamInputs) {
+          return this.error(`${schema} schema is only available in stream definitions`, expr);
+        }
+
+        if (fn in QUERY_FUNCTIONS) {
+          const fnImpl = QUERY_FUNCTIONS[fn];
+          return {
+            key: 'stream.params()',
             lookupParameterValue(parameters) {
               return fnImpl.call(parameters);
             },
@@ -757,7 +788,57 @@ export class SqlTools {
 
     return value as BucketPriority;
   }
+
+  private basicInputParameter(clause: ParameterValueClause): InputParameter {
+    if (this.supportsStreamInputs) {
+      let key = this.inferredStaticParameters.get(clause.key)?.name;
+      if (key == null) {
+        key = this.newInferredBucketParameterName();
+        this.inferredStaticParameters.set(clause.key, {
+          name: key,
+          variant: 'static',
+          clause
+        });
+      }
+
+      return {
+        key,
+        expands: false,
+        filteredRowToLookupValue: () => {
+          return SQLITE_FALSE; // Only relevant for parameter queries, but this is a stream query.
+        },
+        parametersToLookupValue: () => {
+          return SQLITE_FALSE;
+        }
+      };
+    }
+
+    return {
+      key: clause.key,
+      expands: false,
+      filteredRowToLookupValue: (filterParameters) => {
+        return filterParameters[clause.key];
+      },
+      parametersToLookupValue: (parameters) => {
+        return clause.lookupParameterValue(parameters);
+      }
+    };
+  }
+
+  public get inferredParameters(): InferredBucketParameter[] {
+    return [...this.inferredStaticParameters.values()];
+  }
+
+  private newInferredBucketParameterName() {
+    return `p${this.inferredStaticParameters.size}`;
+  }
 }
+
+export type InferredBucketParameter = {
+  name: string;
+} & StaticBucketParameter;
+
+export type StaticBucketParameter = { variant: 'static'; clause: ParameterValueClause };
 
 function isStatic(expr: Expr) {
   return ['integer', 'string', 'numeric', 'boolean', 'null'].includes(expr.type);
@@ -793,18 +874,5 @@ function staticValueClause(value: SqliteValue): StaticValueClause {
     },
     usesAuthenticatedRequestParameters: false,
     usesUnauthenticatedRequestParameters: false
-  };
-}
-
-function basicInputParameter(clause: ParameterValueClause): InputParameter {
-  return {
-    key: clause.key,
-    expands: false,
-    filteredRowToLookupValue: (filterParameters) => {
-      return filterParameters[clause.key];
-    },
-    parametersToLookupValue: (parameters) => {
-      return clause.lookupParameterValue(parameters);
-    }
   };
 }

--- a/packages/sync-rules/src/sql_filters.ts
+++ b/packages/sync-rules/src/sql_filters.ts
@@ -427,10 +427,6 @@ export class SqlTools {
           return this.error(`${schema} schema is not available in data queries`, expr);
         }
 
-        if (fn == 'parameters' && this.supportsStreamInputs) {
-          return this.error(`'request.parameters()' is unavailable on streams - use 'stream.params()' instead.`, expr);
-        }
-
         if (expr.args.length > 0) {
           return this.error(`Function '${schema}.${fn}' does not take arguments`, expr);
         }
@@ -438,7 +434,7 @@ export class SqlTools {
         if (fn in REQUEST_FUNCTIONS) {
           const fnImpl = REQUEST_FUNCTIONS[fn];
           return {
-            key: 'request.parameters()',
+            key: `stream.${fn}()`,
             lookupParameterValue(parameters) {
               return fnImpl.call(parameters);
             },
@@ -456,7 +452,7 @@ export class SqlTools {
         if (fn in QUERY_FUNCTIONS) {
           const fnImpl = QUERY_FUNCTIONS[fn];
           return {
-            key: 'stream.params()',
+            key: `stream.${fn}()`,
             lookupParameterValue(parameters) {
               return fnImpl.call(parameters);
             },

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -86,6 +86,11 @@ export interface ParameterValueSet {
   rawUserParameters: string;
 
   /**
+   * For streams, the raw JSON string of stream parameters.
+   */
+  rawStreamParameters: string | null;
+
+  /**
    * JSON string of raw request parameters.
    */
   rawTokenPayload: string;
@@ -101,6 +106,8 @@ export class RequestParameters implements ParameterValueSet {
    * JSON string of raw request parameters.
    */
   rawUserParameters: string;
+
+  rawStreamParameters: string | null;
 
   /**
    * JSON string of raw request parameters.
@@ -125,6 +132,7 @@ export class RequestParameters implements ParameterValueSet {
 
     this.rawUserParameters = JSONBig.stringify(clientParameters);
     this.userParameters = toSyncRulesParameters(clientParameters);
+    this.rawStreamParameters = null;
   }
 
   lookup(table: string, column: string): SqliteJsonValue {
@@ -136,10 +144,9 @@ export class RequestParameters implements ParameterValueSet {
     throw new Error(`Unknown table: ${table}`);
   }
 
-  withAddedParameters(params: Record<string, any>): RequestParameters {
+  withAddedStreamParameters(params: Record<string, any>): RequestParameters {
     const clone = structuredClone(this);
-    clone.rawUserParameters = JSONBig.stringify(params);
-    clone.userParameters = toSyncRulesParameters(params);
+    clone.rawStreamParameters = JSONBig.stringify(params);
 
     return clone;
   }

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -18,6 +18,10 @@ export interface QueryParseOptions extends SyncRulesOptions {
   priority?: BucketPriority;
 }
 
+export interface StreamParseOptions extends QueryParseOptions {
+  default?: boolean;
+}
+
 export interface EvaluatedParameters {
   lookup: ParameterLookup;
 

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -135,6 +135,14 @@ export class RequestParameters implements ParameterValueSet {
     }
     throw new Error(`Unknown table: ${table}`);
   }
+
+  withAddedParameters(params: Record<string, any>): RequestParameters {
+    const clone = structuredClone(this);
+    clone.rawUserParameters = JSONBig.stringify(params);
+    clone.userParameters = toSyncRulesParameters(params);
+
+    return clone;
+  }
 }
 
 /**

--- a/packages/sync-rules/test/src/streams.test.ts
+++ b/packages/sync-rules/test/src/streams.test.ts
@@ -1,0 +1,126 @@
+import { assert, describe, expect, test } from 'vitest';
+import { SqlSyncRules } from '../../src/index.js';
+import { ASSETS, BASIC_SCHEMA, PARSE_OPTIONS } from './util.js';
+
+describe('streams', () => {
+  test('without parameters', () => {
+    const desc = parseSingleBucketDescription(`
+streams:
+  lists:
+    query: SELECT * FROM assets
+`);
+    expect(desc.bucketParameters).toBeFalsy();
+  });
+
+  test('static filter', () => {
+    const desc = parseSingleBucketDescription(`
+streams:
+  lists:
+    query: SELECT * FROM assets WHERE count > 5
+`);
+    expect(desc.bucketParameters).toBeFalsy();
+    assert.isEmpty(desc.parameterQueries);
+
+    assert.isEmpty(
+      desc.evaluateRow({
+        sourceTable: ASSETS,
+        record: {
+          count: 4
+        }
+      })
+    );
+
+    expect(
+      desc.evaluateRow({
+        sourceTable: ASSETS,
+        record: {
+          count: 6
+        }
+      })
+    ).toHaveLength(1);
+  });
+
+  test('stream param', () => {
+    const desc = parseSingleBucketDescription(`
+streams:
+  lists:
+    query: SELECT * FROM assets WHERE id = stream.params() ->> 'id';
+`);
+
+    // This should be desuraged to
+    //  params: SELECT request.params() ->> 'id' AS p0
+    //  data: SELECT * FROM assets WHERE id = bucket.p0
+
+    expect(desc.globalParameterQueries).toHaveLength(1);
+    const [parameter] = desc.globalParameterQueries;
+    expect(parameter.bucketParameters).toEqual(['p0']);
+
+    const [data] = desc.dataQueries;
+    expect(data.bucketParameters).toEqual(['bucket.p0']);
+  });
+
+  test('user filter', () => {
+    const desc = parseSingleBucketDescription(`
+streams:
+  lists:
+    query: SELECT * FROM assets WHERE request.jwt() ->> 'isAdmin'
+`);
+
+    // This should be desuraged to
+    //  params: SELECT request.params() ->> 'id' AS p0
+    //  data: SELECT * FROM assets WHERE id = bucket.p0
+
+    const [data] = desc.dataQueries;
+    expect(data.bucketParameters).toEqual(['bucket.p0']);
+  });
+});
+
+/**
+
+SELECT * FROM assets WHERE id IN (SELECT id FROM asset_groups WHERE owner = request.user_id())
+  parameter: SELECT id AS p0 FROM asset_groups WHERE owner = request.user_id()
+  data: SELECT * FROM assets WHERE id = bucket.p0
+
+SELECT * FROM assets WHERE id IN (SELECT id FROM asset_groups WHERE owner = request.user_id())
+                        OR count > 10
+  parameter: SELECT id AS p0 FROM asset_groups WHERE owner = request.user_id()
+  data: SELECT * FROM assets WHERE id = bucket.p0 OR count > 10
+
+SELECT * FROM assets WHERE id IN (SELECT id FROM asset_groups WHERE owner = request.user_id())
+                       OR request.jwt() ->> 'isAdmin'
+  parameter: SELECT id AS p0, request.jwt() ->> 'isAdmin' AS p1 FROM asset_groups WHERE owner = request.user_id()
+  parameter: SELECT NULL as p0, request.jwt() ->> 'isAdmin' AS p1
+  data: SELECT * FROM assets WHERE id = bucket.p0 OR bucket.p1
+
+SELECT * FROM assets WHERE id IN (SELECT id FROM asset_groups WHERE owner = request.user_id())
+                       AND request.jwt() ->> 'isAdmin'
+  parameter: SELECT id AS p0, request.jwt() ->> 'isAdmin' AS p1 FROM asset_groups WHERE owner = request.user_id()
+                                                                                        AND request.jwt() ->> 'isAdmin'
+  data: SELECT * FROM assets WHERE id = bucket.p0
+
+SELECT * FROM assets WHERE id IN (SELECT id FROM asset_groups WHERE owner = request.user_id())
+                        OR name IN (SELECT name FROM test2 WHERE owner = request.user_id())
+  parameter: SELECT id AS p0, NULL AS p1 FROM asset_groups WHERE owner = request.user_id()
+  parameter: SELECT NULL AS p0, NULL AS p1 FROM test2 WHERE owner = request.user_id()
+  data: SELECT * FROM assets WHERE id = bucket.p0 OR name = bucket.p1
+
+SELECT * FROM assets WHERE id IN (SELECT id FROM asset_groups WHERE owner = request.user_id())
+                        AND name IN (SELECT name FROM test2 WHERE owner = request.user_id())
+  parameter: SELECT id AS p0, NULL AS p1 FROM asset_groups WHERE owner = request.user_id()
+  parameter: SELECT NULL AS p0, NULL AS p1 FROM test2 WHERE owner = request.user_id()
+  data: SELECT * FROM assets WHERE id = bucket.p0 AND name = bucket.p1
+  */
+
+const options = { schema: BASIC_SCHEMA, ...PARSE_OPTIONS };
+
+function parseSyncRules(yaml: string) {
+  const rules = SqlSyncRules.fromYaml(yaml, options);
+  assert.isEmpty(rules.errors);
+  return rules;
+}
+
+function parseSingleBucketDescription(yaml: string) {
+  const rules = parseSyncRules(yaml);
+  expect(rules.bucketDescriptors).toHaveLength(1);
+  return rules.bucketDescriptors[0];
+}

--- a/packages/sync-rules/test/src/util.ts
+++ b/packages/sync-rules/test/src/util.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_TAG,
+  GetQuerierOptions,
   RequestJwtPayload,
   RequestParameters,
   SourceTableInterface,
@@ -59,4 +60,18 @@ export function normalizeTokenParameters(
   } satisfies RequestJwtPayload;
   delete tokenPayload.parameters.user_id;
   return new RequestParameters(tokenPayload, user_parameters ?? {});
+}
+
+export function normalizeQuerierOptions(
+  token_parameters: Record<string, any>,
+  user_parameters?: Record<string, any>
+): GetQuerierOptions {
+  const globalParameters = normalizeTokenParameters(token_parameters, user_parameters);
+  return {
+    globalParameters,
+    hasDefaultSubscriptions: true,
+    resolveSubscription(name) {
+      return null;
+    }
+  };
 }


### PR DESCRIPTION
This is  a work-in-progress PR for sync streams.

Sync streams essentially consist of two features:

1. A new way to define sync rules in a way that only requires a single definition instead of parameter and data queries (the internal "Subqueries / New Sync Streams Syntax" document).
2. The ability for clients to explicitly subscribe to sync streams (the internal "Sync Streams" document).

This PR implements a small subset of feature 1 by desugaring the unified query into the parameter / data queries we have today. That seemed like the easiest way to get started on this, but I think it's not a good approach to handle subqueries (which are not implemented in this PR). I will open a follow-up PR to implement the new syntax in a clean structure able to handle that better.

Instead, most of this PR is related to protocol changes enabling the second feature. While most of the subscription management happens on the client, there are two fundamental changes:

1. Clients need to know why they're receiving a bucket: We want clients to be able to track progress (and also provide the usual `hasSynced` / `lastSyncedAt` fields) for individual stream subscriptions. Since progress is ultimately attached to buckets, clients need enough information to associate buckets with stream subscriptions.
2. Bucket queriers can yield the same bucket multiple times: Since clients can subscribe to the same stream with different parameters, it's possible to subscribe in a way that causes streams to have overlapping results. Consider for instance a stream defined as `SELECT * FROM assets WHERE id IN (request.args() -> 'asset_ids')` and a client subscribing once with `{'asset_id': [1]}` and another time with `{'asset_id': [1, 2]}`. Here, both subscriptions yield the bucket `assets[id=1]`. We obviously don't want the bucket to be included in the checkpoint multiple times, but clients need to know that progress on bucket `assets[id=1]` contributes to both stream subscriptions.

Most of the logic related to the first requirement is implemented in the `sync-rules` package:

1. In `SqlSyncRules.getBucketParameterQuerier`, we take an additional array of explicit stream subscriptions. When we find a matching stream, we evaluate parameter queries for each of those subscriptions. Otherwise, we evaluate the default subscription if the stream has one.
2. Each stream subscription has an opaque id, which is internal to a sync stream (so, as far as the service is concerned, stateless), and generated by the client. When a bucket is found as part of a querier, we either:
 - remember that the bucket was generated by a legacy sync rule or a default stream
 - or otherwise, include the opaque id of the stream that resulted in that bucket.

In `service-core`, we:

1. Forward stream subscriptions from the client to `sync-rules`.
2. Merge multiple buckets created from different stream subscriptions into one if they're duplicate.
  - TODO: Check if it makes sense to do this in `sync-rules` directly - it's a bit easier to do it when building checksums because we need access to all buckets (static and dynamic) to do this.
3. Apply subscription options, like a custom bucket priority for buckets within a subscription.

This is still missing tests, but I wanted to get it out for an initial discussion.