### PR TITLE
Avoid illegal source import

### DIFF
--- a/modules/module-mongodb-storage/src/storage/implementation/MongoPersistedSyncRules.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoPersistedSyncRules.ts
@@ -1,7 +1,6 @@
-import { SqlSyncRules, HydratedSyncRules } from '@powersync/service-sync-rules';
+import { SqlSyncRules, HydratedSyncRules, versionedHydrationState } from '@powersync/service-sync-rules';
 
 import { storage } from '@powersync/service-core';
-import { versionedHydrationState } from '@powersync/service-sync-rules/src/HydrationState.js';
 
 export class MongoPersistedSyncRules implements storage.PersistedSyncRules {
   public readonly slot_name: string;

--- a/modules/module-postgres-storage/src/storage/sync-rules/PostgresPersistedSyncRulesContent.ts
+++ b/modules/module-postgres-storage/src/storage/sync-rules/PostgresPersistedSyncRulesContent.ts
@@ -1,10 +1,9 @@
 import * as lib_postgres from '@powersync/lib-service-postgres';
 import { ErrorCode, logger, ServiceError } from '@powersync/lib-services-framework';
 import { storage } from '@powersync/service-core';
-import { SqlSyncRules } from '@powersync/service-sync-rules';
+import { SqlSyncRules, versionedHydrationState } from '@powersync/service-sync-rules';
 
 import { models } from '../../types/types.js';
-import { versionedHydrationState } from '@powersync/service-sync-rules/src/HydrationState.js';
 
 export class PostgresPersistedSyncRulesContent implements storage.PersistedSyncRulesContent {
   public readonly slot_name: string;

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -27,4 +27,5 @@ export * from './types.js';
 export * from './types/custom_sqlite_value.js';
 export * from './types/time.js';
 export * from './utils.js';
+export { versionedHydrationState } from './HydrationState.js';
 export * from './HydratedSyncRules.js';


### PR DESCRIPTION
The storage modules used to import from `@powersync/service-sync-rules/src/HydrationState.js`, which is rejected by recent node versions. Only `index.js` is allowed to be imported unless we export `HydrationState.js` in `package.json`.

This fixes that by exporting the function from `index.js`.