### PR TITLE
[MongoDB Storage] Compact parameter lookups

### DIFF
--- a/.changeset/angry-mice-hide.md
+++ b/.changeset/angry-mice-hide.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-module-postgres-storage': minor
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-core-tests': minor
+'@powersync/service-core': minor
+'@powersync/service-image': minor
+---
+
+[MongoDB Storage] Compact action now also compacts parameter lookup storage.

--- a/docs/parameters-lookups.md
+++ b/docs/parameters-lookups.md
@@ -1,0 +1,122 @@
+# Parameter Lookup Implementation
+
+Most of the other docs focus on bucket data, but parameter lookup data also contains some tricky bits.
+
+## Basic requirements
+
+The essence of what we do when syncing data is:
+
+1. Get the latest checkpoint.
+2. Evaluate all parameter queries _at the state of the checkpoint_.
+3. Return bucket data for the checkpoint.
+
+This doc focuses on point 2.
+
+## Current lookup implementation
+
+We effectively store an "index" for exact lookups on parameter query tables.
+
+The format is in MongoDB storage is:
+
+    _id: OpId # auto-incrementing op-id, using the same sequence as checkpoints
+    key: {g: <sync rules group id>, t: <table id>, k: RowReplicationId } # uniquely identifies the source row
+    lookup: doc # lookup entry for this source row
+    bucket_parameters: data # results returned to the parameter query
+
+If one row evaluates to multiple lookups, those are each stored as a separate document with the same key.
+
+When a row is deleted, we empty `bucket_parameters` for the same (key, lookup) combinations.
+
+To query, we do:
+
+1. Filter by sync rules version: key.g.
+2. Filter by lookup.
+3. Filter by checkpoint: \_id <= checkpoint.
+4. Return the last parameter data for each (key, lookup) combination (highest \_id)
+
+## Compacting
+
+In many cases, parameter query tables are updated infrequently, and compacting is not important. However, there are cases where parameter query tables are updated regularly in cron jobs (for example), and the resulting indefinite storage increase causes significant query overhead and other issues.
+
+To handle this, we compact older data. For each (key.g, key, lookup) combination, we only need to keep the last copy (highest \_id). And if the last one is a remove operation (empty parameter_data), we can remove it completely.
+
+One big consideration is sync clients may still need some of that data. To cover for this, parameter lookup queries should specifically use a _snapshot_ query mode, querying at the same snapshot that was used for the checkpoint lookup. This is different from the "Future Options: Snapshot queries" point above: We're not using a snapshot at the time the checkpoint was created, but rather a snapshot at the time the checkpoint was read. This means we always use a fresh snapshot.
+
+# Alternatives
+
+## Future option: Incremental compacting
+
+Right now, compacting scans through the entire collection to compact data. It should be possible to make this more incremental, only scanning through documents added since the last compact.
+
+## Future Option: Snapshot queries
+
+If we could do a snapshot query with a snapshot matching the checkpoint, the rest of the implementation could become quite simple. We could "just" replicate the latest copy of parameter tables, and run arbitrary parameter queries on them.
+
+Unforunately, running snapshot queries for specific checkpoints are not that simple. Tricky parts include associating a snapshot with a specific checkpoint, and snapshots typically expiring after a short duration. Nonetheless, this remains an option to consider in the future.
+
+To implement this with MongoDB:
+
+1. Every time we `commit()` in the replication process, store the current clusterTime (we can use `$$CLUSTER_TIME` for this).
+2. When we query for data, use that clustertime.
+3. _Make sure we commit at least once every 5 minutes_, ideally every minute.
+
+The last point means that replication issues could also turn into query issues:
+
+1. Replication process being down for 5 minutes means queries stop working.
+2. Being more than 5 minutes behind in replication is not an issue, as long as we keep doing new commits.
+3. Taking longer than 5 minutes to complete replication for a _single transaction_ will cause API failures. This includes operations such as adding or removing tables.
+
+In theory, we could take this even further to run query parameter queries directly on the _source_ database, without replicating.
+
+## Compacting - Implementation alternatives
+
+Instead of snapshot queries, some other alternatives are listed below. These are not used, just listed here in case we ever need to re-evaluate the implementation.
+
+### 1. Last active checkpoint
+
+Compute a "last active" checkpoint - a checkpoint that started being active at least 5 minutes ago, meaning that we can cleanup data only used for checkpoints older than that.
+
+The issues here are:
+
+1. We don't store older checkpoints, so it can be tricky to find an older checkpoint without waiting 5 minutes.
+2. It is difficult to build in hard guarantees for parameter queries here, without relying on time-based heuristics.
+3. Keep track of checkpoints used in the API service can be quite tricky.
+
+### 2. Merge / invalidate lookups
+
+Instead of deleting older parameter lookup records, we can merge them.
+
+Say we have two records with the same key and lookup, and \_id of A and B (A < B). The above approach would just delete A, if A < lastActiveCheckpoint.
+
+What we can do instead is merge into:
+
+    _id: A
+    parameter_data: B.parameter_data
+    not_valid_before: B
+
+The key here is the `not_valid_before` field: When we query for parameter data, we filter by \_id as usual. But if `checkpoint < not_valid_before`, we need to discard that checkpoint.
+
+Now we still need to try to avoid merging recent parameter lookup records, otherwise we may keep on invalidating checkpoints as fast as we generate them. But this could function as a final safety check,
+giving us proper consistency guarantees.
+
+This roughly matches the design of `target_op` in MOVE operations.
+
+This still does not cover deleted data: With this approach alone, we can never fully remove records after the source row was deleted, since we need that `not_valid_before` field. So this is not a complete solution.
+
+### 3. Globally invalidate checkpoints
+
+Another alternative is to globally invalidate checkpoints when compacting. So:
+
+1. We pick a `lastActiveCheckpoint`.
+2. Persist `noCheckpointBefore: lastActiveCheckpoint` in the sync_rules collection.
+3. At some point between doing the parameter lookups and sending a `checkpoint_complete` message, we lookup the `noCheckpointBefore` checkpoint, and invalidate the checkpoint if required.
+
+This allows us to cleanly delete older checkpoints, at the expense of needing to run another query.
+
+This could also replace the current logic we have for `target_op` in MOVE operations.
+
+To do the lookup very efficiently, we can apply some workarounds:
+
+1. For each parameter query (and data query?), store the clusterTime of the results.
+2. Right before sending checkpointComplete, query for the noCheckpointBefore value, using `afterClusterTime`.
+3. _We can cache those results_, re-using it for other clients. As long as the `afterClusterTime` condition is satisfied, we can use the cached value.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoParameterCompactor.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoParameterCompactor.ts
@@ -3,6 +3,13 @@ import { bson, InternalOpId } from '@powersync/service-core';
 import { LRUCache } from 'lru-cache';
 import { PowerSyncMongo } from './db.js';
 
