### PR TITLE
Fix `auth.parameters()` in sync streams

### DIFF
--- a/.changeset/stupid-lizards-vanish.md
+++ b/.changeset/stupid-lizards-vanish.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Sync streams: Fix `auth.parameter()` to use top-level parameters instead of the nested `parameters` object that the legacy `token_parameters` table uses.

--- a/packages/sync-rules/src/streams/functions.ts
+++ b/packages/sync-rules/src/streams/functions.ts
@@ -34,7 +34,7 @@ export const STREAM_FUNCTIONS: Record<string, Record<string, SqlParameterFunctio
         return v.rawTokenPayload;
       },
       extractJsonParsed: function (v: ParameterValueSet) {
-        return v.tokenParameters;
+        return v.parsedTokenPayload;
       },
       sourceDescription: 'JWT payload as JSON',
       sourceDocumentation: 'JWT payload as a JSON string. This is always validated against trusted keys',


### PR DESCRIPTION
With sync streams, we expose parameters as a pair of functions: `.parameters()` to return the raw JSON object as a string and `.parameter(path)` to extract values from that JSON object.

For JWT tokens, lookups with `.parameter` were broken because they only searched in a `parameters` sub-object of the JWT instead of the top-level structure. So if one does `WHERE project_id = auth.parameter('project_id')` for instance, the JWT would have to encode a `{..., "parameters": {"project_id": "value"}}` pair instead of being able to use `project_id` at the top-level.

This is inconsistent and not the behavior we want, this fixes that.