### PR TITLE
[MongoDB] Adaptive batchSize to improve change stream timeout handling

### DIFF
--- a/.changeset/tasty-bottles-relate.md
+++ b/.changeset/tasty-bottles-relate.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': patch
+---
+
+Use adaptive batchSize for better recovery in PSYNC_S1345 change stream timeouts.

--- a/.github/actions/start-mongodb/action.yml
+++ b/.github/actions/start-mongodb/action.yml
@@ -1,5 +1,5 @@
 name: Start MongoDB
-description: Pre-pull and start MongoDB with a replica set for tests
+description: Start MongoDB with a replica set for tests
 
 inputs:
   mongodb-version:
@@ -10,14 +10,53 @@ inputs:
 runs:
   using: composite
   steps:
-    # The mongodb-github-action below doesn't use the Docker credentials for the pull.
-    # We pre-pull, so that the image is cached.
-    - name: Pre-pull Mongo image
-      shell: bash
-      run: docker pull mongo:${{ inputs.mongodb-version }}
-
+    # Previously we used supercharge/mongodb-github-action@1.12.1.
+    # However, we specifically want `--setParameter enableTestCommands=1`, which that doesn't support.
+    # This now just starts MongoDB directly using Docker, and waits until it is ready.
     - name: Start MongoDB