+/**
+ * Compacts parameter lookup data (the bucket_parameters collection).
+ *
+ * This scans through the entire collection to find data to compact.
+ *
+ * For background, see the `/docs/parameters-lookups.md` file.
+ */
 export class MongoParameterCompactor {
   constructor(
     private db: PowerSyncMongo,

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoParameterCompactor.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoParameterCompactor.ts
@@ -64,6 +64,7 @@ export class MongoParameterCompactor {
         }
         const rawDoc: RawParameterData = {
           _id: doc._id,
+          // Serializing to a Buffer is an easy way to check for exact equality of arbitrary BSON values.
           data: bson.serialize({
             key: doc.key,
             lookup: doc.lookup

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoParameterCompactor.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoParameterCompactor.ts
@@ -1,0 +1,97 @@
+import { logger } from '@powersync/lib-services-framework';
+import { bson, InternalOpId } from '@powersync/service-core';
+import { PowerSyncMongo } from './db.js';
+
+export class MongoParameterCompactor {
+  constructor(
+    private db: PowerSyncMongo,
+    private group_id: number,
+    private checkpoint: InternalOpId
+  ) {}
+
+  /**
+   * This is the oldest checkpoint that we consider safe to still use. We cleanup old parameter
+   * but no data that would be used by this checkpoint.
+   *
+   * Specifically, we return a checkpoint that has been available for at least 5 minutes, then
+   * we can delete data only used for checkpoints older than that.
+   *
+   * @returns null if there is no safe checkpoint available.
+   */
+  async getActiveCheckpoint(): Promise<InternalOpId | null> {
+    const syncRules = await this.db.sync_rules.findOne({ _id: this.group_id });
+    if (syncRules == null) {
+      return null;
+    }
+
+    return syncRules.last_checkpoint;
+  }
+
+  async compact() {
+    logger.info(`Compacting parameters for group ${this.group_id} up to checkpoint ${this.checkpoint}`);
+    // This is the currently-active checkpoint.
+    // We do not remove any data that may be used by this checkpoint.
+    // snapshot queries ensure that if any clients are still using older checkpoints, they would
+    // not be affected by this compaction.
+    const checkpoint = await this.checkpoint;
+    if (checkpoint == null) {
+      return;
+    }
+
+    // Index on {'key.g': 1, lookup: 1, _id: 1}
+    // In theory, we could let MongoDB do more of the work here, by grouping by (key, lookup)
+    // in MongoDB already. However, that risks running into cases where MongoDB needs to process
+    // very large amounts of data before returning results, which could lead to timeouts.
+    const cursor = this.db.bucket_parameters.find(
+      {
+        'key.g': this.group_id
+      },
+      {
+        sort: { lookup: 1, _id: 1 },
+        batchSize: 10_000,
+        projection: { _id: 1, key: 1, lookup: 1 }
+      }
+    );
+
+    let lastDoc: RawParameterData | null = null;
+    let removeIds: InternalOpId[] = [];
+
+    while (await cursor.hasNext()) {
+      const batch = cursor.readBufferedDocuments();
+      for (let doc of batch) {
+        if (doc._id >= checkpoint) {
+          continue;
+        }
+        const rawDoc: RawParameterData = {
+          _id: doc._id,
+          data: bson.serialize({
+            key: doc.key,
+            lookup: doc.lookup
+          }) as Buffer
+        };
+        if (lastDoc != null && lastDoc.data.equals(rawDoc.data) && lastDoc._id < doc._id) {
+          removeIds.push(lastDoc._id);
+        }
+
+        lastDoc = rawDoc;
+      }
+
+      if (removeIds.length >= 1000) {
+        await this.db.bucket_parameters.deleteMany({ _id: { $in: removeIds } });
+        logger.info(`Removed ${removeIds.length} stale parameter entries`);
+        removeIds = [];
+      }
+    }
+
+    if (removeIds.length > 0) {
+      await this.db.bucket_parameters.deleteMany({ _id: { $in: removeIds } });
+      logger.info(`Removed ${removeIds.length} stale parameter entries`);
+    }
+    logger.info('Parameter compaction completed');
+  }
+}
+
+interface RawParameterData {
+  _id: InternalOpId;
+  data: Buffer;
+}

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -314,9 +314,17 @@ export class MongoSyncBucketStorage
               }
             }
           ],
-          { session, readConcern: 'snapshot' }
+          {
+            session,
+            readConcern: 'snapshot',
+            // Limit the time for the operation to complete, to avoid getting connection timeouts
+            maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
+          }
         )
-        .toArray();
+        .toArray()
+        .catch((e) => {
+          throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
+        });
       const groupedParameters = rows.map((row) => {
         return row.bucket_parameters;
       });

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -295,6 +295,7 @@ export class MongoSyncBucketStorage
       // on {'key.g': 1, lookup: 1, 'key.t': 1, 'key.k': 1, _id: -1},
       // but could not do the same using $group.
       // For now, just rely on compacting to remove extraneous data.
+      // For a description of the data format, see the `/docs/parameters-lookups.md` file.
       const rows = await this.db.bucket_parameters
         .aggregate(
           [

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -276,7 +276,7 @@ export class MongoSyncBucketStorage
       // This is a roundabout way of setting {readConcern: {atClusterTime: clusterTime}}, since
       // that is not exposed directly by the driver.
       // Future versions of the driver may change the snapshotTime behavior, so we need tests to
-      // validate that this works as expected.
+      // validate that this works as expected. We test this in the compacting tests.
       setSessionSnapshotTime(session, checkpoint.clusterTime.clusterTime);
       const lookupFilter = lookups.map((lookup) => {
         return storage.serializeLookup(lookup);

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -290,6 +290,11 @@ export class MongoSyncBucketStorage
       const lookupFilter = lookups.map((lookup) => {
         return storage.serializeLookup(lookup);
       });
+      // This query does not use indexes super efficiently, apart from the lookup filter.
+      // From some experimentation I could do individual lookups more efficient using an index
+      // on {'key.g': 1, lookup: 1, 'key.t': 1, 'key.k': 1, _id: -1},
+      // but could not do the same using $group.
+      // For now, just rely on compacting to remove extraneous data.
       const rows = await this.db.bucket_parameters
         .aggregate(
           [

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -261,7 +261,7 @@ export class MongoSyncBucketStorage
     return result!;
   }
 
-  async getParameterSets(checkpoint: utils.InternalOpId, lookups: ParameterLookup[]): Promise<SqliteJsonRow[]> {
+  async getParameterSets(checkpoint: ReplicationCheckpoint, lookups: ParameterLookup[]): Promise<SqliteJsonRow[]> {
     const lookupFilter = lookups.map((lookup) => {
       return storage.serializeLookup(lookup);
     });
@@ -271,7 +271,7 @@ export class MongoSyncBucketStorage
           $match: {
             'key.g': this.group_id,
             lookup: { $in: lookupFilter },
-            _id: { $lte: checkpoint }
+            _id: { $lte: checkpoint.checkpoint }
           }
         },
         {

--- a/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
@@ -3,3 +3,5 @@ import { describe } from 'vitest';
 import { INITIALIZED_MONGO_STORAGE_FACTORY } from './util.js';
 
 describe('Mongo Sync Bucket Storage Compact', () => register.registerCompactTests(INITIALIZED_MONGO_STORAGE_FACTORY));
+describe('Mongo Sync Parameter Storage Compact', () =>
+  register.registerParameterCompactTests(INITIALIZED_MONGO_STORAGE_FACTORY));

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -8,6 +8,7 @@ import {
   internalToExternalOpId,
   LastValueSink,
   maxLsn,
+  ReplicationCheckpoint,
   storage,
   utils,
   WatchWriteCheckpointOptions
@@ -350,7 +351,7 @@ export class PostgresSyncRulesStorage
   }
 
   async getParameterSets(
-    checkpoint: utils.InternalOpId,
+    checkpoint: ReplicationCheckpoint,
     lookups: sync_rules.ParameterLookup[]
   ): Promise<sync_rules.SqliteJsonRow[]> {
     const rows = await this.db.sql`
@@ -373,7 +374,7 @@ export class PostgresSyncRulesStorage
         value: lookups.map((l) => storage.serializeLookupBuffer(l).toString('hex'))
       }}) AS FILTER
         )
-        AND id <= ${{ type: 'int8', value: checkpoint }}
+        AND id <= ${{ type: 'int8', value: checkpoint.checkpoint }}
       ORDER BY
         lookup,
         source_table,

--- a/packages/service-core-tests/src/tests/register-compacting-tests.ts
+++ b/packages/service-core-tests/src/tests/register-compacting-tests.ts
@@ -1,6 +1,7 @@
 import { storage } from '@powersync/service-core';
 import { expect, test } from 'vitest';
 import * as test_utils from '../test-utils/test-utils-index.js';
+import { ParameterLookup } from '@powersync/service-sync-rules';
 
 const TEST_TABLE = test_utils.makeTestTable('test', ['id']);
 
@@ -441,5 +442,81 @@ bucket_definitions:
         }
       ])
     );
+  });
+
+  test('compacting parameters', async () => {
+    await using factory = await generateStorageFactory();
+    const syncRules = await factory.updateSyncRules({
+      content: `
+bucket_definitions:
+  test:
+    parameters: select id from test where id = request.user_id()
+    data: []
+    `
+    });
+    const bucketStorage = factory.getInstance(syncRules);
+
+    await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: storage.SaveOperationTag.INSERT,
+        after: {
+          id: 't1'
+        },
+        afterReplicaId: 't1'
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: storage.SaveOperationTag.INSERT,
+        after: {
+          id: 't2'
+        },
+        afterReplicaId: 't2'
+      });
+
+      await batch.commit('1/1');
+    });
+
+    const lookup = ParameterLookup.normalized('test', '1', ['t1']);
+
+    const checkpoint1 = await bucketStorage.getCheckpoint();
+    const parameters1 = await checkpoint1.getParameterSets([lookup]);
+    expect(parameters1).toEqual([{ id: 't1' }]);
+
+    await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: storage.SaveOperationTag.UPDATE,
+        before: {
+          id: 't1'
+        },
+        beforeReplicaId: 't1',
+        after: {
+          id: 't1'
+        },
+        afterReplicaId: 't1'
+      });
+
+      await batch.save({
+        sourceTable: TEST_TABLE,
+        tag: storage.SaveOperationTag.DELETE,
+        before: {
+          id: 't1'
+        },
+        beforeReplicaId: 't1'
+      });
+      await batch.commit('1/2');
+    });
+    const checkpoint2 = await bucketStorage.getCheckpoint();
+    const parameters2 = await checkpoint2.getParameterSets([lookup]);
+    expect(parameters2).toEqual([]);
+
+    await bucketStorage.compact({ compactParameterData: true });
+
+    const parameters1b = await checkpoint1.getParameterSets([lookup]);
+    const parameters2b = await checkpoint2.getParameterSets([lookup]);
+    expect(parameters1b).toEqual([{ id: 't1' }]);
+    expect(parameters2b).toEqual([]);
   });
 }

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -75,8 +75,6 @@ bucket_definitions:
     });
 
     const checkpoint = await bucketStorage.getCheckpoint();
-    console.log('Checkpoint:', checkpoint);
-    console.log(await bucketStorage.getStatus());
     const parameters = await checkpoint.getParameterSets([ParameterLookup.normalized('mybucket', '1', ['user1'])]);
     expect(parameters).toEqual([
       {

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -77,9 +77,7 @@ bucket_definitions:
     const checkpoint = await bucketStorage.getCheckpoint();
     console.log('Checkpoint:', checkpoint);
     console.log(await bucketStorage.getStatus());
-    const parameters = await bucketStorage.getParameterSets(checkpoint, [
-      ParameterLookup.normalized('mybucket', '1', ['user1'])
-    ]);
+    const parameters = await checkpoint.getParameterSets([ParameterLookup.normalized('mybucket', '1', ['user1'])]);
     expect(parameters).toEqual([
       {
         group_id: 'group1a'
@@ -127,9 +125,7 @@ bucket_definitions:
     });
     const checkpoint2 = await bucketStorage.getCheckpoint();
 
-    const parameters = await bucketStorage.getParameterSets(checkpoint2, [
-      ParameterLookup.normalized('mybucket', '1', ['user1'])
-    ]);
+    const parameters = await checkpoint2.getParameterSets([ParameterLookup.normalized('mybucket', '1', ['user1'])]);
     expect(parameters).toEqual([
       {
         group_id: 'group2'
@@ -137,9 +133,7 @@ bucket_definitions:
     ]);
 
     // Use the checkpoint to get older data if relevant
-    const parameters2 = await bucketStorage.getParameterSets(checkpoint1, [
-      ParameterLookup.normalized('mybucket', '1', ['user1'])
-    ]);
+    const parameters2 = await checkpoint1.getParameterSets([ParameterLookup.normalized('mybucket', '1', ['user1'])]);
     expect(parameters2).toEqual([
       {
         group_id: 'group1'
@@ -207,7 +201,7 @@ bucket_definitions:
     // There removal operation for the association of `list2`::`todo2` should not interfere with the new
     // association of `list1`::`todo2`
     const checkpoint = await bucketStorage.getCheckpoint();
-    const parameters = await bucketStorage.getParameterSets(checkpoint, [
+    const parameters = await checkpoint.getParameterSets([
       ParameterLookup.normalized('mybucket', '1', ['list1']),
       ParameterLookup.normalized('mybucket', '1', ['list2'])
     ]);
@@ -256,15 +250,15 @@ bucket_definitions:
 
     const checkpoint = await bucketStorage.getCheckpoint();
 
-    const parameters1 = await bucketStorage.getParameterSets(checkpoint, [
+    const parameters1 = await checkpoint.getParameterSets([
       ParameterLookup.normalized('mybucket', '1', [314n, 314, 3.14])
     ]);
     expect(parameters1).toEqual([TEST_PARAMS]);
-    const parameters2 = await bucketStorage.getParameterSets(checkpoint, [
+    const parameters2 = await checkpoint.getParameterSets([
       ParameterLookup.normalized('mybucket', '1', [314, 314n, 3.14])
     ]);
     expect(parameters2).toEqual([TEST_PARAMS]);
-    const parameters3 = await bucketStorage.getParameterSets(checkpoint, [
+    const parameters3 = await checkpoint.getParameterSets([
       ParameterLookup.normalized('mybucket', '1', [314n, 314, 3])
     ]);
     expect(parameters3).toEqual([]);
@@ -319,7 +313,7 @@ bucket_definitions:
 
     const checkpoint = await bucketStorage.getCheckpoint();
 
-    const parameters1 = await bucketStorage.getParameterSets(checkpoint, [
+    const parameters1 = await checkpoint.getParameterSets([
       ParameterLookup.normalized('mybucket', '1', [1152921504606846976n])
     ]);
     expect(parameters1).toEqual([TEST_PARAMS]);
@@ -424,12 +418,12 @@ bucket_definitions:
     const lookups = q1.getLookups(parameters);
     expect(lookups).toEqual([ParameterLookup.normalized('by_workspace', '1', ['u1'])]);
 
-    const parameter_sets = await bucketStorage.getParameterSets(checkpoint, lookups);
+    const parameter_sets = await checkpoint.getParameterSets(lookups);
     expect(parameter_sets).toEqual([{ workspace_id: 'workspace1' }]);
 
     const buckets = await sync_rules.getBucketParameterQuerier(parameters).queryDynamicBucketDescriptions({
       getParameterSets(lookups) {
-        return bucketStorage.getParameterSets(checkpoint, lookups);
+        return checkpoint.getParameterSets(lookups);
       }
     });
     expect(buckets).toEqual([{ bucket: 'by_workspace["workspace1"]', priority: 3 }]);
@@ -495,13 +489,13 @@ bucket_definitions:
     const lookups = q1.getLookups(parameters);
     expect(lookups).toEqual([ParameterLookup.normalized('by_public_workspace', '1', [])]);
 
-    const parameter_sets = await bucketStorage.getParameterSets(checkpoint, lookups);
+    const parameter_sets = await checkpoint.getParameterSets(lookups);
     parameter_sets.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
     expect(parameter_sets).toEqual([{ workspace_id: 'workspace1' }, { workspace_id: 'workspace3' }]);
 
     const buckets = await sync_rules.getBucketParameterQuerier(parameters).queryDynamicBucketDescriptions({
       getParameterSets(lookups) {
-        return bucketStorage.getParameterSets(checkpoint, lookups);
+        return checkpoint.getParameterSets(lookups);
       }
     });
     buckets.sort((a, b) => a.bucket.localeCompare(b.bucket));
@@ -585,7 +579,7 @@ bucket_definitions:
     const lookups1 = q1.getLookups(parameters);
     expect(lookups1).toEqual([ParameterLookup.normalized('by_workspace', '1', [])]);
 
-    const parameter_sets1 = await bucketStorage.getParameterSets(checkpoint, lookups1);
+    const parameter_sets1 = await checkpoint.getParameterSets(lookups1);
     parameter_sets1.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
     expect(parameter_sets1).toEqual([{ workspace_id: 'workspace1' }]);
 
@@ -593,7 +587,7 @@ bucket_definitions:
     const lookups2 = q2.getLookups(parameters);
     expect(lookups2).toEqual([ParameterLookup.normalized('by_workspace', '2', ['u1'])]);
 
-    const parameter_sets2 = await bucketStorage.getParameterSets(checkpoint, lookups2);
+    const parameter_sets2 = await checkpoint.getParameterSets(lookups2);
     parameter_sets2.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
     expect(parameter_sets2).toEqual([{ workspace_id: 'workspace3' }]);
 
@@ -601,7 +595,7 @@ bucket_definitions:
     const buckets = (
       await sync_rules.getBucketParameterQuerier(parameters).queryDynamicBucketDescriptions({
         getParameterSets(lookups) {
-          return bucketStorage.getParameterSets(checkpoint, lookups);
+          return checkpoint.getParameterSets(lookups);
         }
       })
     ).map((e) => e.bucket);
@@ -904,9 +898,7 @@ bucket_definitions:
 
     const checkpoint = await bucketStorage.getCheckpoint();
 
-    const parameters = await bucketStorage.getParameterSets(checkpoint, [
-      ParameterLookup.normalized('mybucket', '1', ['user1'])
-    ]);
+    const parameters = await checkpoint.getParameterSets([ParameterLookup.normalized('mybucket', '1', ['user1'])]);
     expect(parameters).toEqual([]);
   });
 

--- a/packages/service-core/src/entry/commands/compact-action.ts
+++ b/packages/service-core/src/entry/commands/compact-action.ts
@@ -59,7 +59,15 @@ export function registerCompactAction(program: Command) {
         return;
       }
       logger.info('Performing compaction...');
-      await active.compact({ memoryLimitMB: COMPACT_MEMORY_LIMIT_MB, compactBuckets: buckets });
+      if (buckets != null) {
+        await active.compact({
+          memoryLimitMB: COMPACT_MEMORY_LIMIT_MB,
+          compactBuckets: buckets,
+          compactParameterData: false
+        });
+      } else {
+        await active.compact({ memoryLimitMB: COMPACT_MEMORY_LIMIT_MB, compactParameterData: true });
+      }
       logger.info('Successfully compacted storage.');
     } catch (e) {
       logger.error(`Failed to compact: ${e.toString()}`);

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -67,11 +67,6 @@ export interface SyncRulesBucketStorage
   getCheckpoint(): Promise<ReplicationCheckpoint>;
 
   /**
-   * Used to resolve "dynamic" parameter queries.
-   */
-  getParameterSets(checkpoint: ReplicationCheckpoint, lookups: ParameterLookup[]): Promise<SqliteJsonRow[]>;
-
-  /**
    * Given two checkpoints, return the changes in bucket data and parameters that may have occurred
    * in that period.
    *
@@ -243,6 +238,13 @@ export interface SyncBucketDataChunk {
 export interface ReplicationCheckpoint {
   readonly checkpoint: util.InternalOpId;
   readonly lsn: string | null;
+
+  /**
+   * Used to resolve "dynamic" parameter queries.
+   *
+   * This gets parameter sets specific to this checkpoint.
+   */
+  getParameterSets(lookups: ParameterLookup[]): Promise<SqliteJsonRow[]>;
 }
 
 export interface WatchWriteCheckpointOptions {

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -193,6 +193,8 @@ export interface CompactOptions {
    */
   compactBuckets?: string[];
 
+  compactParameterData?: boolean;
+
   /** Minimum of 2 */
   clearBatchLimit?: number;
 

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -69,7 +69,7 @@ export interface SyncRulesBucketStorage
   /**
    * Used to resolve "dynamic" parameter queries.
    */
-  getParameterSets(checkpoint: util.InternalOpId, lookups: ParameterLookup[]): Promise<SqliteJsonRow[]>;
+  getParameterSets(checkpoint: ReplicationCheckpoint, lookups: ParameterLookup[]): Promise<SqliteJsonRow[]>;
 
   /**
    * Given two checkpoints, return the changes in bucket data and parameters that may have occurred

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -440,7 +440,7 @@ export class BucketParameterState {
     if (hasParameterChange || this.cachedDynamicBuckets == null || this.cachedDynamicBucketSet == null) {
       dynamicBuckets = await querier.queryDynamicBucketDescriptions({
         getParameterSets(lookups) {
-          return storage.getParameterSets(checkpoint.base.checkpoint, lookups);
+          return storage.getParameterSets(checkpoint.base, lookups);
         }
       });
       this.cachedDynamicBuckets = dynamicBuckets;

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -440,7 +440,7 @@ export class BucketParameterState {
     if (hasParameterChange || this.cachedDynamicBuckets == null || this.cachedDynamicBucketSet == null) {
       dynamicBuckets = await querier.queryDynamicBucketDescriptions({
         getParameterSets(lookups) {
-          return storage.getParameterSets(checkpoint.base, lookups);
+          return checkpoint.base.getParameterSets(lookups);
         }
       });
       this.cachedDynamicBuckets = dynamicBuckets;
@@ -501,7 +501,7 @@ export interface CheckpointLine {
 }
 
 // Use a more specific type to simplify testing
-export type BucketChecksumStateStorage = Pick<storage.SyncRulesBucketStorage, 'getChecksums' | 'getParameterSets'>;
+export type BucketChecksumStateStorage = Pick<storage.SyncRulesBucketStorage, 'getChecksums'>;
 
 function limitedBuckets(buckets: string[] | { bucket: string }[], limit: number) {
   buckets = buckets.map((b) => {

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -5,6 +5,7 @@ import {
   CHECKPOINT_INVALIDATE_ALL,
   ChecksumMap,
   InternalOpId,
+  ReplicationCheckpoint,
   SyncContext,
   WatchFilterEvent
 } from '@/index.js';
@@ -485,10 +486,10 @@ bucket_definitions:
     });
 
     storage.getParameterSets = async (
-      checkpoint: InternalOpId,
+      checkpoint: ReplicationCheckpoint,
       lookups: ParameterLookup[]
     ): Promise<SqliteJsonRow[]> => {
-      expect(checkpoint).toEqual(1n);
+      expect(checkpoint.checkpoint).toEqual(1n);
       expect(lookups).toEqual([ParameterLookup.normalized('by_project', '1', ['u1'])]);
       return [{ id: 1 }, { id: 2 }];
     };
@@ -532,10 +533,10 @@ bucket_definitions:
     line.updateBucketPosition({ bucket: 'by_project[2]', nextAfter: 1n, hasMore: false });
 
     storage.getParameterSets = async (
-      checkpoint: InternalOpId,
+      checkpoint: ReplicationCheckpoint,
       lookups: ParameterLookup[]
     ): Promise<SqliteJsonRow[]> => {
-      expect(checkpoint).toEqual(2n);
+      expect(checkpoint.checkpoint).toEqual(2n);
       expect(lookups).toEqual([ParameterLookup.normalized('by_project', '1', ['u1'])]);
       return [{ id: 1 }, { id: 2 }, { id: 3 }];
     };
@@ -595,7 +596,7 @@ class MockBucketChecksumStateStorage implements BucketChecksumStateStorage {
     );
   }
 
-  async getParameterSets(checkpoint: InternalOpId, lookups: ParameterLookup[]): Promise<SqliteJsonRow[]> {
+  async getParameterSets(checkpoint: ReplicationCheckpoint, lookups: ParameterLookup[]): Promise<SqliteJsonRow[]> {
     throw new Error('Method not implemented.');
   }
 }


### PR DESCRIPTION
The compact action now also compacts bucket parameter storage.

I many use cases, parameter lookups are not modified often, and take up fairly little storage. However, there are some cases where it _is_ modified often, and this causes two issues:
1. Storage increases indefinitely.
2. Parameter queries gets slower.

This compacts the parameter storage when using MongoDB storage.

See the new `docs/parameters-lookups.md` for details on the implementation.

One notable change is that we now do "snapshot" queries for parameter data, matching the snapshot state of the checkpoint query. This is required for consistency of parameter lookups during a compact operation. This required some refactoring to the storage APIs.

TODO:
 * [ ] Add tests specific to removing deleted parameter lookup entries.