### PR TITLE
Implement limit for parameter results

### DIFF
--- a/.changeset/fresh-pumpkins-poke.md
+++ b/.changeset/fresh-pumpkins-poke.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-postgres-storage': minor
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-core': minor
+'@powersync/service-sync-rules': minor
+---
+
+Avoid parameter results loaded from bucket storage exceeding the configured limit.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -358,13 +358,13 @@ export abstract class MongoSyncBucketStorage
   protected abstract getParameterSetsImpl(
     checkpoint: MongoReplicationCheckpoint,
     lookups: ScopedParameterLookup[],
-    limit: number | undefined
+    limit: number
   ): Promise<SqliteJsonRow[]>;
 
   async getParameterSets(
     checkpoint: MongoReplicationCheckpoint,
     lookups: ScopedParameterLookup[],
-    limit: number | undefined
+    limit: number
   ): Promise<SqliteJsonRow[]> {
     return this.getParameterSetsImpl(checkpoint, lookups, limit);
   }
@@ -779,7 +779,7 @@ class MongoReplicationCheckpoint implements ReplicationCheckpoint {
     this.#storage = storage;
   }
 
-  async getParameterSets(lookups: ScopedParameterLookup[], limit?: number): Promise<SqliteJsonRow[]> {
+  async getParameterSets(lookups: ScopedParameterLookup[], limit: number): Promise<SqliteJsonRow[]> {
     return this.#storage.getParameterSets(this, lookups, limit);
   }
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -357,14 +357,16 @@ export abstract class MongoSyncBucketStorage
 
   protected abstract getParameterSetsImpl(
     checkpoint: MongoReplicationCheckpoint,
-    lookups: ScopedParameterLookup[]
+    lookups: ScopedParameterLookup[],
+    limit: number | undefined
   ): Promise<SqliteJsonRow[]>;
 
   async getParameterSets(
     checkpoint: MongoReplicationCheckpoint,
-    lookups: ScopedParameterLookup[]
+    lookups: ScopedParameterLookup[],
+    limit: number | undefined
   ): Promise<SqliteJsonRow[]> {
-    return this.getParameterSetsImpl(checkpoint, lookups);
+    return this.getParameterSetsImpl(checkpoint, lookups, limit);
   }
 
   protected abstract getBucketDataBatchImpl(
@@ -777,8 +779,8 @@ class MongoReplicationCheckpoint implements ReplicationCheckpoint {
     this.#storage = storage;
   }
 
-  async getParameterSets(lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
-    return this.#storage.getParameterSets(this, lookups);
+  async getParameterSets(lookups: ScopedParameterLookup[], limit?: number): Promise<SqliteJsonRow[]> {
+    return this.#storage.getParameterSets(this, lookups, limit);
   }
 }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -6,6 +6,7 @@ import {
   GetCheckpointChangesOptions,
   InternalOpId,
   internalToExternalOpId,
+  ParameterSetLimitExceededError,
   ProtocolOpId,
   storage,
   utils
@@ -96,9 +97,10 @@ export class MongoSyncBucketStorageV1 extends MongoSyncBucketStorage {
 
   protected getParameterSetsImpl(
     checkpoint: MongoSyncBucketStorageCheckpoint,
-    lookups: ScopedParameterLookup[]
+    lookups: ScopedParameterLookup[],
+    limit: number | undefined
   ): Promise<SqliteJsonRow[]> {
-    return getParameterSetsV1(this.versionContext, checkpoint, lookups);
+    return getParameterSetsV1(this.versionContext, checkpoint, lookups, limit);
   }
 
   protected getBucketDataBatchImpl(
@@ -195,47 +197,53 @@ export class MongoSyncBucketStorageV1 extends MongoSyncBucketStorage {
 export async function getParameterSetsV1(
   ctx: MongoSyncBucketStorageContext<VersionedPowerSyncMongoV1>,
   checkpoint: MongoSyncBucketStorageCheckpoint,
-  lookups: ScopedParameterLookup[]
+  lookups: ScopedParameterLookup[],
+  limit: number | undefined
 ): Promise<SqliteJsonRow[]> {
   return ctx.db.client.withSession({ snapshot: true }, async (session) => {
     setSessionSnapshotTime(session, checkpoint.snapshotTime);
     const lookupFilter = lookups.map((lookup) => {
       return storage.serializeLookup(lookup);
     });
-    const rows = await ctx.db.parameterIndexV1
-      .aggregate(
-        [
-          {
-            $match: {
-              'key.g': ctx.group_id,
-              lookup: { $in: lookupFilter },
-              _id: { $lte: checkpoint.checkpoint }
-            }
-          },
-          {
-            $sort: {
-              _id: -1
-            }
-          },
-          {
-            $group: {
-              _id: { key: '$key', lookup: '$lookup' },
-              bucket_parameters: {
-                $first: '$bucket_parameters'
-              }
-            }
-          }
-        ],
-        {
-          session,
-          readConcern: 'snapshot',
-          maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
+    const pipeline: mongo.Document[] = [
+      {
+        $match: {
+          'key.g': ctx.group_id,
+          lookup: { $in: lookupFilter },
+          _id: { $lte: checkpoint.checkpoint }
         }
-      )
+      },
+      {
+        $sort: {
+          _id: -1
+        }
+      },
+      {
+        $group: {
+          _id: { key: '$key', lookup: '$lookup' },
+          bucket_parameters: {
+            $first: '$bucket_parameters'
+          }
+        }
+      }
+    ];
+    if (limit != null) {
+      pipeline.push({ $limit: limit + 1 });
+    }
+    const rows = await ctx.db.parameterIndexV1
+      .aggregate(pipeline, {
+        session,
+        readConcern: 'snapshot',
+        maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
+      })
       .toArray()
       .catch((e) => {
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
       });
+    if (limit != null && rows.length > limit) {
+      throw new ParameterSetLimitExceededError(limit);
+    }
+
     const groupedParameters = rows.map((row) => {
       return row.bucket_parameters;
     });

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -98,7 +98,7 @@ export class MongoSyncBucketStorageV1 extends MongoSyncBucketStorage {
   protected getParameterSetsImpl(
     checkpoint: MongoSyncBucketStorageCheckpoint,
     lookups: ScopedParameterLookup[],
-    limit: number | undefined
+    limit: number
   ): Promise<SqliteJsonRow[]> {
     return getParameterSetsV1(this.versionContext, checkpoint, lookups, limit);
   }
@@ -198,56 +198,58 @@ export async function getParameterSetsV1(
   ctx: MongoSyncBucketStorageContext<VersionedPowerSyncMongoV1>,
   checkpoint: MongoSyncBucketStorageCheckpoint,
   lookups: ScopedParameterLookup[],
-  limit: number | undefined
+  limit: number
 ): Promise<SqliteJsonRow[]> {
   return ctx.db.client.withSession({ snapshot: true }, async (session) => {
     setSessionSnapshotTime(session, checkpoint.snapshotTime);
     const lookupFilter = lookups.map((lookup) => {
       return storage.serializeLookup(lookup);
     });
-    const pipeline: mongo.Document[] = [
-      {
-        $match: {
-          'key.g': ctx.group_id,
-          lookup: { $in: lookupFilter },
-          _id: { $lte: checkpoint.checkpoint }
-        }
-      },
-      {
-        $sort: {
-          _id: -1
-        }
-      },
-      {
-        $group: {
-          _id: { key: '$key', lookup: '$lookup' },
-          bucket_parameters: {
-            $first: '$bucket_parameters'
-          }
-        }
-      }
-    ];
-    if (limit != null) {
-      pipeline.push({ $limit: limit + 1 });
-    }
     const rows = await ctx.db.parameterIndexV1
-      .aggregate(pipeline, {
-        session,
-        readConcern: 'snapshot',
-        maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
-      })
+      .aggregate(
+        [
+          {
+            $match: {
+              'key.g': ctx.group_id,
+              lookup: { $in: lookupFilter },
+              _id: { $lte: checkpoint.checkpoint }
+            }
+          },
+          {
+            $sort: {
+              _id: -1
+            }
+          },
+          {
+            $group: {
+              _id: { key: '$key', lookup: '$lookup' },
+              bucket_parameters: {
+                $first: '$bucket_parameters'
+              }
+            }
+          },
+          {
+            $limit: limit
+          }
+        ],
+        {
+          session,
+          readConcern: 'snapshot',
+          maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
+        }
+      )
       .toArray()
       .catch((e) => {
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
       });
-    if (limit != null && rows.length > limit) {
-      throw new ParameterSetLimitExceededError(limit);
-    }
-
     const groupedParameters = rows.map((row) => {
       return row.bucket_parameters;
     });
-    return groupedParameters.flat();
+    const results = groupedParameters.flat();
+    if (results.length > limit) {
+      throw new ParameterSetLimitExceededError(limit);
+    }
+    return results;
   });
 }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -221,15 +221,15 @@ export async function getParameterSetsV1(
             }
           },
           {
+            $limit: limit + 1
+          },
+          {
             $group: {
               _id: { key: '$key', lookup: '$lookup' },
               bucket_parameters: {
                 $first: '$bucket_parameters'
               }
             }
-          },
-          {
-            $limit: limit + 1
           }
         ],
         {

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -229,7 +229,7 @@ export async function getParameterSetsV1(
             }
           },
           {
-            $limit: limit
+            $limit: limit + 1
           }
         ],
         {

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -221,15 +221,16 @@ export async function getParameterSetsV1(
             }
           },
           {
-            $limit: limit + 1
-          },
-          {
             $group: {
               _id: { key: '$key', lookup: '$lookup' },
               bucket_parameters: {
                 $first: '$bucket_parameters'
               }
             }
+          },
+          { $unwind: '$bucket_parameters' },
+          {
+            $limit: limit + 1
           }
         ],
         {
@@ -242,10 +243,8 @@ export async function getParameterSetsV1(
       .catch((e) => {
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
       });
-    const groupedParameters = rows.map((row) => {
-      return row.bucket_parameters;
-    });
-    const results = groupedParameters.flat();
+
+    const results = rows.map((row) => row.bucket_parameters);
     if (results.length > limit) {
       throw new ParameterSetLimitExceededError(limit);
     }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -137,7 +137,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
   protected getParameterSetsImpl(
     checkpoint: MongoSyncBucketStorageCheckpoint,
     lookups: ScopedParameterLookup[],
-    limit: number | undefined
+    limit: number
   ): Promise<SqliteJsonRow[]> {
     return getParameterSetsV3(this.versionContext, checkpoint, lookups, limit);
   }
@@ -209,7 +209,7 @@ export async function getParameterSetsV3(
   ctx: MongoSyncBucketStorageContext<VersionedPowerSyncMongoV3>,
   checkpoint: MongoSyncBucketStorageCheckpoint,
   lookups: ScopedParameterLookup[],
-  limit: number | undefined
+  limit: number
 ): Promise<SqliteJsonRow[]> {
   return ctx.db.client.withSession({ snapshot: true }, async (session) => {
     setSessionSnapshotTime(session, checkpoint.snapshotTime);
@@ -223,45 +223,42 @@ export async function getParameterSetsV3(
       const indexId = lookup.indexId;
       const collection = ctx.db.parameterIndexV3(ctx.group_id, indexId);
       const lookupFilter = serializeParameterLookupV3(lookup);
-      const pipeline: mongo.Document[] = [
-        {
-          $match: {
-            lookup: lookupFilter,
-            _id: { $lte: checkpoint.checkpoint }
-          }
-        },
-        {
-          $sort: {
-            key: 1,
-            _id: -1
-          }
-        },
-        {
-          $group: {
-            _id: {
-              key: '$key'
-            },
-            bucket_parameters: {
-              $first: '$bucket_parameters'
-            }
-          }
-        },
-        {
-          $project: {
-            _id: 0,
-            bucket_parameters: 1
-          }
-        }
-      ];
-      if (limit != null) {
-        // This still has potential to return too many rows because it's put into a union, but at least the amount of
-        // rows we get wouldn't be unbounded.
-        pipeline.push({ $limit: limit });
-      }
 
       return {
         collection,
-        pipeline
+        pipeline: [
+          {
+            $match: {
+              lookup: lookupFilter,
+              _id: { $lte: checkpoint.checkpoint }
+            }
+          },
+          {
+            $sort: {
+              key: 1,
+              _id: -1
+            }
+          },
+          {
+            $group: {
+              _id: {
+                key: '$key'
+              },
+              bucket_parameters: {
+                $first: '$bucket_parameters'
+              }
+            }
+          },
+          {
+            $project: {
+              _id: 0,
+              bucket_parameters: 1
+            }
+          },
+          // This limit still allows returning too many rows because this filter might be put into a $unionWith, but
+          // at least the amount of rows we'd return isn't unbounded.
+          { $limit: limit }
+        ]
       };
     };
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -239,6 +239,9 @@ export async function getParameterSetsV3(
               _id: -1
             }
           },
+          // This limit still allows returning too many rows because this filter might be put into a $unionWith, but
+          // at least the amount of rows we'd return isn't unbounded.
+          { $limit: limit + 1 },
           {
             $group: {
               _id: {
@@ -254,10 +257,7 @@ export async function getParameterSetsV3(
               _id: 0,
               bucket_parameters: 1
             }
-          },
-          // This limit still allows returning too many rows because this filter might be put into a $unionWith, but
-          // at least the amount of rows we'd return isn't unbounded.
-          { $limit: limit + 1 }
+          }
         ]
       };
     };
@@ -293,7 +293,7 @@ export async function getParameterSetsV3(
       });
 
     const expandedRows = rows.flatMap((row) => row.bucket_parameters);
-    if (limit != null && expandedRows.length > limit) {
+    if (expandedRows.length > limit) {
       throw new ParameterSetLimitExceededError(limit);
     }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -257,7 +257,7 @@ export async function getParameterSetsV3(
           },
           // This limit still allows returning too many rows because this filter might be put into a $unionWith, but
           // at least the amount of rows we'd return isn't unbounded.
-          { $limit: limit }
+          { $limit: limit + 1 }
         ]
       };
     };

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -5,6 +5,7 @@ import {
   GetCheckpointChangesOptions,
   InternalOpId,
   internalToExternalOpId,
+  ParameterSetLimitExceededError,
   ProtocolOpId,
   storage,
   utils
@@ -135,9 +136,10 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 
   protected getParameterSetsImpl(
     checkpoint: MongoSyncBucketStorageCheckpoint,
-    lookups: ScopedParameterLookup[]
+    lookups: ScopedParameterLookup[],
+    limit: number | undefined
   ): Promise<SqliteJsonRow[]> {
-    return getParameterSetsV3(this.versionContext, checkpoint, lookups);
+    return getParameterSetsV3(this.versionContext, checkpoint, lookups, limit);
   }
 
   protected getBucketDataBatchImpl(
@@ -206,7 +208,8 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 export async function getParameterSetsV3(
   ctx: MongoSyncBucketStorageContext<VersionedPowerSyncMongoV3>,
   checkpoint: MongoSyncBucketStorageCheckpoint,
-  lookups: ScopedParameterLookup[]
+  lookups: ScopedParameterLookup[],
+  limit: number | undefined
 ): Promise<SqliteJsonRow[]> {
   return ctx.db.client.withSession({ snapshot: true }, async (session) => {
     setSessionSnapshotTime(session, checkpoint.snapshotTime);
@@ -220,38 +223,45 @@ export async function getParameterSetsV3(
       const indexId = lookup.indexId;
       const collection = ctx.db.parameterIndexV3(ctx.group_id, indexId);
       const lookupFilter = serializeParameterLookupV3(lookup);
-      return {
-        collection,
-        pipeline: [
-          {
-            $match: {
-              lookup: lookupFilter,
-              _id: { $lte: checkpoint.checkpoint }
-            }
-          },
-          {
-            $sort: {
-              key: 1,
-              _id: -1
-            }
-          },
-          {
-            $group: {
-              _id: {
-                key: '$key'
-              },
-              bucket_parameters: {
-                $first: '$bucket_parameters'
-              }
-            }
-          },
-          {
-            $project: {
-              _id: 0,
-              bucket_parameters: 1
+      const pipeline: mongo.Document[] = [
+        {
+          $match: {
+            lookup: lookupFilter,
+            _id: { $lte: checkpoint.checkpoint }
+          }
+        },
+        {
+          $sort: {
+            key: 1,
+            _id: -1
+          }
+        },
+        {
+          $group: {
+            _id: {
+              key: '$key'
+            },
+            bucket_parameters: {
+              $first: '$bucket_parameters'
             }
           }
-        ]
+        },
+        {
+          $project: {
+            _id: 0,
+            bucket_parameters: 1
+          }
+        }
+      ];
+      if (limit != null) {
+        // This still has potential to return too many rows because it's put into a union, but at least the amount of
+        // rows we get wouldn't be unbounded.
+        pipeline.push({ $limit: limit });
+      }
+
+      return {
+        collection,
+        pipeline
       };
     };
 
@@ -285,7 +295,12 @@ export async function getParameterSetsV3(
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
       });
 
-    return rows.flatMap((row) => row.bucket_parameters);
+    const expandedRows = rows.flatMap((row) => row.bucket_parameters);
+    if (limit != null && expandedRows.length > limit) {
+      throw new ParameterSetLimitExceededError(limit);
+    }
+
+    return expandedRows;
   });
 }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -239,9 +239,6 @@ export async function getParameterSetsV3(
               _id: -1
             }
           },
-          // This limit still allows returning too many rows because this filter might be put into a $unionWith, but
-          // at least the amount of rows we'd return isn't unbounded.
-          { $limit: limit + 1 },
           {
             $group: {
               _id: {
@@ -278,11 +275,13 @@ export async function getParameterSetsV3(
             pipeline: query.pipeline
           }
         };
-      })
+      }),
+      { $unwind: '$bucket_parameters' },
+      { $limit: limit + 1 }
     ];
 
     const rows = await firstQuery.collection
-      .aggregate<{ bucket_parameters: SqliteJsonRow[] }>(pipeline, {
+      .aggregate<{ bucket_parameters: SqliteJsonRow }>(pipeline, {
         session,
         readConcern: 'snapshot',
         maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
@@ -292,7 +291,7 @@ export async function getParameterSetsV3(
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
       });
 
-    const expandedRows = rows.flatMap((row) => row.bucket_parameters);
+    const expandedRows = rows.map((row) => row.bucket_parameters);
     if (expandedRows.length > limit) {
       throw new ParameterSetLimitExceededError(limit);
     }

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -198,7 +198,7 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
         expect(lookups.map((l) => l.indexKey)).toEqual([['shape-check']]);
         expect(lookups[0].indexId).toEqual('1');
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups);
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
         expect(parameter_sets).toEqual([{ owner_id: 'user-1' }]);
         return parameter_sets;
       }

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -398,9 +398,9 @@ export class PostgresSyncRulesStorage
   async getParameterSets(
     checkpoint: ReplicationCheckpoint,
     lookups: sync_rules.ScopedParameterLookup[],
-    limit: number | undefined
+    limit: number
   ): Promise<sync_rules.SqliteJsonRow[]> {
-    let stmt = lib_postgres.sql`
+    const rows = await this.db.sql`
       SELECT DISTINCT
         ON (lookup, source_table, source_key) lookup,
         source_table,
@@ -416,9 +416,9 @@ export class PostgresSyncRulesStorage
             decode((FILTER ->> 0)::text, 'hex') -- Decode the hex string to bytea
           FROM
             jsonb_array_elements(${{
-              type: 'jsonb',
-              value: lookups.map((l) => storage.serializeLookupBuffer(l).toString('hex'))
-            }}) AS FILTER
+        type: 'jsonb',
+        value: lookups.map((l) => storage.serializeLookupBuffer(l).toString('hex'))
+      }}) AS FILTER
         )
         AND id <= ${{ type: 'int8', value: checkpoint.checkpoint }}
       ORDER BY
@@ -426,15 +426,12 @@ export class PostgresSyncRulesStorage
         source_table,
         source_key,
         id DESC
-    `;
-    if (limit != null) {
-      stmt.params!.push({ type: 'int4', value: limit + 1 });
-      stmt = { statement: ' LIMIT $', params: stmt.params };
-    }
-
-    const codec = pick(models.BucketParameters, ['bucket_parameters']);
-    const rows = (await this.db.queryRows(stmt)).map((row) => codec.decode(row as any));
-    if (limit != null && rows.length > limit) {
+      LIMIT
+        ${{ type: 'int4', value: limit }}
+    `
+      .decoded(pick(models.BucketParameters, ['bucket_parameters']))
+      .rows();
+    if (rows.length > limit) {
       throw new ParameterSetLimitExceededError(limit);
     }
 
@@ -908,7 +905,7 @@ class PostgresReplicationCheckpoint implements storage.ReplicationCheckpoint {
     public readonly lsn: string | null
   ) {}
 
-  getParameterSets(lookups: sync_rules.ScopedParameterLookup[], limit?: number): Promise<sync_rules.SqliteJsonRow[]> {
+  getParameterSets(lookups: sync_rules.ScopedParameterLookup[], limit: number): Promise<sync_rules.SqliteJsonRow[]> {
     return this.storage.getParameterSets(this, lookups, limit);
   }
 }

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -9,6 +9,7 @@ import {
   internalToExternalOpId,
   LastValueSink,
   maxLsn,
+  ParameterSetLimitExceededError,
   PartialChecksum,
   PopulateChecksumCacheOptions,
   PopulateChecksumCacheResults,
@@ -396,9 +397,10 @@ export class PostgresSyncRulesStorage
 
   async getParameterSets(
     checkpoint: ReplicationCheckpoint,
-    lookups: sync_rules.ScopedParameterLookup[]
+    lookups: sync_rules.ScopedParameterLookup[],
+    limit: number | undefined
   ): Promise<sync_rules.SqliteJsonRow[]> {
-    const rows = await this.db.sql`
+    let stmt = lib_postgres.sql`
       SELECT DISTINCT
         ON (lookup, source_table, source_key) lookup,
         source_table,
@@ -414,9 +416,9 @@ export class PostgresSyncRulesStorage
             decode((FILTER ->> 0)::text, 'hex') -- Decode the hex string to bytea
           FROM
             jsonb_array_elements(${{
-        type: 'jsonb',
-        value: lookups.map((l) => storage.serializeLookupBuffer(l).toString('hex'))
-      }}) AS FILTER
+              type: 'jsonb',
+              value: lookups.map((l) => storage.serializeLookupBuffer(l).toString('hex'))
+            }}) AS FILTER
         )
         AND id <= ${{ type: 'int8', value: checkpoint.checkpoint }}
       ORDER BY
@@ -424,9 +426,17 @@ export class PostgresSyncRulesStorage
         source_table,
         source_key,
         id DESC
-    `
-      .decoded(pick(models.BucketParameters, ['bucket_parameters']))
-      .rows();
+    `;
+    if (limit != null) {
+      stmt.params!.push({ type: 'int4', value: limit + 1 });
+      stmt = { statement: ' LIMIT $', params: stmt.params };
+    }
+
+    const codec = pick(models.BucketParameters, ['bucket_parameters']);
+    const rows = (await this.db.queryRows(stmt)).map((row) => codec.decode(row as any));
+    if (limit != null && rows.length > limit) {
+      throw new ParameterSetLimitExceededError(limit);
+    }
 
     const groupedParameters = rows.map((row) => {
       return JSONBig.parse(row.bucket_parameters) as sync_rules.SqliteJsonRow;
@@ -898,7 +908,7 @@ class PostgresReplicationCheckpoint implements storage.ReplicationCheckpoint {
     public readonly lsn: string | null
   ) {}
 
-  getParameterSets(lookups: sync_rules.ScopedParameterLookup[]): Promise<sync_rules.SqliteJsonRow[]> {
-    return this.storage.getParameterSets(this, lookups);
+  getParameterSets(lookups: sync_rules.ScopedParameterLookup[], limit?: number): Promise<sync_rules.SqliteJsonRow[]> {
+    return this.storage.getParameterSets(this, lookups, limit);
   }
 }

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -427,7 +427,7 @@ export class PostgresSyncRulesStorage
         source_key,
         id DESC
       LIMIT
-        ${{ type: 'int4', value: limit }}
+        ${{ type: 'int4', value: limit + 1 }}
     `
       .decoded(pick(models.BucketParameters, ['bucket_parameters']))
       .rows();

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -401,32 +401,40 @@ export class PostgresSyncRulesStorage
     limit: number
   ): Promise<sync_rules.SqliteJsonRow[]> {
     const rows = await this.db.sql`
-      SELECT DISTINCT
-        ON (lookup, source_table, source_key) lookup,
-        source_table,
-        source_key,
-        id,
-        bucket_parameters
-      FROM
-        bucket_parameters
-      WHERE
-        group_id = ${{ type: 'int4', value: this.group_id }}
-        AND bucket_parameters != '[]'
-        AND lookup = ANY (
-          SELECT
-            decode((FILTER ->> 0)::text, 'hex') -- Decode the hex string to bytea
+      WITH
+        rows AS (
+          SELECT DISTINCT
+            ON (lookup, source_table, source_key) lookup,
+            source_table,
+            source_key,
+            id,
+            bucket_parameters
           FROM
-            jsonb_array_elements(${{
+            bucket_parameters
+          WHERE
+            group_id = ${{ type: 'int4', value: this.group_id }}
+            AND lookup = ANY (
+              SELECT
+                decode((FILTER ->> 0)::text, 'hex') -- Decode the hex string to bytea
+              FROM
+                jsonb_array_elements(${{
         type: 'jsonb',
         value: lookups.map((l) => storage.serializeLookupBuffer(l).toString('hex'))
       }}) AS FILTER
+            )
+            AND id <= ${{ type: 'int8', value: checkpoint.checkpoint }}
+          ORDER BY
+            lookup,
+            source_table,
+            source_key,
+            id DESC
         )
-        AND id <= ${{ type: 'int8', value: checkpoint.checkpoint }}
-      ORDER BY
-        lookup,
-        source_table,
-        source_key,
-        id DESC
+      SELECT
+        bucket_parameters
+      FROM
+        rows
+      WHERE
+        bucket_parameters != '[]'
       LIMIT
         ${{ type: 'int4', value: limit + 1 }}
     `
@@ -441,8 +449,8 @@ export class PostgresSyncRulesStorage
 
     if (parameters.length > limit) {
       // Note that the LIMIT in the query allows more rows than parameters (because each row stores an array of
-      // parameter results). In most cases though, it is unlikely for that array to become very large and so the limit
-      // is good enough.
+      // parameter results). That array is very small though, and it doesn't allow fewer rows (due to the != []), so
+      // the SQL limit is good enough.
       throw new ParameterSetLimitExceededError(limit);
     }
     return parameters;

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -411,6 +411,7 @@ export class PostgresSyncRulesStorage
         bucket_parameters
       WHERE
         group_id = ${{ type: 'int4', value: this.group_id }}
+        AND bucket_parameters != '[]'
         AND lookup = ANY (
           SELECT
             decode((FILTER ->> 0)::text, 'hex') -- Decode the hex string to bytea
@@ -431,14 +432,20 @@ export class PostgresSyncRulesStorage
     `
       .decoded(pick(models.BucketParameters, ['bucket_parameters']))
       .rows();
-    if (rows.length > limit) {
+
+    const parameters = rows
+      .map((row) => {
+        return JSONBig.parse(row.bucket_parameters) as sync_rules.SqliteJsonRow[];
+      })
+      .flat();
+
+    if (parameters.length > limit) {
+      // Note that the LIMIT in the query allows more rows than parameters (because each row stores an array of
+      // parameter results). In most cases though, it is unlikely for that array to become very large and so the limit
+      // is good enough.
       throw new ParameterSetLimitExceededError(limit);
     }
-
-    const groupedParameters = rows.map((row) => {
-      return JSONBig.parse(row.bucket_parameters) as sync_rules.SqliteJsonRow;
-    });
-    return groupedParameters.flat();
+    return parameters;
   }
 
   async *getBucketDataBatch(

--- a/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
@@ -75,7 +75,7 @@ bucket_definitions:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => l.indexKey)).toEqual([['user1']]);
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups);
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
         expect(parameter_sets).toEqual([{ group_id: 'group1a' }]);
         return parameter_sets;
       }
@@ -136,7 +136,7 @@ bucket_definitions:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => l.indexKey)).toEqual([['user1']]);
 
-        const parameter_sets = await checkpoint1.getParameterSets(lookups);
+        const parameter_sets = await checkpoint1.getParameterSets(lookups, 1000);
         expect(parameter_sets).toEqual([{ group_id: 'group1' }]);
         return parameter_sets;
       }
@@ -147,7 +147,7 @@ bucket_definitions:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => l.indexKey)).toEqual([['user1']]);
 
