### PR TITLE
feat(test-client): support RS256 and configurable aud/exp in generate…

### DIFF
--- a/test-client/src/auth.ts
+++ b/test-client/src/auth.ts
@@ -7,6 +7,8 @@ export interface CredentialsOptions {
   endpoint?: string;
   config?: string;
   sub?: string;
+  aud?: string[];
+  exp?: string;
 }
 
 export interface Credentials {
@@ -18,48 +20,65 @@ export async function getCredentials(options: CredentialsOptions): Promise<Crede
   if (options.token != null) {
     if (options.endpoint != null) {
       return { token: options.token, endpoint: options.endpoint };
-    } else {
-      const parsed = jose.decodeJwt(options.token);
-      const aud = Array.isArray(parsed.aud) ? parsed.aud[0] : parsed.aud;
-      if (!(aud ?? '').startsWith('http')) {
-        throw new Error(`Specify endpoint, or aud in the token`);
-      }
-      return {
-        token: options.token,
-        endpoint: aud!
-      };
-    }
-  } else if (options.config != null) {
-    const file = await fs.readFile(options.config, 'utf-8');
-    const parsed = await yaml.parse(file);
-    const keys = (parsed.client_auth?.jwks?.keys ?? []).filter((key: any) => key.alg == 'HS256');
-    if (keys.length == 0) {
-      throw new Error('No HS256 key found in the config');
     }
 
-    let endpoint = options.endpoint;
-    if (endpoint == null) {
-      endpoint = `http://127.0.0.1:${parsed.port ?? 8080}`;
+    const parsed = jose.decodeJwt(options.token);
+    const aud = Array.isArray(parsed.aud) ? parsed.aud[0] : parsed.aud;
+    if (!(aud ?? '').startsWith('http')) {
+      throw new Error(`Specify endpoint, or aud in the token`);
     }
 
-    const aud = [parsed.client_auth?.audience?.[0], endpoint].filter((a) => a != null);
+    return { token: options.token, endpoint: aud! };
+  }
 
-    const rawKey = keys[0];
-    const key = await jose.importJWK(rawKey);
-
-    const sub = options.sub ?? 'test_user';
-
-    const token = await new jose.SignJWT({})
-      .setProtectedHeader({ alg: rawKey.alg, kid: rawKey.kid })
-      .setSubject(sub)
-      .setIssuedAt()
-      .setIssuer('test-client')
-      .setAudience(aud)
-      .setExpirationTime('24h')
-      .sign(key);
-
-    return { token, endpoint };
-  } else {
+  if (options.config == null) {
     throw new Error(`Specify token or config path`);
   }
+
+  const file = await fs.readFile(options.config, 'utf-8');
+  const parsed = yaml.parse(file);
+
+  const keys = (parsed.client_auth?.jwks?.keys ?? []).filter(
+    (key: any) => key.alg === 'HS256' || key.alg === 'RS256'
+  );
+
+  if (keys.length === 0) {
+    throw new Error('No HS256 or RS256 key found in the config');
+  }
+
+  const rawKey = keys[0];
+
+  if (rawKey.alg === 'RS256' && rawKey.d == null) {
+    throw new Error('RS256 key must include private key parameter "d"');
+  }
+
+  let endpoint = options.endpoint;
+  if (endpoint == null) {
+    endpoint = `http://127.0.0.1:${parsed.port ?? 8080}`;
+  }
+
+  const aud = [
+    ...(parsed.client_auth?.audience ?? []),
+    ...(options.aud ?? []),
+    endpoint
+  ].filter(Boolean);
+
+  const key = await jose.importJWK(rawKey, rawKey.alg);
+
+  const sub = options.sub ?? 'test_user';
+  const exp = options.exp ?? '24h';
+
+  const token = await new jose.SignJWT({})
+    .setProtectedHeader({
+      alg: rawKey.alg,
+      kid: rawKey.kid
+    })
+    .setSubject(sub)
+    .setIssuedAt()
+    .setIssuer('test-client')
+    .setAudience(aud)
+    .setExpirationTime(exp)
+    .sign(key);
+
+  return { token, endpoint };
 }

--- a/test-client/src/bin.ts
+++ b/test-client/src/bin.ts
@@ -19,13 +19,15 @@ program
 
 program
   .command('generate-token')
-  .description('Generate a JWT from for a given powersync.yaml config file')
+  .description('Generate a JWT from a given powersync.yaml config file')
   .option('-c, --config [config]', 'path to powersync.yaml')
   .option('-u, --sub [sub]', 'payload sub')
-  .option('-e, --endpoint [endpoint]', 'additional payload aud')
+  .option('-e, --endpoint [endpoint]', 'additional payload aud (legacy)')
+  .option('--aud <audience...>', 'JWT audience (repeatable)')
+  .option('--exp <duration>', 'JWT expiration time (e.g. 15m, 1h, 24h)')
   .action(async (options) => {
     const credentials = await getCredentials(options);
-    const decoded = await jose.decodeJwt(credentials.token);
+    const decoded = jose.decodeJwt(credentials.token);
 
     console.error(`Payload:\n${JSON.stringify(decoded, null, 2)}\nToken:`);
     console.log(credentials.token);


### PR DESCRIPTION
## Summary

This PR adds RS256 support to the `generate-token` command and improves
JWT generation ergonomics by allowing configurable audience and expiration.

## Changes

- Support RS256 signing keys alongside HS256
- Validate private RSA keys before attempting to sign
- Pass algorithm explicitly to `jose.importJWK`
- Add `--aud` (repeatable) and `--exp` CLI options
- Keep existing behavior fully backward-compatible

## Motivation

The documentation suggests RS256 is supported, but the test-client was
previously hard-coded to HS256. This change aligns implementation with
documentation and enables realistic authentication testing.

## Testing

- Generated tokens using HS256 and RS256 keys
- Verified RS256 tokens against public JWKS configuration
- Confirmed existing HS256 workflows remain unchanged