### PR TITLE
Add changesets for postgres type changes

### DIFF
--- a/.changeset/empty-spiders-carry.md
+++ b/.changeset/empty-spiders-carry.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-postgres': patch
+'@powersync/service-sync-rules': patch
+'@powersync/service-image': patch
+---
+
+Add the `custom_postgres_types` compatibility option. When enabled, domain, composite, enum, range, multirange and custom array types will get synced in a JSON representation instead of the raw postgres wire format.

--- a/.changeset/tender-bulldogs-enjoy.md
+++ b/.changeset/tender-bulldogs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-jpgwire': minor
+---
+
+Add utilities for parsing serialized structures like compound types and arrays.


### PR DESCRIPTION
https://github.com/powersync-ja/powersync-service/pull/339 added a compatibility option to handle custom postgres types better, but didn't add a changeset.

To avoid issues related to missing package updates with the next release, this adds changeset entries to all packages affected by that PR.