### PR TITLE
[MongoDB Storage] Increase timeouts for checksums from 40s -> 80s

### DIFF
--- a/.changeset/silver-keys-confess.md
+++ b/.changeset/silver-keys-confess.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/lib-service-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+[MongoDB Storage] Increase checksum timeouts

--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -9,8 +9,11 @@ export const MONGO_CONNECT_TIMEOUT_MS = 10_000;
 
 /**
  * Time for individual requests to timeout the socket.
+ *
+ * Currently increased to cater for slow checksum calculations - may be reduced to 60s again
+ * if we optimize those.
  */
-export const MONGO_SOCKET_TIMEOUT_MS = 60_000;
+export const MONGO_SOCKET_TIMEOUT_MS = 90_000;
 
 /**
  * Time for individual requests to timeout the operation.
@@ -20,6 +23,18 @@ export const MONGO_SOCKET_TIMEOUT_MS = 60_000;
  * Must be less than MONGO_SOCKET_TIMEOUT_MS to ensure proper error handling.
  */
 export const MONGO_OPERATION_TIMEOUT_MS = 40_000;
+
+/**
+ * Time for individual checksums requests to timeout the operation.
+ *
+ * This is time spent on the cursor, not total time.
+ *
+ * Must be less than MONGO_SOCKET_TIMEOUT_MS to ensure proper error handling.
+ *
+ * This is temporarily increased to cater for slow checksum calculations,
+ * may be reduced to MONGO_OPERATION_TIMEOUT_MS again if we optimize those.
+ */
+export const MONGO_CHECKSUM_TIMEOUT_MS = 80_000;
 
 /**
  * Same as above, but specifically for clear operations.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -537,7 +537,7 @@ export class MongoSyncBucketStorage
             }
           }
         ],
-        { session: undefined, readConcern: 'snapshot', maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS }
+        { session: undefined, readConcern: 'snapshot', maxTimeMS: lib_mongo.db.MONGO_CHECKSUM_TIMEOUT_MS }
       )
       .toArray()
       .catch((e) => {


### PR DESCRIPTION
#300 introduced proper error messages for checksum queries timing out. A side effect of that was also reducing the 60s connection-based timeout to a 40s query-specific timeout.

While the results are cached in memory and incrementally updated, in some cases the initial calculation takes too long, causing the service to repeatedly run the same query. We've seen this hit the 40s timeout when calculating checksums over around 5-10 million operations at a time.

This is a quick-fix that just doubles the timeout, which should make it safe to sync up to around 10 million operations per user. A proper future fix will focus on significantly reducing the time needed to calculate these initial checksums, after which we can reduce the timeout values again.