### PR TITLE
Create idx_bucket_data_compact index to optimize Postgres compact query

### DIFF
--- a/modules/module-postgres-storage/src/migrations/scripts/1734384000000-bucket-data-compact-index.ts
+++ b/modules/module-postgres-storage/src/migrations/scripts/1734384000000-bucket-data-compact-index.ts
@@ -1,0 +1,41 @@
+import { migrations } from '@powersync/service-core';
+
+import { openMigrationDB } from '../migration-utils.js';
+
+/**
+ * Migration: Add specialized index for bucket_data compaction query optimization
+ *
+ * This migration creates an index optimized for the compaction query in PostgresCompactor.ts
+ * which uses COLLATE "C" (binary collation) and DESC ordering.
+ * The index enables PostgreSQL to push COLLATE "C" conditions into Index Cond
+ * instead of applying them as filters, significantly reducing rows scanned.
+ */
+export const up: migrations.PowerSyncMigrationFunction = async (context) => {
+  const {
+    service_context: { configuration }
+  } = context;
+  await using client = openMigrationDB(configuration.storage);
+
+  await client.transaction(async (db) => {
+    await db.sql`
+      CREATE INDEX IF NOT EXISTS idx_bucket_data_compact ON bucket_data (
+        group_id,
+        bucket_name COLLATE "C" DESC,
+        op_id DESC
+      )
+    `.execute();
+
+    await db.sql`ANALYZE bucket_data`.execute();
+  });
+};
+
+export const down: migrations.PowerSyncMigrationFunction = async (context) => {
+  const {
+    service_context: { configuration }
+  } = context;
+  await using client = openMigrationDB(configuration.storage);
+
+  await client.transaction(async (db) => {
+    await db.sql`DROP INDEX IF EXISTS idx_bucket_data_compact`.execute();
+  });
+};

--- a/modules/module-postgres-storage/src/storage/PostgresCompactor.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresCompactor.ts
@@ -123,16 +123,16 @@ export class PostgresCompactor {
           bucket_data
         WHERE
           group_id = ${{ type: 'int4', value: this.group_id }}
-          AND bucket_name >= ${{ type: 'varchar', value: bucketLower }}
+          AND bucket_name >= ${{ type: 'varchar', value: bucketLower }} COLLATE "C"
           AND (
             (
-              bucket_name = ${{ type: 'varchar', value: bucketUpper }}
+              bucket_name = ${{ type: 'varchar', value: bucketUpper }} COLLATE "C"
               AND op_id < ${{ type: 'int8', value: upperOpIdLimit }}
             )
             OR bucket_name < ${{ type: 'varchar', value: bucketUpper }} COLLATE "C" -- Use binary comparison
           )
         ORDER BY
-          bucket_name DESC,
+          bucket_name COLLATE "C" DESC,
           op_id DESC
         LIMIT
           ${{ type: 'int4', value: this.moveBatchQueryLimit }}

--- a/modules/module-postgres-storage/test/src/__snapshots__/storage.test.ts.snap
+++ b/modules/module-postgres-storage/test/src/__snapshots__/storage.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Postgres Sync Bucket Storage - Data > empty storage metrics 1`] = `
 {
-  "operations_size_bytes": 16384,
+  "operations_size_bytes": 24576,
   "parameters_size_bytes": 32768,
   "replication_size_bytes": 16384,
 }


### PR DESCRIPTION
### Description

The query is slow due to the COLLATE "C" clause that was introduced in #217 and prevents the usage of indexes. I confirmed this by temporarily removing it locally and running compaction on 1 million random records multiple times. With COLLATE "C" removed, compaction time dropped from 15–20 seconds to under one second. This means that ideally the clause should be replaced/removed from the query. However, that is not possible because it is required to correctly order the results and removing it would produce incorrect ordering and introduce a risk of data corruption. **I can definitely go this route, but it will require a significant amount of time/days to proper test and validate not only the code but specially the migration path, but let me know if you would be interested on waiting more time, or alternatively I can sync with you and talk about it on the high level**.

As a result, I took a different approach by standardizing the encoding of the bucket_name field in the query and adding an index. The reasoning behind this is to avoid that PG keeps converting between different encodings ("C" and the database default). This change resulted in a 30–40% performance improvement, addressing the original concern raised in #400. More details on how this was tested in below section. Having that said I acknowledge that this is not the most optimized solution, that would be the removal of `COLLATE "C"` that I mentioned before. The tradeoff I'm doing here is to give value in a reasonable time with a solution that is less intrusive and doesn't require a significant amount of changes. **Please be aware that I assumed here that the solution should target the query itself, rather than optimizing the entire compaction process. If this turns out to not be true please let me know**.

### Testing

#### Unit/Integration tests

```
cd ./modules/module-postgres-storage && pnpm run test
...
 Test Files  5 passed (5)
      Tests  73 passed (73)
   Start at  17:40:43
   Duration  22.70s (transform 575ms, setup 1.35s, collect 1.06s, tests 20.14s, environment 0ms, prepare 42ms)
```

#### Manual tests

The way I tested this was by first extracting the query from Typescript code and write an isolated test script, the actions this script does are as following:

1. Cleanup/Drops the database to make sure we start from scratch
2. Creates the table used in the query
3. Inserts 1 million records to use for testing
4. Run the query once to warm-up cache
5. Run the query again multiple times and record the timing as baseline
6. Create the index
7. Run the query once after creating the index to warm-up cache
8. Run the query again multiple times and record the timing for comparison with baseline

Manual test script: [test-optimization.sh](https://github.com/user-attachments/files/24195104/test-optimization.sh), please noticed that I don't have the information on the average distribution of operations that customers have in their table, so I for this test I used arbitrary values.

Example of execution:

```
DROP DATABASE
Inserting 1M rows...

=== BASELINE ===
Timing is on.
Time: 4.732 ms
Time: 3.112 ms
Time: 3.204 ms
Time: 2.687 ms
Time: 2.737 ms

Creating index...

=== OPTIMIZED ===
Timing is on.
Time: 4.109 ms
Time: 2.427 ms
Time: 1.577 ms
Time: 1.551 ms
Time: 1.540 ms
```