-        const parameter_sets = await checkpoint2.getParameterSets(lookups);
+        const parameter_sets = await checkpoint2.getParameterSets(lookups, 1000);
         expect(parameter_sets).toEqual([{ group_id: 'group2' }]);
         return parameter_sets;
       }
@@ -226,7 +226,7 @@ bucket_definitions:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => JSON.stringify(l.indexKey)).sort()).toEqual(['["list1"]', '["list2"]']);
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups);
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
         expect(parameter_sets.sort((a, b) => (a.todo_id as string).localeCompare(b.todo_id as string))).toEqual([
           { todo_id: 'todo1' },
           { todo_id: 'todo2' }
@@ -285,7 +285,7 @@ bucket_definitions:
 
       return await querier.queryDynamicBucketDescriptions({
         async getParameterSets(lookups) {
-          const parameter_sets = await checkpoint.getParameterSets(lookups);
+          const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
           expect(parameter_sets).toEqual(expectedParameterSets);
           return parameter_sets;
         }
@@ -363,7 +363,7 @@ bucket_definitions:
       getParameterSets: async (lookups) => {
         expect(lookups.map((l) => l.indexKey)).toEqual([[n1]]);
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups);
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
         expect(parameter_sets).toEqual([{ group_id: 'group1' }]);
         return parameter_sets;
       }
@@ -415,7 +415,7 @@ bucket_definitions:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => l.indexKey)).toEqual([['u1']]);
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups);
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
         expect(parameter_sets).toEqual([{ workspace_id: 'workspace1' }]);
         return parameter_sets;
       }
