### PR TITLE
Optimize write checkpoint lookups when users have none

### DIFF
--- a/.changeset/wet-grapes-study.md
+++ b/.changeset/wet-grapes-study.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+'@powersync/service-image': patch
+---
+
+Avoid frequent write checkpoint lookups when the user does not have one.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoWriteCheckpointAPI.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoWriteCheckpointAPI.ts
@@ -12,12 +12,10 @@ export type MongoCheckpointAPIOptions = {
 export class MongoWriteCheckpointAPI implements storage.WriteCheckpointAPI {
   readonly db: PowerSyncMongo;
   private _mode: storage.WriteCheckpointMode;
-  private sync_rules_id: number;
 
   constructor(options: MongoCheckpointAPIOptions) {
     this.db = options.db;
     this._mode = options.mode;
-    this.sync_rules_id = options.sync_rules_id;
   }
 
   get writeCheckpointMode() {


### PR DESCRIPTION
#276 included some significant optimizations to how write checkpoint lookups are performed. In general, the strategy is:
1. We watch the `checkpoint_events` capped collection for new checkpoints.
2. Each time we get a new checkpoint, we lookup changed buckets since the last checkpoint, changed parameter lookups, and changed write checkpoints.
3. For each user's stream, we use that as a filter to check whether or not we need to query for further data for that user.

When a new stream is opened, we need to get the initial write checkpoint for the user, before we can use the above approach to efficiently get changes. The implementation in #276 mostly handled that.

However, there was one missed case: If the user does not have any write checkpoint, it would retry the lookup on every new checkpoint. In a case of thousands of concurrent connections and no write checkpoints, we can end up with doing tens of thousands of write checkpoint lookups per second. Even if the write checkpoint collection is empty, this still ends up adding multiple megabytes/s traffic between the instance and the storage database just for sending the query and receiving the empty results.

This fixes the issue by adding a boolean to keep track of whether or not we have done the initial query, instead of using a null check on the write checkpoint.