### PR TITLE
Support circular references in Sync Streams

### DIFF
--- a/.changeset/pretty-ties-judge.md
+++ b/.changeset/pretty-ties-judge.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Support most circular references in join conditions for Sync Streams (the compiler would crash on those before).

--- a/.changeset/pretty-ties-judge.md
+++ b/.changeset/pretty-ties-judge.md
@@ -2,4 +2,4 @@
 '@powersync/service-sync-rules': patch
 ---
 
-Support most circular references in join conditions for Sync Streams (the compiler would crash on those before).
+Support multiple references between the same tables as join conditions for Sync Streams (the compiler would previously crash due to an "internal circular reference error").

--- a/packages/sync-rules/src/compiler/querier_graph.ts
+++ b/packages/sync-rules/src/compiler/querier_graph.ts
@@ -305,6 +305,15 @@ class PendingQuerierPath {
       } else {
         // Must be a match term.
         const partitionBy = (key: PartitionKey, otherRow: SingleDependencyExpression) => {
+          if (otherRow.resultSet && this.resolveStack.indexOf(otherRow.resultSet) != -1) {
+            // The other result set is already being resolved (so this is a circular reference). We will encounter this
+            // expression again as we go up the stack and the other result set would visit this expression (where the
+            // parameters are essentially swapped, the key here would be the otherRow from that perspective). Since this
+            // parameter lookup would have been resolved at that point, we can simply add the key as an output
+            // expression at that stage.
+            return;
+          }
+
           this.removePendingExpression(expression);
           const values = state.partition.putIfAbsent(key, () => []);
 

--- a/packages/sync-rules/src/compiler/querier_graph.ts
+++ b/packages/sync-rules/src/compiler/querier_graph.ts
@@ -305,7 +305,15 @@ class PendingQuerierPath {
       } else {
         // Must be a match term.
         const partitionBy = (key: PartitionKey, otherRow: SingleDependencyExpression) => {
-          if (otherRow.resultSet && this.resolveStack.indexOf(otherRow.resultSet) != -1) {
+          const otherResultSet = otherRow.resultSet;
+          if (
+            otherResultSet &&
+            this.resolveStack.find(
+              (s) =>
+                s === otherResultSet ||
+                (otherResultSet instanceof TableValuedResultSet && otherResultSet.inputResultSet == s)
+            )
+          ) {
             // The other result set is already being resolved (so this is a circular reference). We will encounter this
             // expression again as we go up the stack and the other result set would visit this expression (where the
             // parameters are essentially swapped, the key here would be the otherRow from that perspective). Since this
@@ -317,8 +325,8 @@ class PendingQuerierPath {
           this.removePendingExpression(expression);
           const values = state.partition.putIfAbsent(key, () => []);
 
-          if (otherRow.resultSet != null) {
-            const lookup = this.resolveExpandingLookup(otherRow.resultSet);
+          if (otherResultSet != null) {
+            const lookup = this.resolveExpandingLookup(otherResultSet);
             const index = lookup.addOutput(new RowExpression(otherRow));
             const value = new LookupResultParameterValue(index);
             lookup.dependents.push(value);

--- a/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
@@ -803,6 +803,141 @@ exports[`new sync stream features > circular references > nested 1`] = `
 }
 `;
 
+exports[`new sync stream features > circular references > table-valued 1`] = `
+{
+  "buckets": [
+    {
+      "hash": 250014934,
+      "sources": [
+        0,
+      ],
+      "uniqueName": "stream|0",
+    },
+  ],
+  "dataSources": [
+    {
+      "columns": [
+        "star",
+      ],
+      "filters": [],
+      "hash": 50729839,
+      "outputTableName": "a",
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "function": 0,
+              "outputName": "value",
+            },
+            "type": "data",
+          },
+        },
+        {
+          "expr": {
+            "source": {
+              "column": "k",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "a",
+      },
+      "tableValuedFunctions": [
+        {
+          "functionInputs": [
+            {
+              "source": {
+                "column": "tags",
+              },
+              "type": "data",
+            },
+          ],
+          "functionName": "json_each",
+        },
+      ],
+    },
+  ],
+  "parameterIndexes": [
+    {
+      "filters": [],
+      "hash": 321622908,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "0",
+      },
+      "output": [
+        {
+          "source": {
+            "column": "k",
+          },
+          "type": "data",
+        },
+        {
+          "source": {
+            "column": "v",
+          },
+          "type": "data",
+        },
+      ],
+      "partitionBy": [],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "b",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "streams": [
+    {
+      "queriers": [
+        {
+          "bucket": 0,
+          "lookupStages": [
+            [
+              {
+                "instantiation": [],
+                "lookup": 0,
+                "type": "parameter",
+              },
+            ],
+          ],
+          "requestFilters": [],
+          "sourceInstantiation": [
+            {
+              "lookup": {
+                "idInStage": 0,
+                "stageId": 0,
+              },
+              "resultIndex": 1,
+              "type": "lookup",
+            },
+            {
+              "lookup": {
+                "idInStage": 0,
+                "stageId": 0,
+              },
+              "resultIndex": 0,
+              "type": "lookup",
+            },
+          ],
+        },
+      ],
+      "stream": {
+        "isSubscribedByDefault": true,
+        "name": "stream",
+        "priority": 3,
+      },
+    },
+  ],
+  "version": 1,
+}
+`;
+
 exports[`new sync stream features > in array 1`] = `
 {
   "buckets": [

--- a/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
@@ -434,6 +434,375 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
 }
 `;
 
+exports[`new sync stream features > circular references > at first level 1`] = `
+{
+  "buckets": [
+    {
+      "hash": 391555584,
+      "sources": [
+        0,
+      ],
+      "uniqueName": "stream|0",
+    },
+  ],
+  "dataSources": [
+    {
+      "columns": [
+        "star",
+      ],
+      "filters": [],
+      "hash": 322241169,
+      "outputTableName": "a",
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "c2",
+            },
+            "type": "data",
+          },
+        },
+        {
+          "expr": {
+            "source": {
+              "column": "c1",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "a",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "parameterIndexes": [
+    {
+      "filters": [],
+      "hash": 20765332,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "0",
+      },
+      "output": [
+        {
+          "source": {
+            "column": "c1",
+          },
+          "type": "data",
+        },
+        {
+          "source": {
+            "column": "c2",
+          },
+          "type": "data",
+        },
+      ],
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "u",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "b",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "streams": [
+    {
+      "queriers": [
+        {
+          "bucket": 0,
+          "lookupStages": [
+            [
+              {
+                "instantiation": [
+                  {
+                    "expr": {
+                      "function": "->>",
+                      "parameters": [
+                        {
+                          "source": {
+                            "request": "auth",
+                          },
+                          "type": "data",
+                        },
+                        {
+                          "type": "lit_string",
+                          "value": "$.sub",
+                        },
+                      ],
+                      "type": "function",
+                    },
+                    "type": "request",
+                  },
+                ],
+                "lookup": 0,
+                "type": "parameter",
+              },
+            ],
+          ],
+          "requestFilters": [],
+          "sourceInstantiation": [
+            {
+              "lookup": {
+                "idInStage": 0,
+                "stageId": 0,
+              },
+              "resultIndex": 1,
+              "type": "lookup",
+            },
+            {
+              "lookup": {
+                "idInStage": 0,
+                "stageId": 0,
+              },
+              "resultIndex": 0,
+              "type": "lookup",
+            },
+          ],
+        },
+      ],
+      "stream": {
+        "isSubscribedByDefault": true,
+        "name": "stream",
+        "priority": 3,
+      },
+    },
+  ],
+  "version": 1,
+}
+`;
+
+exports[`new sync stream features > circular references > nested 1`] = `
+{
+  "buckets": [
+    {
+      "hash": 329617792,
+      "sources": [
+        0,
+      ],
+      "uniqueName": "stream|0",
+    },
+  ],
+  "dataSources": [
+    {
+      "columns": [
+        "star",
+      ],
+      "filters": [],
+      "hash": 215694379,
+      "outputTableName": "a",
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "c4",
+            },
+            "type": "data",
+          },
+        },
+        {
+          "expr": {
+            "source": {
+              "column": "c1",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "a",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "parameterIndexes": [
+    {
+      "filters": [],
+      "hash": 527378076,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "0",
+      },
+      "output": [
+        {
+          "source": {
+            "column": "c3",
+          },
+          "type": "data",
+        },
+        {
+          "source": {
+            "column": "c4",
+          },
+          "type": "data",
+        },
+      ],
+      "partitionBy": [],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "d",
+      },
+      "tableValuedFunctions": [],
+    },
+    {
+      "filters": [],
+      "hash": 462853403,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "1",
+      },
+      "output": [
+        {
+          "source": {
+            "column": "c2",
+          },
+          "type": "data",
+        },
+      ],
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "c3",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "c",
+      },
+      "tableValuedFunctions": [],
+    },
+    {
+      "filters": [],
+      "hash": 307161944,
+      "lookupScope": {
+        "lookupName": "lookup",
+        "queryId": "2",
+      },
+      "output": [
+        {
+          "source": {
+            "column": "c1",
+          },
+          "type": "data",
+        },
+      ],
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "column": "c2",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": null,
+        "schema": null,
+        "table": "b",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "streams": [
+    {
+      "queriers": [
+        {
+          "bucket": 0,
+          "lookupStages": [
+            [
+              {
+                "instantiation": [],
+                "lookup": 0,
+                "type": "parameter",
+              },
+            ],
+            [
+              {
+                "instantiation": [
+                  {
+                    "lookup": {
+                      "idInStage": 0,
+                      "stageId": 0,
+                    },
+                    "resultIndex": 0,
+                    "type": "lookup",
+                  },
+                ],
+                "lookup": 1,
+                "type": "parameter",
+              },
+            ],
+            [
+              {
+                "instantiation": [
+                  {
+                    "lookup": {
+                      "idInStage": 0,
+                      "stageId": 1,
+                    },
+                    "resultIndex": 0,
+                    "type": "lookup",
+                  },
+                ],
+                "lookup": 2,
+                "type": "parameter",
+              },
+            ],
+          ],
+          "requestFilters": [],
+          "sourceInstantiation": [
+            {
+              "lookup": {
+                "idInStage": 0,
+                "stageId": 0,
+              },
+              "resultIndex": 1,
+              "type": "lookup",
+            },
+            {
+              "lookup": {
+                "idInStage": 0,
+                "stageId": 2,
+              },
+              "resultIndex": 0,
+              "type": "lookup",
+            },
+          ],
+        },
+      ],
+      "stream": {
+        "isSubscribedByDefault": true,
+        "name": "stream",
+        "priority": 3,
+      },
+    },
+  ],
+  "version": 1,
+}
+`;
+
 exports[`new sync stream features > in array 1`] = `
 {
   "buckets": [

--- a/packages/sync-rules/test/src/compiler/advanced.test.ts
+++ b/packages/sync-rules/test/src/compiler/advanced.test.ts
@@ -334,5 +334,13 @@ streams:
         `)
       ).toMatchSnapshot();
     });
+
+    test('table-valued', () => {
+      expect(
+        compileSingleStreamAndSerialize(`SELECT a.*
+          FROM a, b, json_each(a.tags) AS j
+          WHERE a.k = b.k AND j.value = b.v`)
+      ).toMatchSnapshot();
+    });
   });
 });

--- a/packages/sync-rules/test/src/compiler/advanced.test.ts
+++ b/packages/sync-rules/test/src/compiler/advanced.test.ts
@@ -313,4 +313,26 @@ streams:
 
     expect(serializeSyncPlan(plan)).toMatchSnapshot();
   });
