### PR TITLE
Better error message for partitioned request data

### DIFF
--- a/.changeset/dirty-ties-itch.md
+++ b/.changeset/dirty-ties-itch.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Improve error messages when a query attempts to partition a table-valued function depending on request data.

--- a/packages/sync-rules/src/compiler/querier_graph.ts
+++ b/packages/sync-rules/src/compiler/querier_graph.ts
@@ -214,7 +214,10 @@ class PendingQuerierPath {
     if (!resolved.partition.isEmpty) {
       // This function is only called for table-valued result sets operating on request data. Partitions are only
       // supported for buckets and parameter lookups.
-      this.errors.report('Table-valued result sets cannot be partitioned', resultSet.source.origin);
+      this.errors.report(
+        `This table-valued function depends on request data and can't be partitioned. If possible, try rewriting the query to not use = operators on this function and multiple other tables.`,
+        resultSet.source.origin
+      );
     }
 
     return new PendingExpandingLookup({ type: 'table_valued', source: resultSet, filters: resolved.filters });

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -209,6 +209,23 @@ streams:
     ]);
   });
 
+  test('partitioning table-valued result set', () => {
+    // This is kind of an implementation detail and we could be smarter in querier_graph.ts, but currently we can't have
+    // table-valued functions of request data in the middle of a parameter chain. At least we want a decent error
+    // message.
+    expect(
+      compilationErrorsForSingleStream(
+        `select comments.* from comments, json_each(connection.parameter('items')), user_access WHERE comments.item_id = json_each.value AND user_access.item_id = json_each.value AND user_access.user_id = auth.user_id()`
+      )
+    ).toStrictEqual([
+      {
+        message:
+          "This table-valued function depends on request data and can't be partitioned. If possible, try rewriting the query to not use = operators on this function and multiple other tables.",
+        source: `json_each(connection.parameter('items'))`
+      }
+    ]);
+  });
+
   test('subquery with two columns', () => {
     expect(
       compilationErrorsForSingleStream(


### PR DESCRIPTION
This is related to [this report from Discord](https://discord.com/channels/1138230179878154300/1422138173907144724/1479444609883967618). Consider the query

```sql
select
  comments.*
from
  comments,
  json_each(connection.parameter('items')),
  user_access
WHERE
  comments.item_id = json_each.value AND
  user_access.item_id = json_each.value AND
  user_access.user_id = auth.user_id()
```

Here, the stream compiler tries to:

1. Resolve `comments`, since it's the table we select from.
2. Process the only subexpression mentioning `comments` (`comments.item_id = json_each.value`) by creating a parameter on `item_id` and attempting to resolve it's instantiation.
3. Resolve `json_each`, process the `user_access.item_id = json_each.value` expression and attempt to create a parameter on `json_each.value`.
4. Realize that json-valued functions can't have parameters because they're neither buckets nor parameter lookups, and emit a compiler error.

If one understands how sync streams work internally, this makes sense. However, for users writing such queries the error message "Table-valued result sets cannot be partitioned" isn't exactly helpful. This improves the error message to make it more actionable ("try rewriting the query to not use = operators on this function and multiple other tables"). Hopefully that nudges users to write the query as `WHERE comments.item_id = user_access.item_id AND ...`, which would actually work.