@@ -495,7 +495,7 @@ bucket_definitions:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => l.indexKey)).toEqual([[]]);
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups);
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
         parameter_sets.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
         expect(parameter_sets).toEqual([{ workspace_id: 'workspace1' }, { workspace_id: 'workspace3' }]);
         return parameter_sets;
@@ -601,7 +601,7 @@ bucket_definitions:
       await querier.queryDynamicBucketDescriptions({
         async getParameterSets(lookups) {
           foundLookups.push(...lookups);
-          const output = await checkpoint.getParameterSets(lookups);
+          const output = await checkpoint.getParameterSets(lookups, 1000);
           parameter_sets.push(...output);
           return output;
         }
@@ -664,7 +664,7 @@ bucket_definitions:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => l.indexKey)).toEqual([['user1']]);
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups);
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
         expect(parameter_sets).toEqual([]);
         return parameter_sets;
       }
@@ -763,7 +763,7 @@ streams:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => l.indexKey)).toEqual([['baz']]);
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups);
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
         expect(parameter_sets).toEqual([{ '0': 'bar' }]);
         return parameter_sets;
       }

--- a/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
@@ -779,4 +779,56 @@ streams:
       }
     ]);
   });
+
+  test('respects parameter limit', async () => {
+    await using factory = await generateStorageFactory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  a:
+    auto_subscribe: true
+    query: SELECT * FROM a WHERE id IN (SELECT id FROM b)
+    `,
+        {
+          storageVersion
+        }
+      )
+    );
+    const bucketStorage = factory.getInstance(syncRules);
+    const sync_rules = syncRules.parsed(test_utils.PARSE_OPTIONS).hydratedSyncRules();
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const testTable = await test_utils.resolveTestTable(writer, 'b', ['id'], config);
+    await writer.markAllSnapshotDone('1/1');
+
+    for (let i = 0; i < 10; i++) {
+      await writer.save({
+        sourceTable: testTable,
+        tag: storage.SaveOperationTag.INSERT,
+        after: {
+          id: `t${i}`
+        },
+        afterReplicaId: test_utils.rid(`t${i}`)
+      });
+    }
+
+    await writer.commit('1/1');
+
+    const checkpoint = await bucketStorage.getCheckpoint();
+    const parameters = new RequestParameters(new JwtPayload({ sub: 'u' }), {});
+    const querier = sync_rules.getBucketParameterQuerier(test_utils.querierOptions(parameters)).querier;
+
+    await expect(
+      querier.queryDynamicBucketDescriptions({
+        async getParameterSets(lookups) {
+          const parameter_sets = await checkpoint.getParameterSets(lookups, 5);
+          return parameter_sets;
+        }
+      })
+    ).rejects.toThrow('Too many parameter results (limit was 5)');
+  });
 }

--- a/packages/service-core-tests/src/tests/register-parameter-compacting-tests.ts
+++ b/packages/service-core-tests/src/tests/register-parameter-compacting-tests.ts
@@ -44,7 +44,7 @@ bucket_definitions:
     const lookup = ScopedParameterLookup.direct({ lookupName: 'test', queryId: '1', source: null as any }, ['t1']);
 
     const checkpoint1 = await bucketStorage.getCheckpoint();
-    const parameters1 = await checkpoint1.getParameterSets([lookup]);
+    const parameters1 = await checkpoint1.getParameterSets([lookup], 1000);
     expect(parameters1).toEqual([{ id: 't1' }]);
 
     await writer.save({
@@ -70,15 +70,15 @@ bucket_definitions:
     });
     await writer.commit('1/2');
     const checkpoint2 = await bucketStorage.getCheckpoint();
-    const parameters2 = await checkpoint2.getParameterSets([lookup]);
+    const parameters2 = await checkpoint2.getParameterSets([lookup], 1000);
     expect(parameters2).toEqual([]);
 
     const statsBefore = await bucketStorage.factory.getStorageMetrics();
     await bucketStorage.compact({ compactParameterData: true });
 
     // Check consistency
-    const parameters1b = await checkpoint1.getParameterSets([lookup]);
-    const parameters2b = await checkpoint2.getParameterSets([lookup]);
+    const parameters1b = await checkpoint1.getParameterSets([lookup], 1000);
+    const parameters2b = await checkpoint2.getParameterSets([lookup], 1000);
     expect(parameters1b).toEqual([{ id: 't1' }]);
     expect(parameters2b).toEqual([]);
 
@@ -150,14 +150,14 @@ bucket_definitions:
       const lookup = ScopedParameterLookup.direct({ lookupName: 'test', queryId: '1', source: null as any }, ['u1']);
 
       const checkpoint1 = await bucketStorage.getCheckpoint();
-      const parameters1 = await checkpoint1.getParameterSets([lookup]);
+      const parameters1 = await checkpoint1.getParameterSets([lookup], 1000);
       expect(parameters1).toEqual([]);
 
       const statsBefore = await bucketStorage.factory.getStorageMetrics();
       await bucketStorage.compact({ compactParameterData: true, compactParameterCacheLimit: cacheLimit });
 
       // Check consistency
-      const parameters1b = await checkpoint1.getParameterSets([lookup]);
+      const parameters1b = await checkpoint1.getParameterSets([lookup], 1000);
       expect(parameters1b).toEqual([]);
 
       // Check storage size

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -320,8 +320,41 @@ export interface ReplicationCheckpoint {
    * Used to resolve "dynamic" parameter queries.
    *
    * This gets parameter sets specific to this checkpoint.
+   *
+   * @throws {@link ParameterSetLimitExceededError}
+   * Thrown if a limit parameter is set and the resolved lookups in bucket storage exceeds that limit.
    */
-  getParameterSets(lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]>;
+  getParameterSets(lookups: ScopedParameterLookup[], limit?: number): Promise<SqliteJsonRow[]>;
+}
+
+/**
+ * An exception thrown by {@link ReplicationCheckpoint} implementations if there are too many parameter results.
+ *
+ * This is not a suitable exception to show to users, `BucketParameterState` adds additional context.
+ */
+export class ParameterSetLimitExceededError extends Error {
+  constructor(
+    readonly limit: number,
+    readonly breakdown?: ParameterQueryInvocationLog[]
+  ) {
+    super(`Too many parameter results (limit was ${limit})`);
+  }
+}
+
+export interface ParameterQueryInvocationLog {
+  /**
+   * The definition for which a parameter query was invoked.
+   *
+   * The exact format of definition is unspecified, it's shown to users to help them debug this failure.
+   */
+  definition: string;
+  /**
+   * If {@link didExceedLimit} is false, the amount of rows returned by the invocation.
+   *
+   * Otherwise, the maximum amount of rows this invocation was allowed to return.
+   */
+  resultsOrLimit: number;
+  didExceedLimit: boolean;
 }
 
 export interface WatchWriteCheckpointOptions {

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -322,9 +322,9 @@ export interface ReplicationCheckpoint {
    * This gets parameter sets specific to this checkpoint.
    *
    * @throws {@link ParameterSetLimitExceededError}
-   * Thrown if a limit parameter is set and the resolved lookups in bucket storage exceeds that limit.
+   * Thrown if resolved lookups in bucket storage exceed the `limit` parameter.
    */
-  getParameterSets(lookups: ScopedParameterLookup[], limit?: number): Promise<SqliteJsonRow[]>;
+  getParameterSets(lookups: ScopedParameterLookup[], limit: number): Promise<SqliteJsonRow[]>;
 }
 
 /**

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -21,6 +21,7 @@ import {
   ServiceError
 } from '@powersync/lib-services-framework';
 import { JwtPayload } from '../auth/JwtPayload.js';
+import { ParameterSetLimitExceededError } from '../storage/storage-index.js';
 import { SyncContext } from './SyncContext.js';
 import { getIntersection, hasIntersection } from './util.js';
 
@@ -118,7 +119,7 @@ export class BucketChecksumState {
     const storage = this.bucketStorage;
 
     const update = await this.parameterState.getCheckpointUpdate(next);
-    const { buckets: allBuckets, updatedBuckets, parameterQueryResultsByDefinition } = update;
+    const { buckets: allBuckets, updatedBuckets, dynamicBucketsByDefinition } = update;
 
     /** Set of all buckets in this checkpoint. */
     const bucketDescriptionMap = new Map(allBuckets.map((b) => [b.bucket, b]));
@@ -211,7 +212,7 @@ export class BucketChecksumState {
       });
 
       deferredLog = () => {
-        const totalParamResults = computeTotalParamResults(parameterQueryResultsByDefinition);
+        const totalParamResults = computeTotalParamResults(dynamicBucketsByDefinition);
         let message = `Updated checkpoint: ${base.checkpoint} | `;
         message += `write: ${writeCheckpoint} | `;
         message += `buckets: ${allBuckets.length} | `;
@@ -244,7 +245,7 @@ export class BucketChecksumState {
       } satisfies util.StreamingSyncCheckpointDiff;
     } else {
       deferredLog = () => {
-        const totalParamResults = computeTotalParamResults(parameterQueryResultsByDefinition);
+        const totalParamResults = computeTotalParamResults(dynamicBucketsByDefinition);
         let message = `New checkpoint: ${base.checkpoint} | write: ${writeCheckpoint} | `;
         message += `buckets: ${allBuckets.length}`;
         if (totalParamResults !== undefined) {
@@ -393,10 +394,13 @@ export interface CheckpointUpdate {
   updatedBuckets: Set<string> | typeof INVALIDATE_ALL_BUCKETS;
 
   /**
-   * Number of parameter query results per sync stream definition (before deduplication).
-   * Map from definition name to count.
+   * Number of dynamic buckets (derived from parameter query results) per sync stream definition (before deduplication).
+   *
+   * Note that this doesn't directly map to parameter lookups: Unlike with bucket definitions, where one parameter
+   * lookup was guaranteed to return one bucket instantiation, Sync Streams both support multiple lookups in a single
+   * stream and lookups that are re-used between multiple streams.
    */
-  parameterQueryResultsByDefinition?: Map<string, number>;
+  dynamicBucketsByDefinition?: Map<string, number>;
 }
 
 export class BucketParameterState {
@@ -499,20 +503,61 @@ export class BucketParameterState {
   }
 
   async getCheckpointUpdate(checkpoint: storage.StorageCheckpointUpdate): Promise<CheckpointUpdate> {
+    // We have three limits to check:
+    //
+    //   1. Parameter query results: To avoid overloading the service, all Sync Streams / bucket definitions for the
+    //      current connection have a maximum amount of parameters they're allowed to fetch from bucket storage.
+    //      An `ParameterSetLimitExceededError` error is thrown when this limit is exceeded.
+    //   2. If we were able to fetch all parameter results, we apply the same limit to the amount of buckets returned.
+    //      This is mostly relevant for Sync Streams, where the amount of parameter queries is not strictly related to
+    //      the amount of buckets returned.
+    //   3. Finally, note that the buckets here can contain duplicates in some cases (e.g. if two Sync Stream
+    //      subscriptions have parameters that resolve to the same bucket). `buildNextCheckpointLine` will de-duplicate
+    //      buckets and check that against an independent limit.
+
     const querier = this.querier;
     let update: CheckpointUpdate;
     if (querier.hasDynamicBuckets) {
+      try {
+        update = await this.getCheckpointUpdateDynamic(checkpoint);
+      } catch (e: unknown) {
+        if (e instanceof ParameterSetLimitExceededError) {
+          // Limit 1 exceeded.
+          const error = new ServiceError(
+            ErrorCode.PSYNC_S2305,
+            `Too many parameter query results (limit of ${this.context.maxParameterQueryResults})`
+          );
+
+          let errorMessage = error.message;
+          const logData: any = {
+            checkpoint: checkpoint.base.checkpoint,
+            user_id: this.syncParams.userId
+          };
+
+          if (e.breakdown) {
+            const breakdown = formatParameterQueryBreakdown(this.context.maxParameterQueryResults, e.breakdown);
+            if (breakdown) {
+              errorMessage += breakdown.message;
+              logData.parameterResults = breakdown.largestResults;
+            }
+          }
+
+          this.logger.error(errorMessage, logData);
+          throw error;
+        }
+
+        throw e;
+      }
       update = await this.getCheckpointUpdateDynamic(checkpoint);
     } else {
       update = await this.getCheckpointUpdateStatic(checkpoint);
     }
 
     if (update.buckets.length > this.context.maxParameterQueryResults) {
-      // TODO: Limit number of results even before we get to this point
-      // This limit applies _before_ we get the unique set
+      // Limit 2 exceeded. This limit applies _before_ we get the unique set
       const error = new ServiceError(
         ErrorCode.PSYNC_S2305,
-        `Too many parameter query results: ${update.buckets.length} (limit of ${this.context.maxParameterQueryResults})`
+        `Too many buckets derived from parameter queries: ${update.buckets.length} (limit of ${this.context.maxParameterQueryResults})`
       );
 
       let errorMessage = error.message;
@@ -522,10 +567,9 @@ export class BucketParameterState {
         parameter_query_results: update.buckets.length
       };
 
-      if (update.parameterQueryResultsByDefinition && update.parameterQueryResultsByDefinition.size > 0) {
-        const breakdown = formatParameterQueryBreakdown(update.parameterQueryResultsByDefinition);
+      if (update.dynamicBucketsByDefinition && update.dynamicBucketsByDefinition.size > 0) {
+        const breakdown = formatDynamicBucketBreakdown(update.dynamicBucketsByDefinition);
         errorMessage += breakdown.message;
-        logData.parameter_query_results_by_definition = breakdown.countsByDefinition;
       }
 
       this.logger.error(errorMessage, logData);
@@ -584,25 +628,44 @@ export class BucketParameterState {
     }
 
     let dynamicBuckets: ResolvedBucket[];
-    let parameterQueryResultsByDefinition: Map<string, number> | undefined;
+    let dynamicBucketsByDefinition: Map<string, number> | undefined;
     if (hasParameterChange || this.cachedDynamicBuckets == null || this.cachedDynamicBucketSet == null) {
       const recordedLookups = new Set<string>();
+      const parameterLimit = this.context.maxParameterQueryResults;
+      let remainingBudget = parameterLimit;
+
+      // Log of lookups to provide a breakdown if we exceed the dynamic lookup limit.
+      // FIXME: This is so horrible and will completely fall apart if we e.g. use concurrent queriers. For Sync Streams,
+      // we should use an explicit graph structure based on sync plans to replace the imperative querier interface.
+      const lookupLog: storage.ParameterQueryInvocationLog[] = [];
 
       dynamicBuckets = await querier.queryDynamicBucketDescriptions({
-        getParameterSets(lookups) {
+        async getParameterSets(lookups, definition) {
           for (const lookup of lookups) {
             recordedLookups.add(lookup.serializedRepresentation);
           }
 
-          return checkpoint.base.getParameterSets(lookups);
+          try {
+            const rows = await checkpoint.base.getParameterSets(lookups, remainingBudget);
+            lookupLog.push({ definition, resultsOrLimit: rows.length, didExceedLimit: false });
+            remainingBudget -= rows.length;
+            return rows;
+          } catch (e: unknown) {
+            if (e instanceof ParameterSetLimitExceededError) {
+              lookupLog.push({ definition, resultsOrLimit: remainingBudget, didExceedLimit: false });
+              throw new ParameterSetLimitExceededError(parameterLimit, lookupLog);
+            }
+
+            throw e;
+          }
         }
       });
 
-      // Count parameter query results per definition (before deduplication)
-      parameterQueryResultsByDefinition = new Map<string, number>();
+      // Count dynamic buckets per definition (before deduplication)
+      dynamicBucketsByDefinition = new Map();
       for (const bucket of dynamicBuckets) {
-        const count = parameterQueryResultsByDefinition.get(bucket.definition) ?? 0;
-        parameterQueryResultsByDefinition.set(bucket.definition, count + 1);
+        const count = dynamicBucketsByDefinition.get(bucket.definition) ?? 0;
+        dynamicBucketsByDefinition.set(bucket.definition, count + 1);
       }
 
       this.cachedDynamicBuckets = dynamicBuckets;
@@ -628,13 +691,13 @@ export class BucketParameterState {
         buckets: allBuckets,
         // We cannot track individual bucket updates for dynamic lookups yet
         updatedBuckets: INVALIDATE_ALL_BUCKETS,
-        parameterQueryResultsByDefinition
+        dynamicBucketsByDefinition
       };
     } else {
       return {
         buckets: allBuckets,
         updatedBuckets: updatedBuckets,
-        parameterQueryResultsByDefinition
+        dynamicBucketsByDefinition
       };
     }
   }
@@ -701,12 +764,12 @@ function logCheckpoint(
 }
 
 /**
- * Format a breakdown of parameter query results by sync rule definition.
+ * Format a breakdown of dynamic bucket by sync stream definition.
  *
  * Sorts definitions by count (descending), includes the top 10, and returns both the
  * formatted message string and the counts record suitable for structured log data.
  */
-function formatParameterQueryBreakdown(parameterQueryResultsByDefinition: Map<string, number>): {
+function formatDynamicBucketBreakdown(parameterQueryResultsByDefinition: Map<string, number>): {
   message: string;
   countsByDefinition: Record<string, number>;
 } {
@@ -714,7 +777,7 @@ function formatParameterQueryBreakdown(parameterQueryResultsByDefinition: Map<st
   const allSorted = Array.from(parameterQueryResultsByDefinition.entries()).sort((a, b) => b[1] - a[1]);
   const sortedDefinitions = allSorted.slice(0, 10);
 
-  let message = '\nParameter query results by definition:';
+  let message = '\Dynamic buckets by definition:';
   const countsByDefinition: Record<string, number> = {};
   for (const [definition, count] of sortedDefinitions) {
     message += `\n  ${definition}: ${count}`;
@@ -728,6 +791,33 @@ function formatParameterQueryBreakdown(parameterQueryResultsByDefinition: Map<st
   }
 
   return { message, countsByDefinition };
+}
+
+function formatParameterQueryBreakdown(limit: number, log: storage.ParameterQueryInvocationLog[]) {
+  if (log.length == 0) {
+    return;
+  }
+
+  // When an exception about too many parameter results is thrown, the last entry is the one that finally exceeded the
+  // limit.
+  const failure = log.pop()!;
+
+  let message = '\nInvoked parameter queries by definition:';
+  const largestResults = Array.from(log)
+    .sort((a, b) => b.resultsOrLimit - a.resultsOrLimit)
+    .splice(9);
+
+  for (const entry of largestResults) {
+    message += `\n  ${entry.definition}: ${entry.resultsOrLimit} results.`;
+  }
+
+  if (largestResults.length < log.length) {
+    message += `\n ... and ${log.length - largestResults.length} more invocations`;
+  }
+
+  message += `\n ${failure.definition} exceeded the remaining limit of ${failure.resultsOrLimit} available results.`;
+  largestResults.push(failure);
+  return { message, largestResults };
 }
 
 function limitedBuckets(buckets: string[] | { bucket: string }[], limit: number) {

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -801,12 +801,12 @@ function formatParameterQueryBreakdown(limit: number, log: storage.ParameterQuer
 
   // When an exception about too many parameter results is thrown, the last entry is the one that finally exceeded the
   // limit.
-  const failure = log.pop()!;
+  const results = Array.from(log);
+  const failure = results.pop()!;
 
   let message = '\nInvoked parameter queries by definition:';
-  const largestResults = Array.from(log)
-    .sort((a, b) => b.resultsOrLimit - a.resultsOrLimit)
-    .splice(0, 9);
+  results.sort((a, b) => b.resultsOrLimit - a.resultsOrLimit);
+  const largestResults = results.splice(0, 9);
 
   for (const entry of largestResults) {
     message += `\n  ${entry.definition}: ${entry.resultsOrLimit} results.`;

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -548,7 +548,6 @@ export class BucketParameterState {
 
         throw e;
       }
-      update = await this.getCheckpointUpdateDynamic(checkpoint);
     } else {
       update = await this.getCheckpointUpdateStatic(checkpoint);
     }
@@ -570,6 +569,7 @@ export class BucketParameterState {
       if (update.dynamicBucketsByDefinition && update.dynamicBucketsByDefinition.size > 0) {
         const breakdown = formatDynamicBucketBreakdown(update.dynamicBucketsByDefinition);
         errorMessage += breakdown.message;
+        logData.parameter_query_results_by_definition = breakdown.countsByDefinition;
       }
 
       this.logger.error(errorMessage, logData);
@@ -652,7 +652,7 @@ export class BucketParameterState {
             return rows;
           } catch (e: unknown) {
             if (e instanceof ParameterSetLimitExceededError) {
-              lookupLog.push({ definition, resultsOrLimit: remainingBudget, didExceedLimit: false });
+              lookupLog.push({ definition, resultsOrLimit: remainingBudget, didExceedLimit: true });
               throw new ParameterSetLimitExceededError(parameterLimit, lookupLog);
             }
 
@@ -777,7 +777,7 @@ function formatDynamicBucketBreakdown(parameterQueryResultsByDefinition: Map<str
   const allSorted = Array.from(parameterQueryResultsByDefinition.entries()).sort((a, b) => b[1] - a[1]);
   const sortedDefinitions = allSorted.slice(0, 10);
 
-  let message = '\Dynamic buckets by definition:';
+  let message = '\nDynamic buckets by definition:';
   const countsByDefinition: Record<string, number> = {};
   for (const [definition, count] of sortedDefinitions) {
     message += `\n  ${definition}: ${count}`;
@@ -805,14 +805,14 @@ function formatParameterQueryBreakdown(limit: number, log: storage.ParameterQuer
   let message = '\nInvoked parameter queries by definition:';
   const largestResults = Array.from(log)
     .sort((a, b) => b.resultsOrLimit - a.resultsOrLimit)
-    .splice(9);
+    .splice(0, 9);
 
   for (const entry of largestResults) {
     message += `\n  ${entry.definition}: ${entry.resultsOrLimit} results.`;
   }
 
   if (largestResults.length < log.length) {
-    message += `\n ... and ${log.length - largestResults.length} more invocations`;
+    message += `\n ... and ${largestResults.length - log.length} more invocations`;
   }
 
   message += `\n ${failure.definition} exceeded the remaining limit of ${failure.resultsOrLimit} available results.`;

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -635,8 +635,9 @@ export class BucketParameterState {
       let remainingBudget = parameterLimit;
 
       // Log of lookups to provide a breakdown if we exceed the dynamic lookup limit.
-      // FIXME: This is so horrible and will completely fall apart if we e.g. use concurrent queriers. For Sync Streams,
-      // we should use an explicit graph structure based on sync plans to replace the imperative querier interface.
+      // FIXME: This is horrible, Sync Streams will invoke the callback concurrently and we can't properly deal with
+      // that. We should replace queriers for Sync Streams with an explicit graph structure based on sync plans instead
+      // of adding these checks to the imperative querier interface.
       const lookupLog: storage.ParameterQueryInvocationLog[] = [];
 
       dynamicBuckets = await querier.queryDynamicBucketDescriptions({

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -119,16 +119,38 @@ export class BucketChecksumState {
     const storage = this.bucketStorage;
 
     const update = await this.parameterState.getCheckpointUpdate(next);
-    const { buckets: allBuckets, updatedBuckets, dynamicBucketsByDefinition } = update;
+    const { buckets: allBuckets, updatedBuckets, usedParameterResults } = update;
 
     /** Set of all buckets in this checkpoint. */
     const bucketDescriptionMap = new Map(allBuckets.map((b) => [b.bucket, b]));
 
     if (bucketDescriptionMap.size > this.context.maxBuckets) {
-      throw new ServiceError(
+      const error = new ServiceError(
         ErrorCode.PSYNC_S2305,
         `Too many buckets: ${bucketDescriptionMap.size} (limit of ${this.context.maxBuckets})`
       );
+
+      let errorMessage = error.message;
+      const logData: any = {
+        checkpoint: next.base.checkpoint,
+        user_id: this.parameterState.syncParams.userId,
+        buckets: allBuckets.length
+      };
+
+      // Count buckets per definition.
+      const bucketsByDefinition = new Map<string, number>();
+      for (const bucket of bucketDescriptionMap.values()) {
+        const definition = bucket.definition;
+        const count = bucketsByDefinition.get(definition) ?? 0;
+        bucketsByDefinition.set(definition, count + 1);
+      }
+
+      const breakdown = formatBucketDefinitionBreakdown(bucketsByDefinition);
+      errorMessage += breakdown.message;
+      logData.buckets_by_definition = breakdown.countsByDefinition;
+
+      this.logger.error(errorMessage, logData);
+      throw error;
     }
 
     let checksumMap: util.ChecksumMap;
@@ -212,13 +234,10 @@ export class BucketChecksumState {
       });
 
       deferredLog = () => {
-        const totalParamResults = computeTotalParamResults(dynamicBucketsByDefinition);
         let message = `Updated checkpoint: ${base.checkpoint} | `;
         message += `write: ${writeCheckpoint} | `;
         message += `buckets: ${allBuckets.length} | `;
-        if (totalParamResults !== undefined) {
-          message += `param_results: ${totalParamResults} | `;
-        }
+        message += `param_results: ${usedParameterResults} | `;
         message += `updated: ${limitedBuckets(diff.updatedBuckets, 20)} | `;
         message += `removed: ${limitedBuckets(diff.removedBuckets, 20)}`;
         logCheckpoint(
@@ -231,7 +250,7 @@ export class BucketChecksumState {
             updated: diff.updatedBuckets.length,
             removed: diff.removedBuckets.length
           },
-          totalParamResults
+          usedParameterResults
         );
       };
 
@@ -245,12 +264,9 @@ export class BucketChecksumState {
       } satisfies util.StreamingSyncCheckpointDiff;
     } else {
       deferredLog = () => {
-        const totalParamResults = computeTotalParamResults(dynamicBucketsByDefinition);
         let message = `New checkpoint: ${base.checkpoint} | write: ${writeCheckpoint} | `;
         message += `buckets: ${allBuckets.length}`;
-        if (totalParamResults !== undefined) {
-          message += ` | param_results: ${totalParamResults}`;
-        }
+        message += ` | param_results: ${usedParameterResults}`;
         message += ` ${limitedBuckets(allBuckets, 20)}`;
         logCheckpoint(
           this.logger,
@@ -260,7 +276,7 @@ export class BucketChecksumState {
             user_id: userIdForLogs,
             buckets: allBuckets.length
           },
-          totalParamResults
+          usedParameterResults
         );
       };
       bucketsToFetch = allBuckets;
@@ -393,14 +409,8 @@ export interface CheckpointUpdate {
    */
   updatedBuckets: Set<string> | typeof INVALIDATE_ALL_BUCKETS;
 
-  /**
-   * Number of dynamic buckets (derived from parameter query results) per sync stream definition (before deduplication).
-   *
-   * Note that this doesn't directly map to parameter lookups: Unlike with bucket definitions, where one parameter
-   * lookup was guaranteed to return one bucket instantiation, Sync Streams both support multiple lookups in a single
-   * stream and lookups that are re-used between multiple streams.
-   */
-  dynamicBucketsByDefinition?: Map<string, number>;
+  /** The amount of rows fetched from parameters indexes. */
+  usedParameterResults: number;
 }
 
 export class BucketParameterState {
@@ -503,18 +513,6 @@ export class BucketParameterState {
   }
 
   async getCheckpointUpdate(checkpoint: storage.StorageCheckpointUpdate): Promise<CheckpointUpdate> {
-    // We have three limits to check:
-    //
-    //   1. Parameter query results: To avoid overloading the service, all Sync Streams / bucket definitions for the
-    //      current connection have a maximum amount of parameters they're allowed to fetch from bucket storage.
-    //      An `ParameterSetLimitExceededError` error is thrown when this limit is exceeded.
-    //   2. If we were able to fetch all parameter results, we apply the same limit to the amount of buckets returned.
-    //      This is mostly relevant for Sync Streams, where the amount of parameter queries is not strictly related to
-    //      the amount of buckets returned.
-    //   3. Finally, note that the buckets here can contain duplicates in some cases (e.g. if two Sync Stream
-    //      subscriptions have parameters that resolve to the same bucket). `buildNextCheckpointLine` will de-duplicate
-    //      buckets and check that against an independent limit.
-
     const querier = this.querier;
     let update: CheckpointUpdate;
     if (querier.hasDynamicBuckets) {
@@ -522,7 +520,8 @@ export class BucketParameterState {
         update = await this.getCheckpointUpdateDynamic(checkpoint);
       } catch (e: unknown) {
         if (e instanceof ParameterSetLimitExceededError) {
-          // Limit 1 exceeded.
+          // Too many parameter results, create a breakdown of which streams are responsible for the most queries and
+          // then abort.
           const error = new ServiceError(
             ErrorCode.PSYNC_S2305,
             `Too many parameter query results (limit of ${this.context.maxParameterQueryResults})`
@@ -535,7 +534,7 @@ export class BucketParameterState {
           };
 
           if (e.breakdown) {
-            const breakdown = formatParameterQueryBreakdown(this.context.maxParameterQueryResults, e.breakdown);
+            const breakdown = formatParameterQueryBreakdown(e.breakdown);
             if (breakdown) {
               errorMessage += breakdown.message;
               logData.parameterResults = breakdown.largestResults;
@@ -552,30 +551,6 @@ export class BucketParameterState {
       update = await this.getCheckpointUpdateStatic(checkpoint);
     }
 
-    if (update.buckets.length > this.context.maxParameterQueryResults) {
-      // Limit 2 exceeded. This limit applies _before_ we get the unique set
-      const error = new ServiceError(
-        ErrorCode.PSYNC_S2305,
-        `Too many buckets derived from parameter queries: ${update.buckets.length} (limit of ${this.context.maxParameterQueryResults})`
-      );
-
-      let errorMessage = error.message;
-      const logData: any = {
-        checkpoint: checkpoint.base.checkpoint,
-        user_id: this.syncParams.userId,
-        parameter_query_results: update.buckets.length
-      };
-
-      if (update.dynamicBucketsByDefinition && update.dynamicBucketsByDefinition.size > 0) {
-        const breakdown = formatDynamicBucketBreakdown(update.dynamicBucketsByDefinition);
-        errorMessage += breakdown.message;
-        logData.parameter_query_results_by_definition = breakdown.countsByDefinition;
-      }
-
-      this.logger.error(errorMessage, logData);
-
-      throw error;
-    }
     return update;
   }
 
@@ -589,14 +564,16 @@ export class BucketParameterState {
     if (update.invalidateDataBuckets) {
       return {
         buckets: staticBuckets,
-        updatedBuckets: INVALIDATE_ALL_BUCKETS
+        updatedBuckets: INVALIDATE_ALL_BUCKETS,
+        usedParameterResults: 0
       };
     }
 
     const updatedBuckets = new Set<string>(getIntersection(this.staticBuckets, update.updatedDataBuckets));
     return {
       buckets: staticBuckets,
-      updatedBuckets
+      updatedBuckets,
+      usedParameterResults: 0
     };
   }
 
@@ -628,7 +605,7 @@ export class BucketParameterState {
     }
 
     let dynamicBuckets: ResolvedBucket[];
-    let dynamicBucketsByDefinition: Map<string, number> | undefined;
+    let usedParameterResults = 0;
     if (hasParameterChange || this.cachedDynamicBuckets == null || this.cachedDynamicBucketSet == null) {
       const recordedLookups = new Set<string>();
       const parameterLimit = this.context.maxParameterQueryResults;
@@ -650,6 +627,7 @@ export class BucketParameterState {
             const rows = await checkpoint.base.getParameterSets(lookups, remainingBudget);
             lookupLog.push({ definition, resultsOrLimit: rows.length, didExceedLimit: false });
             remainingBudget -= rows.length;
+            usedParameterResults += rows.length;
             return rows;
           } catch (e: unknown) {
             if (e instanceof ParameterSetLimitExceededError) {
@@ -661,13 +639,6 @@ export class BucketParameterState {
           }
         }
       });
-
-      // Count dynamic buckets per definition (before deduplication)
-      dynamicBucketsByDefinition = new Map();
-      for (const bucket of dynamicBuckets) {
-        const count = dynamicBucketsByDefinition.get(bucket.definition) ?? 0;
-        dynamicBucketsByDefinition.set(bucket.definition, count + 1);
-      }
 
       this.cachedDynamicBuckets = dynamicBuckets;
       this.cachedDynamicBucketSet = new Set<string>(dynamicBuckets.map((b) => b.bucket));
@@ -692,13 +663,13 @@ export class BucketParameterState {
         buckets: allBuckets,
         // We cannot track individual bucket updates for dynamic lookups yet
         updatedBuckets: INVALIDATE_ALL_BUCKETS,
-        dynamicBucketsByDefinition
+        usedParameterResults
       };
     } else {
       return {
         buckets: allBuckets,
         updatedBuckets: updatedBuckets,
-        dynamicBucketsByDefinition
+        usedParameterResults
       };
     }
   }
@@ -733,18 +704,6 @@ export interface CheckpointLine {
 export type BucketChecksumStateStorage = Pick<storage.SyncRulesBucketStorage, 'getChecksums'>;
 
 /**
- * Compute the total number of parameter query results across all definitions.
- */
-function computeTotalParamResults(
-  parameterQueryResultsByDefinition: Map<string, number> | undefined
-): number | undefined {
-  if (!parameterQueryResultsByDefinition) {
-    return undefined;
-  }
-  return Array.from(parameterQueryResultsByDefinition.values()).reduce((sum, count) => sum + count, 0);
-}
-
-/**
  * Log a checkpoint message, enriching it with parameter query result counts if available.
  *
  * @param logger The logger instance to use
@@ -770,15 +729,15 @@ function logCheckpoint(
  * Sorts definitions by count (descending), includes the top 10, and returns both the
  * formatted message string and the counts record suitable for structured log data.
  */
-function formatDynamicBucketBreakdown(parameterQueryResultsByDefinition: Map<string, number>): {
+function formatBucketDefinitionBreakdown(bucketsByDefinition: Map<string, number>): {
   message: string;
   countsByDefinition: Record<string, number>;
 } {
   // Sort definitions by count (descending) and take top 10
-  const allSorted = Array.from(parameterQueryResultsByDefinition.entries()).sort((a, b) => b[1] - a[1]);
+  const allSorted = Array.from(bucketsByDefinition.entries()).sort((a, b) => b[1] - a[1]);
   const sortedDefinitions = allSorted.slice(0, 10);
 
-  let message = '\nDynamic buckets by definition:';
+  let message = '\Buckets by definition:';
   const countsByDefinition: Record<string, number> = {};
   for (const [definition, count] of sortedDefinitions) {
     message += `\n  ${definition}: ${count}`;
@@ -794,7 +753,7 @@ function formatDynamicBucketBreakdown(parameterQueryResultsByDefinition: Map<str
   return { message, countsByDefinition };
 }
 
-function formatParameterQueryBreakdown(limit: number, log: storage.ParameterQueryInvocationLog[]) {
+function formatParameterQueryBreakdown(log: storage.ParameterQueryInvocationLog[]) {
   if (log.length == 0) {
     return;
   }
@@ -813,7 +772,7 @@ function formatParameterQueryBreakdown(limit: number, log: storage.ParameterQuer
   }
 
   if (largestResults.length < log.length) {
-    message += `\n ... and ${largestResults.length - log.length} more invocations`;
+    message += `\n ... and ${log.length - largestResults.length} more invocations`;
   }
 
   message += `\n ${failure.definition} exceeded the remaining limit of ${failure.resultsOrLimit} available results.`;

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -978,26 +978,26 @@ streams:
 
       // Verify error log includes breakdown
       expect(errorMessages[0]).toContain('Invoked parameter queries by definition:');
-      expect(errorMessages[0]).toContain('Index on magic_sequence used by a: 30 results.');
-      expect(errorMessages[0]).toContain('Index on magic_sequence used by b, c: 20 results.');
+      expect(errorMessages[0]).toContain('Stream a evaluating parameter on magic_sequence: 30 results.');
+      expect(errorMessages[0]).toContain('Stream b evaluating parameter on magic_sequence: 20 results.');
       expect(errorMessages[0]).toContain(
-        'Index on magic_sequence used by b, c exceeded the remaining limit of 5 available results.'
+        'Stream c evaluating parameter on magic_sequence exceeded the remaining limit of 5 available results.'
       );
 
       expect(errorData[0].checkpoint).toEqual(1n);
       expect(errorData[0].parameterResults).toEqual([
         {
-          definition: 'Index on magic_sequence used by a',
+          definition: 'Stream a evaluating parameter on magic_sequence',
           didExceedLimit: false,
           resultsOrLimit: 30
         },
         {
-          definition: 'Index on magic_sequence used by b, c',
+          definition: 'Stream b evaluating parameter on magic_sequence',
           didExceedLimit: false,
           resultsOrLimit: 20
         },
         {
-          definition: 'Index on magic_sequence used by b, c',
+          definition: 'Stream c evaluating parameter on magic_sequence',
           didExceedLimit: true,
           resultsOrLimit: 5
         }

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -7,6 +7,7 @@ import {
   ChecksumMap,
   InternalOpId,
   JwtPayload,
+  ParameterSetLimitExceededError,
   ReplicationCheckpoint,
   StreamingSyncRequest,
   SyncContext,
@@ -900,19 +901,131 @@ config:
       expect(logData[0].parameter_query_results).toBe(3);
     });
 
-    test('throws error with breakdown when parameter query limit is exceeded', async () => {
+    test('throws error with breakdown when too many parameters were fetched', async () => {
+      const syncRules = SqlSyncRules.fromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  a:
+    auto_subscribe: true
+    query: SELECT * FROM a WHERE id IN (SELECT id FROM magic_sequence WHERE count0 = auth.parameter('a'))
+  b:
+    auto_subscribe: true
+    query: SELECT * FROM a WHERE id IN (SELECT id FROM magic_sequence WHERE count1 = auth.parameter('b'))
+  c:
+    auto_subscribe: true
+    query: SELECT * FROM a WHERE id IN (SELECT id FROM magic_sequence WHERE count1 = auth.parameter('c'))
+`,
+        { defaultSchema: 'public' }
+      ).config.hydrate({
+        hydrationState: versionedHydrationState(1)
+      });
+
+      const storage = new MockBucketChecksumStateStorage();
+
+      const errorMessages: string[] = [];
+      const errorData: any[] = [];
+      const mockLogger = {
+        info: () => {},
+        error: (message: string, data: any) => {
+          errorMessages.push(message);
+          errorData.push(data);
+        },
+        warn: () => {},
+        debug: () => {}
+      };
+
+      const smallContext = new SyncContext({
+        maxBuckets: 100,
+        maxParameterQueryResults: 55,
+        maxDataFetchConcurrency: 10
+      });
+
+      const state = new BucketChecksumState({
+        syncContext: smallContext,
+        tokenPayload: new JwtPayload({
+          sub: 'u1',
+          // Create 60 total results: 30 a + 20 b + 10 c
+          a: BigInt(30),
+          b: BigInt(20),
+          c: BigInt(10)
+        }),
+        syncRequest,
+        syncRules,
+        bucketStorage: storage,
+        logger: mockLogger as any
+      });
+
+      await expect(
+        state.buildNextCheckpointLine({
+          base: storage.makeCheckpoint(1n, (lookups, limit) => {
+            expect(lookups).toHaveLength(1);
+            const [{ values }] = lookups;
+            expect(values[0]).toStrictEqual('lookup');
+
+            const count = Number(values[2]); // The count parameter from streams
+            if (count > limit) {
+              throw new ParameterSetLimitExceededError(limit);
+            }
+            return Array.from({ length: count }, (_, i) => ({ '0': BigInt(i) }));
+          }),
+          writeCheckpoint: null,
+          update: CHECKPOINT_INVALIDATE_ALL
+        })
+      ).rejects.toThrow('Too many parameter query results (limit of 55)');
+
+      // Verify error log includes breakdown
+      expect(errorMessages[0]).toContain('Invoked parameter queries by definition:');
+      expect(errorMessages[0]).toContain('Index on magic_sequence used by a: 30 results.');
+      expect(errorMessages[0]).toContain('Index on magic_sequence used by b, c: 20 results.');
+      expect(errorMessages[0]).toContain(
+        'Index on magic_sequence used by b, c exceeded the remaining limit of 5 available results.'
+      );
+
+      expect(errorData[0].checkpoint).toEqual(1n);
+      expect(errorData[0].parameterResults).toEqual([
+        {
+          definition: 'Index on magic_sequence used by a',
+          didExceedLimit: false,
+          resultsOrLimit: 30
+        },
+        {
+          definition: 'Index on magic_sequence used by b, c',
+          didExceedLimit: false,
+          resultsOrLimit: 20
+        },
+        {
+          definition: 'Index on magic_sequence used by b, c',
+          didExceedLimit: true,
+          resultsOrLimit: 5
+        }
+      ]);
+    });
+
+    test('throws error with breakdown when dynamic bucket limit is exceeded', async () => {
+      // These streams are designed to return buckets without consuming too many parameters (as exceeding that limit is
+      // a different error).
+      // Note that we have to use different parameters for the streams to ensure they get put into distinct buckets.
       const SYNC_RULES_MULTI = SqlSyncRules.fromYaml(
         `
-bucket_definitions:
+config:
+  edition: 3
+
+with:
+  param: SELECT id FROM users WHERE public_id = auth.user_id()
+
+streams:
   projects:
-    parameters: select id from projects where user_id = request.user_id()
-    data: []
+    auto_subscribe: true
+    query: SELECT id FROM projects WHERE p1 IN param AND p2 IN auth.parameter('a')
   tasks:
-    parameters: select id from tasks where user_id = request.user_id()
-    data: []
+    auto_subscribe: true
+    query: SELECT id FROM tasks WHERE p1 IN param AND p2 IN auth.parameter('b')
   comments:
-    parameters: select id from comments where user_id = request.user_id()
-    data: []
+    auto_subscribe: true
+    query: SELECT id FROM comments WHERE p1 IN param AND p2 IN auth.parameter('c')
     `,
         { defaultSchema: 'public' }
       ).config.hydrate({ hydrationState: versionedHydrationState(4) });
@@ -939,48 +1052,34 @@ bucket_definitions:
 
       const state = new BucketChecksumState({
         syncContext: smallContext,
-        tokenPayload: new JwtPayload({ sub: 'u1' }),
+        tokenPayload: new JwtPayload({
+          sub: 'u1',
+          // Create 60 total results: 30 projects + 20 tasks + 10 comments
+          a: Array.from({ length: 30 }, (_, i) => BigInt(i)),
+          b: Array.from({ length: 20 }, (_, i) => BigInt(i)),
+          c: Array.from({ length: 10 }, (_, i) => BigInt(i))
+        }),
         syncRequest,
         syncRules: SYNC_RULES_MULTI,
         bucketStorage: storage,
         logger: mockLogger as any
       });
 
-      // Create 60 total results: 30 projects + 20 tasks + 10 comments
-      const projectIds = Array.from({ length: 30 }, (_, i) => ({ id: i + 1 }));
-      const taskIds = Array.from({ length: 20 }, (_, i) => ({ id: i + 1 }));
-      const commentIds = Array.from({ length: 10 }, (_, i) => ({ id: i + 1 }));
-
-      for (let i = 1; i <= 30; i++) {
-        storage.updateTestChecksum({ bucket: `projects[${i}]`, checksum: 1, count: 1 });
-      }
-      for (let i = 1; i <= 20; i++) {
-        storage.updateTestChecksum({ bucket: `tasks[${i}]`, checksum: 1, count: 1 });
-      }
-      for (let i = 1; i <= 10; i++) {
-        storage.updateTestChecksum({ bucket: `comments[${i}]`, checksum: 1, count: 1 });
-      }
-
+      let invokedParameterQueries = 0;
       await expect(
         state.buildNextCheckpointLine({
-          base: storage.makeCheckpoint(1n, (lookups) => {
-            const lookup = lookups[0];
-            const lookupName = lookup.values[0];
-            if (lookupName === 'projects') {
-              return projectIds;
-            } else if (lookupName === 'tasks') {
-              return taskIds;
-            } else {
-              return commentIds;
-            }
+          base: storage.makeCheckpoint(1n, () => {
+            invokedParameterQueries++;
+            return [{ '0': 'user' }];
           }),
           writeCheckpoint: null,
           update: CHECKPOINT_INVALIDATE_ALL
         })
-      ).rejects.toThrow('Too many parameter query results: 60 (limit of 50)');
+      ).rejects.toThrow('Too many buckets derived from parameter queries: 60 (limit of 50)');
+      expect(invokedParameterQueries).toStrictEqual(3);
 
       // Verify error log includes breakdown
-      expect(errorMessages[0]).toContain('Parameter query results by definition:');
+      expect(errorMessages[0]).toContain('Dynamic buckets by definition:');
       expect(errorMessages[0]).toContain('projects: 30');
       expect(errorMessages[0]).toContain('tasks: 20');
       expect(errorMessages[0]).toContain('comments: 10');
@@ -995,12 +1094,20 @@ bucket_definitions:
     });
 
     test('limits breakdown to top 10 definitions', async () => {
-      // Create sync rules with 15 different definitions with dynamic parameters
-      let yamlDefinitions = 'bucket_definitions:\n';
+      // Create sync streams with 15 different definitions with dynamic parameters
+      let yamlDefinitions = `
+config:
+  edition: 3
+
+with:
+  param: SELECT id FROM users WHERE public_id = auth.user_id()
+
+streams:
+`;
       for (let i = 1; i <= 15; i++) {
         yamlDefinitions += `  def${i}:\n`;
-        yamlDefinitions += `    parameters: select id from def${i}_table where user_id = request.user_id()\n`;
-        yamlDefinitions += `    data: []\n`;
+        yamlDefinitions += `    auto_subscribe: true\n`;
+        yamlDefinitions += `    query: SELECT * FROM tbl WHERE a IN param AND b = auth.parameter('${i}')\n`;
       }
 
       const SYNC_RULES_MANY = SqlSyncRules.fromYaml(yamlDefinitions, { defaultSchema: 'public' }).config.hydrate({
@@ -1027,28 +1134,25 @@ bucket_definitions:
 
       const state = new BucketChecksumState({
         syncContext: smallContext,
-        tokenPayload: new JwtPayload({ sub: 'u1' }),
+        tokenPayload: new JwtPayload({
+          sub: 'u1',
+          ...Object.fromEntries(Array.from({ length: 30 }, (_, i) => [i.toString(), BigInt(i)]))
+        }),
         syncRequest,
         syncRules: SYNC_RULES_MANY,
         bucketStorage: storage,
         logger: mockLogger as any
       });
 
-      // Each definition creates one bucket, total 15 buckets
-      for (let i = 1; i <= 15; i++) {
-        storage.updateTestChecksum({ bucket: `def${i}[${i}]`, checksum: 1, count: 1 });
-      }
-
       await expect(
         state.buildNextCheckpointLine({
           base: storage.makeCheckpoint(1n, (lookups) => {
-            // Return one result for each definition
-            return [{ id: 1 }];
+            return [{ '0': 'user' }];
           }),
           writeCheckpoint: null,
           update: CHECKPOINT_INVALIDATE_ALL
         })
-      ).rejects.toThrow('Too many parameter query results: 15 (limit of 10)');
+      ).rejects.toThrow('Too many buckets derived from parameter queries: 15 (limit of 10)');
 
       // Verify only top 10 are shown
       const errorMessage = errorMessages[0];
@@ -1094,16 +1198,16 @@ class MockBucketChecksumStateStorage implements BucketChecksumStateStorage {
 
   makeCheckpoint(
     opId: InternalOpId,
-    parameters?: (lookups: ScopedParameterLookup[]) => SqliteJsonRow[]
+    parameters?: (lookups: ScopedParameterLookup[], limit: number) => SqliteJsonRow[]
   ): ReplicationCheckpoint {
     return {
       checkpoint: opId,
       lsn: String(opId),
-      getParameterSets: async (lookups: ScopedParameterLookup[]) => {
+      getParameterSets: async (lookups: ScopedParameterLookup[], limit) => {
         if (parameters == null) {
           throw new Error(`getParametersSets not defined for checkpoint ${opId}`);
         }
-        return parameters(lookups);
+        return parameters(lookups, limit);
       }
     };
   }

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -1004,28 +1004,24 @@ streams:
       ]);
     });
 
-    test('throws error with breakdown when dynamic bucket limit is exceeded', async () => {
+    test('throws error with breakdown when bucket limit is exceeded', async () => {
       // These streams are designed to return buckets without consuming too many parameters (as exceeding that limit is
       // a different error).
-      // Note that we have to use different parameters for the streams to ensure they get put into distinct buckets.
       const SYNC_RULES_MULTI = SqlSyncRules.fromYaml(
         `
 config:
   edition: 3
 
-with:
-  param: SELECT id FROM users WHERE public_id = auth.user_id()
-
 streams:
   projects:
     auto_subscribe: true
-    query: SELECT id FROM projects WHERE p1 IN param AND p2 IN auth.parameter('a')
+    query: SELECT id FROM projects WHERE p IN auth.parameter('a')
   tasks:
     auto_subscribe: true
-    query: SELECT id FROM tasks WHERE p1 IN param AND p2 IN auth.parameter('b')
+    query: SELECT id FROM tasks WHERE p IN auth.parameter('b')
   comments:
     auto_subscribe: true
-    query: SELECT id FROM comments WHERE p1 IN param AND p2 IN auth.parameter('c')
+    query: SELECT id FROM comments WHERE p IN auth.parameter('c')
     `,
         { defaultSchema: 'public' }
       ).config.hydrate({ hydrationState: versionedHydrationState(4) });
@@ -1045,8 +1041,8 @@ streams:
       };
 
       const smallContext = new SyncContext({
-        maxBuckets: 100,
-        maxParameterQueryResults: 50,
+        maxBuckets: 50,
+        maxParameterQueryResults: 10,
         maxDataFetchConcurrency: 10
       });
 
@@ -1075,39 +1071,36 @@ streams:
           writeCheckpoint: null,
           update: CHECKPOINT_INVALIDATE_ALL
         })
-      ).rejects.toThrow('Too many buckets derived from parameter queries: 60 (limit of 50)');
-      expect(invokedParameterQueries).toStrictEqual(3);
+      ).rejects.toThrow('Too many buckets: 60 (limit of 50');
+      expect(invokedParameterQueries).toStrictEqual(0);
 
       // Verify error log includes breakdown
-      expect(errorMessages[0]).toContain('Dynamic buckets by definition:');
+      expect(errorMessages[0]).toContain('Buckets by definition:');
       expect(errorMessages[0]).toContain('projects: 30');
       expect(errorMessages[0]).toContain('tasks: 20');
       expect(errorMessages[0]).toContain('comments: 10');
 
       expect(errorData[0].checkpoint).toEqual(1n);
-      expect(errorData[0].parameter_query_results).toBe(60);
-      expect(errorData[0].parameter_query_results_by_definition).toEqual({
+      expect(errorData[0].buckets).toBe(60);
+      expect(errorData[0].buckets_by_definition).toEqual({
         projects: 30,
         tasks: 20,
         comments: 10
       });
     });
 
-    test('limits breakdown to top 10 definitions', async () => {
+    test('limits bucket breakdown to top 10 definitions', async () => {
       // Create sync streams with 15 different definitions with dynamic parameters
       let yamlDefinitions = `
 config:
   edition: 3
-
-with:
-  param: SELECT id FROM users WHERE public_id = auth.user_id()
 
 streams:
 `;
       for (let i = 1; i <= 15; i++) {
         yamlDefinitions += `  def${i}:\n`;
         yamlDefinitions += `    auto_subscribe: true\n`;
-        yamlDefinitions += `    query: SELECT * FROM tbl WHERE a IN param AND b = auth.parameter('${i}')\n`;
+        yamlDefinitions += `    query: SELECT * FROM tbl WHERE b = auth.parameter('${i}')\n`;
       }
 
       const SYNC_RULES_MANY = SqlSyncRules.fromYaml(yamlDefinitions, { defaultSchema: 'public' }).config.hydrate({
@@ -1127,7 +1120,7 @@ streams:
       };
 
       const smallContext = new SyncContext({
-        maxBuckets: 100,
+        maxBuckets: 10,
         maxParameterQueryResults: 10,
         maxDataFetchConcurrency: 10
       });
@@ -1152,7 +1145,7 @@ streams:
           writeCheckpoint: null,
           update: CHECKPOINT_INVALIDATE_ALL
         })
-      ).rejects.toThrow('Too many buckets derived from parameter queries: 15 (limit of 10)');
+      ).rejects.toThrow('Too many buckets: 15 (limit of 10)');
 
       // Verify only top 10 are shown
       const errorMessage = errorMessages[0];

--- a/packages/sync-rules/src/BucketParameterQuerier.ts
+++ b/packages/sync-rules/src/BucketParameterQuerier.ts
@@ -76,7 +76,7 @@ export interface PendingQueriers {
 }
 
 export interface ParameterLookupSource {
-  getParameterSets: (lookups: ScopedParameterLookup[]) => Promise<SqliteJsonRow[]>;
+  getParameterSets: (lookups: ScopedParameterLookup[], debugDefinition: string) => Promise<SqliteJsonRow[]>;
 }
 
 export interface QueryBucketDescriptorOptions extends ParameterLookupSource {

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -540,11 +540,12 @@ export class SqlParameterQuery implements ParameterIndexLookupCreator {
       };
     }
 
+    const debugName = `Legacy Bucket Definition ${bucketDataScope.source.uniqueName}`;
     return {
       staticBuckets: [],
       hasDynamicBuckets: true,
       queryDynamicBucketDescriptions: async (source: ParameterLookupSource) => {
-        const bucketParameters = await source.getParameterSets(lookups);
+        const bucketParameters = await source.getParameterSets(lookups, debugName);
         return this.resolveBucketDescriptions(bucketParameters, requestParameters, bucketDataScope).map((bucket) => {
           return resolvedBucket(bucket, { definition: this.descriptorName, inclusion_reasons: reasons });
         });

--- a/packages/sync-rules/src/streams/variant.ts
+++ b/packages/sync-rules/src/streams/variant.ts
@@ -185,7 +185,10 @@ export class StreamVariant {
         // Evaluate subqueries
         const subqueryResults = new Map<SubqueryEvaluator, SqliteJsonValue[]>();
         for (const [subquery, lookups] of subqueryToLookups.entries()) {
-          const rows = await source.getParameterSets(lookups);
+          const rows = await source.getParameterSets(
+            lookups,
+            `variant ${variant.id} of legacy Sync Stream ${stream.name}`
+          );
           // The result column used in parameter sets is always named result, see pushParameterRowEvaluation
           const values = rows.map((r) => r.result);
           subqueryResults.set(subquery, values);

--- a/packages/sync-rules/src/sync_plan/evaluator/bucket_source.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/bucket_source.ts
@@ -104,7 +104,12 @@ class PreparedQuerier {
     this.dataSource = options.preparedBuckets.get(querier.bucket)!;
     this.matchesParameters = PreparedQuerier.prepareFilters(options.engine, querier.requestFilters);
 
-    this.lookupStages = RequestParameterEvaluators.prepare(querier.lookupStages, querier.sourceInstantiation, options);
+    this.lookupStages = RequestParameterEvaluators.prepare(
+      stream,
+      querier.lookupStages,
+      querier.sourceInstantiation,
+      options
+    );
   }
 
   querierForSubscription(

--- a/packages/sync-rules/src/sync_plan/evaluator/index.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/index.ts
@@ -48,7 +48,7 @@ export class PrecompiledSyncConfig extends SyncConfig {
     }
 
     for (const parameter of plan.parameterIndexes) {
-      const prepared = new PreparedParameterIndexLookupCreator(parameter, context);
+      const prepared = new PreparedParameterIndexLookupCreator(plan, parameter, context);
       preparedLookups.set(parameter, prepared);
       this.bucketParameterLookupSources.push(prepared);
     }

--- a/packages/sync-rules/src/sync_plan/evaluator/index.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/index.ts
@@ -48,7 +48,7 @@ export class PrecompiledSyncConfig extends SyncConfig {
     }
 
     for (const parameter of plan.parameterIndexes) {
-      const prepared = new PreparedParameterIndexLookupCreator(plan, parameter, context);
+      const prepared = new PreparedParameterIndexLookupCreator(parameter, context);
       preparedLookups.set(parameter, prepared);
       this.bucketParameterLookupSources.push(prepared);
     }

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -12,6 +12,7 @@ import {
 import { MapSourceVisitor, visitExpr } from '../expression_visitor.js';
 import * as plan from '../plan.js';
 import { StreamInput } from './bucket_source.js';
+import { PreparedParameterIndexLookupCreator } from './parameter_index_lookup_creator.js';
 
 /**
  * Finds bucket parameters for a given request or subscription.
@@ -360,11 +361,12 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
     const lookup = this.evaluators.lookupStages[stage][index];
     if (lookup.type == 'parameter') {
       const scope = this.input.hydrationState.getParameterIndexLookupScope(lookup.lookup);
+      const source = scope.source as PreparedParameterIndexLookupCreator;
       const outputs = await this.input.source.getParameterSets(
         [...this.resolveInputs(lookup.instantiation)].map((instantiation) =>
           ScopedParameterLookup.normalized(scope, UnscopedParameterLookup.normalized(instantiation))
         ),
-        'todo'
+        source.debugDescription
       );
 
       // Stream parameters generate an output row like {0: <expr>, 1: <expr>, ...}.

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -363,7 +363,8 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
       const outputs = await this.input.source.getParameterSets(
         [...this.resolveInputs(lookup.instantiation)].map((instantiation) =>
           ScopedParameterLookup.normalized(scope, UnscopedParameterLookup.normalized(instantiation))
-        )
+        ),
+        'todo'
       );
 
       // Stream parameters generate an output row like {0: <expr>, 1: <expr>, ...}.

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -54,6 +54,7 @@ import { PreparedParameterIndexLookupCreator } from './parameter_index_lookup_cr
  */
 export class RequestParameterEvaluators {
   private constructor(
+    readonly stream: plan.StreamOptions,
     /**
      * Pending lookup stages, or their cached outputs.
      */
@@ -98,6 +99,7 @@ export class RequestParameterEvaluators {
     }
 
     return new RequestParameterEvaluators(
+      this.stream,
       this.lookupStages.map((stage) => stage.map(cloneLookup)),
       this.parameterValues.map(cloneValue)
     );
@@ -142,12 +144,18 @@ export class RequestParameterEvaluators {
   /**
    * Prepares evaluators for a description of parameter values obtained from a compiled querier in the sync plan.
    *
+   * @param stream Used to show the name of the stream for debugging purposes.
    * @param lookupStages The {@link plan.StreamQuerier.lookupStages} of the querier to compile.
    * @param values The {@link plan.StreamQuerier.sourceInstantiation} of the querier to compile.
    * @param input Access to bucket and parameter sources generated for buckets and parameter lookups referenced by the
    * querier.
    */
-  static prepare(lookupStages: plan.ExpandingLookup[][], values: plan.ParameterValue[], input: StreamInput) {
+  static prepare(
+    stream: plan.StreamOptions,
+    lookupStages: plan.ExpandingLookup[][],
+    values: plan.ParameterValue[],
+    input: StreamInput
+  ) {
     const mappedStages: PreparedExpandingLookup[][] = [];
     const lookupToStage = new Map<plan.ExpandingLookup, { stage: number; index: number }>();
 
@@ -223,7 +231,7 @@ export class RequestParameterEvaluators {
       }
     }
 
-    return new RequestParameterEvaluators(mappedStages, mapParameterValues(values));
+    return new RequestParameterEvaluators(stream, mappedStages, mapParameterValues(values));
   }
 }
 
@@ -361,12 +369,12 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
     const lookup = this.evaluators.lookupStages[stage][index];
     if (lookup.type == 'parameter') {
       const scope = this.input.hydrationState.getParameterIndexLookupScope(lookup.lookup);
-      const source = scope.source as PreparedParameterIndexLookupCreator;
+      const resolvedLookup = lookup.lookup as PreparedParameterIndexLookupCreator;
       const outputs = await this.input.source.getParameterSets(
         [...this.resolveInputs(lookup.instantiation)].map((instantiation) =>
           ScopedParameterLookup.normalized(scope, UnscopedParameterLookup.normalized(instantiation))
         ),
-        source.debugDescription
+        `Stream ${this.evaluators.stream.name} evaluating parameter on ${resolvedLookup.sourceTable.name}`
       );
 
       // Stream parameters generate an output row like {0: <expr>, 1: <expr>, ...}.

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
@@ -13,17 +13,12 @@ import { TableProcessorToSqlHelper } from './table_processor_to_sql.js';
 export class PreparedParameterIndexLookupCreator implements ParameterIndexLookupCreator {
   readonly defaultLookupScope: ParameterLookupScope;
   private readonly evaluator: ScalarExpressionEvaluator;
-  private readonly sourceTable: TablePattern;
+  readonly sourceTable: TablePattern;
   private readonly evaluatorInputs: plan.ColumnSqlParameterValue[];
   private readonly numberOfOutputs: number;
   private readonly numberOfParameters: number;
-  readonly debugDescription: string;
 
-  constructor(
-    plan: plan.SyncPlan,
-    source: plan.StreamParameterIndexLookupCreator,
-    { engine, defaultSchema }: StreamEvaluationContext
-  ) {
+  constructor(source: plan.StreamParameterIndexLookupCreator, { engine, defaultSchema }: StreamEvaluationContext) {
     this.defaultLookupScope = {
       ...source.defaultLookupScope,
       source: this
@@ -44,25 +39,6 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
     });
     this.sourceTable = source.sourceTable.toTablePattern(defaultSchema);
     this.evaluatorInputs = translationHelper.mapper.instantiation;
-
-    const usedByStreams = plan.streams
-      .filter((s) => {
-        for (const querier of s.queriers) {
-          for (const stage of querier.lookupStages) {
-            for (const element of stage) {
-              if (element.type == 'parameter' && element.lookup === source) {
-                return true;
-              }
-            }
-          }
-        }
-
-        return false;
-      })
-      .map((s) => s.stream.name)
-      .join(', ');
-
-    this.debugDescription = `Index on ${source.sourceTable.name} used by ${usedByStreams}`;
   }
 
   getSourceTables(): Set<TablePattern> {

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
@@ -17,9 +17,11 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
   private readonly evaluatorInputs: plan.ColumnSqlParameterValue[];
   private readonly numberOfOutputs: number;
   private readonly numberOfParameters: number;
+  readonly debugDescription: string;
 
   constructor(
-    private readonly source: plan.StreamParameterIndexLookupCreator,
+    plan: plan.SyncPlan,
+    source: plan.StreamParameterIndexLookupCreator,
     { engine, defaultSchema }: StreamEvaluationContext
   ) {
     this.defaultLookupScope = {
@@ -42,6 +44,25 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
     });
     this.sourceTable = source.sourceTable.toTablePattern(defaultSchema);
     this.evaluatorInputs = translationHelper.mapper.instantiation;
+
+    const usedByStreams = plan.streams
+      .filter((s) => {
+        for (const querier of s.queriers) {
+          for (const stage of querier.lookupStages) {
+            for (const element of stage) {
+              if (element.type == 'parameter' && element.lookup === source) {
+                return true;
+              }
+            }
+          }
+        }
+
+        return false;
+      })
+      .map((s) => s.stream.name)
+      .join(', ');
+
+    this.debugDescription = `Index on ${source.sourceTable.name} used by ${usedByStreams}`;
   }
 
   getSourceTables(): Set<TablePattern> {


### PR DESCRIPTION
Currently, limits for parameters are checked after we've fetched parameter results from bucket storage. So despite the fact that we have a 1k default limit, we might load millions of parameter results for pathological Sync Streams before we emit an error. This typically leads to an OOM on the instance before we're able to show a warning.

As a solution, this implements a limit when loading results and prints an early breakdown of what went wrong when too many parameters are returned. There's an existing check counting parameter results on buckets (before deduplication). That check claims to count parameter results, but it doesn't really do that:

- For sync streams, not every parameter result is a bucket since one can combine parameter queries with e.g. table-valued functions to generate many buckets without that many parameter lookups.
  - This is still a problem for sync rules: Since all queriers are merged into one, it's possible to get a "too many parameters" error even with a single parameter result if the other buckets are contributed by static buckets.

Since we're now able to track parameters properly, we can remove that check. It still makes sense to print a breakdown for users when a bucket limit is exceeded, so I've moved that check to run if the amount of de-duplicated buckets exceeds the allowed limit instead.

To avoid having to load everything upfront before checking results, we need to forward a remaining limit to bucket storage. To still be able to provide a breakdown of used parameters, this instruments calls to `getParameterSets` in `BucketParameterState` to add include information about the stream responsible for resolving parameters. This still isn't great, there are potential race conditions since sync streams will invoke it concurrently without waiting for a previous result. But even in the worst case, this creates an upper bound on the amount of parameter rows we'd fetch.

While this PR is an improvement, our error reporting for too many parameters and too many buckets is really rough when Sync Streams are involved. I don't think it's possible to make this substantially better with the `Querier` interface because the information of what's actually causing a parameter fetch (ideally, we'd like to know about the stream _subscription_ causing this instead of just the stream) isn't available where we need it. The entire `BucketParameterState` logic can probably be improved a lot for Sync Streams since we can cache lookups across streams and even connections by inspecting sync plans. Doing that would be a good opportunity to add first-class support for these errors and to track them with much more context.