### PR TITLE
Avoid persisting SqliteInputValues

### DIFF
--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -1,11 +1,5 @@
 import { mongo } from '@powersync/lib-service-mongodb';
-import {
-  applyRowContext,
-  SqlEventDescriptor,
-  SqliteRow,
-  SqliteValue,
-  SqlSyncRules
-} from '@powersync/service-sync-rules';
+import { SqlEventDescriptor, SqliteRow, SqliteValue, SqlSyncRules } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 
 import {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -1,5 +1,11 @@
 import { mongo } from '@powersync/lib-service-mongodb';
-import { SqlEventDescriptor, SqliteRow, SqlSyncRules } from '@powersync/service-sync-rules';
+import {
+  applyRowContext,
+  SqlEventDescriptor,
+  SqliteRow,
+  SqliteValue,
+  SqlSyncRules
+} from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 
 import {
@@ -319,7 +325,8 @@ export class MongoBucketBatch
     const record = operation.record;
     const beforeId = operation.beforeId;
     const afterId = operation.afterId;
-    let after = record.after;
+    let sourceAfter = record.after;
+    let after = sourceAfter && applyRowContext(sourceAfter, this.sync_rules.compatibility);
     const sourceTable = record.sourceTable;
 
     let existing_buckets: CurrentBucket[] = [];
@@ -367,7 +374,7 @@ export class MongoBucketBatch
         existing_lookups = result.lookups;
         if (this.storeCurrentData) {
           const data = deserializeBson((result.data as mongo.Binary).buffer) as SqliteRow;
-          after = storage.mergeToast(after!, data);
+          after = storage.mergeToast<SqliteValue>(after!, data);
         }
       }
     } else if (record.tag == SaveOperationTag.DELETE) {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -326,7 +326,7 @@ export class MongoBucketBatch
     const beforeId = operation.beforeId;
     const afterId = operation.afterId;
     let sourceAfter = record.after;
-    let after = sourceAfter && applyRowContext(sourceAfter, this.sync_rules.compatibility);
+    let after = sourceAfter && this.sync_rules.applyRowContext(sourceAfter);
     const sourceTable = record.sourceTable;
 
     let existing_buckets: CurrentBucket[] = [];

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -687,7 +687,8 @@ export class PostgresBucketBatch
     // We store bytea colums for source keys
     const beforeId = operation.beforeId;
     const afterId = operation.afterId;
-    let after = record.after;
+    let sourceAfter = record.after;
+    let after = sourceAfter && sync_rules.applyRowContext(sourceAfter, this.sync_rules.compatibility);
     const sourceTable = record.sourceTable;
 
     let existingBuckets: CurrentBucket[] = [];

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -688,7 +688,7 @@ export class PostgresBucketBatch
     const beforeId = operation.beforeId;
     const afterId = operation.afterId;
     let sourceAfter = record.after;
-    let after = sourceAfter && sync_rules.applyRowContext(sourceAfter, this.sync_rules.compatibility);
+    let after = sourceAfter && this.sync_rules.applyRowContext(sourceAfter);
     const sourceTable = record.sourceTable;
 
     let existingBuckets: CurrentBucket[] = [];

--- a/packages/service-core-tests/src/tests/register-data-storage-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-tests.ts
@@ -3,9 +3,10 @@ import {
   getUuidReplicaIdentityBson,
   InternalOpId,
   OplogEntry,
+  SaveOptions,
   storage
 } from '@powersync/service-core';
-import { ParameterLookup, RequestParameters } from '@powersync/service-sync-rules';
+import { DateTimeValue, ParameterLookup, RequestParameters } from '@powersync/service-sync-rules';
 import { expect, test, describe, beforeEach } from 'vitest';
 import * as test_utils from '../test-utils/test-utils-index.js';
 import { SqlBucketDescriptor } from '@powersync/service-sync-rules/src/SqlBucketDescriptor.js';
@@ -1994,5 +1995,71 @@ bucket_definitions:
     const checkpoint2 = result2!.flushed_op;
     // we expect 0n and 1n, or 1n and 2n.
     expect(checkpoint2).toBeGreaterThan(checkpoint1);
+  });
+
+  test('data with custom types', async () => {
+    await using factory = await generateStorageFactory();
+    const testValue = {
+      sourceTable: TEST_TABLE,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 't1',
+        description: new DateTimeValue('2025-08-28T11:30:00')
+      },
+      afterReplicaId: test_utils.rid('t1')
+    } satisfies SaveOptions;
+
+    {
+      // First, deploy old sync rules and row with date time value
+      const syncRules = await factory.updateSyncRules({
+        content: `
+  bucket_definitions:
+    global:
+      data:
+        - SELECT id, description FROM test
+  `
+      });
+      const bucketStorage = factory.getInstance(syncRules);
+      await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+        await batch.save(testValue);
+        await batch.commit('1/1');
+      });
+
+      const { checkpoint } = await bucketStorage.getCheckpoint();
+      const batch = await test_utils.fromAsync(
+        bucketStorage.getBucketDataBatch(checkpoint, new Map([['global[]', 0n]]))
+      );
+      expect(batch[0].chunkData.data).toMatchObject([
+        {
+          data: '{"id":"t1","description":"2025-08-28 11:30:00"}'
+        }
+      ]);
+    }
+
+    const syncRules = await factory.updateSyncRules({
+      content: `
+  bucket_definitions:
+    global:
+      data:
+        - SELECT id, description FROM test
+  
+  config:
+    edition: 2
+  `
+    });
+    const bucketStorage = factory.getInstance(syncRules);
+    await bucketStorage.startBatch(test_utils.BATCH_OPTIONS, async (batch) => {
+      await batch.save(testValue);
+      await batch.commit('1/2');
+    });
+    const { checkpoint } = await bucketStorage.getCheckpoint();
+    const batch = await test_utils.fromAsync(
+      bucketStorage.getBucketDataBatch(checkpoint, new Map([['2#global[]', 0n]]))
+    );
+    expect(batch[0].chunkData.data).toMatchObject([
+      {
+        data: '{"id":"t1","description":"2025-08-28T11:30:00"}'
+      }
+    ]);
   });
 }

