### PR TITLE
Move input conversion to source stream

### DIFF
--- a/.changeset/dry-pots-leave.md
+++ b/.changeset/dry-pots-leave.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-module-postgres': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+'@powersync/service-module-mysql': patch
+'@powersync/service-sync-rules': patch
+---
+
+Correctly handle custom types in primary keys.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -319,8 +319,7 @@ export class MongoBucketBatch
     const record = operation.record;
     const beforeId = operation.beforeId;
     const afterId = operation.afterId;
-    let sourceAfter = record.after;
-    let after = sourceAfter && this.sync_rules.applyRowContext(sourceAfter);
+    let after = record.after;
     const sourceTable = record.sourceTable;
 
     let existing_buckets: CurrentBucket[] = [];

--- a/modules/module-mongodb/src/replication/MongoRelation.ts
+++ b/modules/module-mongodb/src/replication/MongoRelation.ts
@@ -1,16 +1,13 @@
 import { mongo } from '@powersync/lib-service-mongodb';
 import { storage } from '@powersync/service-core';
-import { JSONBig, JsonContainer } from '@powersync/service-jsonbig';
+import { JsonContainer } from '@powersync/service-jsonbig';
 import {
   CompatibilityContext,
   CustomArray,
   CustomObject,
   CustomSqliteValue,
-  DatabaseInputValue,
   SqliteInputRow,
   SqliteInputValue,
-  SqliteRow,
-  SqliteValue,
   DateTimeValue
 } from '@powersync/service-sync-rules';
 

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -687,8 +687,7 @@ export class PostgresBucketBatch
     // We store bytea colums for source keys
     const beforeId = operation.beforeId;
     const afterId = operation.afterId;
-    let sourceAfter = record.after;
-    let after = sourceAfter && this.sync_rules.applyRowContext(sourceAfter);
+    let after = record.after;
     const sourceTable = record.sourceTable;
 
     let existingBuckets: CurrentBucket[] = [];

--- a/packages/service-core/src/storage/BucketStorageBatch.ts
+++ b/packages/service-core/src/storage/BucketStorageBatch.ts
@@ -1,11 +1,5 @@
 import { ObserverClient } from '@powersync/lib-services-framework';
-import {
-  EvaluatedParameters,
-  EvaluatedRow,
-  SqliteInputRow,
-  SqliteRow,
-  ToastableSqliteRow
-} from '@powersync/service-sync-rules';
+import { EvaluatedParameters, EvaluatedRow, SqliteRow, ToastableSqliteRow } from '@powersync/service-sync-rules';
 import { BSON } from 'bson';
 import { ReplicationEventPayload } from './ReplicationEventPayload.js';
 import { SourceTable, TableSnapshotStatus } from './SourceTable.js';
@@ -138,7 +132,7 @@ export interface SaveInsert {
   sourceTable: SourceTable;
   before?: undefined;
   beforeReplicaId?: undefined;
-  after: SqliteInputRow;
+  after: SqliteRow;
   afterReplicaId: ReplicaId;
 }
 
