### PR TITLE
Sync Streams compiler: Fix inferring column names

### DIFF
--- a/.changeset/itchy-ladybugs-wait.md
+++ b/.changeset/itchy-ladybugs-wait.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix output names of columns in sync streams for quoted identifiers.

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -389,8 +389,19 @@ export class StreamQueryParser {
     );
   }
 
-  private inferColumnName(column: SelectedColumn): string {
-    return column.alias?.name ?? this.originalText.substring(column._location!.start, column._location!.end);
+  private inferColumnName({ alias, expr }: SelectedColumn): string {
+    if (alias?.name) {
+      return alias.name;
+    }
+
+    if (expr.type == 'ref') {
+      return expr.name;
+    }
+
+    // We try to infer the output name of custom expressions by looking at sources, but this is kind of hacky
+    // (SQLite mentions that the name of such columns is unspecified for instance), so we also want to warn about this.
+    this.errors.report('The name of this column is unspecified, consider adding an alias.', expr, { isWarning: true });
+    return this.originalText.substring(expr._location!.start, expr._location!.end);
   }
 
   private processResultColumns(stmt: PGNode, columns: SelectedColumn[]) {

--- a/packages/sync-rules/test/src/compiler/compatibility.test.ts
+++ b/packages/sync-rules/test/src/compiler/compatibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { compileSingleStreamAndSerialize } from './utils.js';
+import { compileSingleStreamAndSerialize, yamlToSyncPlan } from './utils.js';
 
 describe('old streams test', () => {
   // Testcases ported from streams.test.ts
@@ -194,5 +194,29 @@ describe('old streams test', () => {
         'select * from account_member as "outer" where account_id in (select "inner".account_id from account_member as "inner" where "inner".id = auth.user_id())'
       )
     ).toMatchSnapshot();
+  });
+
+  test('output column names', () => {
+    const [errors, plan] = yamlToSyncPlan(`
+config:
+  edition: 3
+
+streams:
+  stream:
+    queries:
+      - SELECT 1, ShouldBeLowerCase, "quotedColumn" FROM users
+`);
+
+    expect(errors).toStrictEqual([
+      {
+        isWarning: true,
+        message: 'The name of this column is unspecified, consider adding an alias.',
+        source: '1'
+      }
+    ]);
+
+    const [source] = plan.dataSources;
+    const aliases = source.columns.map((c) => (typeof c == 'object' ? c.alias : null));
+    expect(aliases).toStrictEqual(['1', 'shouldbelowercase', 'quotedColumn']);
   });
 });

--- a/packages/sync-rules/test/src/compiler/cte.test.ts
+++ b/packages/sync-rules/test/src/compiler/cte.test.ts
@@ -89,7 +89,7 @@ streams:
     auto_subscribe: true
     with:
       workspaces_param: |
-        SELECT value ->> 'id'
+        SELECT value ->> 'id' AS id
         FROM json_each(auth.parameter('workspaces'))
         WHERE value ->> 'role' = 'user'
           AND value ->> 'type' = 'individual'
@@ -100,5 +100,21 @@ streams:
 `);
 
     expect(serializeSyncPlan(plan)).toMatchSnapshot();
+  });
+
+  test('can reference quoted names from subqueries', () => {
+    // Regression test for https://discord.com/channels/1138230179878154300/1422138173907144724/1479119316573094042.
+    // We just want this to compile without errors.
+    compileToSyncPlanWithoutErrors(`
+config:
+  edition: 3
+streams:
+  migrated_to_streams:
+    auto_subscribe: true
+    with:
+      user_items_param: SELECT "orgId" FROM "OrgMember" WHERE "userId" = auth.user_id()
+    queries:
+      - SELECT "Project".* FROM "Project", user_items_param AS bucket WHERE "Project"."orgId" = bucket."orgId"
+`);
   });
 });

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -45,14 +45,14 @@ config:
 streams:
   stream:
     with:
-      foo: SELECT 1
+      foo: SELECT id FROM users
 `);
 
     expect(errors).toStrictEqual([
       {
         message: 'One of `queries` or `query` must be given.',
         source: `with:
-      foo: SELECT 1
+      foo: SELECT id FROM users
 `
       }
     ]);
