### PR TITLE
Initial replication checksums

### DIFF
--- a/.changeset/chilly-melons-check.md
+++ b/.changeset/chilly-melons-check.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-module-postgres': patch
+'@powersync/service-core': patch
+'@powersync/lib-service-mongodb': patch
+'@powersync/service-image': patch
+---
+
+Fix pre-computing of checksums after intial replication causing replication timeouts

--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -9,11 +9,8 @@ export const MONGO_CONNECT_TIMEOUT_MS = 10_000;
 
 /**
  * Time for individual requests to timeout the socket.
- *
- * Currently increased to cater for slow checksum calculations - may be reduced to 60s again
- * if we optimize those.
  */
-export const MONGO_SOCKET_TIMEOUT_MS = 90_000;
+export const MONGO_SOCKET_TIMEOUT_MS = 60_000;
 
 /**
  * Time for individual requests to timeout the operation.
@@ -30,11 +27,8 @@ export const MONGO_OPERATION_TIMEOUT_MS = 40_000;
  * This is time spent on the cursor, not total time.
  *
  * Must be less than MONGO_SOCKET_TIMEOUT_MS to ensure proper error handling.
- *
- * This is temporarily increased to cater for slow checksum calculations,
- * may be reduced to MONGO_OPERATION_TIMEOUT_MS again if we optimize those.
  */
-export const MONGO_CHECKSUM_TIMEOUT_MS = 80_000;
+export const MONGO_CHECKSUM_TIMEOUT_MS = 50_000;
 
 /**
  * Same as above, but specifically for clear operations.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
@@ -4,9 +4,9 @@ import { addChecksums, InternalOpId, isPartialChecksum, storage, utils } from '@
 
 import { PowerSyncMongo } from './db.js';
 import { BucketDataDocument, BucketDataKey, BucketStateDocument } from './models.js';
+import { MongoSyncBucketStorage } from './MongoSyncBucketStorage.js';
 import { cacheKey } from './OperationBatch.js';
 import { readSingleBatch } from './util.js';
-import { MongoSyncBucketStorage } from './MongoSyncBucketStorage.js';
 
 interface CurrentBucketState {
   /** Bucket name */
@@ -531,7 +531,7 @@ export class MongoCompactor {
     for (let bucketChecksum of checksums.values()) {
       if (isPartialChecksum(bucketChecksum)) {
         // Should never happen since we don't specify `start`
-        throw new ServiceAssertionError(`Full checksum expected for bucket ${bucketChecksum.bucket}`);
+        throw new ServiceAssertionError(`Full checksum expected, got ${JSON.stringify(bucketChecksum)}`);
       }
 
       this.bucketStateUpdates.push({

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -679,7 +679,7 @@ export class MongoSyncBucketStorage
   }
 
   private async slowChecksum(request: storage.FetchPartialBucketChecksum): Promise<PartialOrFullChecksum> {
-    const batchLimit = 100_000;
+    const batchLimit = 50_000;
 
     let lowerBound = 0n;
     const bucket = request.bucket;

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -585,6 +585,7 @@ export class MongoSyncBucketStorage
       return await this.queryPartialChecksumsInternal(batch);
     } catch (e) {
       if (e.codeName == 'MaxTimeMSExpired') {
+        logger.warn(`Checksum query timed out; falling back to slower version`, e);
         // Timeout - try the slower but more robust version
         return await this.queryPartialChecksumsFallback(batch);
       }

--- a/packages/service-core/src/util/utils.ts
+++ b/packages/service-core/src/util/utils.ts
@@ -113,26 +113,30 @@ export function addBucketChecksums(a: BucketChecksum, b: PartialChecksum | Bucke
 
 export function addPartialChecksums(
   bucket: string,
-  a: BucketChecksum | null,
+  a: PartialChecksum | BucketChecksum | null,
   b: PartialChecksum | BucketChecksum | null
 ): PartialChecksum | BucketChecksum {
   if (a != null && b != null) {
     if (!isPartialChecksum(b)) {
-      // Replaces preState
+      // Replaces a
       return b;
     }
     // merge
-    return {
-      bucket,
-      checksum: addChecksums(a.checksum, b.partialChecksum),
-      count: a.count + b.partialCount
-    };
+    if (!isPartialChecksum(a)) {
+      return {
+        bucket,
+        checksum: addChecksums(a.checksum, b.partialChecksum),
+        count: a.count + b.partialCount
+      };
+    } else {
+      return {
+        bucket,
+        partialChecksum: addChecksums(a.partialChecksum, b.partialChecksum),
+        partialCount: a.partialCount + b.partialCount
+      };
+    }
   } else if (a != null) {
-    return {
-      bucket,
-      checksum: a.checksum,
-      count: a.count
-    };
+    return a;
   } else if (b != null) {
     return b;
   } else {


### PR DESCRIPTION
#341 introduced pre-computing of checksums when compacting, and also triggered a compact as part of initial replication. However, the compacting was not resumeable like the rest of initial replication, and could also be very slow. That could lead to an indefinite loop of trying to compact, and failing with a timeout before being able to mark initial replication as complete, often with a `Replication error Unable to do postgres query on ended connection` error.

This changes the pre-computing after initial replication to use the same checksum calculations as for normal API requests. Then it also changes that checksum calculation to handle timeouts by falling back to a piece-wise checksum calculation. This is slower for many buckets, but is more robust, so it's only used as a fall-back.