@@ -149,7 +143,7 @@ export interface SaveUpdate {
   /**
    * This is only present when the id has changed, and will only contain replica identity columns.
    */
-  before?: SqliteInputRow;
+  before?: SqliteRow;
   beforeReplicaId?: ReplicaId;
 
   /**
@@ -164,7 +158,7 @@ export interface SaveUpdate {
 export interface SaveDelete {
   tag: SaveOperationTag.DELETE;
   sourceTable: SourceTable;
-  before?: SqliteInputRow;
+  before?: SqliteRow;
   beforeReplicaId: ReplicaId;
   after?: undefined;
   afterReplicaId?: undefined;

--- a/packages/service-core/src/util/utils.ts
+++ b/packages/service-core/src/util/utils.ts
@@ -182,7 +182,7 @@ export function uuidForRowBson(row: sync_rules.SqliteRow): bson.UUID {
   return new bson.UUID(uuid.v5(repr, ID_NAMESPACE, buffer));
 }
 
-export function hasToastedValues(row: sync_rules.ToastableSqliteRow) {
+export function hasToastedValues<V>(row: sync_rules.ToastableSqliteRow<V>) {
   for (let key in row) {
     if (typeof row[key] == 'undefined') {
       return true;
@@ -196,10 +196,10 @@ export function hasToastedValues(row: sync_rules.ToastableSqliteRow) {
  *
  * If we don't store data, we assume we always have a complete row.
  */
-export function isCompleteRow(
+export function isCompleteRow<V>(
   storeData: boolean,
-  row: sync_rules.ToastableSqliteRow
-): row is sync_rules.SqliteInputRow {
+  row: sync_rules.ToastableSqliteRow<V>
+): row is sync_rules.SqliteRow<V> {
   if (!storeData) {
     // Assume the row is complete - no need to check
     return true;

--- a/packages/sync-rules/src/BucketSource.ts
+++ b/packages/sync-rules/src/BucketSource.ts
@@ -3,13 +3,7 @@ import { ColumnDefinition } from './ExpressionType.js';
 import { SourceTableInterface } from './SourceTableInterface.js';
 import { GetQuerierOptions } from './SqlSyncRules.js';
 import { TablePattern } from './TablePattern.js';
-import {
-  EvaluatedParametersResult,
-  EvaluateRowOptions,
-  EvaluationResult,
-  SourceSchema,
-  SqliteInputRow
-} from './types.js';
+import { EvaluatedParametersResult, EvaluateRowOptions, EvaluationResult, SourceSchema, SqliteRow } from './types.js';
 
 /**
  * An interface declaring
@@ -34,7 +28,7 @@ export interface BucketSource {
    * The returned {@link ParameterLookup} can be referenced by {@link pushBucketParameterQueriers} to allow the storage
    * system to find buckets.
    */
-  evaluateParameterRow(sourceTable: SourceTableInterface, row: SqliteInputRow): EvaluatedParametersResult[];
+  evaluateParameterRow(sourceTable: SourceTableInterface, row: SqliteRow): EvaluatedParametersResult[];
 
   /**
    * Given a row as it appears in a table that affects sync data, return buckets, logical table names and transformed

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -22,7 +22,6 @@ import {
   SourceSchema,
   SqliteRow
 } from './types.js';
-import { applyRowContext } from './utils.js';
 
 export interface QueryParseResult {
   /**

--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -21,7 +21,6 @@ import {
   QueryParseOptions,
   RequestParameters,
   SourceSchema,
-  SqliteInputRow,
   SqliteInputValue,
   SqliteJsonRow,
   SqliteRow,
@@ -426,7 +425,7 @@ export class SqlSyncRules implements SyncRules {
   /**
    * Throws errors.
    */
-  evaluateParameterRow(table: SourceTableInterface, row: SqliteInputRow): EvaluatedParameters[] {
+  evaluateParameterRow(table: SourceTableInterface, row: SqliteRow): EvaluatedParameters[] {
     const { results, errors } = this.evaluateParameterRowWithErrors(table, row);
     if (errors.length > 0) {
       throw new Error(errors[0].error);
@@ -436,7 +435,7 @@ export class SqlSyncRules implements SyncRules {
 
   evaluateParameterRowWithErrors(
     table: SourceTableInterface,
-    row: SqliteInputRow
+    row: SqliteRow
   ): { results: EvaluatedParameters[]; errors: EvaluationError[] } {
     let rawResults: EvaluatedParametersResult[] = [];
     for (let source of this.bucketSources) {

--- a/packages/sync-rules/src/events/SqlEventDescriptor.ts
+++ b/packages/sync-rules/src/events/SqlEventDescriptor.ts
@@ -5,7 +5,6 @@ import { QueryParseResult } from '../SqlBucketDescriptor.js';
 import { SyncRulesOptions } from '../SqlSyncRules.js';
 import { TablePattern } from '../TablePattern.js';
 import { EvaluateRowOptions } from '../types.js';
-import { applyRowContext } from '../utils.js';
 import { EvaluatedEventRowWithErrors, SqlEventSourceQuery } from './SqlEventSourceQuery.js';
 
 /**

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -218,7 +218,7 @@ export type SqliteInputRow = SqliteRow<SqliteInputValue>;
  *
  * Toasted values are `undefined`.
  */
-export type ToastableSqliteRow<V = SqliteInputValue> = SqliteRow<V | undefined>;
+export type ToastableSqliteRow<V = SqliteValue> = SqliteRow<V | undefined>;
 
 /**
  * A value as received from the database.

--- a/packages/sync-rules/src/utils.ts
+++ b/packages/sync-rules/src/utils.ts
@@ -197,7 +197,7 @@ export function applyRowContext<MaybeToast extends undefined = never>(
   value: SqliteRow<SqliteInputValue | MaybeToast>,
   context: CompatibilityContext
 ): SqliteRow<SqliteValue | MaybeToast> {
-  let replacedCustomValues: SqliteRow<SqliteValue | MaybeToast> = {};
+  let replacedCustomValues: SqliteRow<SqliteValue> = {};
   let didReplaceValue = false;
 
   for (let [key, rawValue] of Object.entries(value)) {


### PR DESCRIPTION
This reverts the bucket batch API to only accept regular input rows (instead of `SqliteInputRow`s that need additional context to be evaluated). As a consequence, the source streams (`BinLogStream`, `ChangeStream`, `WalStream`) are now responsible for applying the context (which is not a problem because they keep a reference to the sync rules).

Applying the conversion as early as possible fixes issues when a `CustomSqliteValue` is used in a primary key, because we'd serialize it to BSON in that case. It also simplifies the bucket implementation just a tiny bit.

This also applies a small optimization to `applyRowContext` to avoid copying the row if it contains no custom values.