### PR TITLE
Streams: Support subqueries with multiple parameters

### DIFF
--- a/.changeset/old-buckets-lay.md
+++ b/.changeset/old-buckets-lay.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix compiling streams with multiple parameter matchers in a subquery.

--- a/packages/sync-rules/src/streams/variant.ts
+++ b/packages/sync-rules/src/streams/variant.ts
@@ -214,8 +214,10 @@ export class StreamVariant {
       return [];
     }
 
-    // This will be an array of values (i.e. a total evaluation) because there are no dynamic parameters.
-    return this.partiallyEvaluateParameters(params) as SqliteJsonValue[][];
+    return this.cartesianProductOfParameterInstantiations(
+      // This will be an array of values (i.e. a total evaluation) because there are no dynamic parameters.
+      this.partiallyEvaluateParameters(params) as SqliteJsonValue[][]
+    );
   }
 
   /**


### PR DESCRIPTION
Evaluating streams using subqueries with multiple parameters is currently broken in two ways. To illustrate this, consider this example taken from a [report on Discord](https://discord.com/channels/1138230179878154300/1422138173907144724/1443338137660031117):

```SQL
SELECT *
FROM "Scene"
WHERE
  project IN (
    SELECT project
    FROM "ProjectInvitation"
    WHERE
    AND (auth.parameters() ->> 'haystack_id') IN "appliedTo"
    AND project = subscription.parameter('project')
  )
```

This subquery has two parameter match clauses: the `IN` operator and the direct equals.

The first issue is that we used to compute the `WHERE` clause of the subquery with `SqlTools.compileClause`. That method will merge the `AND` into a single `ParameterMatchClause`, which is valid for bucket definitions but not for streams! Since each parameter is an explicit object with streams, this would cause two parameters to be derived from the same `ParameterMatchClause`, which then causes values for the two parameters to get duplicated:

- __Before__: `evaluateParameterRow(projectInvitation, {project: 'p', appliedTo: '[1,2]'})` yields lookup with keys `[1,p], [1,p], [2, p], [2, p]`.
- __After__: Yields lookup with keys `[1, p], [2, p]`.

The reason we used `compileClause` is that we only support a subset of filter operators for `WHERE` clauses in subqueries, and those happened to align with what `SqlTools.compileClause` would support. So the first part of the fix is to compile subquery predicates with the same logic as we compile the outer query, and then applying a validator to ensure there are no nested subqueries or other unsupported filters.

A second issue is that `StreamVariant.findStaticInstantiations` (used in `Subquery.compileEvaluator`) was missing a transform from "list of values per parameter" to "list of lookups" via the cartesian product. That's only relevant for subqueries with more than one parameter:

- __Before__: Would attempt to lookup `[1], [p]`.
- __After__: Looks up the correct key `[1, p]`.