### PR TITLE
Allow binary data in HTTP streams

### DIFF
--- a/.changeset/green-queens-float.md
+++ b/.changeset/green-queens-float.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Support BSON lines through the HTTP endpoint via the `application/vnd.powersync.bson-stream` content-type.

--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -37,6 +37,7 @@
     "jose": "^4.15.1",
     "lodash": "^4.17.21",
     "lru-cache": "^10.2.2",
+    "negotiator": "^1.0.0",
     "node-fetch": "^3.3.2",
     "ts-codec": "^1.3.0",
     "uri-js": "^4.4.1",
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@types/async": "^3.2.24",
+    "@types/negotiator": "^0.6.4",
     "@types/lodash": "^4.17.5",
     "fastify": "4.23.2",
     "fastify-plugin": "^4.5.1"

--- a/packages/service-core/src/routes/endpoints/socket-route.ts
+++ b/packages/service-core/src/routes/endpoints/socket-route.ts
@@ -1,6 +1,5 @@
 import { ErrorCode, errors, schema } from '@powersync/lib-services-framework';
 import { RequestParameters } from '@powersync/service-sync-rules';
-import { serialize } from 'bson';
 
 import * as sync from '../../sync/sync-index.js';
 import * as util from '../../util/util-index.js';
@@ -110,16 +109,11 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
             break;
           }
           if (data == null) {
-            // Empty value just to flush iterator memory
             continue;
-          } else if (typeof data == 'string') {
-            // Should not happen with binary_data: true
-            throw new Error(`Unexpected string data: ${data}`);
           }
 
           {
-            // On NodeJS, serialize always returns a Buffer
-            const serialized = serialize(data) as Buffer;
+            const serialized = sync.syncLineToBson(data);
             responder.onNext({ data: serialized }, false);
             requestedN--;
             tracker.addDataSynced(serialized.length);

--- a/packages/service-core/src/routes/endpoints/sync-stream.ts
+++ b/packages/service-core/src/routes/endpoints/sync-stream.ts
@@ -32,13 +32,16 @@ export const syncStreamed = routeDefinition({
     const clientId = payload.params.client_id;
     const streamStart = Date.now();
     // This falls back to JSON unless there's preference for the bson-stream in the Accept header.
-    const useBson = new Negotiator(payload.request).mediaType(supportedContentTypes) == concatenatedBsonContentType;
+    const useBson =
+      payload.request.headers.accept &&
+      new Negotiator(payload.request).mediaType(supportedContentTypes) == concatenatedBsonContentType;
 
     logger.defaultMeta = {
       ...logger.defaultMeta,
       user_agent: userAgent,
       client_id: clientId,
-      user_id: payload.context.user_id
+      user_id: payload.context.user_id,
+      bson: useBson
     };
 
     if (routerEngine.closed) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,9 @@ importers:
       lru-cache:
         specifier: ^10.2.2
         version: 10.4.3
+      negotiator:
+        specifier: ^1.0.0
+        version: 1.0.0
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -568,6 +571,9 @@ importers:
       '@types/lodash':
         specifier: ^4.17.5
         version: 4.17.6
+      '@types/negotiator':
+        specifier: ^0.6.4
+        version: 0.6.4
       fastify:
         specifier: 4.23.2
         version: 4.23.2
@@ -1513,6 +1519,9 @@ packages:
 
   '@types/mysql@2.15.22':
     resolution: {integrity: sha512-wK1pzsJVVAjYCSZWQoWHziQZbNggXFDUEIGf54g4ZM/ERuP86uGdWeKZWMYlqTPMZfHJJvLPyogXGvCOg87yLQ==}
+
+  '@types/negotiator@0.6.4':
+    resolution: {integrity: sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -2868,6 +2877,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   node-cleanup@2.1.2:
@@ -4962,6 +4975,8 @@ snapshots:
     dependencies:
       '@types/node': 22.16.2
 
+  '@types/negotiator@0.6.4': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@13.13.52': {}
@@ -6342,6 +6357,8 @@ snapshots:
       randexp: 0.4.6
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   node-cleanup@2.1.2: {}
 


### PR DESCRIPTION
This adds support for serving sync lines in BSON format through `/sync/stream`. The behavior is opt-in and will only be enabled when there's an `Accept` header _and_ that header indicates a preference for the `application/vnd.powersync.bson-stream` content type.

This will allow the transport of binary data without the use of RSocket/Websockets, which may be something we need if we want to primarily use binary sync lines in the future (since RSocket on Dart continues to be uncertain).

When serving lines as BSON, we will simply concatenate them for the stream. Since the documents are length-prefixed, clients can split them fairly easily (todo: link Dart SDK PR).