### PR TITLE
Sync streams: Implement `debugWriteOutputTables`

### DIFF
--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -37,6 +37,22 @@ describe('evaluating rows', () => {
     ]);
   });
 
+  syncTest('debugWriteOutputTables', ({ sync }) => {
+    const desc = sync.prepareWithoutHydration([
+      {
+        name: 'stream',
+        queries: ['SELECT * FROM users', 'SELECT * FROM notes WHERE owner = auth.user_id() AND length(content) > 10']
+      }
+    ]);
+
+    // This output is arguably not particularly helpful, but it's only used for debugging purposes and it provides some
+    // insights into how the stream has been turned into a scalar query.
+    expect(desc.debugGetOutputTables()).toStrictEqual({
+      users: [{ query: 'SELECT 1' }],
+      notes: [{ query: 'SELECT ?1 WHERE "length"(?2) > 10' }]
+    });
+  });
+
   syncTest('forwards parameters', ({ sync }) => {
     const desc = sync.prepareSyncStreams([
       { name: 'stream', queries: ["SELECT * FROM users WHERE value = subscription.parameter('p')"] }

--- a/packages/sync-rules/test/src/sync_plan/evaluator/utils.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/utils.ts
@@ -13,6 +13,7 @@ import { ScalarExpressionEngine } from '../../../../src/sync_plan/engine/scalar_
 
 interface SyncTest {
   engine: ScalarExpressionEngine;
+  prepareWithoutHydration(inputs: SyncStreamInput[]): SqlSyncRules;
   prepareSyncStreams(inputs: SyncStreamInput[]): HydratedSyncRules;
 }
 
@@ -22,12 +23,15 @@ export const syncTest = test.extend<{ sync: SyncTest }>({
 
     await use({
       engine,
-      prepareSyncStreams: (inputs) => {
+      prepareWithoutHydration: (inputs) => {
         const plan = compileToSyncPlanWithoutErrors(inputs);
         const rules = new SqlSyncRules('');
 
         addPrecompiledSyncPlanToRules(plan, rules, { engine });
-        return rules.hydrate({ hydrationState: versionedHydrationState(1) });
+        return rules;
+      },
+      prepareSyncStreams(inputs) {
+        return this.prepareWithoutHydration(inputs).hydrate({ hydrationState: versionedHydrationState(1) });
       }
     });
 


### PR DESCRIPTION
This implements `debugWriteOutputTables` instead of throwing.

For debugging, the output indicates what SQL query would be run for source rows being processed by the stream. This doesn't look anything like the underlying SQL query from the definition of the stream, but we don't have that available in the compiled plan and this still has some use for debugging.