### PR TITLE
Restructure linting checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   format-check:
-    name: Format Check
+    name: Linting
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
@@ -26,6 +26,9 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install
+
+      - name: Validate tsconfig references
+        run: pnpm validate:tsconfig-references
 
       - name: Check formatting
         run: pnpm format:check
@@ -95,9 +98,6 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install
-
-      - name: Validate tsconfig references
-        run: pnpm validate:tsconfig-references
 
       - name: Build
         shell: bash


### PR DESCRIPTION
Very minor change: Restructure GHA to run validations together with format checks.

It fits there better than with tests, and this change prevents it from blocking other tests.