### PR TITLE
Tweak handling of DO_NOT_LOG in production.

### DIFF
--- a/libs/lib-services/src/logger/Logger.ts
+++ b/libs/lib-services/src/logger/Logger.ts
@@ -29,7 +29,17 @@ export const DO_NOT_LOG = Symbol('DO_NOT_LOG');
  */
 const logFilter = (key: string, value: unknown) => {
   if (value != null && typeof value == 'object' && (value as any)[DO_NOT_LOG]) {
-    throw new ServiceAssertionError(`${Object.getPrototypeOf(value)?.constructor?.name} must not be logged`);
+    const name = Object.getPrototypeOf(value)?.constructor?.name;
+    const message = `${key}: ${name} must not be logged`;
+    if (process.env.NODE_ENV == 'production') {
+      // In production, log a warning and filter out the value.
+      // We do this in case a DO_NOT_LOG value is only logged in rare edge cases not covered by tests,
+      // and we don't want to cause cascading failures in that case.
+      logger.error(message);
+      return undefined;
+    }
+    // In local development and testing, this is a hard error to surface the issue clearly.
+    throw new ServiceAssertionError(message);
   }
   return value;
 };


### PR DESCRIPTION
Follow-up to #593, relating to [this comment](https://github.com/powersync-ja/powersync-service/pull/593#discussion_r3054947204).

This handles these log issues more gracefully when running into the issue in production. Essentially, if a log line slips through that we did not pick up during local runs or automated testing, the filtering should not cause a cascading failure. This still keeps the hard error during development testing, so that automated testing can pick up these issues as far as possible.

The specific case in #585 is actually a good example of this:
1. The test in service-core does not use module-mongodb-storage and uses a mock logger, so does not run into the case of logging `db`.
2. The tests in module-mongodb-storage does not cover this specific case logging the message.

So the automated tests never pick up this logging issue, but it is easily triggered in production.

Note that we have `NODE_ENV=production` in all our docker images, so it's a fairly safe check here.