### PR TITLE
370: Support for connection parameters passed via the DB connection s…

### DIFF
--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -53,11 +53,11 @@ export function createMongoClient(config: BaseMongoConfigDecoded, options?: Mong
       password: normalized.password
     },
     // Time for connection to timeout
-    connectTimeoutMS: MONGO_CONNECT_TIMEOUT_MS,
+    connectTimeoutMS: normalized.connectTimeoutMS ?? MONGO_CONNECT_TIMEOUT_MS,
     // Time for individual requests to timeout
-    socketTimeoutMS: MONGO_SOCKET_TIMEOUT_MS,
+    socketTimeoutMS: normalized.socketTimeoutMS ?? MONGO_SOCKET_TIMEOUT_MS,
     // How long to wait for new primary selection
-    serverSelectionTimeoutMS: 30_000,
+    serverSelectionTimeoutMS: normalized.serverSelectionTimeoutMS ?? 30_000,
 
     // Identify the client
     appName: options?.powersyncVersion ? `powersync-storage ${options.powersyncVersion}` : 'powersync-storage',
@@ -73,10 +73,10 @@ export function createMongoClient(config: BaseMongoConfigDecoded, options?: Mong
     // Avoid too many connections:
     // 1. It can overwhelm the source database.
     // 2. Processing too many queries in parallel can cause the process to run out of memory.
-    maxPoolSize: options?.maxPoolSize ?? 8,
+    maxPoolSize: normalized.maxPoolSize ?? options?.maxPoolSize ?? 8,
 
     maxConnecting: 3,
-    maxIdleTimeMS: 60_000
+    maxIdleTimeMS: normalized.maxIdleTimeMS ?? 60_000
   });
 }
 

--- a/libs/lib-mongodb/src/types/types.ts
+++ b/libs/lib-mongodb/src/types/types.ts
@@ -17,7 +17,13 @@ export const BaseMongoConfig = t.object({
   username: t.string.optional(),
   password: t.string.optional(),
 
-  reject_ip_ranges: t.array(t.string).optional()
+  reject_ip_ranges: t.array(t.string).optional(),
+
+  connectTimeoutMS: t.number.optional(),
+  socketTimeoutMS: t.number.optional(),
+  serverSelectionTimeoutMS: t.number.optional(),
+  maxPoolSize: t.number.optional(),
+  maxIdleTimeMS: t.number.optional()
 });
 
 export type BaseMongoConfig = t.Encoded<typeof BaseMongoConfig>;