@@ -68,10 +68,10 @@ streams:
   });
 
   test('not selecting from anything', () => {
-    expect(compilationErrorsForSingleStream('SELECT 1, 2, 3')).toStrictEqual([
+    expect(compilationErrorsForSingleStream('SELECT 1 AS a, 2 AS b, 3 AS c')).toStrictEqual([
       {
         message: 'Must have a result column selecting from a table',
-        source: 'SELECT 1, 2, 3'
+        source: 'SELECT 1 AS a, 2 AS b, 3 AS c'
       }
     ]);
   });
@@ -112,7 +112,7 @@ streams:
   });
 
   test('selecting connection value', () => {
-    expect(compilationErrorsForSingleStream("SELECT u.*, auth.parameter('x') FROM users u;")).toStrictEqual([
+    expect(compilationErrorsForSingleStream("SELECT u.*, auth.parameter('x') AS p FROM users u;")).toStrictEqual([
       {
         message: 'This attempts to sync a connection parameter. Only values from the source database can be synced.',
         source: "auth.parameter('x')"
@@ -262,6 +262,23 @@ streams:
     expect(compilationErrorsForSingleStream('select * from users where id = subscription.whatever()')).toStrictEqual([
       { message: 'Unknown request function', source: 'subscription.whatever' }
     ]);
+  });
+
+  test('warns about missing alias', () => {
+    expect(compilationErrorsForSingleStream('select id, lower(name) from users')).toStrictEqual([
+      {
+        message: 'The name of this column is unspecified, consider adding an alias.',
+        source: 'lower(name)',
+        isWarning: true
+      }
+    ]);
+
+    // Should not warn for subqueries with fixed column names.
+    expect(
+      compilationErrorsForSingleStream(
+        'select id, name from (select id, lower(name) from users) as my_table (id, name)'
+      )
+    ).toStrictEqual([]);
   });
 
   describe('schema errors', () => {

--- a/packages/sync-rules/test/src/compiler/subqueries.test.ts
+++ b/packages/sync-rules/test/src/compiler/subqueries.test.ts
@@ -42,14 +42,14 @@ streams:
 
   describe('errors', () => {
     test('select star', () => {
-      expect(compilationErrorsForSingleStream('SELECT 1 FROM (SELECT * FROM users) AS u')).toStrictEqual([
+      expect(compilationErrorsForSingleStream('SELECT 1 AS id FROM (SELECT * FROM users) AS u')).toStrictEqual([
         {
           message: '* columns are not allowed in subqueries or common table expressions',
           source: '*'
         },
         {
           message: 'Must have a result column selecting from a table',
-          source: 'SELECT 1 FROM (SELECT * FROM users) AS u'
+          source: 'SELECT 1 AS id FROM (SELECT * FROM users) AS u'
         }
       ]);
     });


### PR DESCRIPTION
Currently, the compiler infers output names by looking at aliases if given and otherwise using the lexeme of the expression making up the column as a name. This is incorrect for references, because:

1. For consistency with the rest of the parser, `SELECT MyColumn` should be a lowercase `mycolumn`.
2. `SELECT "MyColumn"` should create a column named `MyColumn` and not `"MyColumn"`, yikes!!

It can also be counterintuitive for other expressions. The old SQL tools implementation used to reject these columns, I've kept the existing lexeme lookup as a fallback but added a warning suggesting an alias.

This fixes an [issue reported on Discord](https://discord.com/channels/1138230179878154300/1422138173907144724/1479119316573094042). Note that, despite changing column names in replicated data, this is not a breaking change as it takes a re-deployment this fix to become active. Existing sync plans would continue replicating with their original column names.