### PR TITLE
Streams: Add test with multiple filters on the same column

### DIFF
--- a/packages/sync-rules/test/src/streams.test.ts
+++ b/packages/sync-rules/test/src/streams.test.ts
@@ -408,6 +408,26 @@ describe('streams', () => {
         '1#stream|0["i2","l2"]'
       ]);
     });
+
+    test('parameter and auth match on same column', async () => {
+      const desc = parseStream(
+        "SELECT * FROM comments WHERE issue_id = subscription.parameter('issue') AND issue_id IN auth.parameter('issues')"
+      );
+      expect(evaluateBucketIds(desc, COMMENTS, { id: 'a', issue_id: 'i' })).toStrictEqual(['1#stream|0["i","i"]']);
+
+      expect(
+        await queryBucketIds(desc, {
+          token: { sub: 'a' },
+          parameters: { issue: 'i' }
+        })
+      ).toStrictEqual([]);
+      expect(
+        await queryBucketIds(desc, {
+          token: { sub: 'a', issues: ['i', 'i2'] },
+          parameters: { issue: 'i' }
+        })
+      ).toStrictEqual(['1#stream|0["i","i"]', '1#stream|0["i","i2"]']);
+    });
   });
 
   describe('overlap', () => {


### PR DESCRIPTION
This adds a test with two filters on the same column (one based on a stream parameter and one based on the token). This setup matches sync rules for the dashboard, where have been running into some issues.

These issues turned out to be unrelated to this, but having another test doesn't hurt.