### PR TITLE
[test-client]: set websocket keepalives

### DIFF
--- a/test-client/src/load-testing/rsocket-worker.ts
+++ b/test-client/src/load-testing/rsocket-worker.ts
@@ -21,6 +21,8 @@ const client = new RSocketConnector({
   setup: {
     dataMimeType: 'application/bson',
     metadataMimeType: 'application/bson',
+    keepAlive: 15_000,
+    lifetime: 120_000,
     payload: {
       data: null,
       metadata: Buffer.from(
@@ -51,7 +53,7 @@ const stream = rsocket.requestStream(
   SYNC_QUEUE_REQUEST_N, // The initial N amount
   {
     onError: (e) => {
-      console.error(e);
+      console.error(new Date().toISOString(), i, e);
     },
     onNext: (payload) => {
       const { data } = payload;

--- a/test-client/tsconfig.json
+++ b/test-client/tsconfig.json
@@ -8,5 +8,5 @@
     "sourceMap": true
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../packages/service-core" }]
 }


### PR DESCRIPTION
This avoids the error below on idle connections for `pnpm concurrent-connections --mode websocket`:

```
Error: Closed. Original cause [Error: WebsocketDuplexConnection: Socket closed unexpectedly.].
```

The websocket mode still does not include retries, but this makes it a little more stable.