### PR TITLE
fix: remove duplicate diagnostics error, add recovery guidance, fix stale comments

### DIFF
--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -353,7 +353,7 @@ export class WalStream {
         const fixGuidance =
           slot.invalidation_reason === 'idle_timeout'
             ? `Increase idle_replication_slot_timeout on the source database.`
-            : `Increase max_slot_wal_keep_size on the source database.`;
+            : `Increase max_slot_wal_keep_size on the source database and delete the existing slot to recover.`;
         throw new MissingReplicationSlotError(
           `[PSYNC_S1146] Replication slot ${slotName} was invalidated ` +
             `(reason: ${slot.invalidation_reason ?? 'unknown'}). ` +

--- a/modules/module-postgres/test/src/wal_stream.test.ts
+++ b/modules/module-postgres/test/src/wal_stream.test.ts
@@ -573,8 +573,8 @@ bucket_definitions:
       // When a snapshot is interrupted and the slot is subsequently invalidated,
       // a retry calls initSlot() which finds the lost slot. Since snapshot_done
       // is still false, the error should carry phase: 'snapshot' so that
-      // shouldRetryReplication() can block futile retries. Currently initSlot()
-      // always reports phase: 'streaming' — this test should FAIL until fixed.
+      // shouldRetryReplication() can block retries for snapshot failures
+      // requiring operator intervention to recover.
       await using baseContext = await openContext({ doNotClear: true });
 
       const serverVersion = await baseContext.connectionManager.getServerVersion();
@@ -639,8 +639,7 @@ bucket_definitions:
 
         expect(caughtError).toBeInstanceOf(MissingReplicationSlotError);
         expect(caughtError.walStatus).toBe('lost');
-        // This assertion should FAIL: initSlot() currently reports 'streaming'
-        // but the correct phase is 'snapshot' because snapshot_done is false.
+        // initSlot() derives phase from snapshotDone: snapshot not done → phase is 'snapshot'
         expect(caughtError.phase).toBe('snapshot');
       }
     }

--- a/modules/module-postgres/test/src/wal_stream.test.ts
+++ b/modules/module-postgres/test/src/wal_stream.test.ts
@@ -585,66 +585,6 @@ bucket_definitions:
 
       await using _walSize = await withMaxWalSize(baseContext.pool, '100MB');
 