@@ -29,6 +35,11 @@ export type NormalizedMongoConfig = {
   username: string;
   password: string;
   lookup: LookupFunction | undefined;
+  connectTimeoutMS?: number;
+  socketTimeoutMS?: number;
+  serverSelectionTimeoutMS?: number;
+  maxPoolSize?: number;
+  maxIdleTimeMS?: number;
 };
 
 /**
@@ -70,6 +81,19 @@ export function normalizeMongoConfig(options: BaseMongoConfigDecoded): Normalize
     throw new ServiceError(ErrorCode.PSYNC_S1105, `MongoDB connection: database required`);
   }
 
+  const parseQueryParam = (key: string): number | undefined => {
+    const value = uri.searchParams.get(key);
+    if (value == null) return undefined;
+    const num = Number(value);
+    if (isNaN(num) || num < 0) return undefined;
+    return num;
+  };
+  const connectTimeoutMS = options.connectTimeoutMS ?? parseQueryParam('connectTimeoutMS');
+  const socketTimeoutMS = options.socketTimeoutMS ?? parseQueryParam('socketTimeoutMS');
+  const serverSelectionTimeoutMS = options.serverSelectionTimeoutMS ?? parseQueryParam('serverSelectionTimeoutMS');
+  const maxPoolSize = options.maxPoolSize ?? parseQueryParam('maxPoolSize');
+  const maxIdleTimeMS = options.maxIdleTimeMS ?? parseQueryParam('maxIdleTimeMS');
+
   const lookupOptions: LookupOptions = {
     reject_ip_ranges: options.reject_ip_ranges ?? []
   };
@@ -82,6 +106,12 @@ export function normalizeMongoConfig(options: BaseMongoConfigDecoded): Normalize
     username,
     password,
 
-    lookup
+    lookup,
+
+    connectTimeoutMS,
+    socketTimeoutMS,
+    serverSelectionTimeoutMS,
+    maxPoolSize,
+    maxIdleTimeMS
   };
 }

--- a/libs/lib-postgres/test/src/config.test.ts
+++ b/libs/lib-postgres/test/src/config.test.ts
@@ -1,12 +1,147 @@
 import { describe, expect, test } from 'vitest';
+
 import { normalizeConnectionConfig } from '../../src/types/types.js';
 
 describe('config', () => {
-  test('Should resolve database', () => {
+  test('Should normalize a simple URI', () => {
     const normalized = normalizeConnectionConfig({
       type: 'postgresql',
       uri: 'postgresql://postgres:postgres@localhost:4321/powersync_test'
     });
     expect(normalized.database).equals('powersync_test');
+    expect(normalized.hostname).equals('localhost');
+    expect(normalized.port).equals(4321);
+    expect(normalized.username).equals('postgres');
+    expect(normalized.password).equals('postgres');
+  });
+
+  test('Should normalize an URI with auth', () => {
+    const uri = 'postgresql://user:pass@localhost:5432/powersync_test';
+    const normalized = normalizeConnectionConfig({
+      type: 'postgresql',
+      uri
+    });
+    expect(normalized.database).equals('powersync_test');
+    expect(normalized.username).equals('user');
+    expect(normalized.password).equals('pass');
+  });
+
+  test('Should normalize an URI with query params', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'postgresql',
+      uri: 'postgresql://user:pass@host/db?other=param'
+    });
+    expect(normalized.database).equals('db');
+  });
+
+  test('Should prioritize username and password that are specified explicitly', () => {
+    const uri = 'postgresql://user:pass@localhost:5432/powersync_test';
+    const normalized = normalizeConnectionConfig({
+      type: 'postgresql',
+      uri,
+      username: 'user2',
+      password: 'pass2'
+    });
+    expect(normalized.username).equals('user2');
+    expect(normalized.password).equals('pass2');
+  });
+
+  test('Should parse connection parameters from URI query string', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'postgresql',
+      uri: 'postgresql://user:pass@host/db?connect_timeout=300&keepalives=1&keepalives_idle=60&keepalives_interval=10&keepalives_count=10'
+    });
+    expect(normalized.connect_timeout).equals(300);
+    expect(normalized.keepalives).equals(1);
+    expect(normalized.keepalives_idle).equals(60);
+    expect(normalized.keepalives_interval).equals(10);
+    expect(normalized.keepalives_count).equals(10);
+  });
+
+  test('Should prioritize explicit config over URI query params', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'postgresql',
+      uri: 'postgresql://user:pass@host/db?connect_timeout=300&keepalives_idle=60',
+      connect_timeout: 600,
+      keepalives_idle: 120
+    });
+    expect(normalized.connect_timeout).equals(600);
+    expect(normalized.keepalives_idle).equals(120);
+  });
+
+  test('Should handle partial query parameters', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'postgresql',
+      uri: 'postgresql://user:pass@host/db?connect_timeout=300'
+    });
+    expect(normalized.connect_timeout).equals(300);
+    expect(normalized.keepalives).toBeUndefined();
+    expect(normalized.keepalives_idle).toBeUndefined();
+  });
+
+  test('Should ignore invalid query parameter values', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'postgresql',
+      uri: 'postgresql://user:pass@host/db?connect_timeout=invalid&keepalives_idle=-5'
+    });
+    expect(normalized.connect_timeout).toBeUndefined();
+    expect(normalized.keepalives_idle).toBeUndefined();
+  });
+
+  test('Should handle keepalives=0 to disable keepalives', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'postgresql',
+      uri: 'postgresql://user:pass@host/db?keepalives=0'
+    });
+    expect(normalized.keepalives).equals(0);
+  });
+
+  describe('errors', () => {
+    test('Should throw error when no database specified', () => {
+      ['postgresql://user:pass@localhost:5432', 'postgresql://user:pass@localhost:5432/'].forEach((uri) => {
+        expect(() =>
+          normalizeConnectionConfig({
+            type: 'postgresql',
+            uri
+          })
+        ).toThrow('[PSYNC_S1105] Postgres connection: database required');
+      });
+    });
+
+    test('Should throw error when URI has invalid scheme', () => {
+      expect(() =>
+        normalizeConnectionConfig({
+          type: 'postgresql',
+          uri: 'http://user:pass@localhost:5432/powersync_test'
+        })
+      ).toThrow('[PSYNC_S1109] Invalid URI - protocol must be postgresql');
+    });
+
+    test('Should throw error when hostname is missing', () => {
+      expect(() =>
+        normalizeConnectionConfig({
+          type: 'postgresql',
+          uri: 'postgresql://user:pass@/powersync_test'
+        })
+      ).toThrow('[PSYNC_S1106] Postgres connection: hostname required');
+    });
+
+    test('Should throw error when username is missing', () => {
+      expect(() =>
+        normalizeConnectionConfig({
+          type: 'postgresql',
+          uri: 'postgresql://localhost:5432/powersync_test'
+        })
+      ).toThrow('[PSYNC_S1107] Postgres connection: username required');
+    });
+
+    test('Should throw error when password is missing', () => {
+      expect(() =>
+        normalizeConnectionConfig({
+          type: 'postgresql',
+          uri: 'postgresql://user@localhost:5432/powersync_test'
+        })
+      ).toThrow('[PSYNC_S1108] Postgres connection: password required');
+    });
   });
 });

--- a/modules/module-mongodb/src/replication/MongoManager.ts
+++ b/modules/module-mongodb/src/replication/MongoManager.ts
@@ -29,11 +29,11 @@ export class MongoManager extends BaseObserver<MongoManagerListener> {
 
       lookup: options.lookup,
       // Time for connection to timeout
-      connectTimeoutMS: 5_000,
+      connectTimeoutMS: options.connectTimeoutMS ?? 5_000,
       // Time for individual requests to timeout
-      socketTimeoutMS: 60_000,
+      socketTimeoutMS: options.socketTimeoutMS ?? 60_000,
       // How long to wait for new primary selection
-      serverSelectionTimeoutMS: 30_000,
+      serverSelectionTimeoutMS: options.serverSelectionTimeoutMS ?? 30_000,
 
       // Identify the client
       appName: `powersync ${POWERSYNC_VERSION}`,
@@ -47,10 +47,10 @@ export class MongoManager extends BaseObserver<MongoManagerListener> {
       // Avoid too many connections:
       // 1. It can overwhelm the source database.
       // 2. Processing too many queries in parallel can cause the process to run out of memory.
-      maxPoolSize: 8,
+      maxPoolSize: options.maxPoolSize ?? 8,
 
       maxConnecting: 3,
-      maxIdleTimeMS: 60_000,
+      maxIdleTimeMS: options.maxIdleTimeMS ?? 60_000,
 
       ...BSON_DESERIALIZE_DATA_OPTIONS,
 

--- a/modules/module-mongodb/src/types/types.ts
+++ b/modules/module-mongodb/src/types/types.ts
@@ -52,6 +52,12 @@ export interface NormalizedMongoConnectionConfig {
   lookup?: LookupFunction;
 
   postImages: PostImagesOption;
+
+  connectTimeoutMS?: number;
+  socketTimeoutMS?: number;
+  serverSelectionTimeoutMS?: number;
+  maxPoolSize?: number;
+  maxIdleTimeMS?: number;
 }
 
 export const MongoConnectionConfig = lib_mongo.BaseMongoConfig.and(service_types.configFile.DataSourceConfig).and(

--- a/modules/module-mysql/src/utils/mysql-utils.ts
+++ b/modules/module-mysql/src/utils/mysql-utils.ts
@@ -49,6 +49,11 @@ export function createPool(config: types.NormalizedMySQLConnectionConfig, option
     decimalNumbers: true,
     timezone: 'Z', // Ensure no auto timezone manipulation of the dates occur
     jsonStrings: true, // Return JSON columns as strings
+    connectTimeout: config.connectTimeout,
+    connectionLimit: config.connectionLimit,
+    queueLimit: config.queueLimit,
+    // Note: timeout is not a valid PoolOptions property in mysql2
+    // Query timeouts are handled at the query level, not pool level
     ...(options || {})
   });
 }

--- a/modules/module-mysql/test/src/config.test.ts
+++ b/modules/module-mysql/test/src/config.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'vitest';
+
+import { normalizeConnectionConfig } from '../../src/types/types.js';
+
+describe('config', () => {
+  test('Should normalize a simple URI', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'mysql',
+      uri: 'mysql://user:pass@localhost:3306/powersync_test'
+    });
+    expect(normalized.database).equals('powersync_test');
+    expect(normalized.hostname).equals('localhost');
+    expect(normalized.port).equals(3306);
+    expect(normalized.username).equals('user');
+    expect(normalized.password).equals('pass');
+  });
+
+  test('Should normalize an URI with auth', () => {
+    const uri = 'mysql://user:pass@localhost:3306/powersync_test';
+    const normalized = normalizeConnectionConfig({
+      type: 'mysql',
+      uri
+    });
+    expect(normalized.database).equals('powersync_test');
+    expect(normalized.username).equals('user');
+    expect(normalized.password).equals('pass');
+  });
+
+  test('Should normalize an URI with query params', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'mysql',
+      uri: 'mysql://user:pass@host/db?other=param'
+    });
+    expect(normalized.database).equals('db');
+  });
+
+  test('Should prioritize username and password that are specified explicitly', () => {
+    const uri = 'mysql://user:pass@localhost:3306/powersync_test';
+    const normalized = normalizeConnectionConfig({
+      type: 'mysql',
+      uri,
+      username: 'user2',
+      password: 'pass2'
+    });
+    expect(normalized.username).equals('user2');
+    expect(normalized.password).equals('pass2');
+  });
+
+  test('Should parse connection parameters from URI query string', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'mysql',
+      uri: 'mysql://user:pass@host/db?connectTimeout=10000&connectionLimit=20&queueLimit=10&timeout=30000'
+    });
+    expect(normalized.connectTimeout).equals(10000);
+    expect(normalized.connectionLimit).equals(20);
+    expect(normalized.queueLimit).equals(10);
+    expect(normalized.timeout).equals(30000);
+  });
+
+  test('Should prioritize explicit config over URI query params', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'mysql',
+      uri: 'mysql://user:pass@host/db?connectTimeout=10000&connectionLimit=20',
+      connectTimeout: 20000,
+      connectionLimit: 30
+    });
+    expect(normalized.connectTimeout).equals(20000);
+    expect(normalized.connectionLimit).equals(30);
+  });
+
+  test('Should handle partial query parameters', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'mysql',
+      uri: 'mysql://user:pass@host/db?connectTimeout=10000'
+    });
+    expect(normalized.connectTimeout).equals(10000);
+    expect(normalized.connectionLimit).toBeUndefined();
+    expect(normalized.queueLimit).toBeUndefined();
+  });
+
+  test('Should ignore invalid query parameter values', () => {
+    const normalized = normalizeConnectionConfig({
+      type: 'mysql',
+      uri: 'mysql://user:pass@host/db?connectTimeout=invalid&connectionLimit=-5'
+    });
+    expect(normalized.connectTimeout).toBeUndefined();
+    expect(normalized.connectionLimit).toBeUndefined();
+  });
+
+  describe('errors', () => {
+    test('Should throw error when no database specified', () => {
+      ['mysql://user:pass@localhost:3306', 'mysql://user:pass@localhost:3306/'].forEach((uri) => {
+        expect(() =>
+          normalizeConnectionConfig({
+            type: 'mysql',
+            uri
+          })
+        ).toThrow('[PSYNC_S1105] MySQL connection: database required');
+      });
+    });
+
+    test('Should throw error when URI has invalid scheme', () => {
+      expect(() =>
+        normalizeConnectionConfig({
+          type: 'mysql',
+          uri: 'http://user:pass@localhost:3306/powersync_test'
+        })
+      ).toThrow('[PSYNC_S1109] Invalid URI - protocol must be mysql');
+    });
+
+    test('Should throw error when hostname is missing', () => {
+      expect(() =>
+        normalizeConnectionConfig({
+          type: 'mysql',
+          uri: 'mysql://user:pass@/powersync_test'
+        })
+      ).toThrow('[PSYNC_S1106] MySQL connection: hostname required');
+    });
+
+    test('Should throw error when username is missing', () => {
+      expect(() =>
+        normalizeConnectionConfig({
+          type: 'mysql',
+          uri: 'mysql://localhost:3306/powersync_test'
+        })
+      ).toThrow('[PSYNC_S1107] MySQL connection: username required');
+    });
+
+    test('Should throw error when password is missing', () => {
+      expect(() =>
+        normalizeConnectionConfig({
+          type: 'mysql',
+          uri: 'mysql://user@localhost:3306/powersync_test'
+        })
+      ).toThrow('[PSYNC_S1108] MySQL connection: password required');
+    });
+  });
+});

--- a/packages/jpgwire/src/util.ts
+++ b/packages/jpgwire/src/util.ts
@@ -36,6 +36,12 @@ export interface NormalizedConnectionConfig {
 
   client_certificate: string | undefined;
   client_private_key: string | undefined;
+
+  connect_timeout?: number;
+  keepalives?: number;
+  keepalives_idle?: number;
+  keepalives_interval?: number;
+  keepalives_count?: number;
 }
 
 type Mutable<T> = {
@@ -125,6 +131,11 @@ export async function connectPgWire(
   const connectOptions = (connection as any)._connectOptions as ConnectOptions;
   connectOptions.tlsOptions = tlsOptions;
   connectOptions.lookup = config.lookup;
+  connectOptions.connect_timeout = config.connect_timeout;
+  connectOptions.keepalives = config.keepalives;
+  connectOptions.keepalives_idle = config.keepalives_idle;
+  connectOptions.keepalives_interval = config.keepalives_interval;
+  connectOptions.keepalives_count = config.keepalives_count;
 
   // HACK: Replace row decoding with our own implementation
   (connection as any)._recvDataRow = _recvDataRow;
@@ -209,6 +220,11 @@ export function connectPgWirePool(config: PgWireConnectionOptions, options?: PgP
     const connectOptions = (con as any)._connectOptions as ConnectOptions;
     connectOptions.tlsOptions = tlsOptions;
     connectOptions.lookup = config.lookup;
+    connectOptions.connect_timeout = config.connect_timeout;
+    connectOptions.keepalives = config.keepalives;
+    connectOptions.keepalives_idle = config.keepalives_idle;
+    connectOptions.keepalives_interval = config.keepalives_interval;
+    connectOptions.keepalives_count = config.keepalives_count;
 
     // HACK: Replace row decoding with our own implementation
     (con as any)._recvDataRow = _recvDataRow;


### PR DESCRIPTION
# Support Connection URL Parameters for All Database Types

## Summary

This PR adds support for parsing connection parameters from URI query strings for PostgreSQL, MongoDB, and MySQL database connections. Users can now specify connection timeout, pool settings, and other connection-specific parameters directly in the connection URI, making configuration more flexible and consistent with standard database connection string practices.

## Changes

- Added support for parsing connection parameters from URI query strings
- Parameters can be specified either in the URI query string or as explicit config options
- Explicit config values take precedence over URI query parameters
- Added comprehensive test coverage for URI parsing and parameter validation
- Parameters are validated (must be non-negative numbers) and invalid values are ignored

## Supported URL Formats

### PostgreSQL

**URL Format:** `postgresql://[username]:[password]@[hostname]:[port]/[database]?[query_params]`

**Example:**

```
postgresql://user:pass@localhost:5432/mydb?connect_timeout=**300**&keepalives=1&keepalives_idle=60&keepalives_interval=10&keepalives_count=10
```

### MongoDB

**URL Format:** `mongodb://[username]:[password]@[hostname]:[port]/[database]?[query_params]`

**Example:**

```
mongodb://user:pass@host/powersync_test?connectTimeoutMS=10000&socketTimeoutMS=60000&serverSelectionTimeoutMS=30000&maxPoolSize=10&maxIdleTimeMS=120000
```

### MySQL

**URL Format:** `mysql://[username]:[password]@[hostname]:[port]/[database]?[query_params]`

**Example:**

```
mysql://user:pass@host/db?connectTimeout=10000&connectionLimit=20&queueLimit=10&timeout=30000
```

## Supported Parameters

### PostgreSQL

| Parameter             | Type   | Description                                                     | Naming Convention |
| --------------------- | ------ | --------------------------------------------------------------- | ----------------- |
| `connect_timeout`     | number | Connection timeout in seconds                                   | snake_case        |
| `keepalives`          | number | Enable/disable TCP keepalives (0 to disable, 1 to enable)       | snake_case        |
| `keepalives_idle`     | number | Seconds before sending first keepalive                          | snake_case        |
| `keepalives_interval` | number | Seconds between keepalive probes                                | snake_case        |
| `keepalives_count`    | number | Number of keepalive probes before connection is considered dead | snake_case        |

**Note:** `keepalives_interval` and `keepalives_count` are accepted but cannot be directly applied at the Node.js socket level (limitation of the socket API).

### MongoDB

| Parameter                  | Type   | Description                              | Naming Convention |
| -------------------------- | ------ | ---------------------------------------- | ----------------- |
| `connectTimeoutMS`         | number | Connection timeout in milliseconds       | camelCase         |
| `socketTimeoutMS`          | number | Socket timeout in milliseconds           | camelCase         |
| `serverSelectionTimeoutMS` | number | Server selection timeout in milliseconds | camelCase         |
| `maxPoolSize`              | number | Maximum pool size                        | camelCase         |
| `maxIdleTimeMS`            | number | Maximum idle time in milliseconds        | camelCase         |

### MySQL

| Parameter         | Type   | Description                                               | Naming Convention |
| ----------------- | ------ | --------------------------------------------------------- | ----------------- |
| `connectTimeout`  | number | Connection timeout in milliseconds                        | camelCase         |
| `connectionLimit` | number | Maximum number of connections in the pool                 | camelCase         |
| `queueLimit`      | number | Maximum number of connection requests the pool will queue | camelCase         |
| `timeout`         | number | Query timeout in milliseconds                             | camelCase         |

**Note:** The `timeout` parameter is accepted in the config but is not a valid `PoolOptions` property in mysql2. Query timeouts are handled at the query level, not pool level.

## Parameter Naming Conventions

Each database type uses a naming convention that matches its underlying driver/library:

- **PostgreSQL**: Uses `snake_case` (matches libpq conventions)
- **MongoDB**: Uses `camelCase` (matches MongoDB Node.js driver conventions)
- **MySQL**: Uses `camelCase` (matches mysql2 driver conventions)

**Important:** You must use the correct naming convention for each database type. Mixing conventions will not work (e.g., using `connectTimeout` in a PostgreSQL URI will be ignored).

## Usage Examples

### PostgreSQL

```typescript
// Via URI query string
const config = {
  type: 'postgresql',
  uri: 'postgresql://user:pass@host/db?connect_timeout=300&keepalives=1'
};

// Via explicit config (takes precedence)
const config = {
  type: 'postgresql',
  uri: 'postgresql://user:pass@host/db?connect_timeout=300',
  connect_timeout: 600 // This value will be used instead of 300
};
```

### MongoDB

```typescript
// Via URI query string
const config = {
  type: 'mongodb',
  uri: 'mongodb://user:pass@host/db?connectTimeoutMS=10000&maxPoolSize=10'
};

// Via explicit config (takes precedence)
const config = {
  type: 'mongodb',
  uri: 'mongodb://user:pass@host/db?connectTimeoutMS=10000',
  connectTimeoutMS: 20000 // This value will be used instead of 10000
};
```

### MySQL

```typescript
// Via URI query string
const config = {
  type: 'mysql',
  uri: 'mysql://user:pass@host/db?connectTimeout=10000&connectionLimit=20'
};

// Via explicit config (takes precedence)
const config = {
  type: 'mysql',
  uri: 'mysql://user:pass@host/db?connectTimeout=10000',
  connectTimeout: 20000 // This value will be used instead of 10000
};
```

## Validation

- All parameters must be valid non-negative numbers
- Invalid values (NaN, negative numbers, non-numeric strings) are silently ignored
- Parameters can be partially specified (you don't need to provide all parameters)
- Explicit config values always take precedence over URI query parameters

## Testing

Comprehensive test coverage has been added for:

- URI parsing with query parameters
- Parameter precedence (explicit config over URI params)
- Partial parameter specification
- Invalid parameter value handling
- Error cases (missing database, invalid scheme, etc.)
