### PR TITLE
Change to a patch release

### DIFF
--- a/.changeset/eleven-pets-speak.md
+++ b/.changeset/eleven-pets-speak.md
@@ -5,7 +5,7 @@
 '@powersync/service-module-postgres': minor
 '@powersync/service-errors': minor
 '@powersync/service-module-mongodb': minor
-'@powersync/service-core': minor
+'@powersync/service-core': patch
 '@powersync/service-module-mysql': minor
 '@powersync/lib-services-framework': minor
 ---

--- a/.changeset/new-games-prove.md
+++ b/.changeset/new-games-prove.md
@@ -4,7 +4,7 @@
 '@powersync/service-core-tests': minor
 '@powersync/service-module-postgres': minor
 '@powersync/service-module-mongodb': minor
-'@powersync/service-core': minor
+'@powersync/service-core': patch
 '@powersync/service-module-mssql': minor
 '@powersync/service-module-mysql': minor
 '@powersync/service-sync-rules': minor


### PR DESCRIPTION
This prepares for releasing 1.20.1.

There is no need for this to be a minor release bump, since the changes primarily contain fixes and internal refactoring.