### PR TITLE
Update test tsconfigs

### DIFF
--- a/libs/lib-mongodb/test/tsconfig.json
+++ b/libs/lib-mongodb/test/tsconfig.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "paths": {}
+    "paths": {},
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/libs/lib-postgres/test/tsconfig.json
+++ b/libs/lib-postgres/test/tsconfig.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "paths": {}
+    "paths": {},
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/libs/lib-services/test/tsconfig.json
+++ b/libs/lib-services/test/tsconfig.json
@@ -1,11 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/modules/module-core/test/tsconfig.json
+++ b/modules/module-core/test/tsconfig.json
@@ -1,17 +1,13 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "paths": {
       "@/*": ["../../../packages/service-core/src/*"],
       "@module/*": ["../src/*"],
       "@core-tests/*": ["../../../packages/service-core/test/src/*"]
-    }
+    },
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/modules/module-mongodb-storage/test/tsconfig.json
+++ b/modules/module-mongodb-storage/test/tsconfig.json
@@ -1,17 +1,13 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "paths": {
       "@/*": ["../../../packages/service-core/src/*"],
       "@module/*": ["../src/*"],
       "@core-tests/*": ["../../../packages/service-core/test/src/*"]
-    }
+    },
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/modules/module-mongodb/test/tsconfig.json
+++ b/modules/module-mongodb/test/tsconfig.json
@@ -1,17 +1,13 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "paths": {
       "@/*": ["../../../packages/service-core/src/*"],
       "@module/*": ["../src/*"],
       "@core-tests/*": ["../../../packages/service-core/test/src/*"]
-    }
+    },
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/modules/module-mssql/test/tsconfig.json
+++ b/modules/module-mssql/test/tsconfig.json
@@ -1,17 +1,13 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "paths": {
       "@/*": ["../../../packages/service-core/src/*"],
       "@module/*": ["../src/*"],
       "@core-tests/*": ["../../../packages/service-core/test/src/*"]
-    }
+    },
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/modules/module-mysql/test/tsconfig.json
+++ b/modules/module-mysql/test/tsconfig.json
@@ -1,17 +1,13 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "paths": {
       "@/*": ["../../../packages/service-core/src/*"],
       "@module/*": ["../src/*"],
       "@core-tests/*": ["../../../packages/service-core/test/src/*"]
-    }
+    },
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/modules/module-postgres-storage/test/tsconfig.json
+++ b/modules/module-postgres-storage/test/tsconfig.json
@@ -1,15 +1,11 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
     "declarationDir": "dist/@types",
     "tsBuildInfoFile": "dist/.tsbuildinfo",
     "lib": ["ES2022", "esnext.disposable"],
-    "skipLibCheck": true,
-    "sourceMap": true
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/modules/module-postgres/test/tsconfig.json
+++ b/modules/module-postgres/test/tsconfig.json
@@ -1,17 +1,13 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "paths": {
       "@/*": ["../../../packages/service-core/src/*"],
       "@module/*": ["../src/*"],
       "@core-tests/*": ["../../../packages/service-core/test/src/*"]
-    }
+    },
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/packages/jpgwire/test/tsconfig.json
+++ b/packages/jpgwire/test/tsconfig.json
@@ -1,12 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "noEmit": true,
     "baseUrl": "./",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/packages/rsocket-router/test/tsconfig.json
+++ b/packages/rsocket-router/test/tsconfig.json
@@ -1,11 +1,7 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/packages/service-core/test/tsconfig.json
+++ b/packages/service-core/test/tsconfig.json
@@ -1,15 +1,12 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
     "outDir": "dist",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "paths": {
       "@/*": ["../src/*"]
-    }
+    },
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/packages/service-errors/test/tsconfig.json
+++ b/packages/service-errors/test/tsconfig.json
@@ -1,15 +1,12 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
     "baseUrl": "./",
     "outDir": "dist",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
     "paths": {
       "@/*": ["../src/*"]
-    }
+    },
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/packages/sync-rules/test/tsconfig.json
+++ b/packages/sync-rules/test/tsconfig.json
@@ -1,12 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "noEmit": true,
     "baseUrl": "./",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "sourceMap": true
+    "rootDir": "src"
   },
   "include": ["src"],
   "references": [

--- a/test-client/tsconfig.json
+++ b/test-client/tsconfig.json
@@ -1,12 +1,21 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ES2023", "DOM"],
+    "lib": [
+      "ES2023",
+      "DOM"
+    ],
     "rootDir": "src",
     "outDir": "dist",
     "esModuleInterop": true,
     "sourceMap": true
   },
-  "include": ["src"],
-  "references": [{ "path": "../packages/service-core" }]
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../packages/service-core"
+    }
+  ]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
Some test tsconfigs did not include `noEmit: true`. When combined with #460, this mean that those would often run twice: Once from source, and one from the built version. This often causes weird errors and/or extra test overhead during development.

This moves the test tsconfig to a shared `tsconfig.tests.json`, ensuring we have `noEmit: true` for them all.