### PR TITLE
Sync config validator: Report source offsets for errors

### DIFF
--- a/.changeset/chilly-horses-deny.md
+++ b/.changeset/chilly-horses-deny.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': minor
+'@powersync/service-types': minor
+---
+
+For errors related to a sync configuration, report a source offset.

--- a/packages/service-core/src/api/diagnostics.ts
+++ b/packages/service-core/src/api/diagnostics.ts
@@ -132,12 +132,20 @@ export async function getSyncRulesStatus(
     });
   }
   errors.push(
-    ...syncRuleErrors.map((e) => {
-      return {
-        level: e.type,
-        message: e.message,
+    ...syncRuleErrors.map(({ type, message, location }) => {
+      const error: ReplicationError = {
+        level: type,
+        message,
         ts: now
       };
+      if (location != null) {
+        error.location = {
+          start_offset: location.start,
+          end_offset: location.end
+        };
+      }
+
+      return error;
     })
   );
 

--- a/packages/service-core/test/src/routes/admin.test.ts
+++ b/packages/service-core/test/src/routes/admin.test.ts
@@ -1,0 +1,48 @@
+import { BasicRouterRequest, Context, JwtPayload } from '@/index.js';
+import { logger } from '@powersync/lib-services-framework';
+import { describe, expect, it } from 'vitest';
+import { validate } from '../../../src/routes/endpoints/admin.js';
+import { mockServiceContext } from './mocks.js';
+
+describe('admin routes', () => {
+  describe('validate', () => {
+    it('reports errors with source location', async () => {
+      const context: Context = {
+        logger: logger,
+        service_context: mockServiceContext(null),
+        token_payload: new JwtPayload({
+          sub: '',
+          exp: 0,
+          iat: 0
+        })
+      };
+
+      const request: BasicRouterRequest = {
+        headers: {},
+        hostname: '',
+        protocol: 'http'
+      };
+
+      const response = await validate.handler({
+        context,
+        params: {
+          sync_rules: `
+bucket_definitions:
+  missing_table:
+    data:
+      - SELECT * FROM missing_table
+`
+        },
+        request
+      });
+
+      expect(response.errors).toEqual([
+        expect.objectContaining({
+          level: 'warning',
+          location: { start_offset: 70, end_offset: 83 },
+          message: 'Table public.missing_table not found'
+        })
+      ]);
+    });
+  });
+});

--- a/packages/service-core/test/src/routes/mocks.ts
+++ b/packages/service-core/test/src/routes/mocks.ts
@@ -41,8 +41,29 @@ export function mockServiceContext(storage: Partial<SyncRulesBucketStorage> | nu
         return {
           getParseSyncRulesOptions() {
             return { defaultSchema: 'public' };
+          },
+          async getSourceConfig() {
+            return {
+              tag: 'test_tag',
+              id: 'test_id',
+              type: 'test_type'
+            };
+          },
+          async getConnectionSchema() {
+            return [];
+          },
+          async getConnectionStatus() {
+            return {
+              id: 'test_id',
+              uri: 'http://example.org/',
+              connected: true,
+              errors: []
+            };
+          },
+          async getDebugTablesInfo() {
+            return [];
           }
-        } as Partial<RouteAPI>;
+        } satisfies Partial<RouteAPI> as unknown as RouteAPI;
       },
       addStopHandler() {
         return () => {};

--- a/packages/types/src/definitions.ts
+++ b/packages/types/src/definitions.ts
@@ -1,9 +1,16 @@
 import * as t from 'ts-codec';
 
+export const SourceSpan = t.object({
+  start_offset: t.number,
+  end_offset: t.number
+});
+export type SourceSpan = t.Encoded<typeof SourceSpan>;
+
 export const ReplicationError = t.object({
   /** Warning: Could indicate an issue. Fatal: Prevents replicating. */
   level: t.literal('warning').or(t.literal('fatal')),
   message: t.string,
+  location: SourceSpan.optional(),
   ts: t.string.optional()
 });
 export type ReplicationError = t.Encoded<typeof ReplicationError>;


### PR DESCRIPTION
When validating sync rules and sync streams, we do a pretty good job at reporting error messages with a source location pointing towards the problem in YAML. For the new sync stream compiler for instance, we go to great lengths to ensure attached source locations survive transformations through intermediate formats and the filter optimizer.

So it's a shame that when users try to validate their config before deploying, the errors and warnings they see in the Dashboard [look like this](https://discord.com/channels/1138230179878154300/1436093469306261514/1438992378433241300):

<img width="1112" height="108" src="https://github.com/user-attachments/assets/31e28407-a2c7-48ca-a154-15c20fca026a" />

We know exactly what stream and parameter has caused this, and we even know where it's located in source to give a nice squiggly line in the editor. But that information gets lost along the way and it's very hard for users to analyze these issues!

To solve this, this adds an optional `start_offset` / `end_offset` pair to the `ReplicationError` type that will be set towards the source location in the `/api/admin/v1/validate` endpoint. This should allow the dashboard to correlate errors with sources when displaying them.