### PR TITLE
Fix replication switchover

### DIFF
--- a/.changeset/shiny-pugs-train.md
+++ b/.changeset/shiny-pugs-train.md
@@ -1,0 +1,11 @@
+---
+'@powersync/service-module-postgres-storage': minor
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-core-tests': minor
+'@powersync/service-module-postgres': minor
+'@powersync/service-module-mongodb': minor
+'@powersync/service-core': minor
+'@powersync/service-module-mysql': minor
+---
+
+Delay switching over to new sync rules until we have a consistent checkpoint.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,10 +168,10 @@ jobs:
         shell: bash
         run: pnpm build
 
-      - name: Test
+      - name: Test Replication
         run: pnpm test --filter='./modules/module-postgres'
 
-      - name: Test
+      - name: Test Storage
         run: pnpm test --filter='./modules/module-postgres-storage'
 
   run-mysql-tests:
@@ -252,7 +252,7 @@ jobs:
         shell: bash
         run: pnpm build
 
-      - name: Test
+      - name: Test Replication
         run: pnpm test --filter='./modules/module-mysql'
 
   run-mongodb-tests:
@@ -320,7 +320,7 @@ jobs:
         shell: bash
         run: pnpm build
 
-      - name: Test
+      - name: Test Replication
         run: pnpm test --filter='./modules/module-mongodb'
 
       - name: Test Storage

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -16,6 +16,7 @@ import {
   BucketStorageMarkRecordUnavailable,
   deserializeBson,
   InternalOpId,
+  isCompleteRow,
   SaveOperationTag,
   storage,
   utils
@@ -348,7 +349,7 @@ export class MongoBucketBatch
         // Not an error if we re-apply a transaction
         existing_buckets = [];
         existing_lookups = [];
-        if (this.storeCurrentData) {
+        if (!isCompleteRow(this.storeCurrentData, after!)) {
           if (this.markRecordUnavailable != null) {
             // This will trigger a "resnapshot" of the record.
             // This is not relevant if storeCurrentData is false, since we'll get the full row

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -16,6 +16,7 @@ import {
   GetCheckpointChangesOptions,
   InternalOpId,
   internalToExternalOpId,
+  maxLsn,
   ProtocolOpId,
   ReplicationCheckpoint,
   storage,
@@ -131,7 +132,7 @@ export class MongoSyncBucketStorage
       {
         _id: this.group_id
       },
-      { projection: { last_checkpoint_lsn: 1, no_checkpoint_before: 1, keepalive_op: 1 } }
+      { projection: { last_checkpoint_lsn: 1, no_checkpoint_before: 1, keepalive_op: 1, snapshot_lsn: 1 } }
     );
     const checkpoint_lsn = doc?.last_checkpoint_lsn ?? null;
 
@@ -142,6 +143,7 @@ export class MongoSyncBucketStorage
       groupId: this.group_id,
       slotName: this.slot_name,
       lastCheckpointLsn: checkpoint_lsn,
+      resumeFromLsn: maxLsn(checkpoint_lsn, doc?.snapshot_lsn),
       noCheckpointBeforeLsn: doc?.no_checkpoint_before ?? options.zeroLSN,
       keepaliveOp: doc?.keepalive_op ? BigInt(doc.keepalive_op) : null,
       storeCurrentData: options.storeCurrentData,

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -376,10 +376,9 @@ export class ChangeStream {
         const checkpoint = await createCheckpoint(this.client, this.defaultDb, STANDALONE_CHECKPOINT_ID);
         await batch.markSnapshotDone([], checkpoint);
 
-        // We cannot create a consistent commit at this point. We previously had
-        // commit(snapshotLsn), but since snapshotLsn < checkpoint, it does no more
-        // than a flush().
-        await batch.flush();
+        // This will not create a consistent checkpoint yet, but will persist the op.
+        // Actual checkpoint will be created when streaming replication caught up.
+        await batch.commit(snapshotLsn);
 
         this.logger.info(`Snapshot done. Need to replicate from ${snapshotLsn} to ${checkpoint} to be consistent`);
       }

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -512,6 +512,7 @@ bucket_definitions:
     await collection.insertOne({ description: 'test1', num: 1152921504606846976n });
 
     await context.replicateSnapshot();
+    await context.markSnapshotConsistent();
 
     // Simulate an error
     await context.storage!.reportError(new Error('simulated error'));

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -23,7 +23,9 @@ describe('change stream', () => {
 
 function defineChangeStreamTests(factory: storage.TestStorageFactory) {
   test('replicating basic values', async () => {
-    await using context = await ChangeStreamTestContext.open(factory);
+    await using context = await ChangeStreamTestContext.open(factory, {
+      mongoOptions: { postImages: PostImagesOption.READ_ONLY }
+    });
     const { db } = context;
     await context.updateSyncRules(`
 bucket_definitions:
@@ -32,7 +34,7 @@ bucket_definitions:
       - SELECT _id as id, description, num FROM "test_data"`);
 
     await db.createCollection('test_data', {
-      changeStreamPreAndPostImages: { enabled: false }
+      changeStreamPreAndPostImages: { enabled: true }
     });
     const collection = db.collection('test_data');
 
@@ -42,11 +44,8 @@ bucket_definitions:
 
     const result = await collection.insertOne({ description: 'test1', num: 1152921504606846976n });
     const test_id = result.insertedId;
-    await setTimeout(30);
     await collection.updateOne({ _id: test_id }, { $set: { description: 'test2' } });
-    await setTimeout(30);
     await collection.replaceOne({ _id: test_id }, { description: 'test3' });
-    await setTimeout(30);
     await collection.deleteOne({ _id: test_id });
 
     const data = await context.getBucketData('global[]');

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -516,7 +516,9 @@ bucket_definitions:
 
     // Simulate an error
     await context.storage!.reportError(new Error('simulated error'));
-    expect((await context.factory.getActiveSyncRulesContent())?.last_fatal_error).toEqual('simulated error');
+    const syncRules = await context.factory.getActiveSyncRulesContent();
+    expect(syncRules).toBeTruthy();
+    expect(syncRules?.last_fatal_error).toEqual('simulated error');
 
     // startStreaming() should automatically clear the error.
     context.startStreaming();

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -354,6 +354,9 @@ bucket_definitions:
     const test_id = result.insertedId.toHexString();
 
     await context.replicateSnapshot();
+    // Note: snapshot is only consistent some time into the streaming request.
+    // At the point that we get the first acknowledged checkpoint, as is required
+    // for getBucketData(), the data should be consistent.
     context.startStreaming();
 
     const data = await context.getBucketData('global[]');

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -430,8 +430,6 @@ AND table_type = 'BASE TABLE';`,
   }
 
   async streamChanges() {
-    // Auto-activate as soon as initial replication is done
-    await this.storage.autoActivate();
     const serverId = createRandomServerId(this.storage.group_id);
 
     const connection = await this.connections.getConnection();

--- a/modules/module-mysql/test/src/BinlogStreamUtils.ts
+++ b/modules/module-mysql/test/src/BinlogStreamUtils.ts
@@ -112,7 +112,6 @@ export class BinlogStreamTestContext {
 
   async replicateSnapshot() {
     await this.binlogStream.initReplication();
-    await this.storage!.autoActivate();
     this.replicationDone = true;
   }
 

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -7,6 +7,7 @@ import {
   InternalOpId,
   internalToExternalOpId,
   LastValueSink,
+  maxLsn,
   storage,
   utils,
   WatchWriteCheckpointOptions
@@ -310,13 +311,14 @@ export class PostgresSyncRulesStorage
       SELECT
         last_checkpoint_lsn,
         no_checkpoint_before,
-        keepalive_op
+        keepalive_op,
+        snapshot_lsn
       FROM
         sync_rules
       WHERE
         id = ${{ type: 'int4', value: this.group_id }}
     `
-      .decoded(pick(models.SyncRules, ['last_checkpoint_lsn', 'no_checkpoint_before', 'keepalive_op']))
+      .decoded(pick(models.SyncRules, ['last_checkpoint_lsn', 'no_checkpoint_before', 'keepalive_op', 'snapshot_lsn']))
       .first();
 
     const checkpoint_lsn = syncRules?.last_checkpoint_lsn ?? null;
@@ -330,6 +332,7 @@ export class PostgresSyncRulesStorage
       last_checkpoint_lsn: checkpoint_lsn,
       keep_alive_op: syncRules?.keepalive_op,
       no_checkpoint_before_lsn: syncRules?.no_checkpoint_before ?? options.zeroLSN,
+      resumeFromLsn: maxLsn(syncRules?.snapshot_lsn, checkpoint_lsn),
       store_current_data: options.storeCurrentData,
       skip_existing_rows: options.skipExistingRows ?? false,
       batch_limits: this.options.batchLimits,

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -31,6 +31,7 @@ export interface PostgresBucketBatchOptions {
   no_checkpoint_before_lsn: string;
   store_current_data: boolean;
   keep_alive_op?: InternalOpId | null;
+  resumeFromLsn: string | null;
   /**
    * Set to true for initial replication.
    */
@@ -61,6 +62,8 @@ export class PostgresBucketBatch
 
   public last_flushed_op: InternalOpId | null = null;
 
+  public resumeFromLsn: string | null;
+
   protected db: lib_postgres.DatabaseClient;
   protected group_id: number;
   protected last_checkpoint_lsn: string | null;
@@ -82,6 +85,7 @@ export class PostgresBucketBatch
     this.group_id = options.group_id;
     this.last_checkpoint_lsn = options.last_checkpoint_lsn;
     this.no_checkpoint_before_lsn = options.no_checkpoint_before_lsn;
+    this.resumeFromLsn = options.resumeFromLsn;
     this.write_checkpoint_batch = [];
     this.sync_rules = options.sync_rules;
     this.markRecordUnavailable = options.markRecordUnavailable;

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -413,6 +413,7 @@ export class PostgresBucketBatch
       .decoded(StatefulCheckpoint)
       .first();
 
+    await this.autoActivate(lsn);
     await notifySyncRulesUpdate(this.db, updated!);
 
     this.last_checkpoint_lsn = lsn;

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -737,6 +737,9 @@ WHERE  oid = $1::regclass`,
           rows.map((r) => r.key)
         );
       }
+      // Even with resnapshot, we need to wait until we get a new consistent checkpoint
+      // after the snapshot, so we need to send a keepalive message.
+      await sendKeepAlive(db);
     } finally {
       await db.end();
     }

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -837,7 +837,6 @@ WHERE  oid = $1::regclass`,
 
   async streamChanges(replicationConnection: pgwire.PgConnection) {
     // When changing any logic here, check /docs/wal-lsns.md.
-
     const { createEmptyCheckpoints } = await this.ensureStorageCompatibility();
 
     const replicationOptions: Record<string, string> = {
@@ -866,9 +865,6 @@ WHERE  oid = $1::regclass`,
     });
 
     this.startedStreaming = true;
-
-    // Auto-activate as soon as initial replication is done
-    await this.storage.autoActivate();
 
     let resnapshot: { table: storage.SourceTable; key: PrimaryKeyValue }[] = [];
 

--- a/modules/module-postgres/test/src/checkpoints.test.ts
+++ b/modules/module-postgres/test/src/checkpoints.test.ts
@@ -36,6 +36,8 @@ const checkpointTests = (factory: TestStorageFactory) => {
     await context.replicateSnapshot();
 
     context.startStreaming();
+    // Wait for a consistent checkpoint before we start.
+    await context.getCheckpoint();
     const storage = context.storage!;
 
     const controller = new AbortController();

--- a/modules/module-postgres/test/src/large_batch.test.ts
+++ b/modules/module-postgres/test/src/large_batch.test.ts
@@ -87,7 +87,6 @@ function defineBatchTests(factory: storage.TestStorageFactory) {
       const start = Date.now();
 
       await context.replicateSnapshot();
-      await context.storage!.autoActivate();
       context.startStreaming();
 
       const checkpoint = await context.getCheckpoint({ timeout: 100_000 });

--- a/modules/module-postgres/test/src/slow_tests.test.ts
+++ b/modules/module-postgres/test/src/slow_tests.test.ts
@@ -97,7 +97,6 @@ bucket_definitions:
     await pool.query(`ALTER TABLE test_data REPLICA IDENTITY FULL`);
 
     await walStream.initReplication(replicationConnection);
-    await storage.autoActivate();
     let abort = false;
     streamPromise = walStream.streamChanges(replicationConnection).finally(() => {
       abort = true;
@@ -348,7 +347,6 @@ bucket_definitions:
       let initialReplicationDone = false;
       streamPromise = (async () => {
         await walStream.initReplication(replicationConnection);
-        await storage.autoActivate();
         initialReplicationDone = true;
         await walStream.streamChanges(replicationConnection);
       })()

--- a/modules/module-postgres/test/src/util.ts
+++ b/modules/module-postgres/test/src/util.ts
@@ -90,10 +90,8 @@ export async function getClientCheckpoint(
   while (Date.now() - start < timeout) {
     const storage = await storageFactory.getActiveStorage();
     const cp = await storage?.getCheckpoint();
-    if (cp == null) {
-      throw new Error('No sync rules available');
-    }
-    if (cp.lsn && cp.lsn >= lsn) {
+
+    if (cp?.lsn != null && cp.lsn >= lsn) {
       logger.info(`Got write checkpoint: ${lsn} : ${cp.checkpoint}`);
       return cp.checkpoint;
     }

--- a/modules/module-postgres/test/src/wal_stream.test.ts
+++ b/modules/module-postgres/test/src/wal_stream.test.ts
@@ -179,8 +179,8 @@ bucket_definitions:
       )
     );
 
-    // This update may fail replicating with:
-    // Error: Update on missing record public.test_data:074a601e-fc78-4c33-a15d-f89fdd4af31d :: {"g":1,"t":"651e9fbe9fec6155895057ec","k":"1a0b34da-fb8c-5e6f-8421-d7a3c5d4df4f"}
+    // Since we don't have an old copy of the record with the new primary key, this
+    // may trigger a "resnapshot".
     await pool.query(`UPDATE test_data SET description = 'test2b' WHERE id = '${test_id2}'`);
 
     // Re-use old id again

--- a/modules/module-postgres/test/src/wal_stream_utils.ts
+++ b/modules/module-postgres/test/src/wal_stream_utils.ts
@@ -122,7 +122,6 @@ export class WalStreamTestContext implements AsyncDisposable {
     const promise = (async () => {
       this.replicationConnection = await this.connectionManager.replicationConnection();
       await this.walStream.initReplication(this.replicationConnection);
-      await this.storage!.autoActivate();
     })();
     this.snapshotPromise = promise.catch((e) => e);
     await promise;

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -1603,7 +1603,6 @@ bucket_definitions:
 
     const r = await f.configureSyncRules({ content: 'bucket_definitions: {}', validate: false });
     const storage = f.getInstance(r.persisted_sync_rules!);
-    await storage.autoActivate();
 
     const metrics2 = await f.getStorageMetrics();
     expect(metrics2).toMatchSnapshot();
@@ -1656,7 +1655,6 @@ bucket_definitions:
       validate: false
     });
     const bucketStorage = factory.getInstance(r.persisted_sync_rules!);
-    await bucketStorage.autoActivate();
 
     const abortController = new AbortController();
     context.onTestFinished(() => abortController.abort());
@@ -1697,7 +1695,6 @@ bucket_definitions:
       validate: false
     });
     const bucketStorage = factory.getInstance(r.persisted_sync_rules!);
-    await bucketStorage.autoActivate();
 
     const abortController = new AbortController();
     context.onTestFinished(() => abortController.abort());
@@ -1760,7 +1757,6 @@ bucket_definitions:
       validate: false
     });
     const bucketStorage = factory.getInstance(r.persisted_sync_rules!);
-    await bucketStorage.autoActivate();
     bucketStorage.setWriteCheckpointMode(storage.WriteCheckpointMode.CUSTOM);
 
     const abortController = new AbortController();
@@ -1801,7 +1797,6 @@ bucket_definitions:
       validate: false
     });
     const bucketStorage = factory.getInstance(r.persisted_sync_rules!);
-    await bucketStorage.autoActivate();
     bucketStorage.setWriteCheckpointMode(storage.WriteCheckpointMode.CUSTOM);
 
     const abortController = new AbortController();
@@ -1845,7 +1840,6 @@ bucket_definitions:
       validate: false
     });
     const bucketStorage = factory.getInstance(r.persisted_sync_rules!);
-    await bucketStorage.autoActivate();
     bucketStorage.setWriteCheckpointMode(storage.WriteCheckpointMode.CUSTOM);
 
     const abortController = new AbortController();

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -1603,6 +1603,9 @@ bucket_definitions:
 
     const r = await f.configureSyncRules({ content: 'bucket_definitions: {}', validate: false });
     const storage = f.getInstance(r.persisted_sync_rules!);
+    await storage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      await batch.keepalive('1/0');
+    });
 
     const metrics2 = await f.getStorageMetrics();
     expect(metrics2).toMatchSnapshot();

--- a/packages/service-core-tests/src/tests/register-sync-tests.ts
+++ b/packages/service-core-tests/src/tests/register-sync-tests.ts
@@ -54,7 +54,6 @@ export function registerSyncTests(factory: storage.TestStorageFactory) {
     });
 
     const bucketStorage = f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     const result = await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       await batch.save({
@@ -116,7 +115,6 @@ bucket_definitions:
     });
 
     const bucketStorage = f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     const result = await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       await batch.save({
@@ -178,7 +176,6 @@ bucket_definitions:
     });
 
     const bucketStorage = f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       // Initial data: Add one priority row and 10k low-priority rows.
@@ -289,7 +286,6 @@ bucket_definitions:
     });
 
     const bucketStorage = f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       // Initial data: Add one priority row and 10k low-priority rows.
@@ -431,7 +427,6 @@ bucket_definitions:
     });
 
     const bucketStorage = f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       // Initial data: Add one priority row and 10k low-priority rows.
@@ -561,7 +556,6 @@ bucket_definitions:
       content: BASIC_SYNC_RULES
     });
     const bucketStorage = f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       await batch.save({
@@ -626,7 +620,6 @@ bucket_definitions:
     });
 
     const bucketStorage = await f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     const result = await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       await batch.save({
@@ -671,7 +664,6 @@ bucket_definitions:
     });
 
     const bucketStorage = await f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     const stream = sync.streamResponse({
       syncContext,
@@ -699,7 +691,6 @@ bucket_definitions:
     });
 
     const bucketStorage = await f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     const stream = sync.streamResponse({
       syncContext,
@@ -770,7 +761,6 @@ bucket_definitions:
     const listsTable = test_utils.makeTestTable('lists', ['id']);
 
     const bucketStorage = await f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     const stream = sync.streamResponse({
       syncContext,
@@ -833,7 +823,6 @@ bucket_definitions:
     const listsTable = test_utils.makeTestTable('lists', ['id']);
 
     const bucketStorage = await f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       await batch.save({
@@ -911,7 +900,6 @@ bucket_definitions:
     const listsTable = test_utils.makeTestTable('lists', ['id']);
 
     const bucketStorage = await f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     const stream = sync.streamResponse({
       syncContext,
@@ -974,7 +962,6 @@ bucket_definitions:
     });
 
     const bucketStorage = await f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     const exp = Date.now() / 1000 + 0.1;
 
@@ -1016,7 +1003,6 @@ bucket_definitions:
     });
 
     const bucketStorage = await f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       await batch.save({
@@ -1157,7 +1143,6 @@ bucket_definitions:
     });
 
     const bucketStorage = f.getInstance(syncRules);
-    await bucketStorage.autoActivate();
 
     await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
       // <= the managed write checkpoint LSN below

--- a/packages/service-core-tests/src/tests/register-sync-tests.ts
+++ b/packages/service-core-tests/src/tests/register-sync-tests.ts
@@ -691,6 +691,10 @@ bucket_definitions:
     });
 
     const bucketStorage = await f.getInstance(syncRules);
+    // Activate
+    await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      await batch.keepalive('0/0');
+    });
 
     const stream = sync.streamResponse({
       syncContext,
@@ -761,6 +765,10 @@ bucket_definitions:
     const listsTable = test_utils.makeTestTable('lists', ['id']);
 
     const bucketStorage = await f.getInstance(syncRules);
+    // Activate
+    await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      await batch.keepalive('0/0');
+    });
 
     const stream = sync.streamResponse({
       syncContext,
@@ -900,6 +908,10 @@ bucket_definitions:
     const listsTable = test_utils.makeTestTable('lists', ['id']);
 
     const bucketStorage = await f.getInstance(syncRules);
+    // Activate
+    await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      await batch.keepalive('0/0');
+    });
 
     const stream = sync.streamResponse({
       syncContext,
@@ -962,6 +974,10 @@ bucket_definitions:
     });
 
     const bucketStorage = await f.getInstance(syncRules);
+    // Activate
+    await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      await batch.keepalive('0/0');
+    });
 
     const exp = Date.now() / 1000 + 0.1;
 

--- a/packages/service-core/src/storage/BucketStorageBatch.ts
+++ b/packages/service-core/src/storage/BucketStorageBatch.ts
@@ -72,6 +72,13 @@ export interface BucketStorageBatch extends ObserverClient<BucketBatchStorageLis
    */
   lastCheckpointLsn: string | null;
 
+  /**
+   * LSN to resume from.
+   *
+   * Not relevant for streams where the source keeps track of replication progress, such as Postgres.
+   */
+  resumeFromLsn: string | null;
+
   markSnapshotDone(tables: SourceTable[], no_checkpoint_before_lsn: string): Promise<SourceTable[]>;
 
   updateTableProgress(table: SourceTable, progress: Partial<TableSnapshotStatus>): Promise<SourceTable>;

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -50,8 +50,6 @@ export interface SyncRulesBucketStorage
    */
   clear(options?: ClearStorageOptions): Promise<void>;
 
-  autoActivate(): Promise<void>;
-
   /**
    * Record a replication error.
    *

--- a/packages/service-core/src/util/lsn.ts
+++ b/packages/service-core/src/util/lsn.ts
@@ -1,0 +1,8 @@
+/**
+ * Return the larger of two LSNs.
+ */
+export function maxLsn(a: string | null | undefined, b: string | null | undefined): string | null {
+  if (a == null) return b ?? null;
+  if (b == null) return a;
+  return a > b ? a : b;
+}

--- a/packages/service-core/src/util/util-index.ts
+++ b/packages/service-core/src/util/util-index.ts
@@ -1,5 +1,6 @@
 export * from './alerting.js';
 export * from './env.js';
+export * from './lsn.js';
 export * from './memory-tracking.js';
 export * from './Mutex.js';
 export * from './protocol-types.js';


### PR DESCRIPTION
## Background

When deploying new sync rules, we create a new stream (using for example a new postgres logical replication slot) for the new version, and process it while the current version stays active. When initial replication is complete, clients switch over to sync from the new copy.

For the new sync rules themselves, replication works roughly as follows:
1. Get a snapshot position.
2. Do an initial snapshot.
3. Resume streaming data from the initial snapshot position.

## The issue

The main issue is that when the initial snapshot is complete, there could still be a long period before streaming replication has caught up. This is typically not a problem for instances with small data volumes, it could be significant in cases where replication takes a couple of hours, and a lot of new data has come in during that time.

A secondary issue is specific to replicating MongoDB data - until replication has caught up, there could be inconsistent data synced to clients.

## The fix

This refactors the "autoActivate" behavior - we now only switch over to the new sync rules version when it has a consistent checkpoint.

This is not a complete fix yet - at that point replication of the new sync rules could still be behind and take a while to fully catch up, but it a significant improvement already.

### Additional smaller fixes

1. We now bypass the previous "resnapshot" behavior unless we have TOAST values we need to re-replicate.
2. This improves stability of some tests.

