### PR TITLE
Fix type errors on main

### DIFF
--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -1,6 +1,5 @@
 import { BucketParameterQuerier, QuerierError } from './BucketParameterQuerier.js';
 import { SyncRulesErrors, YamlError } from './errors.js';
-import { TablePattern } from './TablePattern.js';
 import { RequestParameters, SourceSchema, SqliteJsonRow } from './types.js';
 import { SyncConfig, SyncConfigWithErrors } from './SyncConfig.js';
 import { SyncConfigFromYaml } from './from_yaml.js';

--- a/packages/sync-rules/src/from_yaml.ts
+++ b/packages/sync-rules/src/from_yaml.ts
@@ -223,6 +223,7 @@ export class SyncConfigFromYaml {
     }
 
     return new PrecompiledSyncConfig(compiler.output.toSyncPlan(), {
+      defaultSchema: this.options.defaultSchema,
       engine: javaScriptExpressionEngine(compatibility),
       sourceText: this.yaml
     });

--- a/packages/sync-rules/test/src/compiler/utils.ts
+++ b/packages/sync-rules/test/src/compiler/utils.ts
@@ -7,8 +7,8 @@ import {
   serializeSyncPlan,
   SqlSyncRules,
   SyncPlan,
-  SyncStreamsCompiler,
-  SyncStreamsCompilerOptions
+  SyncRulesOptions,
+  SyncStreamsCompiler
 } from '../../../src/index.js';
 
 interface TranslationError {
@@ -71,7 +71,7 @@ function compileSingleStream(...sql: string[]): [TranslationError[], SyncPlan] {
 
 export function yamlToSyncPlan(
   source: string,
-  options: SyncStreamsCompilerOptions = { defaultSchema: 'test_schema' }
+  options: SyncRulesOptions = { defaultSchema: 'test_schema' }
 ): [TranslationError[], SyncPlan] {
   const { config, errors } = SqlSyncRules.fromYaml(source, {
     throwOnError: false,


### PR DESCRIPTION
While #493 and #497 merged without git detecting a conflict, they changed types in a way that made them incompatible. This fixes the resulting type errors on `main`