### PR TITLE
Fix unsound merge of exists subqueries in OR clause

### DIFF
--- a/.changeset/soft-bikes-collect.md
+++ b/.changeset/soft-bikes-collect.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix sync streams ignoring parts of `OR` conditions for subqueries not contributing bucket parameters.

--- a/packages/sync-rules/src/compiler/bucket_resolver.ts
+++ b/packages/sync-rules/src/compiler/bucket_resolver.ts
@@ -1,4 +1,4 @@
-import { Equatable, HashSet, StableHasher } from './equality.js';
+import { Equality, Equatable, HashSet, StableHasher, unorderedEquality } from './equality.js';
 import { equalsIgnoringResultSetList, equalsIgnoringResultSetUnordered } from './compatibility.js';
 import { RequestExpression, RowExpression } from './filter.js';
 import { PointLookup, RowEvaluator, SourceRowProcessor } from './rows.js';
@@ -19,6 +19,7 @@ export class StreamResolver {
 
   buildInstantiationHash(hasher: StableHasher) {
     equalsIgnoringResultSetUnordered.hash(hasher, this.requestFilters);
+    StreamResolver.lookupStageEquality.hash(hasher, this.lookupStages);
     this.resolvedBucket.buildInstantiationHash(hasher);
   }
 
@@ -31,8 +32,33 @@ export class StreamResolver {
       return false;
     }
 
+    if (!StreamResolver.lookupStageEquality.equals(other.lookupStages, this.lookupStages)) {
+      return false;
+    }
+
     return other.resolvedBucket.hasIdenticalInstantiation(this.resolvedBucket);
   }
+
+  // When comparing lookup stages, we don't care about the order and how lookups have been assigned into stages.
+  // Each inner lookup would include its input in its equality/hashcode implementation, so we get the ordering through
+  // that. And as long as that input structure matches, two resolvers with the same lookups in a different order are
+  // still equal.
+  private static readonly flatLookupEquality = unorderedEquality(StableHasher.defaultEquality);
+
+  private static readonly lookupStageEquality: Equality<ExpandingLookup[][]> = {
+    equals: function (a: ExpandingLookup[][], b: ExpandingLookup[][]): boolean {
+      return StreamResolver.flatLookupEquality.equals(
+        a.flatMap((s) => s),
+        b.flatMap((s) => s)
+      );
+    },
+    hash: function (hasher: StableHasher, value: ExpandingLookup[][]): void {
+      return StreamResolver.flatLookupEquality.hash(
+        hasher,
+        value.flatMap((s) => s)
+      );
+    }
+  };
 }
 
 /**

--- a/packages/sync-rules/src/compiler/equality.ts
+++ b/packages/sync-rules/src/compiler/equality.ts
@@ -61,7 +61,7 @@ export class StableHasher {
   /**
    * The default equality for {@link Equatable} types.
    */
