### PR TITLE
Improve error messages for Postgres query failures

### DIFF
--- a/.changeset/six-plums-warn.md
+++ b/.changeset/six-plums-warn.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-postgres': patch
+'@powersync/service-errors': patch
+'@powersync/service-jpgwire': patch
+---
+
+Improve Postgres query errors.

--- a/modules/module-postgres/src/replication/PgManager.ts
+++ b/modules/module-postgres/src/replication/PgManager.ts
@@ -5,6 +5,7 @@ import { PostgresTypeResolver } from '../types/resolver.js';
 import { NormalizedPostgresConnectionConfig } from '../types/types.js';
 import { getApplicationName } from '../utils/application-name.js';
 import { getServerVersion } from '../utils/postgres_version.js';
+import { rquery } from './rquery.js';
 
 export interface PgManagerOptions extends pgwire.PgPoolOptions {}
 
@@ -70,14 +71,14 @@ export class PgManager extends BaseObserver<PgManagerListener> {
     // Use an shorter timeout for snapshot connections.
     // This is to detect broken connections early, instead of waiting
     // for the full 6 minutes.
-    // This we are constantly using the connection, we don't need any
+    // Since we are constantly using the connection, we don't need any
     // custom keepalives.
 
     (connection as any)._socket.setTimeout(SNAPSHOT_SOCKET_TIMEOUT);
 
     // Disable statement timeout for snapshot queries.
     // On Supabase, the default is 2 minutes.
-    await connection.query(`set session statement_timeout = 0`);
+    await rquery(connection, `set session statement_timeout = 0`);
 
     return connection;
   }

--- a/modules/module-postgres/src/replication/SnapshotQuery.ts
+++ b/modules/module-postgres/src/replication/SnapshotQuery.ts
@@ -3,6 +3,7 @@ import { ServiceAssertionError } from '@powersync/lib-services-framework';
 import { ColumnDescriptor, SourceTable, bson } from '@powersync/service-core';
 import { PgChunk, PgConnection, PgType, PgTypeOid } from '@powersync/service-jpgwire';
 import { SqliteValue } from '@powersync/service-sync-rules';
+import { rquery, rstream } from './rquery.js';
 
 export interface SnapshotQuery {
   initialize(): Promise<void>;
@@ -36,11 +37,11 @@ export class SimpleSnapshotQuery implements SnapshotQuery {
   ) {}
 
   public async initialize(): Promise<void> {
-    await this.connection.query(`DECLARE snapshot_cursor CURSOR FOR SELECT * FROM ${this.table.qualifiedName}`);
+    await rquery(this.connection, `DECLARE snapshot_cursor CURSOR FOR SELECT * FROM ${this.table.qualifiedName}`);
   }
 
   public nextChunk(): AsyncIterableIterator<PgChunk> {
-    return this.connection.stream(`FETCH ${this.chunkSize} FROM snapshot_cursor`);
+    return rstream(this.connection, `FETCH ${this.chunkSize} FROM snapshot_cursor`);
   }
 }
 
