### PR TITLE
Postgres module: Remove unused dependencies

### DIFF
--- a/.changeset/proud-swans-drum.md
+++ b/.changeset/proud-swans-drum.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-postgres': patch
+---
+
+Remove unused dependencies.

--- a/modules/module-postgres/package.json
+++ b/modules/module-postgres/package.json
@@ -35,11 +35,8 @@
     "@powersync/service-jsonbig": "workspace:*",
     "@powersync/service-sync-rules": "workspace:*",
     "@powersync/service-types": "workspace:*",
-    "jose": "^4.15.1",
-    "pgwire": "github:exe-dealer/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87",
     "semver": "^7.5.4",
     "ts-codec": "^1.3.0",
-    "uri-js": "^4.4.1",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,21 +391,12 @@ importers:
       '@powersync/service-types':
         specifier: workspace:*
         version: link:../../packages/types
-      jose:
-        specifier: ^4.15.1
-        version: 4.15.9
-      pgwire:
-        specifier: github:exe-dealer/pgwire#f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87
-        version: https://codeload.github.com/exe-dealer/pgwire/tar.gz/f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87
       semver:
         specifier: ^7.5.4
         version: 7.6.2
       ts-codec:
         specifier: ^1.3.0
         version: 1.3.0
-      uri-js:
-        specifier: ^4.4.1
-        version: 4.4.1
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -3461,11 +3452,6 @@ packages:
   pgwire@0.8.1:
     resolution: {integrity: sha512-9Q1Mh5eR0IaeTrfZ+vovkj0zyEpxTijEbGizMezwUjo1vSbJnequf7Y+roSQph7POuJ7xOPDqjQJUMM2OQR+zw==}
     engines: {node: '>=18.17.0'}
-
-  pgwire@https://codeload.github.com/exe-dealer/pgwire/tar.gz/f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87:
-    resolution: {tarball: https://codeload.github.com/exe-dealer/pgwire/tar.gz/f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87}
-    version: 0.7.0
-    engines: {node: '>=14.18.0'}
 
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
@@ -7404,8 +7390,6 @@ snapshots:
       nearley: 2.20.1
 
   pgwire@0.8.1: {}
-
-  pgwire@https://codeload.github.com/exe-dealer/pgwire/tar.gz/f1cb95f9a0f42a612bb5a6b67bb2eb793fc5fc87: {}
 
   picocolors@1.0.1: {}
 


### PR DESCRIPTION
`modules/module-postgres` does not directly import `jose`, `pgwire` or `uri-js`. In particular for `pgwire`, it had a dependency that was in conflict with `@powersync/service-jpgwire` (which should be fine because we've never directly imported it, but may confuse tools reading dependencies).

Since the dependencies aren't used, this gets rid of them.