### PR TITLE
Fix miscompilations and compiler crashes when CTEs are referenced multiple times

### DIFF
--- a/.changeset/dull-carrots-peel.md
+++ b/.changeset/dull-carrots-peel.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix miscompilations and compiler crashes when CTEs are referenced multiple times.

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -278,9 +278,7 @@ export class StreamQueryParser {
   }
 
   private addSubquery(source: SyntacticResultSetSource, subquery: PreparedSubquery) {
-    subquery.tables.forEach((v, k) => {
-      this.resultSets.set(k, v);
-    });
+    subquery.tables.forEach((v, k) => this.resultSets.set(k, v));
 
     if (subquery.where) {
       this.where.push(subquery.where);

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -32,6 +32,7 @@ import { SqlScope } from './scope.js';
 import { PostgresToSqlite, PreparedSubquery } from './sqlite.js';
 import {
   BaseSourceResultSet,
+  CloneTableReferences,
   PhysicalSourceResultSet,
   SourceResultSet,
   SyntacticResultSetSource,
@@ -277,7 +278,10 @@ export class StreamQueryParser {
   }
 
   private addSubquery(source: SyntacticResultSetSource, subquery: PreparedSubquery) {
-    subquery.tables.forEach((v, k) => this.resultSets.set(k, v));
+    subquery.tables.forEach((v, k) => {
+      this.resultSets.set(k, v);
+    });
+
     if (subquery.where) {
       this.where.push(subquery.where);
     }
@@ -295,7 +299,9 @@ export class StreamQueryParser {
       // If this references a CTE in scope, use that instead of names.
       const cte = from.name.schema == null ? scope.resolveCommonTableExpression(from.name.name) : null;
       if (cte) {
-        this.addSubquery(source, cte);
+        // Inline the CTE here by cloning it for this specific reference, see the comment on CloneTableReferences for
+        // why this is necessary.
+        this.addSubquery(source, CloneTableReferences.clonePreparedSubquery(cte, this.nodeLocations));
       } else {
         // Not a CTE, so treat it as a source database table.
         const pattern = new ImplicitSchemaTablePattern(from.name.schema ?? null, from.name.name);
@@ -496,7 +502,7 @@ export class StreamQueryParser {
       // references.
       const defaultResultSet = this.statementScope.defaultResultSet;
       if (defaultResultSet) {
-        return this.resolveSoure(defaultResultSet);
+        return this.resolveSource(defaultResultSet);
       } else {
         this.errors.report('Invalid unqualified reference since multiple tables are in scope', node);
         return null;
@@ -508,11 +514,11 @@ export class StreamQueryParser {
         return null;
       }
 
-      return this.resolveSoure(result);
+      return this.resolveSource(result);
     }
   }
 
-  private resolveSoure(source: SyntacticResultSetSource): SourceResultSet | PreparedSubquery {
+  private resolveSource(source: SyntacticResultSetSource): SourceResultSet | PreparedSubquery {
     if (this.resultSets.has(source)) {
       return this.resultSets.get(source)!;
     } else if (this.subqueryResultSets.has(source)) {

--- a/packages/sync-rules/src/compiler/table.ts
+++ b/packages/sync-rules/src/compiler/table.ts
@@ -1,8 +1,12 @@
 import { PGNode } from 'pgsql-ast-parser';
 import { ImplicitSchemaTablePattern, SourceSchemaTable } from '../index.js';
+import { SqlExpression } from '../sync_plan/expression.js';
+import { MapSourceVisitor, visitExpr } from '../sync_plan/expression_visitor.js';
 import { equalsIgnoringResultSetList } from './compatibility.js';
 import { StableHasher } from './equality.js';
+import { ColumnInRow, ExpressionInput, NodeLocations, SyncExpression } from './expression.js';
 import { SingleDependencyExpression } from './filter.js';
+import { PreparedSubquery } from './sqlite.js';
 
 /**
  * A result set that a query stream selects from.
@@ -42,6 +46,8 @@ export abstract class BaseSourceResultSet {
    * is also the result set itself.
    */
   abstract get evaluationTarget(): SourceResultSet;
+
+  abstract clone(references: CloneTableReferences): BaseSourceResultSet;
 
   static areCompatible(a: SourceResultSet, b: SourceResultSet): boolean {
     if (a === b) {
@@ -85,6 +91,14 @@ export class PhysicalSourceResultSet extends BaseSourceResultSet {
 
   get description(): string {
     return this.tablePattern.name;
+  }
+
+  clone(references: CloneTableReferences): PhysicalSourceResultSet {
+    return new PhysicalSourceResultSet(
+      this.tablePattern,
+      references.getClonedSyntacticSource(this.source),
+      this.schemaTablesForWarnings
+    );
   }
 }
 
@@ -162,5 +176,86 @@ export class TableValuedResultSet extends BaseSourceResultSet {
       other.tableValuedFunctionName == this.tableValuedFunctionName &&
       equalsIgnoringResultSetList.equals(other.parameters, this.parameters)
     );
+  }
+
+  clone(references: CloneTableReferences): TableValuedResultSet {
+    return new TableValuedResultSet(
+      this.tableValuedFunctionName,
+      this.parameters.map((p) => new SingleDependencyExpression(references.cloneSyncExpression(p.expression))),
+      references.getClonedSyntacticSource(this.source)
+    );
+  }
+}
+
+/**
+ * Clones result set instances and associated expressions.
+ *
+ * This is necessary to safely implement common table expressions in Sync Streams: We use the identity of
+ * {@link SourceResultSet} instances to track dependencies between expressions and to convert `WHERE` clauses into a
+ * querier and parameter lookups. Semantically, when a CTE is joined multiple times, each CTE acts as an independently-
+ * joined subquery. To implement these semantics correctly, we need to join result set instances every time we add a
+ * CTE to a query.
+ */
+export class CloneTableReferences {
+  private synctacticClone = new Map<SyntacticResultSetSource, SyntacticResultSetSource>();
+  private clonedResultSets = new Map<SourceResultSet, SourceResultSet>();
+
+  private cloneExpressions: MapSourceVisitor<ExpressionInput, ExpressionInput>;
+
+  constructor(originalResultSets: Map<SyntacticResultSetSource, SourceResultSet>, locations: NodeLocations) {
+    this.cloneExpressions = new MapSourceVisitor<ExpressionInput, ExpressionInput>((data) => {
+      if (data instanceof ColumnInRow) {
+        return new ColumnInRow(data.syntacticOrigin, this.getClonedSource(data.resultSet), data.column);
+      }
+
+      return data;
+    }, locations);
+
+    for (const source of originalResultSets.keys()) {
+      const clone = new SyntacticResultSetSource(source.origin, source.explicitName);
+      this.synctacticClone.set(source, clone);
+    }
+
+    for (const value of originalResultSets.values()) {
+      this.clonedResultSets.set(value, value.clone(this));
+    }
+  }
+
+  getClonedSyntacticSource(source: SyntacticResultSetSource): SyntacticResultSetSource {
+    return this.synctacticClone.get(source)!;
+  }
+
+  getClonedSource(source: SourceResultSet): SourceResultSet {
+    return this.clonedResultSets.get(source)!;
+  }
+
+  cloneExpression(source: SqlExpression<ExpressionInput>): SqlExpression<ExpressionInput> {
+    return visitExpr(this.cloneExpressions, source, null);
+  }
+
+  cloneSyncExpression(expr: SyncExpression): SyncExpression {
+    return new SyncExpression(this.cloneExpression(expr.node), expr.locations);
+  }
+
+  static clonePreparedSubquery(subquery: PreparedSubquery, locations: NodeLocations): PreparedSubquery {
+    const cloner = new CloneTableReferences(subquery.tables, locations);
+
+    const resultColumns: Record<string, SqlExpression<ExpressionInput>> = {};
+    const tables = new Map<SyntacticResultSetSource, SourceResultSet>();
+    let where: SqlExpression<ExpressionInput> | null = null;
+
+    for (const [name, value] of Object.entries(subquery.resultColumns)) {
+      resultColumns[name] = cloner.cloneExpression(value);
+    }
+
+    if (subquery.where) {
+      where = cloner.cloneExpression(subquery.where);
+    }
+
+    return {
+      resultColumns,
+      tables,
+      where
+    };
   }
 }

--- a/packages/sync-rules/src/compiler/table.ts
+++ b/packages/sync-rules/src/compiler/table.ts
@@ -197,7 +197,7 @@ export class TableValuedResultSet extends BaseSourceResultSet {
  * CTE to a query.
  */
 export class CloneTableReferences {
-  private synctacticClone = new Map<SyntacticResultSetSource, SyntacticResultSetSource>();
+  private syntacticClone = new Map<SyntacticResultSetSource, SyntacticResultSetSource>();
   private clonedResultSets = new Map<SourceResultSet, SourceResultSet>();
 
   private cloneExpressions: MapSourceVisitor<ExpressionInput, ExpressionInput>;
@@ -213,7 +213,7 @@ export class CloneTableReferences {
 
     for (const source of originalResultSets.keys()) {
       const clone = new SyntacticResultSetSource(source.origin, source.explicitName);
-      this.synctacticClone.set(source, clone);
+      this.syntacticClone.set(source, clone);
     }
 
     for (const value of originalResultSets.values()) {
@@ -222,11 +222,17 @@ export class CloneTableReferences {
   }
 
   getClonedSyntacticSource(source: SyntacticResultSetSource): SyntacticResultSetSource {
-    return this.synctacticClone.get(source)!;
+    const cloned = this.syntacticClone.get(source);
+    if (cloned == null) throw new Error('Syntactic source not part of original result sets');
+
+    return cloned;
   }
 
   getClonedSource(source: SourceResultSet): SourceResultSet {
-    return this.clonedResultSets.get(source)!;
+    const cloned = this.clonedResultSets.get(source);
+    if (cloned == null) throw new Error('Source not part of original result sets');
+
+    return cloned;
   }
 
   cloneExpression(source: SqlExpression<ExpressionInput>): SqlExpression<ExpressionInput> {
@@ -247,6 +253,9 @@ export class CloneTableReferences {
     for (const [name, value] of Object.entries(subquery.resultColumns)) {
       resultColumns[name] = cloner.cloneExpression(value);
     }
+    subquery.tables.forEach((v, k) => {
+      tables.set(cloner.getClonedSyntacticSource(k), cloner.getClonedSource(v));
+    });
 
     if (subquery.where) {
       where = cloner.cloneExpression(subquery.where);

--- a/packages/sync-rules/src/sync_plan/expression_visitor.ts
+++ b/packages/sync-rules/src/sync_plan/expression_visitor.ts
@@ -1,3 +1,4 @@
+import { NodeLocations } from '../compiler/expression.js';
 import {
   BetweenExpression,
   BinaryExpression,
@@ -160,10 +161,22 @@ export abstract class RecursiveExpressionVisitor<Data, R, Arg = undefined> imple
  * A visitor applying a mapping function to external data references in expressions.
  */
 export class MapSourceVisitor<DataIn, DataOut> implements ExpressionVisitor<DataIn, SqlExpression<DataOut>> {
-  constructor(private readonly map: (a: DataIn) => DataOut) {}
+  constructor(
+    private readonly map: (a: DataIn) => DataOut,
+    private readonly locations?: NodeLocations
+  ) {}
+
+  #trackLocations(source: SqlExpression<DataIn>, mapped: SqlExpression<DataOut>): SqlExpression<DataOut> {
+    const location = this.locations?.sourceForNode?.get(source);
+    if (location) {
+      this.locations!.sourceForNode.set(mapped, location);
+    }
+
+    return mapped;
+  }
 
   visitExternalData(expr: ExternalData<DataIn>): SqlExpression<DataOut> {
-    return { type: 'data', source: this.map(expr.source) };
+    return this.#trackLocations(expr, { type: 'data', source: this.map(expr.source) });
   }
 
   visitUnaryExpression(expr: UnaryExpression<DataIn>, arg: undefined): SqlExpression<DataOut> {
@@ -172,7 +185,7 @@ export class MapSourceVisitor<DataIn, DataOut> implements ExpressionVisitor<Data
       return expr as SqlExpression<DataOut>; // unchanged subtree
     }
 
-    return { type: 'unary', operator: expr.operator, operand };
+    return this.#trackLocations(expr, { type: 'unary', operator: expr.operator, operand });
   }
 
   visitBinaryExpression(expr: BinaryExpression<DataIn>, arg: undefined): SqlExpression<DataOut> {
@@ -182,7 +195,7 @@ export class MapSourceVisitor<DataIn, DataOut> implements ExpressionVisitor<Data
       return expr as SqlExpression<DataOut>; // unchanged subtree
     }
 
-    return { type: 'binary', operator: expr.operator, left, right };
+    return this.#trackLocations(expr, { type: 'binary', operator: expr.operator, left, right });
   }
 
   visitBetweenExpression(expr: BetweenExpression<DataIn>, arg: undefined): SqlExpression<DataOut> {
@@ -193,19 +206,19 @@ export class MapSourceVisitor<DataIn, DataOut> implements ExpressionVisitor<Data
       return expr as SqlExpression<DataOut>; // unchanged subtree
     }
 
-    return { type: 'between', value, low, high };
+    return this.#trackLocations(expr, { type: 'between', value, low, high });
   }
 
   visitScalarInExpression(expr: ScalarInExpression<DataIn>, arg: undefined): SqlExpression<DataOut> {
-    return {
+    return this.#trackLocations(expr, {
       type: 'scalar_in',
       target: visitExpr(this, expr.target, arg),
       in: expr.in.map((e) => visitExpr(this, e, arg))
-    };
+    });
   }
 
   visitCaseWhenExpression(expr: CaseWhenExpression<DataIn>, arg: undefined): SqlExpression<DataOut> {
-    return {
+    return this.#trackLocations(expr, {
       type: 'case_when',
       operand: expr.operand && visitExpr(this, expr.operand, arg),
       whens: expr.whens.map(({ when, then }) => ({
@@ -213,7 +226,7 @@ export class MapSourceVisitor<DataIn, DataOut> implements ExpressionVisitor<Data
         then: visitExpr(this, then, arg)
       })),
       else: expr.else && visitExpr(this, expr.else, arg)
-    };
+    });
   }
 
   visitCastExpression(expr: CastExpression<DataIn>, arg: undefined): SqlExpression<DataOut> {
@@ -222,18 +235,18 @@ export class MapSourceVisitor<DataIn, DataOut> implements ExpressionVisitor<Data
       return expr as SqlExpression<DataOut>; // unchanged subtree
     }
 
-    return { type: 'cast', operand, cast_as: expr.cast_as };
+    return this.#trackLocations(expr, { type: 'cast', operand, cast_as: expr.cast_as });
   }
 
   visitScalarFunctionCallExpression(
     expr: ScalarFunctionCallExpression<DataIn>,
     arg: undefined
   ): SqlExpression<DataOut> {
-    return {
+    return this.#trackLocations(expr, {
       type: 'function',
       function: expr.function,
       parameters: expr.parameters.map((p) => visitExpr(this, p, arg))
-    };
+    });
   }
 
   visitLiteralExpression(expr: LiteralExpression, arg: undefined): SqlExpression<DataOut> {

--- a/packages/sync-rules/test/src/compiler/__snapshots__/cte.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/cte.test.ts.snap
@@ -323,6 +323,224 @@ exports[`common table expressions > as parameter query 1`] = `
 }
 `;
 
+exports[`common table expressions > can reference CTE multiple times 1`] = `
+{
+  "buckets": [
+    {
+      "hash": 187425881,
+      "sources": [
+        0,
+      ],
+      "uniqueName": "a|0",
+    },
+  ],
+  "dataSources": [
+    {
+      "columns": [
+        "star",
+      ],
+      "filters": [],
+      "hash": 6968780,
+      "outputTableName": "tbl_a",
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "col_1",
+            },
+            "type": "data",
+          },
+        },
+        {
+          "expr": {
+            "source": {
+              "column": "col_2",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "tbl_a",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "parameterIndexes": [
+    {
+      "filters": [],
+      "hash": 250920890,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "0",
+      },
+      "output": [
+        {
+          "source": {
+            "column": "id",
+          },
+          "type": "data",
+        },
+      ],
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "id",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "user_profiles",
+      },
+      "tableValuedFunctions": [],
+    },
+    {
+      "filters": [],
+      "hash": 215867003,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "1",
+      },
+      "output": [
+        {
+          "source": {
+            "column": "id",
+          },
+          "type": "data",
+        },
+      ],
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "col_1",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "tbl_2",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "streams": [
+    {
+      "queriers": [
+        {
+          "bucket": 0,
+          "lookupStages": [
+            [
+              {
+                "instantiation": [
+                  {
+                    "expr": {
+                      "function": "->>",
+                      "parameters": [
+                        {
+                          "source": {
+                            "request": "auth",
+                          },
+                          "type": "data",
+                        },
+                        {
+                          "type": "lit_string",
+                          "value": "$.sub",
+                        },
+                      ],
+                      "type": "function",
+                    },
+                    "type": "request",
+                  },
+                ],
+                "lookup": 0,
+                "type": "parameter",
+              },
+            ],
+            [
+              {
+                "instantiation": [
+                  {
+                    "expr": {
+                      "function": "->>",
+                      "parameters": [
+                        {
+                          "source": {
+                            "request": "auth",
+                          },
+                          "type": "data",
+                        },
+                        {
+                          "type": "lit_string",
+                          "value": "$.sub",
+                        },
+                      ],
+                      "type": "function",
+                    },
+                    "type": "request",
+                  },
+                ],
+                "lookup": 0,
+                "type": "parameter",
+              },
+              {
+                "instantiation": [
+                  {
+                    "lookup": {
+                      "idInStage": 0,
+                      "stageId": 0,
+                    },
+                    "resultIndex": 0,
+                    "type": "lookup",
+                  },
+                ],
+                "lookup": 1,
+                "type": "parameter",
+              },
+            ],
+          ],
+          "requestFilters": [],
+          "sourceInstantiation": [
+            {
+              "lookup": {
+                "idInStage": 0,
+                "stageId": 1,
+              },
+              "resultIndex": 0,
+              "type": "lookup",
+            },
+            {
+              "lookup": {
+                "idInStage": 1,
+                "stageId": 1,
+              },
+              "resultIndex": 0,
+              "type": "lookup",
+            },
+          ],
+        },
+      ],
+      "stream": {
+        "isSubscribedByDefault": false,
+        "name": "a",
+        "priority": 3,
+      },
+    },
+  ],
+  "version": 1,
+}
+`;
+
 exports[`common table expressions > multiple output references 1`] = `
 {
   "buckets": [

--- a/packages/sync-rules/test/src/compiler/cte.test.ts
+++ b/packages/sync-rules/test/src/compiler/cte.test.ts
@@ -206,4 +206,27 @@ streams:
       }
     ]);
   });
+
+  test('can reference CTE multiple times', () => {
+    const plan = compileToSyncPlanWithoutErrors(`
+config:
+  edition: 3
+
+streams:
+  a:
+    accept_potentially_dangerous_queries: true
+    with:
+      selected_profile: |
+        SELECT id FROM user_profiles WHERE id = auth.user_id()
+    queries:
+      - SELECT * FROM tbl_a
+        WHERE col_1 IN selected_profile
+          AND col_2 IN (
+            SELECT id FROM tbl_2
+            WHERE col_1 IN selected_profile
+          )
+`);
+
+    expect(serializeSyncPlan(plan)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
When a CTE is referenced in a `FROM` clause, that semantically behaves as if the CTE had been inlined at that specific source location. As a consequence, a CTE referenced two times should behave as two distinct subqueries. Consider this query as an example:

```sql
-- with cte: SELECT a, b FROM users WHERE org = auth.param('org_id') 

SELECT * FROM tbl_a WHERE
  col_1 IN (SELECT a FROM cte) AND
  col_2 IN (SELECT b FROM cte)
```

Here, the source result sets making up the CTE need to be duplicated! We can't assume that `col_1 IN` and `col_3 IN` reference the same underlying `users` row.

In the Sync Streams compiler, we use the identity of result set objects to track dependencies between expressions. And because the CTE is prepared just once, there'll be a single `users` result set in the resulting object graph. This causes miscompilations (and typically a compiler crash about circular referenced as we try to resolve `tbl_a` -> `users` -> `tbl_a` again).

A relatively straightforward fix is to clone result sets (and associated expressions) when a CTE is added. I've also considered re-preparing the CTE every time it's referenced, but that might lead to duplicate error messages. So this feels like the right approach, even though it adds an annoying amount of code for this fix. Other ideas to fix this are definitely welcome!

I think this is not a security issue, since merging rows would always make filters more strict than they should be. I can't come up with a case where this would ignore a filter expression, but that doesn't mean none exist.