### PR TITLE
Fix compiler error when using table-valued output multiple times

### DIFF
--- a/.changeset/young-walls-fly.md
+++ b/.changeset/young-walls-fly.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Sync Streams: Fix compiler errors when an output value of a table-valued function is used multiple times.

--- a/packages/sync-rules/src/compiler/table.ts
+++ b/packages/sync-rules/src/compiler/table.ts
@@ -44,12 +44,16 @@ export abstract class BaseSourceResultSet {
   abstract get evaluationTarget(): SourceResultSet;
 
   static areCompatible(a: SourceResultSet, b: SourceResultSet): boolean {
+    if (a === b) {
+      return true;
+    }
+
     if (a instanceof TableValuedResultSet) {
       return a.canAttachTo(b);
     } else if (b instanceof TableValuedResultSet) {
       return b.canAttachTo(a);
     } else {
-      return a === b;
+      return false;
     }
   }
 }

--- a/packages/sync-rules/test/src/compiler/__snapshots__/cte.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/cte.test.ts.snap
@@ -322,3 +322,168 @@ exports[`common table expressions > as parameter query 1`] = `
   "version": 1,
 }
 `;
+
+exports[`common table expressions > multiple output references 1`] = `
+{
+  "buckets": [
+    {
+      "hash": 498511015,
+      "sources": [
+        0,
+      ],
+      "uniqueName": "workspaces/role=user/type=individual|0",
+    },
+  ],
+  "dataSources": [
+    {
+      "columns": [
+        "star",
+      ],
+      "filters": [],
+      "hash": 28119074,
+      "outputTableName": "workspace",
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "id",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "workspace",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "parameterIndexes": [],
+  "streams": [
+    {
+      "queriers": [
+        {
+          "bucket": 0,
+          "lookupStages": [
+            [
+              {
+                "filters": [
+                  {
+                    "left": {
+                      "left": {
+                        "function": "->>",
+                        "parameters": [
+                          {
+                            "source": {
+                              "column": "value",
+                            },
+                            "type": "data",
+                          },
+                          {
+                            "type": "lit_string",
+                            "value": "role",
+                          },
+                        ],
+                        "type": "function",
+                      },
+                      "operator": "=",
+                      "right": {
+                        "type": "lit_string",
+                        "value": "user",
+                      },
+                      "type": "binary",
+                    },
+                    "operator": "and",
+                    "right": {
+                      "left": {
+                        "function": "->>",
+                        "parameters": [
+                          {
+                            "source": {
+                              "column": "value",
+                            },
+                            "type": "data",
+                          },
+                          {
+                            "type": "lit_string",
+                            "value": "type",
+                          },
+                        ],
+                        "type": "function",
+                      },
+                      "operator": "=",
+                      "right": {
+                        "type": "lit_string",
+                        "value": "individual",
+                      },
+                      "type": "binary",
+                    },
+                    "type": "binary",
+                  },
+                ],
+                "functionInputs": [
+                  {
+                    "function": "->>",
+                    "parameters": [
+                      {
+                        "source": {
+                          "request": "auth",
+                        },
+                        "type": "data",
+                      },
+                      {
+                        "type": "lit_string",
+                        "value": "workspaces",
+                      },
+                    ],
+                    "type": "function",
+                  },
+                ],
+                "functionName": "json_each",
+                "outputs": [
+                  {
+                    "function": "->>",
+                    "parameters": [
+                      {
+                        "source": {
+                          "column": "value",
+                        },
+                        "type": "data",
+                      },
+                      {
+                        "type": "lit_string",
+                        "value": "id",
+                      },
+                    ],
+                    "type": "function",
+                  },
+                ],
+                "type": "table_valued",
+              },
+            ],
+          ],
+          "requestFilters": [],
+          "sourceInstantiation": [
+            {
+              "lookup": {
+                "idInStage": 0,
+                "stageId": 0,
+              },
+              "resultIndex": 0,
+              "type": "lookup",
+            },
+          ],
+        },
+      ],
+      "stream": {
+        "isSubscribedByDefault": true,
+        "name": "workspaces/role=user/type=individual",
+        "priority": 3,
+      },
+    },
+  ],
+  "version": 1,
+}
+`;

--- a/packages/sync-rules/test/src/compiler/cte.test.ts
+++ b/packages/sync-rules/test/src/compiler/cte.test.ts
@@ -77,4 +77,28 @@ streams:
       ]);
     });
   });
+
+  test('multiple output references', () => {
+    // Regression test for https://github.com/powersync-ja/powersync-service/issues/546
+    const plan = compileToSyncPlanWithoutErrors(`
+config:
+  edition: 3
+
+streams:
+  workspaces/role=user/type=individual:
+    auto_subscribe: true
+    with:
+      workspaces_param: |
+        SELECT value ->> 'id'
+        FROM json_each(auth.parameter('workspaces'))
+        WHERE value ->> 'role' = 'user'
+          AND value ->> 'type' = 'individual'
+    queries:
+      - SELECT *
+        FROM workspace
+        WHERE workspace.id IN workspaces_param
+`);
+
+    expect(serializeSyncPlan(plan)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
For a filter expression like `FROM json_each(auth.parameter('workspaces')) WHERE value ->> 'role' = 'user' AND value ->> 'type' = 'individual'`, the filter simplifier attempts to merge the two expressions from the `AND` node into a single expression since they both depend on no tables. Due to a bug in `BaseSourceResultSet.areCompatible`, this then crashed the compiler because two identical `TableValuedResultSet`s aren't considered to be compatible.

The implementation of `canAttachTo` is correct, but it shouldn't be the only thing determining compatibility. Checking equality before anything else fixes the issue, I've attached the query as a regression test (I've manually verified the compiled sync plan).

Closes https://github.com/powersync-ja/powersync-service/issues/546.