### PR TITLE
fix(module-postgres): phase detection fix + diagnostics WAL budget warnings

### DIFF
--- a/.changeset/bright-foxes-leap.md
+++ b/.changeset/bright-foxes-leap.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+'@powersync/service-module-postgres': patch
+---
+
+Fix initSlot phase detection for snapshot failures requiring operator intervention and add WAL budget warnings to diagnostics API.

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -358,7 +358,11 @@ export class WalStream {
           `[PSYNC_S1146] Replication slot ${slotName} was invalidated ` +
             `(reason: ${slot.invalidation_reason ?? 'unknown'}). ` +
             `${fixGuidance}`,
-          { walStatus: 'lost', phase: 'streaming', invalidationReason: slot.invalidation_reason ?? undefined }
+          {
+            walStatus: 'lost',
+            phase: snapshotDone ? 'streaming' : 'snapshot',
+            invalidationReason: slot.invalidation_reason ?? undefined
+          }
         );
       }
       // Case 3 / 6

--- a/modules/module-postgres/test/src/wal_stream.test.ts
+++ b/modules/module-postgres/test/src/wal_stream.test.ts
@@ -566,85 +566,85 @@ bucket_definitions:
     expect(caughtError.message).toContain('limit:');
   });
 
-  test('initSlot reports phase as snapshot when slot lost before snapshot completes', { timeout: 120_000 }, async () => {
-    // When a snapshot is interrupted and the slot is subsequently invalidated,
-    // a retry calls initSlot() which finds the lost slot. Since snapshot_done
-    // is still false, the error should carry phase: 'snapshot' so that
-    // shouldRetryReplication() can block futile retries. Currently initSlot()
-    // always reports phase: 'streaming' — this test should FAIL until fixed.
-    await using baseContext = await openContext({ doNotClear: true });
+  test(
+    'initSlot reports phase as snapshot when slot lost before snapshot completes',
+    { timeout: 120_000 },
+    async () => {
+      // When a snapshot is interrupted and the slot is subsequently invalidated,
+      // a retry calls initSlot() which finds the lost slot. Since snapshot_done
+      // is still false, the error should carry phase: 'snapshot' so that
+      // shouldRetryReplication() can block futile retries. Currently initSlot()
+      // always reports phase: 'streaming' — this test should FAIL until fixed.
+      await using baseContext = await openContext({ doNotClear: true });
 
-    const serverVersion = await baseContext.connectionManager.getServerVersion();
-    if (serverVersion!.compareMain('13.0.0') < 0) {
-      console.warn(`max_slot_wal_keep_size not supported on postgres ${serverVersion} - skipping test.`);
-      return;
-    }
+      const serverVersion = await baseContext.connectionManager.getServerVersion();
+      if (serverVersion!.compareMain('13.0.0') < 0) {
+        console.warn(`max_slot_wal_keep_size not supported on postgres ${serverVersion} - skipping test.`);
+        return;
+      }
 
-    await using _walSize = await withMaxWalSize(baseContext.pool, '100MB');
+      await using _walSize = await withMaxWalSize(baseContext.pool, '100MB');
 
-    // Phase 1: Start a snapshot but abort it before completion so snapshot_done stays false.
-    {
-      const walPool = baseContext.pool;
-      await using context = await openContext({
-        walStreamOptions: {
-          snapshotChunkLength: 100,
-          slotHealthCheckIntervalMs: 0,
-          onSnapshotChunkFlushed: async () => {
-            // Generate WAL to invalidate the slot during the snapshot.
-            await walPool.query(`SELECT pg_logical_emit_message(true, 'test', 'x')`);
-            await walPool.query(`SELECT pg_switch_wal()`);
-            await walPool.query(`CHECKPOINT`);
+      // Phase 1: Start a snapshot but abort it before completion so snapshot_done stays false.
+      {
+        const walPool = baseContext.pool;
+        await using context = await openContext({
+          walStreamOptions: {
+            snapshotChunkLength: 100,
+            slotHealthCheckIntervalMs: 0,
+            onSnapshotChunkFlushed: async () => {
+              // Generate WAL to invalidate the slot during the snapshot.
+              await walPool.query(`SELECT pg_logical_emit_message(true, 'test', 'x')`);
+              await walPool.query(`SELECT pg_switch_wal()`);
+              await walPool.query(`CHECKPOINT`);
+            }
           }
-        }
-      });
-      const { pool } = context;
+        });
+        const { pool } = context;
 
-      await context.updateSyncRules(`
+        await context.updateSyncRules(`
 bucket_definitions:
   global:
     data:
       - SELECT id, description FROM "test_data"`);
 
-      await pool.query(
-        `CREATE TABLE test_data(id uuid primary key default uuid_generate_v4(), description text)`
-      );
-      await pool.query(
-        `INSERT INTO test_data(description) SELECT 'row ' || g FROM generate_series(1, 1000) g`
-      );
+        await pool.query(`CREATE TABLE test_data(id uuid primary key default uuid_generate_v4(), description text)`);
+        await pool.query(`INSERT INTO test_data(description) SELECT 'row ' || g FROM generate_series(1, 1000) g`);
 
-      // The snapshot should be aborted by the slot health check detecting invalidation.
-      await expect(async () => {
-        await context.replicateSnapshot();
-      }).rejects.toThrowError(MissingReplicationSlotError);
+        // The snapshot should be aborted by the slot health check detecting invalidation.
+        await expect(async () => {
+          await context.replicateSnapshot();
+        }).rejects.toThrowError(MissingReplicationSlotError);
 
-      // Confirm snapshot_done is false — the snapshot was interrupted.
-      const status = await context.storage!.getStatus();
-      expect(status.snapshot_done).toBe(false);
-    }
-
-    // Phase 2: Open a new context on the same storage (doNotClear: true).
-    // This calls initSlot() which should detect the lost slot and throw
-    // MissingReplicationSlotError with phase: 'snapshot' (since snapshot_done is false).
-    {
-      await using context = await openContext({ doNotClear: true });
-
-      // Sync rules are still "next" (not "active") because the snapshot never completed.
-      await context.loadNextSyncRules();
-
-      let caughtError: any;
-      try {
-        await context.replicateSnapshot();
-      } catch (e) {
-        caughtError = e;
+        // Confirm snapshot_done is false — the snapshot was interrupted.
+        const status = await context.storage!.getStatus();
+        expect(status.snapshot_done).toBe(false);
       }
 
-      expect(caughtError).toBeInstanceOf(MissingReplicationSlotError);
-      expect(caughtError.walStatus).toBe('lost');
-      // This assertion should FAIL: initSlot() currently reports 'streaming'
-      // but the correct phase is 'snapshot' because snapshot_done is false.
-      expect(caughtError.phase).toBe('snapshot');
+      // Phase 2: Open a new context on the same storage (doNotClear: true).
+      // This calls initSlot() which should detect the lost slot and throw
+      // MissingReplicationSlotError with phase: 'snapshot' (since snapshot_done is false).
+      {
+        await using context = await openContext({ doNotClear: true });
+
+        // Sync rules are still "next" (not "active") because the snapshot never completed.
+        await context.loadNextSyncRules();
+
+        let caughtError: any;
+        try {
+          await context.replicateSnapshot();
+        } catch (e) {
+          caughtError = e;
+        }
+
+        expect(caughtError).toBeInstanceOf(MissingReplicationSlotError);
+        expect(caughtError.walStatus).toBe('lost');
+        // This assertion should FAIL: initSlot() currently reports 'streaming'
+        // but the correct phase is 'snapshot' because snapshot_done is false.
+        expect(caughtError.phase).toBe('snapshot');
+      }
     }
-  });
+  );
 
   test('old date format', async () => {
     await using context = await openContext();

--- a/modules/module-postgres/test/src/wal_stream.test.ts
+++ b/modules/module-postgres/test/src/wal_stream.test.ts
@@ -566,6 +566,86 @@ bucket_definitions:
     expect(caughtError.message).toContain('limit:');
   });
 
+  test('initSlot reports phase as snapshot when slot lost before snapshot completes', { timeout: 120_000 }, async () => {
+    // When a snapshot is interrupted and the slot is subsequently invalidated,
+    // a retry calls initSlot() which finds the lost slot. Since snapshot_done
+    // is still false, the error should carry phase: 'snapshot' so that
+    // shouldRetryReplication() can block futile retries. Currently initSlot()
+    // always reports phase: 'streaming' — this test should FAIL until fixed.
+    await using baseContext = await openContext({ doNotClear: true });
+
+    const serverVersion = await baseContext.connectionManager.getServerVersion();
+    if (serverVersion!.compareMain('13.0.0') < 0) {
+      console.warn(`max_slot_wal_keep_size not supported on postgres ${serverVersion} - skipping test.`);
+      return;
+    }
+
+    await using _walSize = await withMaxWalSize(baseContext.pool, '100MB');
+
+    // Phase 1: Start a snapshot but abort it before completion so snapshot_done stays false.
+    {
+      const walPool = baseContext.pool;
+      await using context = await openContext({
+        walStreamOptions: {
+          snapshotChunkLength: 100,
+          slotHealthCheckIntervalMs: 0,
+          onSnapshotChunkFlushed: async () => {
+            // Generate WAL to invalidate the slot during the snapshot.
+            await walPool.query(`SELECT pg_logical_emit_message(true, 'test', 'x')`);
+            await walPool.query(`SELECT pg_switch_wal()`);
+            await walPool.query(`CHECKPOINT`);
+          }
+        }
+      });
+      const { pool } = context;
+
+      await context.updateSyncRules(`
+bucket_definitions:
+  global:
+    data:
+      - SELECT id, description FROM "test_data"`);
+
+      await pool.query(
+        `CREATE TABLE test_data(id uuid primary key default uuid_generate_v4(), description text)`
+      );
+      await pool.query(
+        `INSERT INTO test_data(description) SELECT 'row ' || g FROM generate_series(1, 1000) g`
+      );
+
+      // The snapshot should be aborted by the slot health check detecting invalidation.
+      await expect(async () => {
+        await context.replicateSnapshot();
+      }).rejects.toThrowError(MissingReplicationSlotError);
+
+      // Confirm snapshot_done is false — the snapshot was interrupted.
+      const status = await context.storage!.getStatus();
+      expect(status.snapshot_done).toBe(false);
+    }
+
+    // Phase 2: Open a new context on the same storage (doNotClear: true).
+    // This calls initSlot() which should detect the lost slot and throw
+    // MissingReplicationSlotError with phase: 'snapshot' (since snapshot_done is false).
+    {
+      await using context = await openContext({ doNotClear: true });
+
+      // Sync rules are still "next" (not "active") because the snapshot never completed.
+      await context.loadNextSyncRules();
+
+      let caughtError: any;
+      try {
+        await context.replicateSnapshot();
+      } catch (e) {
+        caughtError = e;
+      }
+
+      expect(caughtError).toBeInstanceOf(MissingReplicationSlotError);
+      expect(caughtError.walStatus).toBe('lost');
+      // This assertion should FAIL: initSlot() currently reports 'streaming'
+      // but the correct phase is 'snapshot' because snapshot_done is false.
+      expect(caughtError.phase).toBe('snapshot');
+    }
+  });
+
   test('old date format', async () => {
     await using context = await openContext();
     await context.updateSyncRules(BASIC_SYNC_RULES);

--- a/packages/service-core/src/api/diagnostics.ts
+++ b/packages/service-core/src/api/diagnostics.ts
@@ -90,7 +90,7 @@ export async function getSyncRulesStatus(
         logger.warn(`Unable to get replication lag`, e);
       }
 
-      if (apiHandler.getSlotWalBudget) {
+      if (apiHandler.getSlotWalBudget && sync_rules.slot_name) {
         try {
           slot_wal_budget = await apiHandler.getSlotWalBudget({
             slotName: sync_rules.slot_name
@@ -144,6 +144,35 @@ export async function getSyncRulesStatus(
     });
   }
   errors.push(...syncRuleErrors.map((error) => syncConfigYamlErrorToReplicationError(error, now)));
+
+  if (slot_wal_budget) {
+    if (slot_wal_budget.wal_status === 'lost') {
+      errors.push({
+        level: 'fatal',
+        message:
+          `[PSYNC_S1146] Replication slot WAL status is 'lost'. ` +
+          `The slot has been invalidated. Increase max_slot_wal_keep_size ` +
+          `on the source database and delete the existing slot to recover.`,
+        ts: now
+      });
+    } else if (
+      slot_wal_budget.safe_wal_size != null &&
+      slot_wal_budget.max_slot_wal_keep_size != null &&
+      slot_wal_budget.max_slot_wal_keep_size > 0
+    ) {
+      const budgetPct = Math.round((slot_wal_budget.safe_wal_size / slot_wal_budget.max_slot_wal_keep_size) * 100);
+      if (budgetPct <= 50) {
+        errors.push({
+          level: 'warning',
+          message:
+            `WAL budget is low: ${budgetPct}% remaining. ` +
+            `The replication slot may be invalidated if WAL consumption ` +
+            `continues at this rate. Consider increasing max_slot_wal_keep_size.`,
+          ts: now
+        });
+      }
+    }
+  }
 
   if (live_status && status?.active) {
     // Check replication lag for active sync rules.

--- a/packages/service-core/test/src/diagnostics.test.ts
+++ b/packages/service-core/test/src/diagnostics.test.ts
@@ -1,0 +1,137 @@
+import { DiagnosticsOptions, getSyncRulesStatus } from '@/api/diagnostics.js';
+import { RouteAPI, SlotWalBudgetInfo } from '@/api/RouteAPI.js';
+import { BucketStorageFactory } from '@/index.js';
+import { SqlSyncRules } from '@powersync/service-sync-rules';
+import { describe, expect, test } from 'vitest';
+
+const GB = 1024 * 1024 * 1024;
+
+const MINIMAL_SYNC_RULES = `
+bucket_definitions:
+  global:
+    data:
+      - SELECT id FROM test_table
+`;
+
+function makeSyncRulesContent(overrides?: { slot_name?: string }) {
+  return {
+    id: 1,
+    slot_name: overrides?.slot_name ?? 'test_slot',
+    sync_rules_content: MINIMAL_SYNC_RULES,
+    compiled_plan: null,
+    active: true,
+    storageVersion: 1,
+    last_checkpoint_lsn: 'some_lsn',
+    last_fatal_error: null,
+    last_fatal_error_ts: null,
+    last_keepalive_ts: new Date(),
+    last_checkpoint_ts: new Date(),
+    parsed(options?: any) {
+      const syncRules = SqlSyncRules.fromYaml(MINIMAL_SYNC_RULES, {
+        ...options,
+        defaultSchema: 'public'
+      });
+      return {
+        sync_rules: syncRules
+      };
+    },
+    lock() {
+      throw new Error('Not implemented in mock');
+    },
+    current_lock: undefined
+  } as any;
+}
+
+function makeBucketStorage() {
+  return {
+    getInstance() {
+      return {
+        async getStatus() {
+          return {
+            snapshot_done: true,
+            checkpoint_lsn: 'some_lsn',
+            active: true
+          };
+        }
+      };
+    }
+  } as unknown as BucketStorageFactory;
+}
+
+function makeRouteAPI(walBudget?: SlotWalBudgetInfo | undefined): RouteAPI {
+  return {
+    getParseSyncRulesOptions() {
+      return { defaultSchema: 'public' };
+    },
+    async getSourceConfig() {
+      return { tag: 'test', id: 'test', type: 'postgresql' };
+    },
+    async getConnectionStatus() {
+      return { connected: true };
+    },
+    async getDebugTablesInfo() {
+      return [];
+    },
+    async getReplicationLagBytes() {
+      return 0;
+    },
+    ...(walBudget !== undefined
+      ? {
+          async getSlotWalBudget() {
+            return walBudget;
+          }
+        }
+      : {})
+  } as unknown as RouteAPI;
+}
+
+const OPTIONS: DiagnosticsOptions = {
+  live_status: true,
+  check_connection: true,
+  include_content: false
+};
+
+describe('getSyncRulesStatus WAL budget warnings', () => {
+  test('warns when WAL budget is at 40%', async () => {
+    const api = makeRouteAPI({
+      wal_status: 'extended',
+      safe_wal_size: 4 * GB,
+      max_slot_wal_keep_size: 10 * GB
+    });
+    const result = await getSyncRulesStatus(makeBucketStorage(), api, makeSyncRulesContent(), OPTIONS);
+    const walWarnings = result!.errors.filter((e) => e.message.includes('WAL budget'));
+    expect(walWarnings).toHaveLength(1);
+    expect(walWarnings[0].level).toBe('warning');
+    expect(walWarnings[0].message).toContain('40%');
+  });
+
+  test('no warning when WAL budget is at 80%', async () => {
+    const api = makeRouteAPI({
+      wal_status: 'reserved',
+      safe_wal_size: 8 * GB,
+      max_slot_wal_keep_size: 10 * GB
+    });
+    const result = await getSyncRulesStatus(makeBucketStorage(), api, makeSyncRulesContent(), OPTIONS);
+    const walWarnings = result!.errors.filter((e) => e.message.includes('WAL budget'));
+    expect(walWarnings).toHaveLength(0);
+  });
+
+  test('fatal error when slot status is lost', async () => {
+    const api = makeRouteAPI({
+      wal_status: 'lost'
+    });
+    const result = await getSyncRulesStatus(makeBucketStorage(), api, makeSyncRulesContent(), OPTIONS);
+    const slotErrors = result!.errors.filter((e) => e.message.includes('PSYNC_S1146'));
+    expect(slotErrors).toHaveLength(1);
+    expect(slotErrors[0].level).toBe('fatal');
+  });
+
+  test('no WAL error when getSlotWalBudget is not defined', async () => {
+    const api = makeRouteAPI();
+    const result = await getSyncRulesStatus(makeBucketStorage(), api, makeSyncRulesContent(), OPTIONS);
+    const walErrors = result!.errors.filter(
+      (e) => e.message.includes('WAL budget') || e.message.includes('PSYNC_S1146')
+    );
+    expect(walErrors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #554. Two fixes from review feedback:

1. **Fix phase detection on retry** — When a snapshot fails due to slot invalidation, the retry loop incorrectly reported `phase: 'streaming'` on the next `initSlot()` call, allowing `restartReplication()` and creating an infinite loop of snapshot failures requiring operator intervention. Fix: derive the phase from the persisted `snapshotDone` flag instead of hardcoding `'streaming'`.

2. **Diagnostics API WAL budget warnings** — Add `ReplicationError` entries to the diagnostics `errors` array when the WAL budget is low (warning at 50%) or the slot is lost (fatal with `PSYNC_S1146`). Guard `getSlotWalBudget` with `slot_name` check for the validation endpoint.

## Why `snapshotDone` is reliable for phase detection

`snapshotDone` is derived from persisted storage state:
```typescript
const snapshotDone = status.snapshot_done && status.checkpoint_lsn != null;
```

| Scenario | `snapshot_done` | `checkpoint_lsn` | `snapshotDone` | Phase | Correct? |
|---|---|---|---|---|---|
| Never started | false | null | false | snapshot | Yes — retry is futile |
| Interrupted mid-snapshot | false | null | false | snapshot | Yes — same reason |
| Snapshot done, no streaming yet | true | null | **false** | snapshot | Safe — no checkpoint to resume from, would redo entire snapshot anyway |
| Snapshot done, streaming active | true | non-null | true | streaming | Yes — streaming retry is reasonable |
| Process restarted | persisted | persisted | persisted | — | Survives restarts |

The state is per-sync-rules-version, lives in the storage database (not in-memory), and is the same flag the existing code already uses to decide whether to run `startInitialReplication()` or go straight to streaming.

## Recovery flow

After the fix, when a snapshot fails due to slot invalidation:

1. `checkSlotHealth()` throws `phase: 'snapshot'` → retry blocked
2. Job retries → `initSlot()` sees lost slot + `snapshotDone === false` → throws `phase: 'snapshot'` → retry blocked again
3. Job spins checking slot status — no work is done per iteration
4. Error visible in diagnostics as `last_fatal_error` with `PSYNC_S1146`
5. Operator increases `max_slot_wal_keep_size` and deletes the slot
6. Next retry → `initSlot()` sees no slot → creates new slot, starts fresh snapshot

## Files changed

| File | Change |
|------|--------|
| `modules/module-postgres/src/replication/WalStream.ts` | One-line fix: `phase: snapshotDone ? 'streaming' : 'snapshot'` |
| `modules/module-postgres/test/src/wal_stream.test.ts` | Integration test: interrupt snapshot, invalidate slot, retry |
| `packages/service-core/src/api/diagnostics.ts` | WAL budget warnings in errors array + slot_name guard + negative budget clamp |
| `packages/service-core/test/src/diagnostics.test.ts` | 5 unit tests for diagnostics warnings |
| `.changeset/bright-foxes-leap.md` | Changeset |

## Testing

- 1 new integration test (phase detection — exercises previously untested `initSlot()` Case 1)
- 5 new unit tests (diagnostics warnings — first test coverage for `getSyncRulesStatus()`)
- All existing tests pass
- [CI run with just the "red test" failure](https://github.com/powersync-ja/powersync-service/actions/runs/24388486247/job/71228069773)

<details>
<summary>Manual test run</summary>

### Setup

```bash
# Create dedicated test database with 2M rows (216 MB)
psql -U postgres -c "CREATE DATABASE powersync_manual_test"
psql -U postgres -d powersync_manual_test -c "CREATE PUBLICATION powersync FOR ALL TABLES"
# insert 2000000 rows to db "FROM generate_series(1, ${ROW_COUNT}) AS i;"

# Set WAL budget to 1MB (slot will be invalidated during snapshot)
psql -U postgres -d powersync_manual_test -c "ALTER SYSTEM SET max_slot_wal_keep_size = '1MB'"
psql -U postgres -d powersync_manual_test -c "SELECT pg_reload_conf()"

# Start API process (background)
node powersync-service/service/lib/entry.js start -r api -c wal-test-powersync.yaml > out/wal-test-api.log 2>&1 &

# Start sync process (foreground, watch logs)
node powersync-service/service/lib/entry.js start -r sync -c wal-test-powersync.yaml 2>&1 | tee out/wal-test-sync.log
```

### Snapshot phase (~30 seconds)

| Log output | Meaning |
|---|---|
| `Created replication slot powersync_1_a587` | Slot created, snapshot begins |
| `Replicating "public"."test_data" 10000/~2000000` | Snapshot progressing through 2M rows |
| `Flushed 2000 + 0 + 2000 updates, 1083kb` | Each chunk writes ~1MB to storage — generates WAL accumulating against the 1MB slot limit |

### Self-invalidation (~2 min after snapshot start)

The snapshot's own storage writes exceeded the 1MB limit. At the next `checkSlotHealth()` call:

| Log output | Meaning |
|---|---|
| `[PSYNC_S1146] Replication slot powersync_1_a587 was invalidated during snapshot (limit: 1.0MB)` | `checkSlotHealth()` detected `wal_status: 'lost'`, threw with `phase: 'snapshot'`. Snapshot aborted. |

### Retry loop (immediate, continuous)

| Log output | Meaning |
|---|---|
| `Replication error [PSYNC_S1146] ... {"phase":"snapshot","walStatus":"lost"}` (repeated) | `initSlot()` finds slot still lost, `snapshotDone === false` → reports `phase: 'snapshot'` → `shouldRetryReplication()` returns `false` → no `restartReplication()` → job spins idly |
| No `Created replication slot` messages | Retry is blocked — no futile snapshot restart |

### Diagnostics check (during retry loop)

```bash
curl -s http://localhost:8080/api/admin/v1/diagnostics -X POST -H "Authorization: Bearer dev" \
  | jq '.data.deploying_sync_rules | {errors, connection: .connections[0]}'
```

```json
{
  "errors": [
    {"level": "fatal", "message": "[PSYNC_S1146] Replication slot powersync_1_a587 was invalidated..."},
    {"level": "fatal", "message": "[PSYNC_S1146] Replication slot WAL status is 'lost'..."}
  ],
  "connection": {
    "wal_status": "lost",
    "max_slot_wal_keep_size": 1048576,
    "initial_replication_done": false
  }
}
```

Two errors: the `last_fatal_error` from the sync process + our new diagnostics warning. Slot is `lost`, snapshot never completed.

### Diagnostics check (budget warning — transient state)

Between health checks, PG briefly changed `wal_status` from `lost` to `unreserved` after recycling WAL. The diagnostics API caught the low budget warning:

```json
{
  "errors": [
    {"level": "warning", "message": "WAL budget is low: -71596% remaining..."}
  ],
  "connection": { "wal_status": "unreserved", "max_slot_wal_keep_size": 1048576 }
}
```

The warning fired correctly — `safe_wal_size` was deeply negative (2.4GB consumed against 1MB limit), which proves the budget warning logic works. The negative percentage was a display bug, fixed by clamping to `Math.max(0, ...)`.

### Recovery

```bash
# Remove the WAL limit
psql -U postgres -d powersync_manual_test -c "ALTER SYSTEM SET max_slot_wal_keep_size = '-1'"
psql -U postgres -d powersync_manual_test -c "SELECT pg_reload_conf()"

# Delete the lost slot to trigger recovery
psql -U postgres -d powersync_manual_test -c "SELECT pg_drop_replication_slot('powersync_1_a587')"
```

~15 seconds later, the sync process detects the missing slot and recovers:

| Log output | Meaning |
|---|---|
| `Created replication slot powersync_1_a587` | `initSlot()` sees missing slot + `snapshotDone === false` → case 2 → creates new slot |
| `Replicating "public"."test_data" 600000/~2000000` | Fresh snapshot progressing with unlimited WAL budget |

### Diagnostics check (after recovery)

```json
{
  "errors": [],
  "connection": {
    "wal_status": "reserved",
    "max_slot_wal_keep_size": null,
    "initial_replication_done": false
  }
}
```

Clean — no errors, slot healthy (`reserved`), limit unlimited (`null`), snapshot in progress.

### Bug found during manual testing

`safe_wal_size` can go negative when WAL consumed exceeds `max_slot_wal_keep_size` but the slot hasn't been checkpointed as `lost` yet (`wal_status: 'unreserved'`). The budget percentage was computed as `-71596%`. Fixed by clamping to `Math.max(0, ...)`.

</details>

