### PR TITLE
Fix pgwire import warning.

### DIFF
--- a/packages/jpgwire/src/pgwire_node.js
+++ b/packages/jpgwire/src/pgwire_node.js
@@ -1,6 +1,6 @@
 import { pbkdf2 as _pbkdf2 } from 'crypto';
 
-import { _net } from 'pgwire';
+import { _net } from 'pgwire/index.js';
 import { SocketAdapter } from './socket_adapter.js';
 
 Object.assign(_net, {
@@ -28,4 +28,4 @@ Object.assign(_net, {
   }
 });
 
-export * from 'pgwire';
+export * from 'pgwire/index.js';


### PR DESCRIPTION
The pgwire version from #433 gives this deprecation warning whenever the service starts up:

```
(node:899493) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json for /home/ralf/src/powersync-service/packages/jpgwire/node_modules/pgwire/ resolving the main entry point "index.js", imported from /home/ralf/src/powersync-service/packages/jpgwire/dist/pgwire_node.js.
Default "index" lookups for the main are deprecated for ES modules.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

This change appears to remove the warning.