@@ -120,7 +121,8 @@ export class ChunkedSnapshotQuery implements SnapshotQuery {
     let stream: AsyncIterableIterator<PgChunk>;
     const escapedKeyName = escapeIdentifier(this.key.name);
     if (this.lastKey == null) {
-      stream = this.connection.stream(
+      stream = rstream(
+        this.connection,
         `SELECT * FROM ${this.table.qualifiedName} ORDER BY ${escapedKeyName} LIMIT ${this.chunkSize}`
       );
     } else {
@@ -128,7 +130,7 @@ export class ChunkedSnapshotQuery implements SnapshotQuery {
         throw new Error(`typeId required for primary key ${this.key.name}`);
       }
       const type = Number(this.key.typeId);
-      stream = this.connection.stream({
+      stream = rstream(this.connection, {
         statement: `SELECT * FROM ${this.table.qualifiedName} WHERE ${escapedKeyName} > $1 ORDER BY ${escapedKeyName} LIMIT ${this.chunkSize}`,
         params: [{ value: this.lastKey, type }]
       });
@@ -200,7 +202,7 @@ export class IdSnapshotQuery implements SnapshotQuery {
     if (type == null) {
       throw new Error(`Cannot determine primary key array type for ${JSON.stringify(keyDefinition)}`);
     }
-    yield* this.connection.stream({
+    yield* rstream(this.connection, {
       statement: `SELECT * FROM ${this.table.qualifiedName} WHERE ${escapeIdentifier(keyDefinition.name)} = ANY($1)`,
       params: [
         {

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -38,6 +38,7 @@ import { MissingReplicationSlotError } from './MissingReplicationSlotError.js';
 import { PgManager } from './PgManager.js';
 import { getPgOutputRelation, getRelId, referencedColumnTypeIds } from './PgRelation.js';
 import { checkSourceConfiguration, checkTableRls, getReplicationIdentityColumns } from './replication-utils.js';
+import { rquery } from './rquery.js';
 import {
   ChunkedSnapshotQuery,
   IdSnapshotQuery,
@@ -232,7 +233,7 @@ export class WalStream {
         query += ' AND c.relname = $2';
       }
 
-      const result = await db.query({
+      const result = await rquery(db, {
         statement: query,
         params: [
           { type: 'varchar', value: schema },
@@ -256,7 +257,7 @@ export class WalStream {
         continue;
       }
 
-      const rs = await db.query({
+      const rs = await rquery(db, {
         statement: `SELECT 1 FROM pg_publication_tables WHERE pubname = $1 AND schemaname = $2 AND tablename = $3`,
         params: [
           { type: 'varchar', value: PUBLICATION_NAME },
@@ -315,7 +316,7 @@ export class WalStream {
 
     // Check if replication slot exists
     const slot = pgwire.pgwireRows(
-      await this.connections.pool.query({
+      await rquery(this.connections.pool, {
         // We specifically want wal_status and invalidation_reason, but it's not available on older versions,
         // so we just query *.
         statement: 'SELECT * FROM pg_replication_slots WHERE slot_name = $1',
@@ -393,7 +394,7 @@ export class WalStream {
 
     try {
       const rows = pgwire.pgwireRows(
-        await this.connections.pool.query({
+        await rquery(this.connections.pool, {
           statement: `SELECT setting, unit FROM pg_settings WHERE name = 'max_slot_wal_keep_size'`
         })
       );
@@ -471,7 +472,7 @@ export class WalStream {
     await this.queryMaxSlotWalKeepSize();
 
     const rows = pgwire.pgwireRows(
-      await this.connections.pool.query({
+      await rquery(this.connections.pool, {
         statement: 'SELECT * FROM pg_replication_slots WHERE slot_name = $1',
         params: [{ type: 'varchar', value: this.slot_name }]
       })
@@ -512,7 +513,7 @@ export class WalStream {
   }
 
   async estimatedCountNumber(db: pgwire.PgConnection, table: storage.SourceTable): Promise<number> {
-    const results = await db.query({
+    const results = await rquery(db, {
       statement: `SELECT reltuples::bigint AS estimate
 FROM   pg_class
 WHERE  oid = $1::regclass`,
@@ -543,14 +544,14 @@ WHERE  oid = $1::regclass`,
       // initial replication where we left off.
       await this.storage.clear({ signal: this.abort_signal });
 
-      await db.query({
+      await rquery(db, {
         statement: 'SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = $1',
         params: [{ type: 'varchar', value: slotName }]
       });
 
       // We use the replication connection here, not a pool.
       // The replication slot must be created before we start snapshotting tables.
-      await replicationConnection.query(`CREATE_REPLICATION_SLOT ${slotName} LOGICAL pgoutput`);
+      await rquery(replicationConnection, `CREATE_REPLICATION_SLOT ${slotName} LOGICAL pgoutput`);
 
       this.logger.info(`Created replication slot ${slotName}`);
     }
@@ -599,7 +600,7 @@ WHERE  oid = $1::regclass`,
 
         // Get the current LSN for the snapshot.
         // We could also use the LSN from the last table snapshot.
-        const rs = await db.query(`select pg_current_wal_lsn() as lsn`);
+        const rs = await rquery(db, `select pg_current_wal_lsn() as lsn`);
         const noCommitBefore = rs.rows[0].decodeWithoutCustomTypes(0);
 
         await batch.markAllSnapshotDone(noCommitBefore);
@@ -655,7 +656,7 @@ WHERE  oid = $1::regclass`,
     // Note: We use the default "Read Committed" isolation level here, not snapshot isolation.
     // The data may change during the transaction, but that is compensated for in the streaming
     // replication afterwards.
-    await db.query('BEGIN');
+    await rquery(db, 'BEGIN');
     try {
       await this.snapshotTable(batch, db, table, limited);
 
@@ -672,15 +673,20 @@ WHERE  oid = $1::regclass`,
       // 1. Complete the snapshot.
       // 2. Wait until logical replication has caught up with all the change between A and B.
       // Calling `markSnapshotDone(LSN B)` covers that.
-      const rs = await db.query(`select pg_current_wal_lsn() as lsn`);
+      const rs = await rquery(db, `select pg_current_wal_lsn() as lsn`);
       const tableLsnNotBefore = rs.rows[0].decodeWithoutCustomTypes(0);
       // Side note: A ROLLBACK would probably also be fine here, since we only read in this transaction.
-      await db.query('COMMIT');
+      await rquery(db, 'COMMIT');
       const [resultTable] = await batch.markTableSnapshotDone([table], tableLsnNotBefore);
       this.relationCache.update(resultTable);
       return resultTable;
     } catch (e) {
-      await db.query('ROLLBACK');
+      try {
+        await rquery(db, 'ROLLBACK');
+      } catch (e) {
+        // Ignore rollback errors after a failed transaction.
+        // If this happens, the connection is not likely recoverable anyway.
+      }
       throw e;
     }
   }

--- a/modules/module-postgres/src/replication/replication-utils.ts
+++ b/modules/module-postgres/src/replication/replication-utils.ts
@@ -7,6 +7,7 @@ import { PatternResult, storage } from '@powersync/service-core';
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as service_types from '@powersync/service-types';
 import { ReplicationIdentity } from './PgRelation.js';
+import { rquery } from './rquery.js';
 
 export interface ReplicaIdentityResult {
   replicationColumns: storage.ColumnDescriptor[];
@@ -234,11 +235,12 @@ export async function getDebugTablesInfo(options: GetDebugTablesInfoOptions): Pr
   );
 
   let rows: BatchedDebugTableRow[];
-  await db.query('BEGIN');
+  await rquery(db, 'BEGIN');
   try {
     // Anonymous DO blocks cannot take bind parameters directly, so pass the
     // pattern payload through transaction-local settings on the pinned connection.
-    const fetched = await db.query(
+    const fetched = await rquery(
+      db,
       {
         statement: `SELECT set_config('powersync.debug.table_patterns', $1, true)`,
         params: [{ type: 'varchar', value: patternPayload }]
@@ -256,10 +258,10 @@ export async function getDebugTablesInfo(options: GetDebugTablesInfoOptions): Pr
     );
 
     rows = pgwire.pgwireRows<BatchedDebugTableRow>(fetched);
-    await db.query('COMMIT');
+    await rquery(db, 'COMMIT');
   } catch (e) {
     try {
-      await db.query('ROLLBACK');
+      await rquery(db, 'ROLLBACK');
     } catch {
       // Ignore rollback errors after a failed transaction.
     }
@@ -343,7 +345,7 @@ export async function getDebugTablesInfo(options: GetDebugTablesInfoOptions): Pr
 export async function cleanUpReplicationSlot(slotName: string, db: pgwire.PgClient): Promise<void> {
   logger.info(`Cleaning up Postgres replication slot: ${slotName}...`);
 
-  await db.query({
+  await rquery(db, {
     statement: 'SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name = $1',
     params: [{ type: 'varchar', value: slotName }]
   });

--- a/modules/module-postgres/src/replication/rquery.ts
+++ b/modules/module-postgres/src/replication/rquery.ts
@@ -1,0 +1,38 @@
+import { PgChunk, PgClient, PgResult, Statement } from '@powersync/service-jpgwire';
+import { mapPostgresReplicationError } from '../utils/errors.js';
+
+export function rquery(db: PgClient, query: string): Promise<PgResult>;
+export function rquery(db: PgClient, ...statements: Statement[]): Promise<PgResult>;
+
+/**
+ * Run a replication query, mapping errors.
+ */
+export async function rquery(db: PgClient, ...args: any[]): Promise<PgResult> {
+  try {
+    return await db.query(...args);
+  } catch (e) {
+    let query: string | undefined;
+    if (typeof args[0] == 'string') {
+      query = args[0];
+    } else if (typeof args[0]?.statement == 'string') {
+      query = args[0].statement;
+    }
+    throw mapPostgresReplicationError(e, query);
+  }
+}
+
+export function rstream(db: PgClient, query: string): AsyncIterableIterator<PgChunk>;
+export function rstream(db: PgClient, ...statements: Statement[]): AsyncIterableIterator<PgChunk>;
+export async function* rstream(db: PgClient, ...args: any[]): AsyncIterableIterator<PgChunk> {
+  try {
+    yield* db.stream(...args);
+  } catch (e) {
+    let query: string | undefined;
+    if (typeof args[0] == 'string') {
+      query = args[0];
+    } else if (typeof args[0]?.statement == 'string') {
+      query = args[0].statement;
+    }
+    throw mapPostgresReplicationError(e, query);
+  }
+}

--- a/modules/module-postgres/src/utils/errors.ts
+++ b/modules/module-postgres/src/utils/errors.ts
@@ -1,0 +1,32 @@
+import { DatabaseQueryError, ErrorCode, ServiceError } from '@powersync/lib-services-framework';
+import { SocketTimeoutError } from '@powersync/service-jpgwire';
+
+export function mapPostgresReplicationError(error: unknown, query?: string): ServiceError {
+  if (error instanceof ServiceError) {
+    return error;
+  }
+
+  if ((error as Error).message == 'postgres query late') {
+    // This comes from pgwire
+    // The "postgres query late" message is not very useful on its own.
+    // The cause may contain more details, but the error itself contains the most useful stack.
+    // So we preserve the error, but replace the message.
+    let message = `Postgres query failed`;
+    if ((error as any).cause?.message) {
+      message += ': ' + (error as any).cause?.message;
+    }
+    (error as Error).message = message;
+  }
+  let result: DatabaseQueryError;
+  if (error instanceof SocketTimeoutError || (error as Error).cause instanceof SocketTimeoutError) {
+    result = new DatabaseQueryError(ErrorCode.PSYNC_S1121, 'Socket timed out while replicating', error);
+  } else {
+    result = new DatabaseQueryError(ErrorCode.PSYNC_S1120, 'Postgres error while replicating', error);
+  }
+
+  if (query) {
+    result.query = query;
+  }
+
+  return result;
+}

--- a/packages/jpgwire/src/errors.ts
+++ b/packages/jpgwire/src/errors.ts
@@ -1,0 +1,1 @@
+export class SocketTimeoutError extends Error {}

--- a/packages/jpgwire/src/index.ts
+++ b/packages/jpgwire/src/index.ts
@@ -1,4 +1,5 @@
 export * from './certs.js';
+export * from './errors.js';
 export * from './metrics.js';
 export * from './pgwire.js';
 export * from './pgwire_types.js';

--- a/packages/jpgwire/src/socket_adapter.ts
+++ b/packages/jpgwire/src/socket_adapter.ts
@@ -3,6 +3,7 @@
 import { once } from 'node:events';
 import net from 'node:net';
 import tls from 'node:tls';
+import { SocketTimeoutError } from './errors.js';
 import { recordBytesRead } from './metrics.js';
 
 // pgwire doesn't natively support configuring timeouts, but we just hardcode a default.
@@ -76,7 +77,7 @@ export class SocketAdapter {
     this._socket.on('end', () => this._readResume());
     // Custom timeout handling
     this._socket.on('timeout', () => {
-      this._socket.destroy(new Error('Socket idle timeout'));
+      this._socket.destroy(new SocketTimeoutError(`Socket timed out after ${this._socket.timeout}ms`));
     });
     this._socket.on('error', (error) => {
       this._error = error;

--- a/packages/jpgwire/src/socket_adapter.ts
+++ b/packages/jpgwire/src/socket_adapter.ts
@@ -40,7 +40,7 @@ export class SocketAdapter {
       lookup: options.lookup,
 
       // This closes the connection if no data was sent or received for the given time,
-      // even if the connection is still actaully alive.
+      // even if the connection is still actually alive.
       timeout: POWERSYNC_SOCKET_DEFAULT_TIMEOUT,
 
       // This configures TCP keepalive.

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -154,7 +154,7 @@ export enum ErrorCode {
    * Socket timeout while querying the source database.
    *
    * This can happen if Postgres takes too long to respond to a query, or if there is
-   * a network-levle issue.
+   * a network-level issue.
    */
   PSYNC_S1121 = 'PSYNC_S1121',
 

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -146,6 +146,19 @@ export enum ErrorCode {
   PSYNC_S1110 = 'PSYNC_S1110',
 
   /**
+   * Error querying the source database.
+   */
+  PSYNC_S1120 = 'PSYNC_S1120',
+
+  /**
+   * Socket timeout while querying the source database.
+   *
+   * This can happen if Postgres takes too long to respond to a query, or if there is
+   * a network-levle issue.
+   */
+  PSYNC_S1121 = 'PSYNC_S1121',
+
+  /**
    * Publication does not exist.
    *
    * Run: `CREATE PUBLICATION powersync FOR ALL TABLES` on the source database.

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -254,6 +254,13 @@ export class DatabaseConnectionError extends ServiceError {
 export class DatabaseQueryError extends ServiceError {
   public cause: any;
 
+  /**
+   * Source query that triggered the error.
+   *
+   * This should never returned to a client, but will show up in logs.
+   */
+  public query: string | undefined = undefined;
+
   constructor(code: ErrorCode, message: string, cause?: any) {
     super({
       code: code,

--- a/packages/service-errors/src/errors.ts
+++ b/packages/service-errors/src/errors.ts
@@ -257,7 +257,7 @@ export class DatabaseQueryError extends ServiceError {
   /**
    * Source query that triggered the error.
    *
-   * This should never returned to a client, but will show up in logs.
+   * This should never be returned to a client, but will show up in logs.
    */
   public query: string | undefined = undefined;
 


### PR DESCRIPTION
This improves error messages for Postgres query failures to assist with debugging. Unfortunately we have to wrap every query invocation (or the entire client) to achieve this, but this PR covers most of them.

This introduces two new error codes for Postgres:

```ts
/**
 * Error querying the source database.
 */
PSYNC_S1120 = 'PSYNC_S1120',

/**
 * Socket timeout while querying the source database.
 *
 * This can happen if Postgres takes too long to respond to a query, or if there is
 * a network-level issue.
 */
PSYNC_S1121 = 'PSYNC_S1121',
```

Before:

```
error: [powertest_184_d1c6] Replication error postgres query late {"stack":"Error: postgres query late\n    at PgConnection.stream (file:///home/ralf/src/powersync-service/node_modules/.pnpm/pgwire@0.8.1/node_modules/pgwire/mod.js:270:13)\n    at stream.next (<anonymous>)\n    at PgResult.fromStream (file:///home/ralf/src/powersync-service/node_modules/.pnpm/pgwire@0.8.1/node_modules/pgwire/mod.js:1063:22)\n    at PgConnection.query (file:///home/ralf/src/powersync-service/node_modules/.pnpm/pgwire@0.8.1/node_modules/pgwire/mod.js:266:21)\n    at WalStream.snapshotTableInTx (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:501:22)\n    at async file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:423:17\n    at async MongoSyncBucketStorageV3.startBatch (file:///home/ralf/src/powersync-service/modules/module-mongodb-storage/dist/storage/implementation/MongoSyncBucketStorage.js:129:9)\n    at async WalStream.initialReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:399:30)\n    at async WalStream.startInitialReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:395:9)\n    at async WalStream.initReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:793:13)"}
error: [powertest_184_d1c6] cause Socket idle timeout {"stack":"Error: Socket idle timeout\n    at Socket.<anonymous> (file:///home/ralf/src/powersync-service/packages/jpgwire/dist/socket_adapter.js:57:34)\n    at Socket.emit (node:events:509:28)\n    at Socket._onTimeout (node:net:610:8)\n    at listOnTimeout (node:internal/timers:605:17)\n    at process.processTimers (node:internal/timers:541:7)"}
```

After:

```
error: [powertest_184_d1c6] Replication error [PSYNC_S1121] Socket timed out while replicating
  cause: postgres query failed {"cause":{},"errorData":{"code":"PSYNC_S1121","description":"Socket timed out while replicating","details":"cause: postgres query failed","name":"DatabaseQueryError","stack":"Error: postgres query failed\n    at PgConnection.stream (file:///home/ralf/src/powersync-service/node_modules/.pnpm/pgwire@0.8.1/node_modules/pgwire/mod.js:334:15)\n    at async rstream (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/rquery.js:22:9)\n    at async ChunkedSnapshotQuery.nextChunk (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/SnapshotQuery.js:111:24)\n    at async WalStream.snapshotTable (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:552:28)\n    at async WalStream.snapshotTableInTx (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:479:13)\n    at async file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:424:17\n    at async MongoSyncBucketStorageV3.startBatch (file:///home/ralf/src/powersync-service/modules/module-mongodb-storage/dist/storage/implementation/MongoSyncBucketStorage.js:129:9)\n    at async WalStream.initialReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:400:30)\n    at async WalStream.startInitialReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:396:9)\n    at async WalStream.initReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:800:13)","status":500},"is_service_error":true,"name":"DatabaseQueryError","query":"SELECT * FROM \"public\".\"bulk_data\" WHERE \"id\" > $1 ORDER BY \"id\" LIMIT 10000","stack":"Error: postgres query failed\n    at PgConnection.stream (file:///home/ralf/src/powersync-service/node_modules/.pnpm/pgwire@0.8.1/node_modules/pgwire/mod.js:334:15)\n    at async rstream (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/rquery.js:22:9)\n    at async ChunkedSnapshotQuery.nextChunk (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/SnapshotQuery.js:111:24)\n    at async WalStream.snapshotTable (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:552:28)\n    at async WalStream.snapshotTableInTx (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:479:13)\n    at async file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:424:17\n    at async MongoSyncBucketStorageV3.startBatch (file:///home/ralf/src/powersync-service/modules/module-mongodb-storage/dist/storage/implementation/MongoSyncBucketStorage.js:129:9)\n    at async WalStream.initialReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:400:30)\n    at async WalStream.startInitialReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:396:9)\n    at async WalStream.initReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:800:13)"}
error: [powertest_184_d1c6] cause postgres query failed {"stack":"Error: postgres query failed\n    at PgConnection.stream (file:///home/ralf/src/powersync-service/node_modules/.pnpm/pgwire@0.8.1/node_modules/pgwire/mod.js:334:15)\n    at async rstream (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/rquery.js:22:9)\n    at async ChunkedSnapshotQuery.nextChunk (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/SnapshotQuery.js:111:24)\n    at async WalStream.snapshotTable (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:552:28)\n    at async WalStream.snapshotTableInTx (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:479:13)\n    at async file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:424:17\n    at async MongoSyncBucketStorageV3.startBatch (file:///home/ralf/src/powersync-service/modules/module-mongodb-storage/dist/storage/implementation/MongoSyncBucketStorage.js:129:9)\n    at async WalStream.initialReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:400:30)\n    at async WalStream.startInitialReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:396:9)\n    at async WalStream.initReplication (file:///home/ralf/src/powersync-service/modules/module-postgres/dist/replication/WalStream.js:800:13)"}
```

There are still general log formatting issues here that make the output difficult to read, but at least the details are better:
1. The main error message is more useful: `[PSYNC_S1121] Socket timed out while replicating` instead of `postgres query late`
2. Includes the query: `SELECT * FROM \"public\".\"bulk_data\" WHERE \"id\" > $1 ORDER BY \"id\" LIMIT 10000`
3. Stack trace includes the original error location, rather than the rollback.