-      uses: supercharge/mongodb-github-action@1.12.1
-      with:
-        mongodb-version: ${{ inputs.mongodb-version }}
-        mongodb-replica-set: test-rs
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        container_name="mongodb"
+        image="mongo:${{ inputs.mongodb-version }}"
+
+        docker rm -f "$container_name" >/dev/null 2>&1 || true
+
+        docker run \
+          --name "$container_name" \
+          --publish 27017:27017 \
+          --detach \
+          "$image" \
+          mongod \
+          --port 27017 \
+          --replSet test-rs \
+          --bind_ip_all \
+          --setParameter enableTestCommands=1
+
+        for i in $(seq 1 30); do
+          if docker exec "$container_name" mongosh --quiet --port 27017 --eval "db.adminCommand({ ping: 1 })" >/dev/null; then
+            break
+          fi
+          sleep 1
+          if [ "$i" -eq 30 ]; then
+            echo "MongoDB did not become ready in time"
+            docker logs "$container_name"
+            exit 1
+          fi
+        done
+
+        docker exec "$container_name" mongosh --quiet --port 27017 --eval \
+          'rs.initiate({_id:"test-rs", members:[{_id:0, host:"localhost:27017"}]})'
+
+        for i in $(seq 1 30); do
+          if docker exec "$container_name" mongosh --quiet --port 27017 --eval 'quit(db.hello().isWritablePrimary ? 0 : 1)' >/dev/null; then
+            break
+          fi
+          sleep 1
+          if [ "$i" -eq 30 ]; then
+            echo "MongoDB replica set did not become primary in time"
+            docker logs "$container_name"
+            exit 1
+          fi
+        done

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -808,12 +808,6 @@ export class ChangeStream {
     }
 
     return rawChangeStream(watchDb, pipeline, {
-      // We use a lowest possible batch size here to help recover when hitting:
-      //   [PSYNC_S1345] Timeout while reading MongoDB ChangeStream
-      // When we run into that, the stream is restarted automatically - either by the rawChangeStream's
-      // internal retry mechanism, or with us restarting the entire job. That sends a new aggregate command,
-      // with the small batch size, which should be able to complete faster.
-      initialBatchSize: 1,
       batchSize: options.batchSize ?? this.snapshotChunkLength,
       maxAwaitTimeMS: options.maxAwaitTimeMS ?? this.maxAwaitTimeMS,
       maxTimeMS: this.changeStreamTimeout,

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -1137,11 +1137,13 @@ export class ChangeStream {
             }
           }
 
-          if (firstBatch) {
+          if (firstBatch && splitDocument == null) {
             // The first request may be slow. To make sure we don't get repeated timeouts, always
             // mark progress in the first batch.
             firstBatch = false;
             const { comparable: lsn } = MongoLSN.fromResumeToken(resumeToken);
+            await batch.flush();
+            // TODO: We should consider making this standard behavior of flush().
             await batch.setResumeLsn(lsn);
           }
           this.logger.info(`Processed batch of ${events.length} changes in ${Date.now() - batchStart}ms`);

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -1136,7 +1136,7 @@ export class ChangeStream {
             // so this is a good natural point to flush and mark progress.
             // We avoid this when splitDocument is set, since we cannot resume in the middle of a split event.
             const { comparable: lsn } = MongoLSN.fromResumeToken(resumeToken);
-            await batch.flush();
+            await batch.flush({ oldestUncommittedChange: this.replicationLag.oldestUncommittedChange });
             // TODO: We should consider making this standard behavior of flush().
             await batch.setResumeLsn(lsn);
           }

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -874,7 +874,6 @@ export class ChangeStream {
 
         let lastEmptyResume = performance.now();
         let lastTxnKey: string | null = null;
-        let firstBatch = true;
 
         for await (let eventBatch of batchStream) {
           const { events, resumeToken } = eventBatch;
@@ -1137,10 +1136,11 @@ export class ChangeStream {
             }
           }
 
-          if (firstBatch && splitDocument == null) {
-            // The first request may be slow. To make sure we don't get repeated timeouts, always
-            // mark progress in the first batch.
-            firstBatch = false;
+          if (splitDocument == null) {
+            // We flush and mark progress on every batch of data we receive.
+            // Batches are generally large (64MB or 6000 events, whichever comes first),
+            // so this is a good natural point to flush and mark progress.
+            // We avoid this when splitDocument is set, since we cannot resume in the middle of a split event.
             const { comparable: lsn } = MongoLSN.fromResumeToken(resumeToken);
             await batch.flush();
             // TODO: We should consider making this standard behavior of flush().

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -1141,7 +1141,7 @@ export class ChangeStream {
             // The first request may be slow. To make sure we don't get repeated timeouts, always
             // mark progress in the first batch.
             firstBatch = false;
-            const { comparable: lsn } = MongoLSN.fromResumeToken(resumeFromLsn);
+            const { comparable: lsn } = MongoLSN.fromResumeToken(resumeToken);
             await batch.setResumeLsn(lsn);
           }
           this.logger.info(`Processed batch of ${events.length} changes in ${Date.now() - batchStart}ms`);

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -808,6 +808,12 @@ export class ChangeStream {
     }
 
     return rawChangeStream(watchDb, pipeline, {
+      // We use a lowest possible batch size here to help recover when hitting:
+      //   [PSYNC_S1345] Timeout while reading MongoDB ChangeStream
+      // When we run into that, the stream is restarted automatically - either by the rawChangeStream's
+      // internal retry mechanism, or with us restarting the entire job. That sends a new aggregate command,
+      // with the small batch size, which should be able to complete faster.
+      initialBatchSize: 1,
       batchSize: options.batchSize ?? this.snapshotChunkLength,
       maxAwaitTimeMS: options.maxAwaitTimeMS ?? this.maxAwaitTimeMS,
       maxTimeMS: this.changeStreamTimeout,
@@ -868,6 +874,7 @@ export class ChangeStream {
 
         let lastEmptyResume = performance.now();
         let lastTxnKey: string | null = null;
+        let firstBatch = true;
 
         for await (let eventBatch of batchStream) {
           const { events, resumeToken } = eventBatch;
@@ -1128,6 +1135,14 @@ export class ChangeStream {
                 collectionInfo: collection
               });
             }
+          }
+
+          if (firstBatch) {
+            // The first request may be slow. To make sure we don't get repeated timeouts, always
+            // mark progress in the first batch.
+            firstBatch = false;
+            const { comparable: lsn } = MongoLSN.fromResumeToken(resumeFromLsn);
+            await batch.setResumeLsn(lsn);
           }
           this.logger.info(`Processed batch of ${events.length} changes in ${Date.now() - batchStart}ms`);
         }

--- a/modules/module-mongodb/src/replication/RawChangeStream.ts
+++ b/modules/module-mongodb/src/replication/RawChangeStream.ts
@@ -9,15 +9,32 @@ import { ChangeStreamInvalidatedError } from './ChangeStream.js';
 
 export interface RawChangeStreamOptions {
   signal?: AbortSignal;
+
   /**
    * How long to wait for new data per batch (max time for long-polling).
+   *
+   * This is used for maxTimeMS for the getMore command.
    */
   maxAwaitTimeMS: number;
+
   /**
    * Timeout for the initial aggregate command.
    */
   maxTimeMS: number;
+
+  /**
+   * batchSize for the getMore commands.
+   *
+   * Also provides the batchSize for the aggregate command, unless initialBatchSize is set.
+   */
   batchSize: number;
+
+  /**
+   * batchSize for the initial aggregate command.
+   *
+   * Defaults to batchSize.
+   */
+  initialBatchSize?: number;
 
   /**
    * Mostly for testing.
@@ -123,7 +140,6 @@ async function* rawChangeStreamInner(
    */
   let nsCollection: string | null = null;
 
-  const maxTimeMS = options.maxAwaitTimeMS;
   const batchSize = options.batchSize;
   const collection = options.collection ?? 1;
   let abortPromise: Promise<any> | null = null;
@@ -149,7 +165,9 @@ async function* rawChangeStreamInner(
           {
             aggregate: collection,
             pipeline,
-            cursor: { batchSize },
+            cursor: {
+              batchSize: options.initialBatchSize ?? options.batchSize
+            },
             maxTimeMS: options.maxTimeMS
           },
           { session, raw: true }
@@ -184,7 +202,7 @@ async function* rawChangeStreamInner(
             getMore: cursorId,
             collection: nsCollection,
             batchSize,
-            maxTimeMS
+            maxTimeMS: options.maxAwaitTimeMS
           },
           { session, raw: true }
         )
@@ -311,7 +329,7 @@ export function parseChangeDocument(buffer: Buffer): ProjectedChangeStreamDocume
 function isResumableChangeStreamError(e: unknown) {
   // See: https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md#resumable-error
   if (!isMongoServerError(e)) {
-    // Any error encountered which is not a server error (e.g. a timeout error or network error)
+    // Any error encountered which is not a server error (e.g. a socket timeout error or network error)
     return true;
   } else if (e.codeName == 'CursorNotFound') {
     // A server error with code 43 (CursorNotFound)
@@ -319,8 +337,13 @@ function isResumableChangeStreamError(e: unknown) {
   } else if (e.hasErrorLabel('ResumableChangeStreamError')) {
     // For servers with wire version 9 or higher (server version 4.4 or higher), any server error with the ResumableChangeStreamError error label.
     return true;
+  } else if (e.codeName == 'MaxTimeMSExpired') {
+    // Our own exception for MaxTimeMSExpired.
+    // This can help us retry faster, with a smaller batch size (if initialBatchSize is set to 1), which should hopefully avoid the timeout.
+    return true;
   } else {
-    // We ignore servers with wire version less than 9, since we only support MongoDB 6.0+.
+    // Other errors are not retried.
+    // We ignore the spec for servers with wire version less than 9, since we only support MongoDB 6.0+.
     return false;
   }
 }

--- a/modules/module-mongodb/src/replication/RawChangeStream.ts
+++ b/modules/module-mongodb/src/replication/RawChangeStream.ts
@@ -25,16 +25,11 @@ export interface RawChangeStreamOptions {
   /**
    * batchSize for the getMore commands.
    *
-   * Also provides the batchSize for the aggregate command, unless initialBatchSize is set.
+   * The aggregate command always uses a batchSize of 1.
+   *
+   * After a timeout error, the batchSize will be reduced and ramped up again.
    */
   batchSize: number;
-
-  /**
-   * batchSize for the initial aggregate command.
-   *
-   * Defaults to batchSize.
-   */
-  initialBatchSize?: number;
 
   /**
    * Mostly for testing.
@@ -80,6 +75,8 @@ export async function* rawChangeStream(db: mongo.Db, pipeline: mongo.Document[],
   }
   let lastResumeToken: unknown | null = null;
 
+  const batchSizer = new AdaptiveBatchSize(options.batchSize);
+
   // > If the server supports sessions, the resume attempt MUST use the same session as the previous attempt's command.
   const session = db.client.startSession();
   await using _ = { [Symbol.asyncDispose]: () => session.endSession() };
@@ -96,9 +93,15 @@ export async function* rawChangeStream(db: mongo.Db, pipeline: mongo.Document[],
         changeStreamStage.resumeAfter = lastResumeToken;
         innerPipeline = [{ $changeStream: changeStreamStage }, ...rest];
       }
-      const inner = rawChangeStreamInner(session, db, innerPipeline, {
-        ...options
-      });
+      const inner = rawChangeStreamInner(
+        session,
+        db,
+        innerPipeline,
+        {
+          ...options
+        },
+        batchSizer
+      );
       for await (let batch of inner) {
         yield batch;
         lastResumeToken = batch.resumeToken;
@@ -128,7 +131,8 @@ async function* rawChangeStreamInner(
   session: mongo.ClientSession,
   db: mongo.Db,
   pipeline: mongo.Document[],
-  options: RawChangeStreamOptions
+  options: RawChangeStreamOptions,
+  batchSizer: AdaptiveBatchSize
 ): AsyncGenerator<ChangeStreamBatch> {
   // See specs:
   // https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md
@@ -166,7 +170,9 @@ async function* rawChangeStreamInner(
             aggregate: collection,
             pipeline,
             cursor: {
-              batchSize: options.initialBatchSize ?? options.batchSize
+              // Always use batchSize of 1 for the initial aggregate command,
+              // to maximize the chance of success in case of timeouts.
+              batchSize: 1
             },
             maxTimeMS: options.maxTimeMS
           },
@@ -201,7 +207,7 @@ async function* rawChangeStreamInner(
           {
             getMore: cursorId,
             collection: nsCollection,
-            batchSize,
+            batchSize: batchSizer.next(),
             maxTimeMS: options.maxAwaitTimeMS
           },
           { session, raw: true }
@@ -214,6 +220,9 @@ async function* rawChangeStreamInner(
           }
 
           if (isResumableChangeStreamError(e)) {
+            if (isTimeoutError(e)) {
+              batchSizer.reduceAfterError();
+            }
             throw new ResumableChangeStreamError(e.message, { cause: e });
           }
           throw mapChangeStreamError(e);
@@ -250,6 +259,45 @@ async function* rawChangeStreamInner(
 }
 
 class ResumableChangeStreamError extends Error {}
+
+/**
+ * Manage batch sizes after timeout errors.
+ *
+ * This starts with the initial batch size.
+ *
+ * After a timeout error, we reduce the batch size to 2, then double for each batch
+ * until we hit reach the original size again.
+ *
+ * We use this to protect against timeout errors:
+ *   [PSYNC_S1345] Timeout while reading MongoDB ChangeStream
+ *
+ * When we run into that, the stream is restarted automatically. starting with an aggregate command
+ * with batchSize: 1.
+ *
+ * We then ramp up the batchSize for getMore commands.
+ */
+class AdaptiveBatchSize {
+  private nextBatchSize: number;
+
+  constructor(private maxBatchSize: number) {
+    this.nextBatchSize = maxBatchSize;
+  }
+
+  next() {
+    const current = this.nextBatchSize;
+    this.nextBatchSize = Math.min(this.maxBatchSize, this.nextBatchSize * 2);
+    return current;
+  }
+
+  /**
+   * After a timeout error, the next batchSize will be 2.
+   *
+   * This is _after_ the aggregate command with a batchSize of 1.
+   */
+  reduceAfterError() {
+    this.nextBatchSize = 2;
+  }
+}
 
 type RawBsonValue =
   | string
@@ -326,6 +374,10 @@ export function parseChangeDocument(buffer: Buffer): ProjectedChangeStreamDocume
   return doc as any;
 }
 
+function isTimeoutError(e: unknown) {
+  return isMongoNetworkTimeoutError(e) || (isMongoServerError(e) && e.codeName == 'MaxTimeMSExpired');
+}
+
 function isResumableChangeStreamError(e: unknown) {
   // See: https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.md#resumable-error
   if (!isMongoServerError(e)) {
@@ -349,13 +401,12 @@ function isResumableChangeStreamError(e: unknown) {
 }
 
 export function mapChangeStreamError(e: unknown) {
-  if (isMongoNetworkTimeoutError(e)) {
-    // This typically has an unhelpful message like "connection 2 to 159.41.94.47:27017 timed out".
-    // We wrap the error to make it more useful.
-    throw new DatabaseConnectionError(ErrorCode.PSYNC_S1345, `Timeout while reading MongoDB ChangeStream`, e);
-  } else if (isMongoServerError(e) && e.codeName == 'MaxTimeMSExpired') {
-    // maxTimeMS was reached. Example message:
-    // MongoServerError: Executor error during aggregate command on namespace: powersync_test_data.$cmd.aggregate :: caused by :: operation exceeded time limit
+  if (isTimeoutError(e)) {
+    // For isMongoNetworkTimeoutError():
+    //   This typically has an unhelpful message like "connection 2 to 159.41.94.47:27017 timed out".
+    //   We wrap the error to make it more useful.
+    // Example for MaxTimeMSExpired:
+    //   MongoServerError: Executor error during aggregate command on namespace: powersync_test_data.$cmd.aggregate :: caused by :: operation exceeded time limit
     throw new DatabaseConnectionError(ErrorCode.PSYNC_S1345, `Timeout while reading MongoDB ChangeStream`, e);
   } else if (
     isMongoServerError(e) &&

--- a/modules/module-mongodb/src/replication/RawChangeStream.ts
+++ b/modules/module-mongodb/src/replication/RawChangeStream.ts
@@ -261,12 +261,19 @@ async function* rawChangeStreamInner(
 class ResumableChangeStreamError extends Error {}
 
 /**
+ * After a timeout error, we reduce the batch size to this number, then multiply by this for each batch.
+ *
+ * Must be an integer >= 2 with the current implementation.
+ */
+const BATCH_SIZE_MULTIPLIER = 2;
+
+/**
  * Manage batch sizes after timeout errors.
  *
  * This starts with the initial batch size.
  *
- * After a timeout error, we reduce the batch size to 2, then double for each batch
- * until we hit reach the original size again.
+ * After a timeout error, we reduce the batch size for aggregate command to 1,
+ * then multiply by BATCH_SIZE_MULTIPLIER for each subsequent batch, until we reach the initial batch size again.
  *
  * We use this to protect against timeout errors:
  *   [PSYNC_S1345] Timeout while reading MongoDB ChangeStream
@@ -283,19 +290,22 @@ class AdaptiveBatchSize {
     this.nextBatchSize = maxBatchSize;
   }
 
+  /**
+   * Get the next batchSize for a getMore command.
+   */
   next() {
     const current = this.nextBatchSize;
-    this.nextBatchSize = Math.min(this.maxBatchSize, this.nextBatchSize * 2);
+    this.nextBatchSize = Math.min(this.maxBatchSize, this.nextBatchSize * BATCH_SIZE_MULTIPLIER);
     return current;
   }
 
   /**
-   * After a timeout error, the next batchSize will be 2.
+   * After a timeout error, the next aggregate command will start with a batchSize of 1.
    *
-   * This is _after_ the aggregate command with a batchSize of 1.
+   * The next getMore will then have a batchSize of BATCH_SIZE_MULTIPLIER.
    */
   reduceAfterError() {
-    this.nextBatchSize = 2;
+    this.nextBatchSize = BATCH_SIZE_MULTIPLIER;
   }
 }
 

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -9,7 +9,7 @@ import { test_utils } from '@powersync/service-core-tests';
 import { MongoRouteAPIAdapter } from '@module/api/MongoRouteAPIAdapter.js';
 import { PostImagesOption } from '@module/types/types.js';
 import { ChangeStreamTestContext } from './change_stream_utils.js';
-import { describeWithStorage, requireFailCommand, StorageVersionTestContext, TEST_CONNECTION_OPTIONS } from './util.js';
+import { describeWithStorage, StorageVersionTestContext, TEST_CONNECTION_OPTIONS } from './util.js';
 
 const BASIC_SYNC_RULES = `
 bucket_definitions:

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -9,7 +9,7 @@ import { test_utils } from '@powersync/service-core-tests';
 import { MongoRouteAPIAdapter } from '@module/api/MongoRouteAPIAdapter.js';
 import { PostImagesOption } from '@module/types/types.js';
 import { ChangeStreamTestContext } from './change_stream_utils.js';
-import { describeWithStorage, StorageVersionTestContext, TEST_CONNECTION_OPTIONS } from './util.js';
+import { describeWithStorage, requireFailCommand, StorageVersionTestContext, TEST_CONNECTION_OPTIONS } from './util.js';
 
 const BASIC_SYNC_RULES = `
 bucket_definitions:

--- a/modules/module-mongodb/test/src/raw_change_stream.test.ts
+++ b/modules/module-mongodb/test/src/raw_change_stream.test.ts
@@ -68,7 +68,6 @@ describe('internal mongodb utils', () => {
       ],
       {
         batchSize: 10,
-        initialBatchSize: 1,
         maxAwaitTimeMS: 50,
         maxTimeMS: 1_000
       }
@@ -115,10 +114,11 @@ describe('internal mongodb utils', () => {
         }
       ],
       {
-        batchSize: 10,
-        initialBatchSize: 1,
+        batchSize: 3,
         maxAwaitTimeMS: 50,
         maxTimeMS: 1_000
+        // To get more details when debugging, enable the logger:
+        // logger: logger
       }
     );
 
@@ -132,14 +132,42 @@ describe('internal mongodb utils', () => {
       }
     });
 
-    const batchPromise = readUntilNonEmptyBatch(stream, 10);
-    await collection.insertOne({ test: 1 });
-    const batch = await batchPromise;
+    for (let i = 1; i <= 8; i++) {
+      await collection.insertOne({ test: i });
+    }
 
-    expect(batch.events).toHaveLength(1);
-    expect(batch.events.map((e) => bson.deserialize(e, { useBigInt64: true }).fullDocument)).toMatchObject([
-      { test: 1 }
-    ]);
+    // Test the exponentially-increasing batch size after the retry
+    {
+      // This will fail the getMore, then retry with aggregate with batchSize 1
+      const batch = await readUntilNonEmptyBatch(stream, 10);
+      expect(batch.events.map((e) => bson.deserialize(e, { useBigInt64: true }).fullDocument)).toMatchObject([
+        { test: 1 }
+      ]);
+    }
+    {
+      // This will be a getMore with batchSize 2
+      const batch = await readUntilNonEmptyBatch(stream, 10);
+      expect(batch.events.map((e) => bson.deserialize(e, { useBigInt64: true }).fullDocument)).toMatchObject([
+        { test: 2 },
+        { test: 3 }
+      ]);
+    }
+    {
+      // At this point, this batch size is at the original size of 3 again.
+      const batch = await readUntilNonEmptyBatch(stream, 10);
+      expect(batch.events.map((e) => bson.deserialize(e, { useBigInt64: true }).fullDocument)).toMatchObject([
+        { test: 4 },
+        { test: 5 },
+        { test: 6 }
+      ]);
+    }
+    {
+      const batch = await readUntilNonEmptyBatch(stream, 10);
+      expect(batch.events.map((e) => bson.deserialize(e, { useBigInt64: true }).fullDocument)).toMatchObject([
+        { test: 7 },
+        { test: 8 }
+      ]);
+    }
 
     const aggregateCommands = started.filter((event) => event.commandName == 'aggregate');
     expect(aggregateCommands.length).toBeGreaterThanOrEqual(2);

--- a/modules/module-mongodb/test/src/raw_change_stream.test.ts
+++ b/modules/module-mongodb/test/src/raw_change_stream.test.ts
@@ -4,7 +4,7 @@ import { ChangeStreamBatch, namespaceCollection, rawChangeStream } from '@module
 import { getCursorBatchBytes } from '@module/replication/replication-index.js';
 import { mongo } from '@powersync/lib-service-mongodb';
 import { bson } from '@powersync/service-core';
-import { clearTestDb, connectMongoData } from './util.js';
+import { clearTestDb, connectMongoData, requireFailCommand } from './util.js';
 
 describe('internal mongodb utils', () => {
   // The implementation relies on internal APIs, so we verify this works as expected for various types of change streams.
@@ -90,9 +90,11 @@ describe('internal mongodb utils', () => {
     expect(getMore?.command.maxTimeMS).toEqual(50);
   });
 
-  test('should resume on MaxTimeMSExpired from getMore', async () => {
+  test('should resume on MaxTimeMSExpired from getMore', async (ctx) => {
     const { db, client } = await connectMongoData({ monitorCommands: true });
     await using _ = { [Symbol.asyncDispose]: async () => await client.close() };
+    await using failCommand = await requireFailCommand(client, ctx);
+
     await clearTestDb(db);
     const collection = db.collection('test_data');
 
@@ -120,47 +122,37 @@ describe('internal mongodb utils', () => {
       }
     );
 
-    try {
-      await stream.next();
+    await stream.next();
 
-      await client.db('admin').command({
-        configureFailPoint: 'failCommand',
-        mode: { times: 1 },
-        data: {
-          failCommands: ['getMore'],
-          errorCode: 50 // MaxTimeMSExpired
+    await failCommand.configure({
+      mode: { times: 1 },
+      data: {
+        failCommands: ['getMore'],
+        errorCode: 50 // MaxTimeMSExpired
+      }
+    });
+
+    const batchPromise = readUntilNonEmptyBatch(stream, 10);
+    await collection.insertOne({ test: 1 });
+    const batch = await batchPromise;
+
+    expect(batch.events).toHaveLength(1);
+    expect(batch.events.map((e) => bson.deserialize(e, { useBigInt64: true }).fullDocument)).toMatchObject([
+      { test: 1 }
+    ]);
+
+    const aggregateCommands = started.filter((event) => event.commandName == 'aggregate');
+    expect(aggregateCommands.length).toBeGreaterThanOrEqual(2);
+    expect(aggregateCommands[0].command.pipeline).toEqual([
+      {
+        $changeStream: {
+          fullDocument: 'updateLookup'
         }
-      });
+      }
+    ]);
+    expect(aggregateCommands[1].command.pipeline[0]?.$changeStream?.resumeAfter).toBeDefined();
 
-      const batchPromise = readUntilNonEmptyBatch(stream, 10);
-      await collection.insertOne({ test: 1 });
-      const batch = await batchPromise;
-
-      expect(batch.events).toHaveLength(1);
-      expect(batch.events.map((e) => bson.deserialize(e, { useBigInt64: true }).fullDocument)).toMatchObject([
-        { test: 1 }
-      ]);
-
-      const aggregateCommands = started.filter((event) => event.commandName == 'aggregate');
-      expect(aggregateCommands.length).toBeGreaterThanOrEqual(2);
-      expect(aggregateCommands[0].command.pipeline).toEqual([
-        {
-          $changeStream: {
-            fullDocument: 'updateLookup'
-          }
-        }
-      ]);
-      expect(aggregateCommands[1].command.pipeline[0]?.$changeStream?.resumeAfter).toBeDefined();
-    } finally {
-      await stream.return?.().catch(() => {});
-      await client
-        .db('admin')
-        .command({
-          configureFailPoint: 'failCommand',
-          mode: 'off'
-        })
-        .catch(() => {});
-    }
+    await stream?.return().catch(() => {});
   });
 
   async function testChangeStreamBsonBytes(type: 'db' | 'collection' | 'cluster') {

--- a/modules/module-mongodb/test/src/raw_change_stream.test.ts
+++ b/modules/module-mongodb/test/src/raw_change_stream.test.ts
@@ -44,6 +44,125 @@ describe('internal mongodb utils', () => {
     expect(totalBytes).toBeLessThan(1200);
   });
 
+  test('uses separate aggregate and getMore command options', async () => {
+    const { db, client } = await connectMongoData({ monitorCommands: true });
+    await using _ = { [Symbol.asyncDispose]: async () => await client.close() };
+    await clearTestDb(db);
+    const collection = db.collection('test_data');
+
+    const started: any[] = [];
+    client.on('commandStarted', (event) => {
+      if (event.commandName == 'aggregate' || event.commandName == 'getMore') {
+        started.push(event);
+      }
+    });
+
+    const stream = rawChangeStream(
+      db,
+      [
+        {
+          $changeStream: {
+            fullDocument: 'updateLookup'
+          }
+        }
+      ],
+      {
+        batchSize: 10,
+        initialBatchSize: 1,
+        maxAwaitTimeMS: 50,
+        maxTimeMS: 1_000
+      }
+    );
+
+    await stream.next();
+    await collection.insertOne({ test: 1 });
+    const nextBatch = await readUntilNonEmptyBatch(stream);
+    await stream.return?.();
+
+    expect(nextBatch.events).toHaveLength(1);
+
+    const aggregate = started.find((event) => event.commandName == 'aggregate');
+    const getMore = started.find((event) => event.commandName == 'getMore');
+
+    expect(aggregate?.command.cursor?.batchSize).toEqual(1);
+    expect(aggregate?.command.maxTimeMS).toEqual(1_000);
+    expect(getMore?.command.batchSize).toEqual(10);
+    expect(getMore?.command.maxTimeMS).toEqual(50);
+  });
+
+  test('should resume on MaxTimeMSExpired from getMore', async () => {
+    const { db, client } = await connectMongoData({ monitorCommands: true });
+    await using _ = { [Symbol.asyncDispose]: async () => await client.close() };
+    await clearTestDb(db);
+    const collection = db.collection('test_data');
+
+    const started: any[] = [];
+    client.on('commandStarted', (event) => {
+      if (event.commandName == 'aggregate' || event.commandName == 'getMore') {
+        started.push(event);
+      }
+    });
+
+    const stream = rawChangeStream(
+      db,
+      [
+        {
+          $changeStream: {
+            fullDocument: 'updateLookup'
+          }
+        }
+      ],
+      {
+        batchSize: 10,
+        initialBatchSize: 1,
+        maxAwaitTimeMS: 50,
+        maxTimeMS: 1_000
+      }
+    );
+
+    try {
+      await stream.next();
+
+      await client.db('admin').command({
+        configureFailPoint: 'failCommand',
+        mode: { times: 1 },
+        data: {
+          failCommands: ['getMore'],
+          errorCode: 50 // MaxTimeMSExpired
+        }
+      });
+
+      const batchPromise = readUntilNonEmptyBatch(stream, 10);
+      await collection.insertOne({ test: 1 });
+      const batch = await batchPromise;
+
+      expect(batch.events).toHaveLength(1);
+      expect(batch.events.map((e) => bson.deserialize(e, { useBigInt64: true }).fullDocument)).toMatchObject([
+        { test: 1 }
+      ]);
+
+      const aggregateCommands = started.filter((event) => event.commandName == 'aggregate');
+      expect(aggregateCommands.length).toBeGreaterThanOrEqual(2);
+      expect(aggregateCommands[0].command.pipeline).toEqual([
+        {
+          $changeStream: {
+            fullDocument: 'updateLookup'
+          }
+        }
+      ]);
+      expect(aggregateCommands[1].command.pipeline[0]?.$changeStream?.resumeAfter).toBeDefined();
+    } finally {
+      await stream.return?.().catch(() => {});
+      await client
+        .db('admin')
+        .command({
+          configureFailPoint: 'failCommand',
+          mode: 'off'
+        })
+        .catch(() => {});
+    }
+  });
+
   async function testChangeStreamBsonBytes(type: 'db' | 'collection' | 'cluster') {
     const { db, client } = await connectMongoData();
     await using _ = { [Symbol.asyncDispose]: async () => await client.close() };
@@ -392,3 +511,17 @@ type CurrentOpIdleCursor = {
     };
   };
 };
+
+async function readUntilNonEmptyBatch(stream: AsyncIterableIterator<ChangeStreamBatch>, maxEmptyBatches: number = 5) {
+  for (let i = 0; i < maxEmptyBatches; i++) {
+    const next = await stream.next();
+    if (next.done) {
+      throw new Error('Change stream ended unexpectedly');
+    }
+    if (next.value.events.length > 0) {
+      return next.value;
+    }
+  }
+
+  throw new Error(`Did not receive a non-empty batch after ${maxEmptyBatches} empty batches`);
+}

--- a/modules/module-mongodb/test/src/resume.test.ts
+++ b/modules/module-mongodb/test/src/resume.test.ts
@@ -15,7 +15,17 @@ function defineResumeTest({ factory: factoryGenerator, storageVersion }: Storage
     return ChangeStreamTestContext.open(factoryGenerator, { ...options, storageVersion });
   };
 
-  test('resuming with a different source database', async () => {
+  test.skip('resuming with a different source database', async () => {
+    // This test is not functioning anymore.
+    // Previously, we mostly used individual change stream _id's for resumeTokens. Those would become invalid
+    // when the database is changed.
+    // Now, we mostly use postBatchResumeToken when we can, which do not become invalidated in this case.
+    // This is recommended by the change stream spec.
+    // The old behavior wasn't 100% consistent either - it _could_ use postBatchResumeToken, in which
+    // case it would similarly not be invalidated.
+    // We can revisit the logic to invalidate the change stream at a later point, potentially by
+    // keeping track of the source database name.
+
     await using context = await openContext();
     const { db } = context;
 

--- a/modules/module-mongodb/test/src/util.ts
+++ b/modules/module-mongodb/test/src/util.ts
@@ -74,6 +74,15 @@ export async function connectMongoData(options: mongo.MongoClientOptions = {}) {
   return { client, db: client.db(dbname) };
 }
 
+/**
+ * This allows us to inject custom failures into commands on the mongodb server.
+ *
+ * For this to work, mongodb must be started with `--setParameter enableTestCommands=1`.
+ *
+ * We require this in CI, but in local development we skip the test if it's not configured.
+ *
+ * https://github.com/mongodb/mongo/wiki/The-failCommand-fail-point
+ */
 export async function requireFailCommand(client: mongo.MongoClient, ctx: TestContext) {
   try {
     await client.db('admin').command({ configureFailPoint: 'failCommand', mode: 'off' });

--- a/modules/module-mongodb/test/src/util.ts
+++ b/modules/module-mongodb/test/src/util.ts
@@ -9,7 +9,7 @@ import {
   TestStorageConfig,
   TestStorageFactory
 } from '@powersync/service-core';
-import { describe, TestOptions } from 'vitest';
+import { describe, TestContext, TestOptions } from 'vitest';
 import { env } from './env.js';
 
 export const TEST_URI = env.MONGO_TEST_DATA_URL;
@@ -72,4 +72,47 @@ export async function connectMongoData(options: mongo.MongoClientOptions = {}) {
   });
   const dbname = new URL(env.MONGO_TEST_DATA_URL).pathname.substring(1);
   return { client, db: client.db(dbname) };
+}
+
+export async function requireFailCommand(client: mongo.MongoClient, ctx: TestContext) {
+  try {
+    await client.db('admin').command({ configureFailPoint: 'failCommand', mode: 'off' });
+  } catch (e: any) {
+    const codeName = e?.codeName;
+    const message = e?.message ?? String(e);
+
+    if (
+      codeName == 'CommandNotFound' ||
+      codeName == 'Unauthorized' ||
+      message.includes('no such command') ||
+      message.includes('enableTestCommands')
+    ) {
+      if (process.env.CI) {
+        // In CI we want to fail if failCommand is not supported, as that likely means something is wrong with the test environment setup.
+        throw e;
+      }
+      // In local development, we skip the test if failCommand is not supported, as developers may be running against a variety of MongoDB versions and configurations.
+      ctx.skip(`failCommand not supported: ${codeName ?? message}`);
+    }
+
+    throw e;
+  }
+
+  return {
+    async configure(data: Omit<mongo.Document, 'configureFailPoint'>) {
+      await client.db('admin').command({
+        configureFailPoint: 'failCommand',
+        ...data
+      });
+    },
+    async [Symbol.asyncDispose]() {
+      await client
+        .db('admin')
+        .command({
+          configureFailPoint: 'failCommand',
+          mode: 'off'
+        })
+        .catch(() => {});
+    }
+  };
 }

--- a/modules/module-mongodb/test/src/util.ts
+++ b/modules/module-mongodb/test/src/util.ts
@@ -62,12 +62,13 @@ export async function clearTestDb(db: mongo.Db) {
   await db.dropDatabase();
 }
 
-export async function connectMongoData() {
+export async function connectMongoData(options: mongo.MongoClientOptions = {}) {
   const client = new mongo.MongoClient(env.MONGO_TEST_DATA_URL, {
     connectTimeoutMS: env.CI ? 15_000 : 5_000,
     socketTimeoutMS: env.CI ? 15_000 : 5_000,
     serverSelectionTimeoutMS: env.CI ? 15_000 : 2_500,
-    ...BSON_DESERIALIZE_DATA_OPTIONS
+    ...BSON_DESERIALIZE_DATA_OPTIONS,
+    ...options
   });
   const dbname = new URL(env.MONGO_TEST_DATA_URL).pathname.substring(1);
   return { client, db: client.db(dbname) };


### PR DESCRIPTION
This makes a change to batchSize values, to improve timeout handling for `[PSYNC_S1345] Timeout while reading MongoDB ChangeStream` errors, helping with recovering automatically. For background on this issue, see #417.

#417 significantly reduced the number of occurrences by improving the pipeline performance on the source database. However, we still see the issue coming up occasionally. This tweaks the batchSize for the aggregate request to further improve the handling.

To understand how this helps, consider a case where we replicate from database A, which receives a slow stream of updates, while database B in the same cluster receives a very high rate of updates for a couple of minutes. If we fall behind with replication, we could end up with a backlog like this:

```
1 000 000 updates on B
1 update on A
1 000 000 updates on B
10 updates on A
1 000 000 updates on C
1 update on A
... repeat this pattern another 20x
```

With our default batchSize of 6000, the change stream request would have to read through _all_ the changes in B before building up 6000 changes in A. So, the solution is to make the batch size smaller.

However, we can't universally make the batch size significantly smaller, since that can reduce throughput for the common case where this timeout isn't an issue. So for this, we use adaptive batch sizing:
1. Always use `batchSize: 1` for the `aggregate` command when opening a change stream. Since this is only run on startup or when retrying, the overhead of the tiny batch size should be small.
2. `batchSize: 6000` for the `getMore` command by default.
3. After a timeout, reduce batchSize to 2 for `getMore`, then double on every batch until it reaches the original batch size.

So if we do run into a timeout, the change stream restarts with a new aggregate command with `batchSize: 1`, then smaller `getMore` batch sizes, which allows us to make progress.

The original attempt only used the `batchSize: 1` for aggregate command, and not changing the batchSize for the getMore command. There are however edge cases where that could result in glacial replication lag. For example, suppose we this backlog:

```
5000 update on A
1 000 000 updates on B
10 updates on A
1 000 000 updates on B
10 updates on A
...
```

With this backlog, we can expect a `batchSize: 6000` request to always fail. But with only `batchSize: 1` on the aggregate command, we only move one record further, then fail again on the next getMore, effectively replicating around 1 change per minute until we move past those original 5000.

By reducing the batchSize for getMore and doubling it again, we should be able to make a lot more progress before running into the timeout. In the above example, we'd make requests with batchSize of 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, before the next request of 4096 fails, and restarting at 1 again.

## Tests

This configures the test setup to use `enableTestCommands=1` in the MongoDB server. That allows us to inject error responses for specific commands, making testing these edge cases easier.

## Flush

This now does a `flush()` and `setResumeToken()` on each change stream batch. This makes sure that we persist progress if we run into a fatal change stream error. This is only possible now that we're using [raw change streams](https://github.com/powersync-ja/powersync-service/pull/591).

This change also breaks our logic for detecting a change in database URI. The old behavior was not reliable here, since it depends on which type of resume token happened to be used. We can revisit this in the future, looking into different mechanisms to detect the database change (such as persisting and comparing the name).
