### PR TITLE
Sync streams: Infer output schema

### DIFF
--- a/packages/sync-rules/src/ExpressionType.ts
+++ b/packages/sync-rules/src/ExpressionType.ts
@@ -8,10 +8,13 @@ export type SqliteType = 'null' | 'blob' | 'text' | 'integer' | 'real' | 'numeri
 
 export type SqliteValueType = 'null' | 'blob' | 'text' | 'integer' | 'real';
 
-export interface ColumnDefinition {
-  name: string;
+export interface ColumnType {
   type: ExpressionType;
   originalType?: string;
+}
+
+export interface ColumnDefinition extends ColumnType {
+  name: string;
 }
 
 export class ExpressionType {

--- a/packages/sync-rules/src/compiler/filter.ts
+++ b/packages/sync-rules/src/compiler/filter.ts
@@ -105,7 +105,7 @@ export class RowExpression extends SingleDependencyExpression {
 
   constructor(expression: SyncExpression | SingleDependencyExpression) {
     super(expression);
-    if (this.resultSet == null) {
+    if (this.dependsOnConnection) {
       throw new InvalidExpressionError('Does not depend on a single result set');
     }
   }

--- a/packages/sync-rules/src/schema-generators/SchemaGenerator.ts
+++ b/packages/sync-rules/src/schema-generators/SchemaGenerator.ts
@@ -34,15 +34,23 @@ export abstract class SchemaGenerator {
    * @returns The SDK column type for the given column definition.
    */
   columnType(def: ColumnDefinition): 'text' | 'real' | 'integer' {
-    const { type } = def;
-    if (type.typeFlags & TYPE_TEXT) {
-      return 'text';
-    } else if (type.typeFlags & TYPE_REAL) {
-      return 'real';
-    } else if (type.typeFlags & TYPE_INTEGER) {
-      return 'integer';
-    } else {
-      return 'text';
-    }
+    return sqlTypeName(def);
+  }
+}
+
+/**
+ * @param def The column definition to generate the type for.
+ * @returns The default SQL column type name for that type.
+ */
+export function sqlTypeName(def: ColumnDefinition): 'text' | 'real' | 'integer' {
+  const { type } = def;
+  if (type.typeFlags & TYPE_TEXT) {
+    return 'text';
+  } else if (type.typeFlags & TYPE_REAL) {
+    return 'real';
+  } else if (type.typeFlags & TYPE_INTEGER) {
+    return 'integer';
+  } else {
+    return 'text';
   }
 }

--- a/packages/sync-rules/src/sync_plan/evaluator/bucket_data_source.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/bucket_data_source.ts
@@ -19,6 +19,7 @@ import {
   ScalarExpressionEvaluator,
   scalarStatementToSql
 } from '../engine/scalar_expression_engine.js';
+import { SyncPlanSchemaAnalyzer } from '../schema_inference.js';
 
 export class PreparedStreamBucketDataSource implements BucketDataSource {
   private readonly sourceTables = new Set<TablePattern>();
@@ -74,7 +75,10 @@ export class PreparedStreamBucketDataSource implements BucketDataSource {
   }
 
   resolveResultSets(schema: SourceSchema, tables: Record<string, Record<string, ColumnDefinition>>): void {
-    throw new Error('resolveResultSets not implemented.');
+    const analyzer = new SyncPlanSchemaAnalyzer(schema);
+    for (const source of this.source.sources) {
+      analyzer.resolveResultSets(source, tables);
+    }
   }
 
   debugWriteOutputTables(result: Record<string, { query: string }[]>): void {

--- a/packages/sync-rules/src/sync_plan/expression_visitor.ts
+++ b/packages/sync-rules/src/sync_plan/expression_visitor.ts
@@ -94,7 +94,18 @@ export abstract class RecursiveExpressionVisitor<Data, R, Arg = undefined> imple
         }
         break;
       case 'case_when':
-        return this.visitCaseWhenExpression(expr, arg);
+        if (expr.operand) {
+          this.visit(expr.operand, arg);
+        }
+
+        for (const { when, then } of expr.whens) {
+          this.visit(when, arg);
+          this.visit(then, arg);
+        }
+        if (expr.else) {
+          this.visit(expr.else, arg);
+        }
+        break;
       case 'cast':
         this.visit(expr.operand, arg);
         break;

--- a/packages/sync-rules/src/sync_plan/schema_inference.ts
+++ b/packages/sync-rules/src/sync_plan/schema_inference.ts
@@ -1,0 +1,146 @@
+import { CompatibilityContext } from '../compatibility.js';
+import { ColumnDefinition, ColumnType, ExpressionType } from '../ExpressionType.js';
+import { generateSqlFunctions, getOperatorReturnType } from '../sql_functions.js';
+import { SourceSchema, SourceSchemaTable } from '../types.js';
+import {
+  ExternalData,
+  UnaryExpression,
+  BinaryExpression,
+  CaseWhenExpression,
+  CastExpression,
+  ScalarFunctionCallExpression,
+  LiteralExpression
+} from './expression.js';
+import { ExpressionVisitor, visitExpr } from './expression_visitor.js';
+import { ColumnSqlParameterValue, StreamDataSource } from './plan.js';
+
+/**
+ * Infers the output schema of sync streams by resolving references against a statically-known source schema.
+ */
+export class SyncPlanSchemaAnalyzer {
+  constructor(private readonly schema: SourceSchema) {}
+
+  /**
+   * Populates an output record of tables with the inferred result sets for a stream data source against a source
+   * schema.
+   */
+  resolveResultSets(source: StreamDataSource, tables: Record<string, Record<string, ColumnDefinition>>) {
+    for (const table of this.schema.getTables(source.sourceTable)) {
+      const typeResolver = new ExpressionTypeInference(table);
+      const outputName = source.outputTableName ?? table.name;
+      const outputTable = (tables[outputName] ??= {});
+
+      function addOutputColumn(definition: ColumnDefinition) {
+        if (definition.name == 'id') {
+          return; // Is implicit
+        }
+
+        const existing = outputTable[definition.name];
+        if (existing != null) {
+          outputTable[definition.name] = {
+            name: definition.name,
+            type: existing.type.or(definition.type),
+            originalType: definition.originalType == existing.originalType ? existing.originalType : undefined
+          };
+        } else {
+          outputTable[definition.name] = definition;
+        }
+      }
+
+      for (const column of source.columns) {
+        if (column === 'star') {
+          for (const actualColumn of table.getColumns()) {
+            addOutputColumn(actualColumn);
+          }
+        } else {
+          const type = visitExpr(typeResolver, column.expr, null);
+          addOutputColumn({ name: column.alias, ...type });
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Infers the type of expressions, resolving column references against a fixed schema table.
+ */
+class ExpressionTypeInference implements ExpressionVisitor<ColumnSqlParameterValue, ColumnType> {
+  constructor(private readonly sourceTable: SourceSchemaTable) {}
+
+  visitExternalData(expr: ExternalData<ColumnSqlParameterValue>): ColumnType {
+    const column = this.sourceTable.getColumn(expr.source.column);
+    if (column) {
+      return { type: column.type, originalType: column.originalType };
+    }
+
+    return { type: ExpressionType.NONE };
+  }
+
+  visitUnaryExpression(expr: UnaryExpression<ColumnSqlParameterValue>): ColumnType {
+    switch (expr.operator) {
+      case 'not':
+        return ExpressionTypeInference.BOOLEAN;
+      case '+':
+        return visitExpr(this, expr.operand, null);
+    }
+  }
+
+  visitBinaryExpression(expr: BinaryExpression<ColumnSqlParameterValue>): ColumnType {
+    return {
+      type: getOperatorReturnType(
+        expr.operator.toUpperCase(),
+        visitExpr(this, expr.left, null).type,
+        visitExpr(this, expr.right, null).type
+      )
+    };
+  }
+
+  visitBetweenExpression(): ColumnType {
+    return ExpressionTypeInference.BOOLEAN;
+  }
+
+  visitScalarInExpression(): ColumnType {
+    return ExpressionTypeInference.BOOLEAN;
+  }
+
+  visitCaseWhenExpression(expr: CaseWhenExpression<ColumnSqlParameterValue>): ColumnType {
+    let type = ExpressionType.NONE;
+    // Create a union of all THEN expressions (and ELSE, if present).
+    for (const { then } of expr.whens) {
+      type = type.or(visitExpr(this, then, null).type);
+    }
+    if (expr.else) {
+      type = type.or(visitExpr(this, expr.else, null).type);
+    }
+
+    return { type };
+  }
+
+  visitCastExpression(expr: CastExpression<ColumnSqlParameterValue>): ColumnType {
+    return { type: ExpressionType.fromTypeText(expr.cast_as) };
+  }
+
+  visitScalarFunctionCallExpression(expr: ScalarFunctionCallExpression<ColumnSqlParameterValue>): ColumnType {
+    const resolved = ExpressionTypeInference.functions.named[expr.function.toLowerCase()];
+    const args = expr.parameters.map((p) => visitExpr(this, p, null).type);
+
+    return { type: resolved.getReturnType(args) };
+  }
+
+  visitLiteralExpression(expr: LiteralExpression): ColumnType {
+    switch (expr.type) {
+      case 'lit_null':
+        return { type: ExpressionType.NONE };
+      case 'lit_double':
+        return { type: ExpressionType.REAL };
+      case 'lit_int':
+        return { type: ExpressionType.INTEGER };
+      case 'lit_string':
+        return { type: ExpressionType.TEXT };
+    }
+  }
+
+  // We don't care about compatibility as these functions are only used to infer types.
+  private static readonly functions = generateSqlFunctions(CompatibilityContext.FULL_BACKWARDS_COMPATIBILITY);
+  private static readonly BOOLEAN: ColumnType = { type: ExpressionType.INTEGER, originalType: 'bool' };
+}

--- a/packages/sync-rules/test/src/sync_plan/evaluator/output_schema.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/output_schema.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'vitest';
+import {
+  addPrecompiledSyncPlanToRules,
+  ColumnDefinition,
+  sqlTypeName,
+  CompatibilityContext,
+  DEFAULT_TAG,
+  javaScriptExpressionEngine,
+  SourceTableDefinition,
+  SqlSyncRules,
+  StaticSchema,
+  TablePattern
+} from '../../../../src/index.js';
+import { compileToSyncPlanWithoutErrors } from '../../compiler/utils.js';
+
+describe('schema inference', () => {
+  const assetsTable: SourceTableDefinition = {
+    name: 'assets',
+    columns: [
+      { name: 'id', sqlite_type: 'text', internal_type: 'uuid' },
+      { name: 'name', sqlite_type: 'text', internal_type: 'text' },
+      { name: 'count', sqlite_type: 'integer', internal_type: 'int4' },
+      { name: 'owner_id', sqlite_type: 'text', internal_type: 'uuid' }
+    ]
+  };
+  const schema = new StaticSchema([
+    {
+      tag: DEFAULT_TAG,
+      schemas: [
+        {
+          name: 'test_schema',
+          tables: [assetsTable]
+        }
+      ]
+    }
+  ]);
+
+  function generateSchema(...queries: string[]) {
+    const plan = compileToSyncPlanWithoutErrors([{ name: 'stream', queries }]);
+    const rules = new SqlSyncRules('');
+
+    addPrecompiledSyncPlanToRules(plan, rules, {
+      // Engine isn't actually used here, but required to load sync plan
+      engine: javaScriptExpressionEngine(CompatibilityContext.FULL_BACKWARDS_COMPATIBILITY)
+    });
+
+    const outputSchema: Record<string, Record<string, ColumnDefinition>> = {};
+    for (const source of rules.bucketDataSources) {
+      source.resolveResultSets(schema, outputSchema);
+    }
+
+    return outputSchema;
+  }
+
+  function typesOnly(source: Record<string, ColumnDefinition>): Record<string, string> {
+    return Object.fromEntries(Object.entries(source).map(([k, v]) => [k, sqlTypeName(v)]));
+  }
+
+  test('table', () => {
+    const resolvedSchema = generateSchema('SELECT * FROM assets');
+    expect(Object.keys(resolvedSchema)).toStrictEqual(['assets']);
+
+    const expectedAssets: Record<string, ColumnDefinition> = {};
+    for (const column of schema.getTables(new TablePattern('test_schema', 'assets'))[0].getColumns()) {
+      if (column.name != 'id') expectedAssets[column.name] = column;
+    }
+    expect(resolvedSchema['assets']).toStrictEqual(expectedAssets);
+  });
+
+  test('table alias', () => {
+    const resolvedSchema = generateSchema(`SELECT * FROM assets public_assets`);
+    expect(Object.keys(resolvedSchema)).toStrictEqual(['public_assets']);
+  });
+
+  test('table pattern', () => {
+    let resolvedSchema = generateSchema(`SELECT * FROM "%"`);
+    expect(Object.keys(resolvedSchema)).toStrictEqual(['assets']);
+
+    resolvedSchema = generateSchema(`SELECT * FROM "%" AS fixed`);
+    expect(Object.keys(resolvedSchema)).toStrictEqual(['fixed']);
+  });
+
+  test('literal', () => {
+    const resolvedSchema = generateSchema(`SELECT id, 1 AS i, 2.5 AS d, null AS n, 'text' AS t FROM assets`).assets;
+    expect(typesOnly(resolvedSchema)).toStrictEqual({
+      i: 'integer',
+      d: 'real',
+      n: 'text', // default type for null
+      t: 'text'
+    });
+  });
+
+  test('cast', () => {
+    const resolvedSchema = generateSchema(`SELECT id, CAST(assets.count AS TEXT) c FROM assets`).assets;
+    expect(typesOnly(resolvedSchema)).toStrictEqual({
+      c: 'text'
+    });
+  });
+
+  test('unary', () => {
+    const resolvedSchema = generateSchema(`SELECT id, NOT name AS name, +count AS count FROM assets`).assets;
+    expect(typesOnly(resolvedSchema)).toStrictEqual({
+      name: 'integer',
+      count: 'integer'
+    });
+  });
+
+  test('binary', () => {
+    const resolvedSchema = generateSchema(`SELECT id, count * 2 AS c FROM assets`).assets;
+    expect(typesOnly(resolvedSchema)).toStrictEqual({
+      c: 'integer'
+    });
+  });
+
+  test('case when', () => {
+    const resolvedSchema = generateSchema(`SELECT id, CASE WHEN TRUE THEN 1 ELSE 2.5 END AS c FROM assets`).assets;
+    expect(typesOnly(resolvedSchema)).toStrictEqual({
+      c: 'real'
+    });
+  });
+
+  test('functions', () => {
+    const resolvedSchema = generateSchema(`SELECT id, hex(null) h FROM assets`).assets;
+    expect(typesOnly(resolvedSchema)).toStrictEqual({
+      h: 'text'
+    });
+  });
+});


### PR DESCRIPTION
This implements `resolveResultSets()` for the bucket data sources implemented by sync streams.

The actual logic is simple, a visitor traverses expressions to recursively infer output types. Column referencs in the AST are resolved against a known table, all other expressions can be inferred based on their syntax alone.