### PR TITLE
Fix MongoDB test container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         run: docker pull mongo:8.0
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.12.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: '8.0'
           mongodb-replica-set: test-rs
@@ -137,7 +137,7 @@ jobs:
         run: docker pull mongo:8.0
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.12.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: '8.0'
           mongodb-replica-set: test-rs
@@ -202,7 +202,7 @@ jobs:
         run: docker pull mongo:8.0
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.12.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: '8.0'
           mongodb-replica-set: test-rs
@@ -263,7 +263,7 @@ jobs:
         run: docker pull mongo:${{ matrix.mongodb-version }}
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.12.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
           mongodb-replica-set: test-rs
@@ -359,7 +359,7 @@ jobs:
         run: docker pull mongo:8.0
 
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.12.0
+        uses: supercharge/mongodb-github-action@1.12.1
         with:
           mongodb-version: '8.0'
           mongodb-replica-set: test-rs


### PR DESCRIPTION
Fixes this new issue on GitHub Actions:

```
docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```

See: https://github.com/supercharge/mongodb-github-action/pull/73
