### PR TITLE
Reimplement dangerous request parameter check with visitor

### DIFF
--- a/.changeset/chilled-lamps-hammer.md
+++ b/.changeset/chilled-lamps-hammer.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Remove `usesAuthenticatedRequestParameters` and `usesUnauthenticatedRequestParameters` in favor of `DetectRequestParameters` computing them on-demand.

--- a/packages/sync-rules/src/request_functions.ts
+++ b/packages/sync-rules/src/request_functions.ts
@@ -1,7 +1,7 @@
 import { ExpressionType } from './ExpressionType.js';
 import { CompatibilityContext, CompatibilityEdition, CompatibilityOption } from './compatibility.js';
 import { generateSqlFunctions } from './sql_functions.js';
-import { ParameterValueSet, SqliteValue } from './types.js';
+import { CompiledClause, ParameterValueClause, ParameterValueSet, SqliteValue } from './types.js';
 
 export interface SqlParameterFunction {
   readonly debugName: string;
@@ -131,3 +131,14 @@ const REQUEST_FUNCTIONS_NAMED = {
 };
 
 export const REQUEST_FUNCTIONS: Record<string, SqlParameterFunction> = REQUEST_FUNCTIONS_NAMED;
+
+/**
+ * A {@link ParameterValueClause} derived from a call to a {@link SqlParameterFunction}.
+ */
+export interface RequestFunctionCall extends ParameterValueClause {
+  function: SqlParameterFunction;
+}
+
+export function isRequestFunctionCall(clause: CompiledClause): clause is RequestFunctionCall {
+  return (clause as RequestFunctionCall).function != null;
+}

--- a/packages/sync-rules/src/validators.ts
+++ b/packages/sync-rules/src/validators.ts
@@ -1,0 +1,62 @@
+import { isRequestFunctionCall } from './request_functions.js';
+import { isParameterMatchClause } from './sql_support.js';
+import { CompiledClause, isLegacyParameterFromTableClause, ParameterMatchClause } from './types.js';
+
+/**
+ * Detects the use of request parameters in a compiled clause.
+ */
+export class DetectRequestParameters {
+  /** request.user_id(), request.jwt(), token_parameters.* */
+  usesAuthenticatedRequestParameters: boolean = false;
+  /** request.parameters(), user_parameters.* */
+  usesUnauthenticatedRequestParameters: boolean = false;
+
+  accept(clause?: CompiledClause) {
+    if (clause == null) {
+      return null;
+    }
+
+    if (isRequestFunctionCall(clause)) {
+      const f = clause.function;
+
+      this.usesAuthenticatedRequestParameters ||= f.usesAuthenticatedRequestParameters;
+      this.usesUnauthenticatedRequestParameters ||= f.usesUnauthenticatedRequestParameters;
+    } else if (isLegacyParameterFromTableClause(clause)) {
+      const table = clause.table;
+      if (table == 'token_parameters') {
+        this.usesAuthenticatedRequestParameters = true;
+      } else if (table == 'user_parameters') {
+        this.usesUnauthenticatedRequestParameters = true;
+      }
+    } else if (isParameterMatchClause(clause) && clause.specialType == 'or') {
+      // We only treat this clause as using authenticated request parameters if all subclauses use authenticated request
+      // parameters.
+      const leftVisitor = new DetectRequestParameters();
+      const rightVisitor = new DetectRequestParameters();
+
+      let isFirstChild = true;
+      clause.visitChildren!((v) => {
+        if (isFirstChild) {
+          leftVisitor.accept(v);
+        } else {
+          rightVisitor.accept(v);
+        }
+      });
+      this.usesAuthenticatedRequestParameters =
+        leftVisitor.usesAuthenticatedRequestParameters && rightVisitor.usesAuthenticatedRequestParameters;
+
+      // For unauthenticated parameters, it's enough if either side reads unauthenticated data.
+      this.usesUnauthenticatedRequestParameters ||= leftVisitor.usesUnauthenticatedRequestParameters;
+      this.usesUnauthenticatedRequestParameters ||= rightVisitor.usesUnauthenticatedRequestParameters;
+      return;
+    }
+
+    clause.visitChildren?.((c) => this.accept(c));
+  }
+
+  acceptAll(clauses: Iterable<CompiledClause>) {
+    for (const clause of clauses) {
+      this.accept(clause);
+    }
+  }
+}


### PR DESCRIPTION
The `usesAuthenticatedRequestParameters` and `usesUnauthenticatedRequestParameters` properties are currently computed whenever we're constructing or composing a clause in the `sync-rules` compiler.

While that's a fairly simple implementation, it doesn't scale well if we're trying to infer more information about used clauses in the future. In particular, I'm looking at a lint that would require knowing whether a query uses stream parameters. Adding that information (or more features in the future) to all clauses would complicate the implementation.

So, this refactors the check to use the visitor pattern:

- When a clause has child clauses, it exposes a function for traversing them.
- The request function and parameter table ref clauses have special identifiers to recognize them.
- A visitor traverses all clauses to check whether authenticated or unauthenticated request parameters are used.
- The `OR`combinator for parameter match clauses also has a special key so that we can apply the special behavior (it only counts if both sides are using authenticated parameters).