### PR TITLE
Disable new sync compiler outside of tests

### DIFF
--- a/packages/sync-rules/src/SqlSyncRules.ts
+++ b/packages/sync-rules/src/SqlSyncRules.ts
@@ -14,6 +14,14 @@ export interface SyncRulesOptions {
   defaultSchema: string;
 
   throwOnError?: boolean;
+
+  /**
+   * Whether to allow the option of using the new sync compiler.
+   *
+   * This is currently disabled outside of tests because the format of sync plans is still unstable and we can't support
+   * deployments based on it yet. Once we have a stable sync plan, this option can be removed.
+   */
+  allowNewSyncCompiler?: boolean;
 }
 
 export interface RequestedStream {
@@ -75,6 +83,7 @@ export class SqlSyncRules extends SyncConfig {
     const parser = new SyncConfigFromYaml(
       {
         throwOnError: options.throwOnError ?? true,
+        allowNewSyncCompiler: options.allowNewSyncCompiler ?? false,
         schema: options.schema,
         defaultSchema: options.defaultSchema
       },

--- a/packages/sync-rules/src/from_yaml.ts
+++ b/packages/sync-rules/src/from_yaml.ts
@@ -82,7 +82,7 @@ export class SyncConfigFromYaml {
     const streamMap = parsed.get('streams') as YAMLMap | null;
 
     let result: SyncConfig;
-    if (useNewCompiler) {
+    if (useNewCompiler && this.options.allowNewSyncCompiler) {
       result = this.#compileSyncPlan(bucketMap, streamMap, compatibility);
     } else {
       result = this.#legacyParseBucketDefinitionsAndStreams(bucketMap, streamMap, compatibility);
@@ -507,4 +507,9 @@ export interface SyncConfigFromYamlOptions {
    * 'public' for Postgres, default database for MongoDB/MySQL.
    */
   readonly defaultSchema: string;
+
+  /**
+   * Whether to allow the option of using the new sync compiler.
+   */
+  readonly allowNewSyncCompiler: boolean;
 }

--- a/packages/sync-rules/test/src/compiler/utils.ts
+++ b/packages/sync-rules/test/src/compiler/utils.ts
@@ -75,6 +75,7 @@ export function yamlToSyncPlan(
 ): [TranslationError[], SyncPlan] {
   const { config, errors } = SqlSyncRules.fromYaml(source, {
     throwOnError: false,
+    allowNewSyncCompiler: true,
     ...options
   });
 


### PR DESCRIPTION
https://github.com/powersync-ja/powersync-service/pull/497 introduced an option to use the new compiler when parsing sync definitions, with the intentention that the rest of the new compiler architecture would also be ready with the next release.

Since we're about to do a patch release, that isn't the case and we can't have users enabling `sync_config_compiler: true` just yet. While things would probably work, we really want to store serialized sync plans in bucket storage to avoid having to support _this specific version of the compiler_ forever. So, this adds a flag to ignore the option outside of tests.