### PR TITLE
jpgwire: Export socket adapter

### DIFF
--- a/.changeset/silly-actors-retire.md
+++ b/.changeset/silly-actors-retire.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-jpgwire': patch
+---
+
+Export SocketAdapter class, the async socket wrapper for pgwire.

--- a/packages/jpgwire/src/index.ts
+++ b/packages/jpgwire/src/index.ts
@@ -3,4 +3,5 @@ export * from './certs.js';
 export * from './util.js';
 export * from './metrics.js';
 export * from './pgwire_types.js';
+export * from './socket_adapter.js';
 export * from './structure_parser.js';


### PR DESCRIPTION
Exporting `SocketAdapter` (which has functioning types because it's written in TypeScript) means that we can use that class for internal services that need to open a Postgres socket connection without sending pgwire messages.

In the medium term, that is hopefully a better alternative than using the internal `_net` property we've stopped exporting.