+
+  describe('circular references', () => {
+    test('at first level', () => {
+      expect(
+        compileSingleStreamAndSerialize(
+          'SELECT a.* FROM a, b WHERE a.c1 = b.c1 AND a.c2 = b.c2 AND b.u = auth.user_id()'
+        )
+      ).toMatchSnapshot();
+    });
+
+    test('nested', () => {
+      // This introduces two bucket parameters (for a.c1 and a.c4). We create a lookup on
+      //   - Table d (lookup index 0), output columns c3 and c4, no partitions.
+      //   - Table c (lookup index 1), output column c2 and partition by c3.
+      //   - Table b (lookup index 2), output column c1 and partition by c2.
+      expect(
+        compileSingleStreamAndSerialize(`SELECT a.* FROM a, b, c, d WHERE
+          a.c1 = b.c1 AND b.c2 = c.c2 AND c.c3 = d.c3 AND d.c4 = a.c4
+        `)
+      ).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -595,6 +595,81 @@ streams:
         }
       }
     });
+
+    syncTest('multiple references', async ({ sync }) => {
+      const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+    auto_subscribe: true
+    query: SELECT a.* FROM a, b, c, d WHERE a.c1 = b.c1 AND b.c2 = c.c2 AND c.c3 = d.c3 AND d.c4 = a.c4
+`);
+
+      const data = { id: 'foo', c1: 'c1', c2: 'c2', c3: 'c3', c4: 'c4' };
+
+      expect(
+        desc
+          .evaluateRow({
+            sourceTable: new TestSourceTable('a'),
+            record: data
+          })
+          .map((r) => r.bucket)
+        // Note that bucket parameters have an arbitrary order, but they must match querier outputs.
+      ).toStrictEqual(['stream|0["c4","c1"]']);
+
+      // Outputs of d are used directly (d.c4 = a.c4) and as an input to c (c.c3 = d.c3)
+      expect(desc.evaluateParameterRow(new TestSourceTable('d'), data)[0]).toStrictEqual({
+        bucketParameters: [{ '0': 'c3', '1': 'c4' }],
+        lookup: ScopedParameterLookup.direct({ lookupName: 'lookup', queryId: '0', source: null as any }, [])
+      });
+      // Table c: Index from c3 to c2 for lookup in b
+      expect(desc.evaluateParameterRow(new TestSourceTable('c'), data)[0]).toStrictEqual({
+        bucketParameters: [{ '0': 'c2' }],
+        lookup: ScopedParameterLookup.direct({ lookupName: 'lookup', queryId: '1', source: null as any }, ['c3'])
+      });
+      // Table b: Index from c2 to c1 for bucket parameter
+      expect(desc.evaluateParameterRow(new TestSourceTable('b'), data)[0]).toStrictEqual({
+        bucketParameters: [{ '0': 'c1' }],
+        lookup: ScopedParameterLookup.direct({ lookupName: 'lookup', queryId: '2', source: null as any }, ['c2'])
+      });
+
+      const { querier, errors } = desc.getBucketParameterQuerier({
+        globalParameters: requestParameters({}, {}),
+        hasDefaultStreams: true,
+        streams: {}
+      });
+      expect(errors).toStrictEqual([]);
+      expect(querier.staticBuckets).toStrictEqual([]);
+
+      expect(
+        await querier.queryDynamicBucketDescriptions({
+          getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
+            for (const lookup of lookups) {
+              expect(lookup.values[0]).toStrictEqual('lookup');
+              switch (lookup.values[1]) {
+                case '0':
+                  return [{ '0': 'c3', '1': 'c4' }];
+                case '1':
+                  return [{ '0': 'c2' }];
+                case '2':
+                  return [{ '0': 'c1' }];
+              }
+            }
+
+            return [];
+          }
+        })
+      ).toStrictEqual([
+        {
+          bucket: 'stream|0["c4","c1"]',
+          definition: 'stream',
+          inclusion_reasons: ['default'],
+          priority: 3
+        }
+      ]);
+    });
   });
 });
 


### PR DESCRIPTION
For Sync Streams, building a graph of parameter lookups is implemented by going through expressions and recursively handling dependencies. E.g. if a stream has outputs of a table `a` and we encounter a filter expression `a.foo = b.bar`, we'd try to resolve `b` as a parameter lookup recursively before looking at additional expressions. This generally works well, because it both resolves partition keys and parameter outputs while sorting the flat list of expressions topologically, giving us a description for a querier.

Because of this recursion, we can't support circular references between result sets. Initially, I believed that circular references are inherently unsupported (we need to look up parameters in sequence, after all). Then I looked at an actual instance of this in the wild, and realized that the circular reference isn't really all that circular:

```SQL
-- This currently crashes the compiler
SELECT invoices.* FROM invoices, stores WHERE invoices.store_name = stores.name AND invoices.region = stores.region AND stores.owner = auth.user_id()
```

Currently, we start by analyzing `invoices`, track `stores` as a dependency due to `invoices.store_name = stores.name`. When parsing `stores`, we discover `invoices.region = stores.region` and crash due to a circular reference. The fix is very simple: Ignore expressions referencing a result set that is currently being analyzed, so we'd then:

1. Start by analyzing `invoices`, track `stores` as a dependency due to `invoices.store_name = stores.name`.
2. Resolve `stores`, find `stores.owner = auth.user_id()` as the only expression and create a pending parameter lookup partitioned by `owner` without any outputs.
3. Resolve the `invoices.store_name = stores.name` expression by adding `stores.name` as an output to the lookup and `invoices.store_name` as a bucket parameter.
4. Encounter the `invoices.region = stores.region` expression in the context of `invoices`, realize we've resolved `stores` already and just do the same add output + bucket parameter step with the resolved parameter lookup.

The same strategy works for larger reference chains as well.