### PR TITLE
MongoDB replication instrumentation

### DIFF
--- a/.changeset/nine-oranges-destroy.md
+++ b/.changeset/nine-oranges-destroy.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+---
+
+[MongoDB] Log replication timing info per batch

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -18,6 +18,7 @@ import {
   deserializeBson,
   InternalOpId,
   isCompleteRow,
+  PerformanceTimer,
   SaveOperationTag,
   storage,
   SyncRuleState,
@@ -85,6 +86,8 @@ export abstract class MongoBucketBatch
   private markRecordUnavailable: BucketStorageMarkRecordUnavailable | undefined;
   private clearedError = false;
 
+  private timer = new PerformanceTimer(['flush_duration', 'evaluating_duration', 'lock_delay', 'retry_delay']);
+
   /**
    * Last LSN received associated with a checkpoint.
    *
@@ -146,6 +149,10 @@ export abstract class MongoBucketBatch
     return this.last_checkpoint_lsn;
   }
 
+  markTimer() {
+    return this.timer.mark();
+  }
+
   protected abstract createPersistedBatch(writtenSize: number): PersistedBatch;
 
   protected abstract get sourceRecordStore(): SourceRecordStore;
@@ -170,19 +177,33 @@ export abstract class MongoBucketBatch
     let last_op: InternalOpId | null = null;
     let resumeBatch: OperationBatch | null = null;
 
-    await this.withReplicationTransaction(`Flushing ${batch?.length ?? 0} ops`, async (session, opSeq) => {
-      if (batch != null) {
-        resumeBatch = await this.replicateBatch(session, batch, opSeq, options);
-      }
+    let evaluatingDuration: number = 0;
 
-      if (this.write_checkpoint_batch.length > 0) {
-        this.logger.info(`Writing ${this.write_checkpoint_batch.length} custom write checkpoints`);
-        await batchCreateCustomWriteCheckpoints(this.db, session, this.write_checkpoint_batch, opSeq.next());
-        this.write_checkpoint_batch = [];
-      }
+    const stats = await this.withReplicationTransaction(
+      `Flushing ${batch?.length ?? 0} ops`,
+      async (session, opSeq) => {
+        if (batch != null) {
+          const start = performance.now();
+          const { batch: b, innerFlushDuration } = await this.replicateBatch(session, batch, opSeq, options);
+          resumeBatch = b;
+          const batchDuration = performance.now() - start;
+          evaluatingDuration += batchDuration - innerFlushDuration;
+        }
 
-      last_op = opSeq.last();
-    });
+        if (this.write_checkpoint_batch.length > 0) {
+          this.logger.info(`Writing ${this.write_checkpoint_batch.length} custom write checkpoints`);
+          await batchCreateCustomWriteCheckpoints(this.db, session, this.write_checkpoint_batch, opSeq.next());
+          this.write_checkpoint_batch = [];
+        }
+
+        last_op = opSeq.last();
+      }
+    );
+
+    this.timer.add('evaluating_duration', evaluatingDuration);
+    this.timer.add('lock_delay', stats.lockDelay);
+    this.timer.add('retry_delay', stats.retryDelay);
+    this.timer.add('flush_duration', stats.totalDuration - evaluatingDuration - stats.lockDelay - stats.retryDelay);
 
     // null if done, set if we need another flush
     this.batch = resumeBatch;
@@ -201,8 +222,9 @@ export abstract class MongoBucketBatch
     batch: OperationBatch,
     op_seq: MongoIdSequence,
     options?: storage.BucketBatchCommitOptions
-  ): Promise<OperationBatch | null> {
+  ): Promise<{ batch: OperationBatch | null; innerFlushDuration: number }> {
     let sizes: Map<string, number> | undefined = undefined;
+    let innerFlushDuration: number = 0;
     if (this.storeCurrentData && !this.skipExistingRows) {
       // We skip this step if we don't store current_data, since the sizes will
       // always be small in that case.
@@ -268,7 +290,8 @@ export abstract class MongoBucketBatch
         if (persistedBatch!.shouldFlushTransaction()) {
           // Transaction is getting big.
           // Flush, and resume in a new transaction.
-          const { flushedAny } = await persistedBatch!.flush(this.session, options);
+          const { flushedAny, duration } = await persistedBatch!.flush(this.session, options);
+          innerFlushDuration += duration;
           didFlush ||= flushedAny;
           persistedBatch = null;
           // Computing our current progress is a little tricky here, since
@@ -280,16 +303,20 @@ export abstract class MongoBucketBatch
 
       if (persistedBatch) {
         transactionSize = persistedBatch.currentSize;
-        const { flushedAny } = await persistedBatch.flush(this.session, options);
+        const { flushedAny, duration } = await persistedBatch.flush(this.session, options);
         didFlush ||= flushedAny;
+        innerFlushDuration += duration;
       }
     }
 
     if (didFlush) {
+      const start = performance.now();
       await this.clearError();
+      const duration = performance.now() - start;
+      innerFlushDuration += duration;
     }
 
-    return resumeBatch?.hasData() ? resumeBatch : null;
+    return { batch: resumeBatch?.hasData() ? resumeBatch : null, innerFlushDuration };
   }
 
   private saveOperation(
@@ -540,7 +567,11 @@ export abstract class MongoBucketBatch
   }
 
   private async withTransaction(cb: () => Promise<void>) {
+    const start = performance.now();
+    let lockDelay: number = 0;
+    let retryDelay: number = 0;
     await replicationMutex.exclusiveLock(async () => {
+      lockDelay = performance.now() - start;
       await this.session.withTransaction(
         async () => {
           try {
@@ -551,19 +582,27 @@ export abstract class MongoBucketBatch
             } else {
               this.logger.warn('Transaction error', e as Error);
             }
-            await timers.setTimeout(Math.random() * 50);
+            const delay = Math.random() * 50;
+            retryDelay += delay;
+            await timers.setTimeout(delay);
             throw e;
           }
         },
         { maxCommitTimeMS: 10000 }
       );
     });
+    const totalDuration = performance.now() - start;
+    return {
+      totalDuration,
+      lockDelay,
+      retryDelay
+    };
   }
 
   private async withReplicationTransaction(
     description: string,
     callback: (session: mongo.ClientSession, opSeq: MongoIdSequence) => Promise<void>
-  ): Promise<void> {
+  ) {
     let flushTry = 0;
 
     const start = Date.now();
@@ -571,7 +610,7 @@ export abstract class MongoBucketBatch
 
     const session = this.session;
 
-    await this.withTransaction(async () => {
+    return await this.withTransaction(async () => {
       flushTry += 1;
       if (flushTry % 10 == 0) {
         this.logger.info(`${description} - try ${flushTry}`);
@@ -978,35 +1017,46 @@ export abstract class MongoBucketBatch
 
     let lastBatchCount = BATCH_LIMIT;
     while (lastBatchCount == BATCH_LIMIT) {
-      await this.withReplicationTransaction(`Truncate ${sourceTable.qualifiedName}`, async (session, opSeq) => {
-        const sourceTableId = mongoTableId(sourceTable.id);
-        const batch = await this.sourceRecordStore.loadTruncateBatch(session, sourceTableId, BATCH_LIMIT);
-        const persistedBatch = this.createPersistedBatch(0);
+      let evaluatingDuration = 0;
+      const stats = await this.withReplicationTransaction(
+        `Truncate ${sourceTable.qualifiedName}`,
+        async (session, opSeq) => {
+          const start = performance.now();
+          const sourceTableId = mongoTableId(sourceTable.id);
+          const batch = await this.sourceRecordStore.loadTruncateBatch(session, sourceTableId, BATCH_LIMIT);
+          const persistedBatch = this.createPersistedBatch(0);
 
-        for (let value of batch) {
-          persistedBatch.saveBucketData({
-            op_seq: opSeq,
-            before_buckets: value.buckets,
-            evaluated: [],
-            table: sourceTable,
-            sourceKey: value.replicaId
-          });
-          persistedBatch.saveParameterData({
-            op_seq: opSeq,
-            existing_lookups: value.lookups,
-            evaluated: [],
-            sourceTable: sourceTable,
-            sourceKey: value.replicaId
-          });
+          for (let value of batch) {
+            persistedBatch.saveBucketData({
+              op_seq: opSeq,
+              before_buckets: value.buckets,
+              evaluated: [],
+              table: sourceTable,
+              sourceKey: value.replicaId
+            });
+            persistedBatch.saveParameterData({
+              op_seq: opSeq,
+              existing_lookups: value.lookups,
+              evaluated: [],
+              sourceTable: sourceTable,
+              sourceKey: value.replicaId
+            });
 
-          // Since this is not from streaming replication, we can do a hard delete
-          persistedBatch.hardDeleteCurrentData(sourceTableId, value.replicaId);
+            // Since this is not from streaming replication, we can do a hard delete
+            persistedBatch.hardDeleteCurrentData(sourceTableId, value.replicaId);
+          }
+          evaluatingDuration += performance.now() - start;
+          await persistedBatch.flush(session);
+          lastBatchCount = batch.length;
+
+          last_op = opSeq.last();
         }
-        await persistedBatch.flush(session);
-        lastBatchCount = batch.length;
+      );
 
-        last_op = opSeq.last();
-      });
+      this.timer.add('evaluating_duration', evaluatingDuration);
+      this.timer.add('lock_delay', stats.lockDelay);
+      this.timer.add('retry_delay', stats.retryDelay);
+      this.timer.add('flush_duration', stats.totalDuration - evaluatingDuration - stats.lockDelay - stats.retryDelay);
     }
 
     return last_op!;

--- a/modules/module-mongodb-storage/src/storage/implementation/common/PersistedBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/common/PersistedBatch.ts
@@ -299,8 +299,8 @@ export abstract class PersistedBatch {
       await this.flushBucketStates(session);
     }
 
+    const duration = Math.round(performance.now() - startAt);
     if (flushedSomething) {
-      const duration = Math.round(performance.now() - startAt);
       if (options?.oldestUncommittedChange != null) {
         const replicationLag = Math.round((Date.now() - options.oldestUncommittedChange.getTime()) / 1000);
 
@@ -341,7 +341,8 @@ export abstract class PersistedBatch {
       bucketDataCount: this.bucketDataCount,
       parameterDataCount: this.bucketParameters.length,
       currentDataCount: this.currentDataCount,
-      flushedAny: flushedSomething
+      flushedAny: flushedSomething,
+      duration: duration
     };
 
     this.bucketData = [];

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -1134,9 +1134,9 @@ export class ChangeStream {
             // so this is a good natural point to flush and mark progress.
             // We avoid this when splitDocument is set, since we cannot resume in the middle of a split event.
             const { comparable: lsn } = MongoLSN.fromResumeToken(resumeToken);
-            await batch.flush({
-              oldestUncommittedChange: this.replicationLag.oldestUncommittedChange
-            });
+            await batch.flush({ oldestUncommittedChange: this.replicationLag.oldestUncommittedChange });
+            // TODO: We should consider making this standard behavior of flush().
+            await batch.setResumeLsn(lsn);
           }
 
           const batchDuration = Math.ceil(performance.now() - batchStart + eventBatch.commandDuration);

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -11,6 +11,7 @@ import {
 } from '@powersync/lib-services-framework';
 import {
   MetricsEngine,
+  PerformanceTimer,
   RelationCache,
   ReplicationLagTracker,
   SaveOperationTag,
@@ -105,6 +106,8 @@ export class ChangeStream {
   private changeStreamTimeout: number;
 
   private readonly sourceRowConverter: SourceRowConverter;
+
+  private internalTimer = new PerformanceTimer(['parse_duration']);
 
   constructor(options: ChangeStreamOptions) {
     this.storage = options.storage;
@@ -510,7 +513,7 @@ export class ChangeStream {
       // Pre-fetch next batch, so that we can read and write concurrently
       nextChunkPromise = query.nextChunk();
       for (let buffer of docBatch) {
-        const { row: record, replicaId: replicaId } = this.sourceRowConverter.rawToSqliteRow(buffer);
+        const { row: record, replicaId: replicaId } = this.rawToSqliteRow(buffer);
 
         // This auto-flushes when the batch reaches its size limit
         await batch.save({
@@ -660,7 +663,7 @@ export class ChangeStream {
 
     this.metrics.getCounter(ReplicationMetric.ROWS_REPLICATED).add(1);
     if (change.operationType == 'insert') {
-      const { row: baseRecord, replicaId: _replicaId } = this.sourceRowConverter.rawToSqliteRow(change.fullDocument);
+      const { row: baseRecord, replicaId: _replicaId } = this.rawToSqliteRow(change.fullDocument);
       return await batch.save({
         tag: SaveOperationTag.INSERT,
         sourceTable: table,
@@ -682,7 +685,7 @@ export class ChangeStream {
           beforeReplicaId: change.documentKey._id
         });
       }
-      const { row: after, replicaId: _replicaId } = this.sourceRowConverter.rawToSqliteRow(change.fullDocument!);
+      const { row: after, replicaId: _replicaId } = this.rawToSqliteRow(change.fullDocument!);
       return await batch.save({
         tag: SaveOperationTag.UPDATE,
         sourceTable: table,
@@ -817,6 +820,14 @@ export class ChangeStream {
     });
   }
 
+  private rawToSqliteRow(row: Buffer) {
+    const start = performance.now();
+    const result = this.sourceRowConverter.rawToSqliteRow(row);
+    const duration = performance.now() - start;
+    this.internalTimer.add('parse_duration', duration);
+    return result;
+  }
+
   async streamChangesInternal() {
     const transactionsReplicatedMetric = this.metrics.getCounter(ReplicationMetric.TRANSACTIONS_REPLICATED);
     const bytesReplicatedMetric = this.metrics.getCounter(ReplicationMetric.DATA_REPLICATED_BYTES);
@@ -872,6 +883,7 @@ export class ChangeStream {
           const { events, resumeToken } = eventBatch;
           const batchStart = performance.now();
           const mark = batch.markTimer();
+          const internalMark = this.internalTimer.mark();
 
           bytesReplicatedMetric.add(eventBatch.byteSize);
           chunksReplicatedMetric.add(1);
@@ -1122,19 +1134,27 @@ export class ChangeStream {
             // so this is a good natural point to flush and mark progress.
             // We avoid this when splitDocument is set, since we cannot resume in the middle of a split event.
             const { comparable: lsn } = MongoLSN.fromResumeToken(resumeToken);
-            await batch.flush({ oldestUncommittedChange: this.replicationLag.oldestUncommittedChange });
-            // TODO: We should consider making this standard behavior of flush().
-            await batch.setResumeLsn(lsn);
+            await batch.flush({
+              oldestUncommittedChange: this.replicationLag.oldestUncommittedChange,
+              resumeLsn: lsn
+            });
           }
 
           const batchDuration = Math.ceil(performance.now() - batchStart + eventBatch.commandDuration);
           const stats = mark.getBreakDown(0);
+          const internalstats = internalMark.getBreakDown(0);
 
-          this.logger.info(`Processed batch of ${events.length} changes in ${batchDuration}ms`, {
-            duration: batchDuration,
-            wait_for_change_stream: Math.round(eventBatch.commandDuration),
-            ...stats
-          });
+          this.logger.info(
+            `Processed batch of ${events.length} changes / ${eventBatch.byteSize} bytes in ${batchDuration}ms`,
+            {
+              count: events.length,
+              bytes: eventBatch.byteSize,
+              duration: batchDuration,
+              wait_for_change_stream: Math.round(eventBatch.commandDuration),
+              ...stats,
+              ...internalstats
+            }
+          );
         }
       }
     );

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -1127,12 +1127,12 @@ export class ChangeStream {
             await batch.setResumeLsn(lsn);
           }
 
-          const batchDuration = performance.now() - batchStart;
-          const stats = mark.getBreakDown();
+          const batchDuration = Math.ceil(performance.now() - batchStart + eventBatch.commandDuration);
+          const stats = mark.getBreakDown(0);
 
           this.logger.info(`Processed batch of ${events.length} changes in ${batchDuration}ms`, {
             duration: batchDuration,
-            wait_for_change_stream: eventBatch.commandDuration,
+            wait_for_change_stream: Math.round(eventBatch.commandDuration),
             ...stats
           });
         }

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -864,7 +864,6 @@ export class ChangeStream {
         let splitDocument: ProjectedChangeStreamDocument | null = null;
 
         let flexDbNameWorkaroundLogged = false;
-        let changesSinceLastCheckpoint = 0;
 
         let lastEmptyResume = performance.now();
         let lastTxnKey: string | null = null;
@@ -1048,7 +1047,6 @@ export class ChangeStream {
 
               if (!checkpointBlocked) {
                 this.replicationLag.markCommitted();
-                changesSinceLastCheckpoint = 0;
               }
             } else if (
               changeDocument.operationType == 'insert' ||
@@ -1083,21 +1081,7 @@ export class ChangeStream {
                   transactionsReplicatedMetric.add(1);
                 }
 
-                const flushResult = await this.writeChange(batch, table, changeDocument);
-                changesSinceLastCheckpoint += 1;
-                if (flushResult != null && changesSinceLastCheckpoint >= 20_000) {
-                  // When we are catching up replication after an initial snapshot, there may be a very long delay
-                  // before we do a commit(). In that case, we need to periodically persist the resume LSN, so
-                  // we don't restart from scratch if we restart replication.
-                  // The same could apply if we need to catch up on replication after some downtime.
-                  const { comparable: lsn } = new MongoLSN({
-                    timestamp: changeDocument.clusterTime!,
-                    resume_token: changeDocument._id
-                  });
-                  this.logger.info(`Updating resume LSN to ${lsn} after ${changesSinceLastCheckpoint} changes`);
-                  await batch.setResumeLsn(lsn);
-                  changesSinceLastCheckpoint = 0;
-                }
+                await this.writeChange(batch, table, changeDocument);
               }
             } else if (changeDocument.operationType == 'drop') {
               const rel = getMongoRelation(changeDocument.ns);

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -871,6 +871,8 @@ export class ChangeStream {
         for await (let eventBatch of batchStream) {
           const { events, resumeToken } = eventBatch;
           const batchStart = performance.now();
+          const mark = batch.markTimer();
+
           bytesReplicatedMetric.add(eventBatch.byteSize);
           chunksReplicatedMetric.add(1);
           if (this.abort_signal.aborted) {
@@ -1126,10 +1128,12 @@ export class ChangeStream {
           }
 
           const batchDuration = performance.now() - batchStart;
+          const stats = mark.getBreakDown();
 
           this.logger.info(`Processed batch of ${events.length} changes in ${batchDuration}ms`, {
             duration: batchDuration,
-            wait_for_change_stream: eventBatch.commandDuration
+            wait_for_change_stream: eventBatch.commandDuration,
+            ...stats
           });
         }
       }

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -870,6 +870,7 @@ export class ChangeStream {
 
         for await (let eventBatch of batchStream) {
           const { events, resumeToken } = eventBatch;
+          const batchStart = performance.now();
           bytesReplicatedMetric.add(eventBatch.byteSize);
           chunksReplicatedMetric.add(1);
           if (this.abort_signal.aborted) {
@@ -903,7 +904,6 @@ export class ChangeStream {
 
           this.touch();
 
-          const batchStart = Date.now();
           for (let eventIndex = 0; eventIndex < events.length; eventIndex++) {
             const rawChangeDocument = events[eventIndex];
             const originalChangeDocument = parseChangeDocument(rawChangeDocument);
@@ -1124,7 +1124,13 @@ export class ChangeStream {
             // TODO: We should consider making this standard behavior of flush().
             await batch.setResumeLsn(lsn);
           }
-          this.logger.info(`Processed batch of ${events.length} changes in ${Date.now() - batchStart}ms`);
+
+          const batchDuration = performance.now() - batchStart;
+
+          this.logger.info(`Processed batch of ${events.length} changes in ${batchDuration}ms`, {
+            duration: batchDuration,
+            wait_for_change_stream: eventBatch.commandDuration
+          });
         }
       }
     );

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -1135,8 +1135,7 @@ export class ChangeStream {
             // We avoid this when splitDocument is set, since we cannot resume in the middle of a split event.
             const { comparable: lsn } = MongoLSN.fromResumeToken(resumeToken);
             await batch.flush({
-              oldestUncommittedChange: this.replicationLag.oldestUncommittedChange,
-              resumeLsn: lsn
+              oldestUncommittedChange: this.replicationLag.oldestUncommittedChange
             });
           }
 

--- a/modules/module-mongodb/src/replication/RawChangeStream.ts
+++ b/modules/module-mongodb/src/replication/RawChangeStream.ts
@@ -46,6 +46,17 @@ export interface ChangeStreamBatch {
    * Size in bytes of this event.
    */
   byteSize: number;
+
+  /**
+   * Time in milliseconds that we waited for a response from MongoDB.
+   *
+   * This includes:
+   * 1. Time to send the command.
+   * 2. Time MongoDB waits for new data to be available.
+   * 3. Time MongoDB scans through the oplog.
+   * 4. Time to send the data back over the network, and parse the outer metadata.
+   */
+  commandDuration: number;
 }
 
 const deserialize = mongo.BSON.deserialize;
