### PR TITLE
Sync streams: Warn for invalid schema references

### DIFF
--- a/packages/sync-rules/src/compiler/compiler.ts
+++ b/packages/sync-rules/src/compiler/compiler.ts
@@ -9,6 +9,19 @@ import { StreamQueryParser } from './parser.js';
 import { NodeLocations } from './expression.js';
 import { SqlScope } from './scope.js';
 import { PreparedSubquery } from './sqlite.js';
+import { SourceSchema } from '../types.js';
+
+export interface SyncStreamsCompilerOptions {
+  defaultSchema: string;
+
+  /**
+   * An optional schema, used exclusively for linting table and column references that can't be resolved in it.
+   *
+   * Sync streams compile to the same plan regardless of the assumed schema, and it's possible to reuse compiled sync
+   * streams across schema changes.
+   */
+  schema?: SourceSchema;
+}
 
 /**
  * State for compiling sync streams.
@@ -27,7 +40,7 @@ export class SyncStreamsCompiler {
   readonly output = new CompiledStreamQueries();
   private readonly locations = new NodeLocations();
 
-  constructor(readonly defaultSchema: string) {}
+  constructor(readonly options: SyncStreamsCompilerOptions) {}
 
   /**
    * Tries to parse the SQL query as a `SELECT` statement into a form supported for common table expressions.
@@ -118,7 +131,7 @@ export interface IndividualSyncStreamCompiler {
  * binds errors to one specific SQL string.
  */
 export interface ParsingErrorListener {
-  report(message: string, location: NodeLocation | PGNode): void;
+  report(message: string, location: NodeLocation | PGNode, options?: { isWarning: boolean }): void;
 }
 
 /**

--- a/packages/sync-rules/src/compiler/table.ts
+++ b/packages/sync-rules/src/compiler/table.ts
@@ -3,6 +3,7 @@ import { RequestExpression } from './filter.js';
 import { StableHasher } from './equality.js';
 import { equalsIgnoringResultSetList } from './compatibility.js';
 import { TablePattern } from '../TablePattern.js';
+import { SourceSchemaTable } from '../index.js';
 
 /**
  * A result set that a query stream selects from.
@@ -41,7 +42,15 @@ export abstract class BaseSourceResultSet {
 export class PhysicalSourceResultSet extends BaseSourceResultSet {
   constructor(
     readonly tablePattern: TablePattern,
-    source: SyntacticResultSetSource
+    source: SyntacticResultSetSource,
+    /**
+     * Source tables that the {@link tablePattern} resolves to in the static schema context used when compiling sync
+     * streams.
+     *
+     * This information must only be used to generate analysis warnings, e.g. for column references that don't exist in
+     * resolved tables. It must not affect how sync streams are compiled, as that is always schema-independent.
+     */
+    readonly schemaTablesForWarnings: SourceSchemaTable[]
   ) {
     super(source);
   }


### PR DESCRIPTION
This allows passing a schema when compiling sync streams, and emits warnings when unknown tables or columns are referenced in their definition.

One thing worth noting is that these warnings can only be computed during the compilation process, the emitted sync plan doesn't have source offsets that could be used to generate them. So in the future, if we store sync plans in bucket storage instead of re-compiling on service startup, we can't surface warnings if the schema changed after sync streams have been deployed. However, we could probably still compile sync streams (and throw the compilation results away if they have already been deployed) just to emit warnings.