-      // Phase 1: Start a snapshot but abort it before completion so snapshot_done stays false.
-      {
-        const walPool = baseContext.pool;
-        await using context = await openContext({
-          walStreamOptions: {
-            snapshotChunkLength: 100,
-            slotHealthCheckIntervalMs: 0,
-            onSnapshotChunkFlushed: async () => {
-              // Generate WAL to invalidate the slot during the snapshot.
-              await walPool.query(`SELECT pg_logical_emit_message(true, 'test', 'x')`);
-              await walPool.query(`SELECT pg_switch_wal()`);
-              await walPool.query(`CHECKPOINT`);
-            }
-          }
-        });
-        const { pool } = context;
-
-        await context.updateSyncRules(`
-bucket_definitions:
-  global:
-    data:
-      - SELECT id, description FROM "test_data"`);
-
-        await pool.query(`CREATE TABLE test_data(id uuid primary key default uuid_generate_v4(), description text)`);
-        await pool.query(`INSERT INTO test_data(description) SELECT 'row ' || g FROM generate_series(1, 1000) g`);
-
-        // The snapshot should be aborted by the slot health check detecting invalidation.
-        await expect(async () => {
-          await context.replicateSnapshot();
-        }).rejects.toThrowError(MissingReplicationSlotError);
-
-        // Confirm snapshot_done is false — the snapshot was interrupted.
-        const status = await context.storage!.getStatus();
-        expect(status.snapshot_done).toBe(false);
-      }
-
-      // Phase 2: Open a new context on the same storage (doNotClear: true).
-      // This calls initSlot() which should detect the lost slot and throw
-      // MissingReplicationSlotError with phase: 'snapshot' (since snapshot_done is false).
-      {
-        await using context = await openContext({ doNotClear: true });
-
-        // Sync rules are still "next" (not "active") because the snapshot never completed.
-        await context.loadNextSyncRules();
-
-        let caughtError: any;
-        try {
-          await context.replicateSnapshot();
-        } catch (e) {
-          caughtError = e;
-        }
-
-        expect(caughtError).toBeInstanceOf(MissingReplicationSlotError);
-        expect(caughtError.walStatus).toBe('lost');
-        // initSlot() derives phase from snapshotDone: snapshot not done → phase is 'snapshot'
-        expect(caughtError.phase).toBe('snapshot');
-      }
-    }
-  );
-
   test('old date format', async () => {
     await using context = await openContext();
     await context.updateSyncRules(BASIC_SYNC_RULES);

--- a/modules/module-postgres/test/src/wal_stream.test.ts
+++ b/modules/module-postgres/test/src/wal_stream.test.ts
@@ -585,6 +585,66 @@ bucket_definitions:
 
       await using _walSize = await withMaxWalSize(baseContext.pool, '100MB');
 
+      // Phase 1: Start a snapshot but abort it before completion so snapshot_done stays false.
+      {
+        const walPool = baseContext.pool;
+        await using context = await openContext({
+          walStreamOptions: {
+            snapshotChunkLength: 100,
+            slotHealthCheckIntervalMs: 0,
+            onSnapshotChunkFlushed: async () => {
+              // Generate WAL to invalidate the slot during the snapshot.
+              await walPool.query(`SELECT pg_logical_emit_message(true, 'test', 'x')`);
+              await walPool.query(`SELECT pg_switch_wal()`);
+              await walPool.query(`CHECKPOINT`);
+            }
+          }
+        });
+        const { pool } = context;
+
+        await context.updateSyncRules(`
+bucket_definitions:
+  global:
+    data:
+      - SELECT id, description FROM "test_data"`);
+
+        await pool.query(`CREATE TABLE test_data(id uuid primary key default uuid_generate_v4(), description text)`);
+        await pool.query(`INSERT INTO test_data(description) SELECT 'row ' || g FROM generate_series(1, 1000) g`);
+
+        // The snapshot should be aborted by the slot health check detecting invalidation.
+        await expect(async () => {
+          await context.replicateSnapshot();
+        }).rejects.toThrowError(MissingReplicationSlotError);
+
+        // Confirm snapshot_done is false — the snapshot was interrupted.
+        const status = await context.storage!.getStatus();
+        expect(status.snapshot_done).toBe(false);
+      }
+
+      // Phase 2: Open a new context on the same storage (doNotClear: true).
+      // This calls initSlot() which should detect the lost slot and throw
+      // MissingReplicationSlotError with phase: 'snapshot' (since snapshot_done is false).
+      {
+        await using context = await openContext({ doNotClear: true });
+
+        // Sync rules are still "next" (not "active") because the snapshot never completed.
+        await context.loadNextSyncRules();
+
+        let caughtError: any;
+        try {
+          await context.replicateSnapshot();
+        } catch (e) {
+          caughtError = e;
+        }
+
+        expect(caughtError).toBeInstanceOf(MissingReplicationSlotError);
+        expect(caughtError.walStatus).toBe('lost');
+        // initSlot() derives phase from snapshotDone: snapshot not done → phase is 'snapshot'
+        expect(caughtError.phase).toBe('snapshot');
+      }
+    }
+  );
+
   test('old date format', async () => {
     await using context = await openContext();
     await context.updateSyncRules(BASIC_SYNC_RULES);

--- a/packages/service-core/src/api/diagnostics.ts
+++ b/packages/service-core/src/api/diagnostics.ts
@@ -145,32 +145,26 @@ export async function getSyncRulesStatus(
   }
   errors.push(...syncRuleErrors.map((error) => syncConfigYamlErrorToReplicationError(error, now)));
 
-  if (slot_wal_budget) {
-    if (slot_wal_budget.wal_status === 'lost') {
+  if (
+    slot_wal_budget &&
+    slot_wal_budget.wal_status !== 'lost' &&
+    slot_wal_budget.safe_wal_size != null &&
+    slot_wal_budget.max_slot_wal_keep_size != null &&
+    slot_wal_budget.max_slot_wal_keep_size > 0
+  ) {
+    const budgetPct = Math.max(
+      0,
+      Math.round((slot_wal_budget.safe_wal_size / slot_wal_budget.max_slot_wal_keep_size) * 100)
+    );
+    if (budgetPct <= 50) {
       errors.push({
-        level: 'fatal',
+        level: 'warning',
         message:
-          `[PSYNC_S1146] Replication slot WAL status is 'lost'. ` +
-          `The slot has been invalidated. Increase max_slot_wal_keep_size ` +
-          `on the source database and delete the existing slot to recover.`,
+          `WAL budget is low: ${budgetPct}% remaining. ` +
+          `The replication slot may be invalidated if WAL consumption ` +
+          `continues at this rate. Consider increasing max_slot_wal_keep_size.`,
         ts: now
       });
-    } else if (
-      slot_wal_budget.safe_wal_size != null &&
-      slot_wal_budget.max_slot_wal_keep_size != null &&
-      slot_wal_budget.max_slot_wal_keep_size > 0
-    ) {
-      const budgetPct = Math.round((slot_wal_budget.safe_wal_size / slot_wal_budget.max_slot_wal_keep_size) * 100);
-      if (budgetPct <= 50) {
-        errors.push({
-          level: 'warning',
-          message:
-            `WAL budget is low: ${budgetPct}% remaining. ` +
-            `The replication slot may be invalidated if WAL consumption ` +
-            `continues at this rate. Consider increasing max_slot_wal_keep_size.`,
-          ts: now
-        });
-      }
     }
   }
 

--- a/packages/service-core/test/src/diagnostics.test.ts
+++ b/packages/service-core/test/src/diagnostics.test.ts
@@ -116,14 +116,28 @@ describe('getSyncRulesStatus WAL budget warnings', () => {
     expect(walWarnings).toHaveLength(0);
   });
 
-  test('fatal error when slot status is lost', async () => {
+  test('clamps negative safe_wal_size to 0%', async () => {
+    const api = makeRouteAPI({
+      wal_status: 'unreserved',
+      safe_wal_size: -2.4 * GB,
+      max_slot_wal_keep_size: 1 * 1024 * 1024 // 1MB
+    });
+    const result = await getSyncRulesStatus(makeBucketStorage(), api, makeSyncRulesContent(), OPTIONS);
+    const walWarnings = result!.errors.filter((e) => e.message.includes('WAL budget'));
+    expect(walWarnings).toHaveLength(1);
+    expect(walWarnings[0].message).toContain('0%');
+    expect(walWarnings[0].message).not.toMatch(/-\d+%/);
+  });
+
+  test('no WAL budget error when slot status is lost', async () => {
     const api = makeRouteAPI({
       wal_status: 'lost'
     });
     const result = await getSyncRulesStatus(makeBucketStorage(), api, makeSyncRulesContent(), OPTIONS);
-    const slotErrors = result!.errors.filter((e) => e.message.includes('PSYNC_S1146'));
-    expect(slotErrors).toHaveLength(1);
-    expect(slotErrors[0].level).toBe('fatal');
+    const walErrors = result!.errors.filter(
+      (e) => e.message.includes('WAL budget') || e.message.includes('PSYNC_S1146')
+    );
+    expect(walErrors).toHaveLength(0);
   });
 
   test('no WAL error when getSlotWalBudget is not defined', async () => {


### PR DESCRIPTION
## Summary

Follow-up cleanup to PR #606. Three small fixes:

1. **Remove duplicate slot-lost error from diagnostics** — `last_fatal_error` already reports `[PSYNC_S1146]` when the slot is lost. The diagnostics WAL budget check was adding a second fatal error with a different message. Removed the duplicate; the budget check now only fires for the warning case (budget depleting, not yet lost).

2. **Add "delete the existing slot to recover" to initSlot() error** — The recovery guidance ("delete the slot") was only in the now-removed diagnostics error. Moved it into the `initSlot()` error message so it's visible in `last_fatal_error`.

3. **Fix stale red-test comments** — Updated comments that said "this test should FAIL" (leftover from the red-green development cycle).

Also: clamp negative `safe_wal_size` to 0% in the budget percentage calculation (previously produced `-71596%` when WAL consumed exceeded the limit but the slot wasn't yet checkpointed as lost).

## Files changed

| File | Change |
|------|--------|
| `packages/service-core/src/api/diagnostics.ts` | Remove `lost` fatal, keep only budget warning. Add `wal_status !== 'lost'` guard. Clamp negative percentage. |
| `packages/service-core/test/src/diagnostics.test.ts` | Replace `lost → fatal` test with `lost → no WAL budget error`. Add negative clamp test. |
| `modules/module-postgres/src/replication/WalStream.ts` | Add "delete the existing slot to recover" to initSlot() error message |
| `modules/module-postgres/test/src/wal_stream.test.ts` | Fix stale "should FAIL" comments |