--- a/packages/service-core/src/storage/BucketStorage.ts
+++ b/packages/service-core/src/storage/BucketStorage.ts
@@ -39,8 +39,8 @@ export enum SyncRuleState {
 export const DEFAULT_DOCUMENT_BATCH_LIMIT = 1000;
 export const DEFAULT_DOCUMENT_CHUNK_LIMIT_BYTES = 1 * 1024 * 1024;
 
-export function mergeToast(record: ToastableSqliteRow, persisted: ToastableSqliteRow): ToastableSqliteRow {
-  const newRecord: ToastableSqliteRow = {};
+export function mergeToast<V>(record: ToastableSqliteRow<V>, persisted: ToastableSqliteRow<V>): ToastableSqliteRow<V> {
+  const newRecord: ToastableSqliteRow<V> = {};
   for (let key in record) {
     if (typeof record[key] == 'undefined') {
       newRecord[key] = persisted[key];

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -37,10 +37,7 @@ export class SqlBucketDescriptor implements BucketSource {
   name: string;
   bucketParameters?: string[];
 
-  constructor(
-    name: string,
-    private readonly compatibility: CompatibilityContext
-  ) {
+  constructor(name: string) {
     this.name = name;
   }
 
@@ -61,11 +58,11 @@ export class SqlBucketDescriptor implements BucketSource {
 
   parameterIdSequence = new IdSequence();
 
-  addDataQuery(sql: string, options: SyncRulesOptions): QueryParseResult {
+  addDataQuery(sql: string, options: SyncRulesOptions, compatibility: CompatibilityContext): QueryParseResult {
     if (this.bucketParameters == null) {
       throw new Error('Bucket parameters must be defined');
     }
-    const dataRows = SqlDataQuery.fromSql(this.name, this.bucketParameters, sql, options, this.compatibility);
+    const dataRows = SqlDataQuery.fromSql(this.name, this.bucketParameters, sql, options, compatibility);
 
     this.dataQueries.push(dataRows);
 
@@ -105,13 +102,7 @@ export class SqlBucketDescriptor implements BucketSource {
         continue;
       }
 
-      results.push(
-        ...query.evaluateRow(
-          options.sourceTable,
-          applyRowContext(options.record, this.compatibility),
-          options.bucketIdTransformer
-        )
-      );
+      results.push(...query.evaluateRow(options.sourceTable, options.record, options.bucketIdTransformer));
     }
     return results;
   }

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -22,13 +22,17 @@ import {
   RequestParameters,
   SourceSchema,
   SqliteInputRow,
+  SqliteInputValue,
   SqliteJsonRow,
+  SqliteRow,
+  SqliteValue,
   StreamParseOptions,
   SyncRules
 } from './types.js';
 import { BucketSource } from './BucketSource.js';
 import { syncStreamFromSql } from './streams/from_sql.js';
 import { CompatibilityContext, CompatibilityEdition, CompatibilityOption } from './compatibility.js';
+import { applyRowContext } from './utils.js';
 
 const ACCEPT_POTENTIALLY_DANGEROUS_QUERIES = Symbol('ACCEPT_POTENTIALLY_DANGEROUS_QUERIES');
 
@@ -380,6 +384,12 @@ export class SqlSyncRules implements SyncRules {
 
   constructor(content: string) {
     this.content = content;
+  }
+
+  applyRowContext<MaybeToast extends undefined = never>(
+    source: SqliteRow<SqliteInputValue | MaybeToast>
+  ): SqliteRow<SqliteValue | MaybeToast> {
+    return applyRowContext(source, this.compatibility);
   }
 
   /**

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -217,7 +217,7 @@ export class SqlSyncRules implements SyncRules {
       const parameters = value.get('parameters', true) as unknown;
       const dataQueries = value.get('data', true) as unknown;
 
-      const descriptor = new SqlBucketDescriptor(key, compatibility);
+      const descriptor = new SqlBucketDescriptor(key);
 
       if (parameters instanceof Scalar) {
         rules.withScalar(parameters, (q) => {
@@ -239,7 +239,7 @@ export class SqlSyncRules implements SyncRules {
       }
       for (let query of dataQueries.items) {
         rules.withScalar(query, (q) => {
-          return descriptor.addDataQuery(q, queryOptions);
+          return descriptor.addDataQuery(q, queryOptions, compatibility);
         });
       }
       rules.bucketSources.push(descriptor);

--- a/packages/sync-rules/src/events/SqlEventDescriptor.ts
+++ b/packages/sync-rules/src/events/SqlEventDescriptor.ts
@@ -51,10 +51,7 @@ export class SqlEventDescriptor {
       };
     }
 
-    return matchingQuery.evaluateRowWithErrors(
-      options.sourceTable,
-      applyRowContext(options.record, this.compatibility)
-    );
+    return matchingQuery.evaluateRowWithErrors(options.sourceTable, options.record);
   }
 
   getSourceTables(): Set<TablePattern> {

--- a/packages/sync-rules/src/streams/from_sql.ts
+++ b/packages/sync-rules/src/streams/from_sql.ts
@@ -100,8 +100,7 @@ class SyncStreamCompiler {
 
     const stream = new SyncStream(
       this.descriptorName,
-      new BaseSqlDataQuery(this.compileDataQuery(tools, query, alias, sourceTable)),
-      this.options.compatibility
+      new BaseSqlDataQuery(this.compileDataQuery(tools, query, alias, sourceTable))
     );
     stream.subscribedToByDefault = this.options.auto_subscribe ?? false;
     if (filter.isValid(tools)) {

--- a/packages/sync-rules/src/streams/stream.ts
+++ b/packages/sync-rules/src/streams/stream.ts
@@ -27,11 +27,7 @@ export class SyncStream implements BucketSource {
   variants: StreamVariant[];
   data: BaseSqlDataQuery;
 
-  constructor(
-    name: string,
-    data: BaseSqlDataQuery,
-    private readonly compatibility: CompatibilityContext
-  ) {
+  constructor(name: string, data: BaseSqlDataQuery) {
     this.name = name;
     this.subscribedToByDefault = false;
     this.priority = DEFAULT_BUCKET_PRIORITY;
@@ -172,15 +168,14 @@ export class SyncStream implements BucketSource {
     }
 
     const stream = this;
-    const mappedRow = applyRowContext(options.record, this.compatibility);
     const row: TableRow = {
       sourceTable: options.sourceTable,
-      record: mappedRow
+      record: options.record
     };
 
     return this.data.evaluateRowWithOptions({
       table: options.sourceTable,
-      row: applyRowContext(options.record, this.compatibility),
+      row: options.record,
       bucketIds() {
         const bucketIds: string[] = [];
         for (const variant of stream.variants) {

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -218,7 +218,7 @@ export type SqliteInputRow = SqliteRow<SqliteInputValue>;
  *
  * Toasted values are `undefined`.
  */
-export type ToastableSqliteRow = SqliteRow<SqliteInputValue | undefined>;
+export type ToastableSqliteRow<V = SqliteInputValue> = SqliteRow<V | undefined>;
 
 /**
  * A value as received from the database.
@@ -297,7 +297,7 @@ export interface InputParameter {
  */
 export type BucketIdTransformer = (regularId: string) => string;
 
-export interface EvaluateRowOptions extends TableRow<SqliteInputRow> {
+export interface EvaluateRowOptions extends TableRow {
   bucketIdTransformer: BucketIdTransformer;
 }
 

--- a/packages/sync-rules/src/utils.ts
+++ b/packages/sync-rules/src/utils.ts
@@ -10,7 +10,8 @@ import {
   SqliteJsonValue,
   SqliteRow,
   SqliteValue,
-  BucketIdTransformer
+  BucketIdTransformer,
+  ToastableSqliteRow
 } from './types.js';
 import { SyncRuleProcessingError as SyncRulesProcessingError } from './errors.js';
 import { CustomArray, CustomObject, CustomSqliteValue } from './types/custom_sqlite_value.js';
@@ -192,10 +193,24 @@ export function applyValueContext(value: SqliteInputValue, context: Compatibilit
   }
 }
 
-export function applyRowContext(value: SqliteInputRow, context: CompatibilityContext): SqliteRow {
-  let record: SqliteRow = {};
-  for (let key of Object.keys(value)) {
-    record[key] = applyValueContext(value[key], context);
+export function applyRowContext(
+  value: ToastableSqliteRow,
+  context: CompatibilityContext
+): SqliteRow<SqliteValue | undefined>;
+
+export function applyRowContext(value: SqliteInputRow, context: CompatibilityContext): SqliteRow;
+
+export function applyRowContext(
+  value: ToastableSqliteRow,
+  context: CompatibilityContext
+): SqliteRow<SqliteValue | undefined> {
+  let record: SqliteRow<SqliteValue | undefined> = {};
+  for (let [key, rawValue] of Object.entries(value)) {
+    if (rawValue === undefined) {
+      record[key] = undefined;
+    } else {
+      record[key] = applyValueContext(rawValue, context);
+    }
   }
   return record;
 }

--- a/packages/sync-rules/src/utils.ts
+++ b/packages/sync-rules/src/utils.ts
@@ -193,21 +193,14 @@ export function applyValueContext(value: SqliteInputValue, context: Compatibilit
   }
 }
 
-export function applyRowContext(
-  value: ToastableSqliteRow,
+export function applyRowContext<MaybeToast extends undefined = never>(
+  value: SqliteRow<SqliteInputValue | MaybeToast>,
   context: CompatibilityContext
-): SqliteRow<SqliteValue | undefined>;
-
-export function applyRowContext(value: SqliteInputRow, context: CompatibilityContext): SqliteRow;
-
-export function applyRowContext(
-  value: ToastableSqliteRow,
-  context: CompatibilityContext
-): SqliteRow<SqliteValue | undefined> {
-  let record: SqliteRow<SqliteValue | undefined> = {};
+): SqliteRow<SqliteValue | MaybeToast> {
+  let record: SqliteRow<SqliteValue | MaybeToast> = {};
   for (let [key, rawValue] of Object.entries(value)) {
     if (rawValue === undefined) {
-      record[key] = undefined;
+      record[key] = undefined as MaybeToast;
     } else {
       record[key] = applyValueContext(rawValue, context);
     }

--- a/packages/sync-rules/test/src/compatibility.test.ts
+++ b/packages/sync-rules/test/src/compatibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { SqlSyncRules, DateTimeValue, toSyncRulesValue } from '../../src/index.js';
+import { SqlSyncRules, DateTimeValue, toSyncRulesValue, SqliteInputRow } from '../../src/index.js';
 
 import { ASSETS, identityBucketTransformer, normalizeQuerierOptions, PARSE_OPTIONS } from './util.js';
 
@@ -22,10 +22,10 @@ bucket_definitions:
         rules.evaluateRow({
           sourceTable: ASSETS,
           bucketIdTransformer: SqlSyncRules.versionedBucketIdTransformer(''),
-          record: {
+          record: rules.applyRowContext<never>({
             id: 'id',
             description: value
-          }
+          })
         })
       ).toStrictEqual([
         { bucket: 'mybucket[]', data: { description: '2025-08-19 09:21:00Z', id: 'id' }, id: 'id', table: 'assets' }
@@ -50,10 +50,10 @@ config:
         rules.evaluateRow({
           sourceTable: ASSETS,
           bucketIdTransformer: SqlSyncRules.versionedBucketIdTransformer(''),
-          record: {
+          record: rules.applyRowContext<never>({
             id: 'id',
             description: value
-          }
+          })
         })
       ).toStrictEqual([
         { bucket: 'mybucket[]', data: { description: '2025-08-19T09:21:00Z', id: 'id' }, id: 'id', table: 'assets' }
@@ -78,10 +78,10 @@ config:
         rules.evaluateRow({
           bucketIdTransformer: SqlSyncRules.versionedBucketIdTransformer('1'),
           sourceTable: ASSETS,
-          record: {
+          record: rules.applyRowContext<never>({
             id: 'id',
             description: value
-          }
+          })
         })
       ).toStrictEqual([
         { bucket: '1#stream|0[]', data: { description: '2025-08-19T09:21:00Z', id: 'id' }, id: 'id', table: 'assets' }
@@ -121,10 +121,10 @@ config:
         rules.evaluateRow({
           bucketIdTransformer: SqlSyncRules.versionedBucketIdTransformer('1'),
           sourceTable: ASSETS,
-          record: {
+          record: rules.applyRowContext<never>({
             id: 'id',
             description: value
-          }
+          })
         })
       ).toStrictEqual([
         { bucket: 'stream|0[]', data: { description: '2025-08-19 09:21:00Z', id: 'id' }, id: 'id', table: 'assets' }
@@ -188,10 +188,10 @@ config:
       rules.evaluateRow({
         sourceTable: ASSETS,
         bucketIdTransformer: SqlSyncRules.versionedBucketIdTransformer('1'),
-        record: {
+        record: rules.applyRowContext<never>({
           id: 'id',
           description: new DateTimeValue('2025-08-19T09:21:00Z')
-        }
+        })
       })
     ).toStrictEqual([
       { bucket: '1#stream|0[]', data: { description: '2025-08-19T09:21:00Z', id: 'id' }, id: 'id', table: 'assets' }
@@ -290,10 +290,10 @@ config:
         rules.evaluateRow({
           sourceTable: ASSETS,
           bucketIdTransformer: SqlSyncRules.versionedBucketIdTransformer('1'),
-          record: {
+          record: rules.applyRowContext<never>({
             id: 'id',
             description: data
-          }
+          })
         })
       ).toStrictEqual([
         {


### PR DESCRIPTION
#331 introduced `SqliteInputValue` and the `CustomSqliteValue` class to represent values that may have to be synced differently depending on compatibility options. The original idea was that each sync stream and SQL bucket or event descriptor would apply their compatibility options when mapping the row, so that`CustomSqliteValue`s are temporary instances living between the replicator and sync rules.

That approach is flawed in two ways:

1. It was based on the assumption that different bucket descriptors may have different compatibility options, which is no longer the case (there's one global compatibility context for sync rules). So applying the mapping at the level of the individual stream or sync rule can be inefficient.
2. Worse, because we may be trying to store rows to recover from TOAST values in Postgres, we would attempt to serialize custom JS instances, which obviously fails.

To fix this, this moves the responsibility of applying the compatibility context to the batch implementation (which has all the necessary data because the compatibility context is known via the sync rules instance). That also means that we'll store mapped representations instead of the original values.