### PR TITLE
Sync plans: Allow using table-valued functions in more places

### DIFF
--- a/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect } from 'vitest';
 import { syncTest } from './utils.js';
 import { requestParameters, TestSourceTable } from '../../util.js';
-import { ScopedParameterLookup, SqliteJsonRow } from '../../../../src/index.js';
+import {
+  deserializeSyncPlan,
+  ImplicitSchemaTablePattern,
+  ScopedParameterLookup,
+  serializeSyncPlan,
+  SqliteJsonRow,
+  StreamDataSource,
+  TableProcessorTableValuedFunction
+} from '../../../../src/index.js';
+import { PreparedStreamBucketDataSource } from '../../../../src/sync_plan/evaluator/bucket_data_source.js';
 
 describe('table-valued functions', () => {
   syncTest('as partition key', ({ sync }) => {
@@ -113,5 +122,130 @@ streams:
     });
 
     expect(rows).toMatchObject([{ bucket: 'stream|0[]', data: { id: 'c1' }, id: 'c1', table: 'customers' }]);
+  });
+
+  syncTest('table-valued output in oplog data', ({ sync }) => {
+    // The compiler currently doesn't support this, but the sync plan format can represent queries like
+    // `SELECT products.id, expanded.value as region FROM products, json_each(region.regions) AS expanded`.
+    const jsonEach: TableProcessorTableValuedFunction = {
+      functionName: 'json_each',
+      functionInputs: [{ type: 'data', source: { column: 'regions' } }],
+      filters: []
+    };
+    const source: StreamDataSource = {
+      outputTableName: 'products',
+      hashCode: 0,
+      sourceTable: new ImplicitSchemaTablePattern(null, 'products'),
+      columns: [
+        { alias: 'id', expr: { type: 'data', source: { column: 'id' } } },
+        { alias: 'region', expr: { type: 'data', source: { function: jsonEach, outputName: 'value' } } }
+      ],
+      filters: [],
+      parameters: [],
+      tableValuedFunctions: [jsonEach]
+    };
+    const plan = deserializeSyncPlan(
+      serializeSyncPlan({
+        dataSources: [source],
+        buckets: [{ hashCode: 0, uniqueName: 'a', sources: [source] }],
+        parameterIndexes: [],
+        streams: []
+      })
+    );
+
+    const evaluator = new PreparedStreamBucketDataSource(plan.buckets[0], {
+      defaultSchema: 'test_schema',
+      engine: sync.engine,
+      sourceText: ''
+    });
+    const products = new TestSourceTable('products');
+
+    expect(
+      evaluator.evaluateRow({
+        sourceTable: products,
+        record: {
+          id: 'id',
+          regions: '[]'
+        }
+      })
+    ).toHaveLength(0);
+    expect(
+      evaluator.evaluateRow({
+        sourceTable: products,
+        record: {
+          id: 'id',
+          regions: '["foo", "bar"]'
+        }
+      })
+    ).toEqual([
+      expect.objectContaining({ data: { id: 'id', region: 'foo' } }),
+      expect.objectContaining({ data: { id: 'id', region: 'bar' } })
+    ]);
+  });
+
+  syncTest('filter on function output and source row', ({ sync }) => {
+    // The compiler currently doesn't support it, but it should. `SELECT * FROM tasks WHERE status IN '["active", "pending"]'`.
+    const jsonEach: TableProcessorTableValuedFunction = {
+      functionName: 'json_each',
+      functionInputs: [{ type: 'lit_string', value: `["active", "pending"]` }],
+      filters: []
+    };
+    const source: StreamDataSource = {
+      outputTableName: 'tasks',
+      hashCode: 0,
+      sourceTable: new ImplicitSchemaTablePattern(null, 'tasks'),
+      columns: ['star'],
+      filters: [
+        {
+          type: 'binary',
+          operator: '=',
+          left: { type: 'data', source: { column: 'status' } },
+          right: { type: 'data', source: { function: jsonEach, outputName: 'value' } }
+        }
+      ],
+      parameters: [],
+      tableValuedFunctions: [jsonEach]
+    };
+    const plan = deserializeSyncPlan(
+      serializeSyncPlan({
+        dataSources: [source],
+        buckets: [{ hashCode: 0, uniqueName: 'a', sources: [source] }],
+        parameterIndexes: [],
+        streams: []
+      })
+    );
+    const evaluator = new PreparedStreamBucketDataSource(plan.buckets[0], {
+      defaultSchema: 'test_schema',
+      engine: sync.engine,
+      sourceText: ''
+    });
+    const tasks = new TestSourceTable('tasks');
+    expect(
+      evaluator.evaluateRow({
+        sourceTable: tasks,
+        record: {
+          id: 'id',
+          status: 'archived'
+        }
+      })
+    ).toHaveLength(0);
+    expect(
+      evaluator.evaluateRow({
+        sourceTable: tasks,
+        record: {
+          id: 'id',
+          status: 'active'
+        }
+      })
+    ).toHaveLength(1);
+    expect(
+      evaluator.evaluateRow({
+        sourceTable: tasks,
+        record: {
+          id: 'id',
+          status: 'pending'
+        }
+      })
+    ).toHaveLength(1);
   });
 });


### PR DESCRIPTION
When processing row or parameter data with sync plans, we essentially evaluate SQL statements of the form `SELECT $output, $parameters FROM $addedTableValuedFunctions WHERE $filter`, where values from the row to sync are embedded as prepared statement parameters.

This is pretty flexible and should give us everything we need. In sync plans however, `$filter` and `$output` could not depend on outputs from table-valued functions. This PR lifts that restriction.

### Supported before

1. Table-valued functions backing bucket parameters: `SELECT products.* FROM products, json_each(products.regions) AS regions WHERE regions.value = auth.parameter('region')`.
2. Table-valued functions backing inputs on parameter indexes (essentially imagine example 1 as a subquery somewhere).
3. Outputs of parameter indexes (`SELECT * FROM users WHERE id IN (SELECT members.value FROM conversations, json_each(conversations.members) AS members WHERE conversations.id = subscription.parameter('chat'))`).
4. Filters only depending on table-valued data: `SELECT * FROM customers WHERE 'synced' IN customers.properties` (which expands to joining `json_each(customers.properties)` and doing `'synced' = json_each.value`).

### Additionally supported now

Note: These aren't yet supported in the compiler, and in case 1. it's not clear to me whether we should. But enabling this in sync plans and adding tests doesn't hurt.

1. Using table-valued functions as columns to sync (`SELECT products.id || '_' || expanded.region as id, products.name FROM products, json_each(region.regions) AS expanded`).
2. Using a filter that depends on both table-valued functions and a column in the row to process (`SELECT * FROM tasks WHERE state IN '["active", "completed"]'`). We should add support for that to the compiler, this prepares support for that in sync plans.

Note: Skipping a changeset entry for this since there are pending `patch` entries on the sync rules package already.