@@ -144,7 +155,6 @@ async function* rawChangeStreamInner(
    */
   let nsCollection: string | null = null;
 
-  const batchSize = options.batchSize;
   const collection = options.collection ?? 1;
   let abortPromise: Promise<any> | null = null;
 
@@ -163,6 +173,7 @@ async function* rawChangeStreamInner(
 
   try {
     {
+      const start = performance.now();
       // Step 1: Send the aggregate command to start the change stream
       const aggregateResult = await db
         .command(
@@ -182,6 +193,8 @@ async function* rawChangeStreamInner(
           throw mapChangeStreamError(e);
         });
 
+      const aggregateDuration = performance.now() - start;
+
       const cursor = deserialize(aggregateResult.cursor, DESERIALIZE_CHANGE_STREAM);
 
       cursorId = BigInt(cursor.id);
@@ -195,13 +208,19 @@ async function* rawChangeStreamInner(
         throw new ReplicationAssertionError(`postBatchResumeToken from aggregate response`);
       }
 
-      yield { events: batch, resumeToken: cursor.postBatchResumeToken, byteSize: aggregateResult.cursor.byteLength };
+      yield {
+        events: batch,
+        resumeToken: cursor.postBatchResumeToken,
+        byteSize: aggregateResult.cursor.byteLength,
+        commandDuration: aggregateDuration
+      };
     }
 
     // Step 2: Poll using getMore until the cursor is closed
     while (cursorId && cursorId !== 0n) {
       options.signal?.throwIfAborted();
 
+      const start = performance.now();
       const getMoreResult: mongo.Document = await db
         .command(
           {
@@ -228,6 +247,8 @@ async function* rawChangeStreamInner(
           throw mapChangeStreamError(e);
         });
 
+      const getMoreDuration = performance.now() - start;
+
       const cursor = deserialize(getMoreResult.cursor, DESERIALIZE_CHANGE_STREAM);
       cursorId = BigInt(cursor.id);
       const nextBatch = cursor.nextBatch;
@@ -237,7 +258,12 @@ async function* rawChangeStreamInner(
         // postBatchResumeToken is returned in MongoDB 4.0.7 and later, and we support 6.0+
         throw new ReplicationAssertionError(`postBatchResumeToken from aggregate response`);
       }
-      yield { events: nextBatch, resumeToken: cursor.postBatchResumeToken, byteSize: getMoreResult.cursor.byteLength };
+      yield {
+        events: nextBatch,
+        resumeToken: cursor.postBatchResumeToken,
+        byteSize: getMoreResult.cursor.byteLength,
+        commandDuration: getMoreDuration
+      };
     }
 
     options.signal?.throwIfAborted();

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -14,6 +14,7 @@ import {
   CheckpointResult,
   deserializeReplicaId,
   InternalOpId,
+  PerformanceTimer,
   storage,
   utils
 } from '@powersync/service-core';
@@ -101,6 +102,7 @@ export class PostgresBucketBatch
   private clearedError = false;
   private readonly storageConfig: storage.StorageVersionConfig;
   private readonly currentDataStore: PostgresCurrentDataStore;
+  private timer = new PerformanceTimer([]);
 
   constructor(protected options: PostgresBucketBatchOptions) {
     super();
@@ -123,6 +125,10 @@ export class PostgresBucketBatch
 
   get lastCheckpointLsn() {
     return this.last_checkpoint_lsn;
+  }
+
+  markTimer(): storage.PerformanceInstrumentation {
+    return this.timer.mark();
   }
 
   async [Symbol.asyncDispose]() {

--- a/packages/service-core/src/storage/BucketStorageBatch.ts
+++ b/packages/service-core/src/storage/BucketStorageBatch.ts
@@ -4,7 +4,7 @@ import { BSON } from 'bson';
 import { InternalOpId } from '../util/utils.js';
 import { ReplicationEventPayload } from './ReplicationEventPayload.js';
 import { SourceTable, TableSnapshotStatus } from './SourceTable.js';
-import { BatchedCustomWriteCheckpointOptions } from './storage-index.js';
+import { BatchedCustomWriteCheckpointOptions, PerformanceInstrumentation } from './storage-index.js';
 
 export const DEFAULT_BUCKET_BATCH_COMMIT_OPTIONS: ResolvedBucketBatchCommitOptions = {
   createEmptyCheckpoints: true,
@@ -12,6 +12,8 @@ export const DEFAULT_BUCKET_BATCH_COMMIT_OPTIONS: ResolvedBucketBatchCommitOptio
 };
 
 export interface BucketStorageBatch extends ObserverClient<BucketBatchStorageListener>, AsyncDisposable {
+  markTimer(): PerformanceInstrumentation;
+
   /**
    * Alias for [Symbol.asyncDispose]
    */

--- a/packages/service-core/src/storage/PerformanceInstrumentation.ts
+++ b/packages/service-core/src/storage/PerformanceInstrumentation.ts
@@ -1,0 +1,33 @@
+export interface PerformanceInstrumentation {
+  getBreakDown(): Record<string, number>;
+}
+
+export class PerformanceTimer<K extends string> {
+  stats: Record<K, number>;
+
+  constructor(keys: K[]) {
+    let stats: Record<K, number> = {} as any;
+    for (let k of keys) {
+      stats[k] = 0;
+    }
+    this.stats = stats;
+  }
+
+  add(k: K, v: number) {
+    this.stats[k] += v;
+  }
+
+  mark(): PerformanceInstrumentation {
+    const start = { ...this.stats };
+
+    return {
+      getBreakDown: () => {
+        return Object.fromEntries(
+          Object.entries(this.stats).map(([k, v]) => {
+            return [k, (v as number) - start[k as K]];
+          })
+        );
+      }
+    };
+  }
+}

--- a/packages/service-core/src/storage/PerformanceInstrumentation.ts
+++ b/packages/service-core/src/storage/PerformanceInstrumentation.ts
@@ -1,5 +1,5 @@
 export interface PerformanceInstrumentation {
-  getBreakDown(): Record<string, number>;
+  getBreakDown(digits?: number): Record<string, number>;
 }
 
 export class PerformanceTimer<K extends string> {
@@ -21,10 +21,14 @@ export class PerformanceTimer<K extends string> {
     const start = { ...this.stats };
 
     return {
-      getBreakDown: () => {
+      getBreakDown: (fractionDigits?: number) => {
         return Object.fromEntries(
           Object.entries(this.stats).map(([k, v]) => {
-            return [k, (v as number) - start[k as K]];
+            let duration = (v as number) - start[k as K];
+            if (fractionDigits != null) {
+              duration = parseFloat(duration.toFixed(fractionDigits));
+            }
+            return [k, duration];
           })
         );
       }

--- a/packages/service-core/src/storage/storage-index.ts
+++ b/packages/service-core/src/storage/storage-index.ts
@@ -3,6 +3,7 @@ export * from './BucketStorage.js';
 export * from './BucketStorageBatch.js';
 export * from './BucketStorageFactory.js';
 export * from './ChecksumCache.js';
+export * from './PerformanceInstrumentation.js';
 export * from './PersistedSyncRulesContent.js';
 export * from './ReplicationEventPayload.js';
 export * from './ReplicationLock.js';


### PR DESCRIPTION
This instruments time spent in various parts of the replication process for MongoDB, and logs with each change stream batch. Example log output:

```
info: [powersync_4] Processed batch of 6000 changes / 4055192 bytes in 320ms {"bytes":4055192,"count":6000,"duration":320,"evaluating_duration":55,"flush_duration":135,"lock_delay":0,"parse_duration":21,"retry_delay":0,"wait_for_change_stream":61}
```

The goal here is to help diagnose slow replication issues on a high level. When replication is slower than expected, we want to know whether the bottleneck is (1) the source db or network, (2) the storage db, or (3) replication process CPU. The stats here help identify that.

This includes:
1. `duration`: Roughly equal total duration between batches.
2. `wait_for_change_stream`: Time spent waiting for the next batch on the change stream, including the source db waiting for more changes, scanning the oplog, processing the change stream pipeline, and network transfer time.
3. `parse_duration`: Time spent converting from raw change stream buffers to input for sync config.
4. `evaluating_duration`: Time spent evaluating sync queries.
5. `flush_duration`: Time spent writing to the storage database.
6. `lock_delay`: Time spent waiting for other replication jobs within the same process.
7. `retry_delay`: Time spent waiting for other replication jobs in different processes.

Fields 2-7 above give a rough breakdown of the total duration, but it is not an exhaustive list - there is more CPU overhead not explicitly tracked.

Other source databases are not currently tracking any of this. Postgres storage also doesn't report the storage-specific stats currently.