-  private static readonly defaultEquality: Equality<Equatable> = {
+  static readonly defaultEquality: Equality<Equatable> = {
     hash(hasher, value) {
       value.buildHash(hasher);
     },

--- a/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
@@ -192,6 +192,248 @@ exports[`new sync stream features > IN operator with two static clauses 1`] = `
 }
 `;
 
+exports[`new sync stream features > checking for existence in two CTEs 1`] = `
+{
+  "buckets": [
+    {
+      "hash": 2313189,
+      "sources": [
+        0,
+      ],
+      "uniqueName": "rbac_stream|0",
+    },
+  ],
+  "dataSources": [
+    {
+      "columns": [
+        "star",
+      ],
+      "filters": [],
+      "hash": 470455392,
+      "outputTableName": "Scene",
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "project",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "Scene",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "parameterIndexes": [
+    {
+      "filters": [
+        {
+          "left": {
+            "type": "lit_string",
+            "value": "a",
+          },
+          "operator": "=",
+          "right": {
+            "source": {
+              "column": "perm",
+            },
+            "type": "data",
+          },
+          "type": "binary",
+        },
+      ],
+      "hash": 469881182,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "0",
+      },
+      "output": [],
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "user",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "global_permissions",
+      },
+      "tableValuedFunctions": [],
+    },
+    {
+      "filters": [
+        {
+          "left": {
+            "type": "lit_string",
+            "value": "b",
+          },
+          "operator": "=",
+          "right": {
+            "source": {
+              "column": "perm",
+            },
+            "type": "data",
+          },
+          "type": "binary",
+        },
+      ],
+      "hash": 391349695,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "1",
+      },
+      "output": [],
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "user",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "project_permissions",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "streams": [
+    {
+      "queriers": [
+        {
+          "bucket": 0,
+          "lookupStages": [
+            [
+              {
+                "instantiation": [
+                  {
+                    "expr": {
+                      "function": "->>",
+                      "parameters": [
+                        {
+                          "source": {
+                            "request": "auth",
+                          },
+                          "type": "data",
+                        },
+                        {
+                          "type": "lit_string",
+                          "value": "$.sub",
+                        },
+                      ],
+                      "type": "function",
+                    },
+                    "type": "request",
+                  },
+                ],
+                "lookup": 0,
+                "type": "parameter",
+              },
+            ],
+          ],
+          "requestFilters": [],
+          "sourceInstantiation": [
+            {
+              "expr": {
+                "function": "->>",
+                "parameters": [
+                  {
+                    "source": {
+                      "request": "subscription",
+                    },
+                    "type": "data",
+                  },
+                  {
+                    "type": "lit_string",
+                    "value": "project",
+                  },
+                ],
+                "type": "function",
+              },
+              "type": "request",
+            },
+          ],
+        },
+        {
+          "bucket": 0,
+          "lookupStages": [
+            [
+              {
+                "instantiation": [
+                  {
+                    "expr": {
+                      "function": "->>",
+                      "parameters": [
+                        {
+                          "source": {
+                            "request": "auth",
+                          },
+                          "type": "data",
+                        },
+                        {
+                          "type": "lit_string",
+                          "value": "$.sub",
+                        },
+                      ],
+                      "type": "function",
+                    },
+                    "type": "request",
+                  },
+                ],
+                "lookup": 1,
+                "type": "parameter",
+              },
+            ],
+          ],
+          "requestFilters": [],
+          "sourceInstantiation": [
+            {
+              "expr": {
+                "function": "->>",
+                "parameters": [
+                  {
+                    "source": {
+                      "request": "subscription",
+                    },
+                    "type": "data",
+                  },
+                  {
+                    "type": "lit_string",
+                    "value": "project",
+                  },
+                ],
+                "type": "function",
+              },
+              "type": "request",
+            },
+          ],
+        },
+      ],
+      "stream": {
+        "isSubscribedByDefault": false,
+        "name": "rbac_stream",
+        "priority": 3,
+      },
+    },
+  ],
+  "version": 1,
+}
+`;
+
 exports[`new sync stream features > in array 1`] = `
 {
   "buckets": [

--- a/packages/sync-rules/test/src/compiler/advanced.test.ts
+++ b/packages/sync-rules/test/src/compiler/advanced.test.ts
@@ -280,4 +280,37 @@ streams:
 `);
     expect(serializeSyncPlan(plan)).toMatchSnapshot();
   });
+
+  test('checking for existence in two CTEs', () => {
+    // Regression test for https://discord.com/channels/1138230179878154300/1480494423417688105/1480494813684961405,
+    // slightly simplified.
+    const plan = compileToSyncPlanWithoutErrors(`
+config:
+  edition: 3
+
+streams:
+  rbac_stream:
+    accept_potentially_dangerous_queries: true
+    with:
+      user_project_permissions: SELECT perm FROM project_permissions WHERE "user" = auth.user_id()
+      user_global_permissions: SELECT perm FROM global_permissions WHERE "user" = auth.user_id()
+
+    query: |
+      SELECT "Scene".*
+      FROM "Scene"
+      WHERE 
+        "Scene".project = subscription.parameter('project')
+        AND (
+            'a' IN user_global_permissions
+            OR 'b' IN user_project_permissions
+        )
+`);
+
+    // There should only be a single bucket, but two ways to get there (thanks to the OR).
+    expect(plan.buckets).toHaveLength(1);
+    expect(plan.streams).toHaveLength(1);
+    expect(plan.streams[0].queriers).toHaveLength(2);
+
+    expect(serializeSyncPlan(plan)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This fixes a bug closely related to https://github.com/powersync-ja/powersync-service/pull/547. While that PR fixed an issue where parameter lookups not contributing parameters were silently ignored (we still need to evaluate them for authorization), this fixes a bug in the optimizer merging identical queriers: It failed to consider that exact same case, and considered queriers that differ in "unused" parameter lookups as identical.

Now luckily, at this one isn't a security issue. This only impacts queries using subqueries for authorization when they have an `OR` clause with different authorization subqueries. In this case, the optimizer would merge queriers, essentially causing all but one part of the `OR` clause to get ignored. So the only impact of this sync streams filtering more aggressively than they should, and this can't cause us to sync data to unauthorized users.

My fix is to include all lookups in in the hash of `StreamResolver`, which then causes `QuerierGraphBuilder.mergeBuckets` to not merge them. The two stream variants are still able to share a single bucket in this case because authorization is checked in the querier only.

Originally reported [on Discord](https://discord.com/channels/1138230179878154300/1480494423417688105/1480494813684961405).