### PR TITLE
Rework `resolveTable(s)`

### DIFF
--- a/.changeset/little-years-flow.md
+++ b/.changeset/little-years-flow.md
@@ -1,0 +1,13 @@
+---
+'@powersync/service-module-postgres-storage': minor
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-core-tests': minor
+'@powersync/service-module-postgres': minor
+'@powersync/service-module-mongodb': minor
+'@powersync/service-core': minor
+'@powersync/service-module-mssql': minor
+'@powersync/service-module-mysql': minor
+'@powersync/service-sync-rules': minor
+---
+
+[Internal] rework resolveTables to handle multiple SourceTables.

--- a/docs/resolve-tables-flow.md
+++ b/docs/resolve-tables-flow.md
@@ -19,9 +19,15 @@ A `TablePattern` is a sync-rule selector:
 
 Think of it as: "which tables should we care about?"
 
+### SourceTableRef
+
+A `SourceTableRef` describes the table of a source row as replicated.
+
+We can do directy matching of `TablePattern.matches(SourceTableRef)`.
+
 ### SourceTable
 
-A `SourceTable` is a concrete tracked runtime table:
+A `SourceTable` is a concrete tracked runtime table with state:
 
 - It represents one resolved physical source table identity.
 - It carries replication identity metadata (replica-id columns).
@@ -29,6 +35,8 @@ A `SourceTable` is a concrete tracked runtime table:
 - It carries resolved sync participation flags (used for data, parameters, events).
 
 Think of it as: "this exact table instance is now being tracked and replicated."
+
+There may be multiple SourceTables per SourceTableRef.
 
 ## High-level flow
 

--- a/docs/resolve-tables-flow.md
+++ b/docs/resolve-tables-flow.md
@@ -1,0 +1,301 @@
+# resolveTables Lifecycle: Discovery, Diff, and Snapshot State
+
+This document explains the conceptual flow around `resolveTables`:
+
+1. Discover a table (either from CDC or initial snapshot scan).
+2. Resolve it into tracked table records.
+3. Detect conflicts/differences with previously tracked records.
+4. Persist changes and snapshot state.
+
+## Core concepts
+
+### TablePattern
+
+A `TablePattern` is a sync-rule selector:
+
+- It describes which source tables should match (exact name or wildcard prefix).
+- It is scoped by connection/schema.
+- It is configuration-level and does not represent persisted runtime state.
+
+Think of it as: "which tables should we care about?"
+
+### SourceTable
+
+A `SourceTable` is a concrete tracked runtime table:
+
+- It represents one resolved physical source table identity.
+- It carries replication identity metadata (replica-id columns).
+- It tracks snapshot lifecycle state (complete/in-progress, progress markers).
+- It carries resolved sync participation flags (used for data, parameters, events).
+
+Think of it as: "this exact table instance is now being tracked and replicated."
+
+## High-level flow
+
+### 1. Table discovery
+
+There are two entry paths:
+
+- CDC path: a relation/change event reveals a table at runtime.
+- Initial snapshot path: the snapshot process scans configured patterns and discovers existing tables before streaming catches up.
+
+In both paths, discovery produces a physical table descriptor:
+
+- connection
+- schema
+- table name
+- object identity (when available)
+- replica-id columns
+
+### 2. Match sync-rule patterns
+
+For each discovered table, the system finds all matching `TablePattern`s.
+
+This may be more than one pattern (for example wildcard + exact match overlaps, or multiple rule sets).
+
+Each matching pattern is resolved independently.
+
+### 3. Resolve into tracked tables (`resolveTables`)
+
+For each matching pattern, `resolveTables` maps the discovered physical table to one or more `SourceTable` records.
+
+Conceptually it does:
+
+- Look up existing tracked records that match the physical identity.
+- Determine which sync-rule sources are already covered.
+- Create missing tracked records when coverage is incomplete.
+- Return the current tracked records that should receive replicated data.
+
+Important: one physical table can resolve to multiple tracked records when different sync-rule source sets are represented separately.
+
+### 4. Detect differences/conflicts (`resolveTablesToDrop`)
+
+After resolution, the system identifies tracked records that conflict with the new definition and should be removed.
+
+Common conflict cases:
+
+- Rename: same physical object identity now has a different name.
+- Identity change: same table name but replica-id definition changed.
+- Object replacement: same schema/name now points at a different physical object identity.
+
+Those conflicting records are dropped/truncated so old state cannot leak into the new table identity.
+
+### 5. Decide whether to snapshot
+
+For each resolved `SourceTable`, snapshotting is needed when:
+
+- snapshot is not complete, and
+- the table is relevant to active sync behavior (data/parameters/events).
+
+Newly discovered tables during CDC can trigger an inline or queued snapshot.
+Initial snapshot mode enqueues all unresolved tables first, then processes them.
+
+### 6. Persist snapshot progress and completion
+
+During snapshot:
+
+- Rows are written as replicated operations.
+- Progress is periodically persisted (estimated total, replicated count, resume key).
+- Flushes persist durable operation state before progress moves forward.
+
+When a table snapshot finishes:
+
+- The table is marked snapshot-complete.
+- Per-table progress markers are cleared.
+- A "do not checkpoint before X" boundary is advanced (LSN/GTID/timestamp equivalent), so final consistency waits for CDC to catch up past the snapshot point.
+
+When all required tables are done in initial snapshot:
+
+- Global snapshot state is marked complete.
+
+### 7. Continue streaming with resolved mappings
+
+Resolved `SourceTable` mappings are cached by relation identity for fast CDC routing.
+Subsequent insert/update/delete events use those mappings to write bucket and parameter updates.
+
+If table metadata changes later, the same resolve + diff + drop cycle runs again.
+
+## Why this design exists
+
+This lifecycle guarantees:
+
+- New tables can be onboarded without restarting replication from scratch.
+- Renames and identity changes do not preserve stale state.
+- Snapshot progress is resumable and durable.
+- CDC and snapshot together converge to a consistent state after catch-up.
+
+## Refactor plan: plural table resolution
+
+Reference branch: `incremental-reprocessing`.
+
+The old branch has the core shape we want, but it is outdated around the surrounding writer/storage architecture. Use it as prior art for the `resolveTables` semantics, not as a direct patch source.
+
+### Current mismatch to fix
+
+The current storage API is singular:
+
+- `resolveTable(options)` returns one resolved `SourceTable`.
+- The same call also returns `dropTables`.
+- Callers cache and snapshot a single table per discovered source row.
+- `TablePattern` matching is mostly implicit inside `HydratedSyncRules.tableSyncsData/tableSyncsParameters/tableTriggersEvent`.
+
+The desired model is plural:
+
+- One physical source row/table can resolve to multiple `SourceTable` records.
+- In MongoDB v3, each `SourceTable` can represent the subset of sync-rule sources it owns.
+- In Postgres and MongoDB v1, we can assume one `SourceTable` per physical source row and keep source ownership implicit.
+- Pattern matching should happen before persistence resolution.
+- Persistence resolution should work with concrete source-table records, with storage-specific support for source memberships where needed.
+
+### Target concepts
+
+Keep a clear distinction between:
+
+- `TablePattern`: a sync-rule selector. It answers "does this rule source care about this physical table?"
+- physical source descriptor: the discovered table/collection identity from CDC or snapshot discovery.
+- `SourceTable`: a persisted runtime table record. It answers "which exact source table record should receive rows and snapshot state?"
+- source membership: for MongoDB v3 only, the set of bucket data sources and parameter lookup sources covered by a `SourceTable`.
+
+The important MongoDB v3 behavior is that adding a new sync-rule source for an already tracked physical table can create a new `SourceTable` for the uncovered source membership, without reprocessing unrelated existing memberships.
+
+For Postgres and MongoDB v1, the compatibility behavior can stay coarser: a physical source row resolves to one `SourceTable`, and row evaluation uses the active sync rules for that table.
+
+### API direction
+
+Introduce a plural resolver on `BucketStorageBatch`:
+
+- `resolveTables(options): Promise<ResolveTablesResult>`
+- `ResolveTablesResult` should contain `tables: SourceTable[]` and `dropTables: SourceTable[]`.
+- Options should include the physical `entity_descriptor`, connection metadata, and matching sources when available.
+- The caller should compute matching sources from the record table schema/name before calling `resolveTables`.
+- If matching sources are not available for the storage version or sync-rule context, the caller should pass `null`.
+- Avoid a generic requirement that every storage layer persists source membership IDs.
+
+The old branch passed a single `pattern` to `resolveTables` and used `rowProcessor.getMatchingSources(pattern)` to compute memberships. That is a useful reference, but the new boundary should pass the already-computed matching sources, or `null` when fine-grained memberships are not meaningful.
+
+Passing already computed source objects gives the cleanest split for MongoDB v3: stream/snapshot code handles matching `TablePattern`s from the record schema/name, while storage handles persisted `SourceTable` identity and translates memberships to storage-specific definition IDs. Postgres and MongoDB v1 should receive `null` because they do not split one physical source row across multiple persisted source memberships.
+
+Placing `resolveTables` on `BucketStorageBatch` is feasible and preferred:
+
+- replication and snapshot call sites already have a batch when they resolve discovered tables
+- the batch already owns the parsed sync rules used for row evaluation
+- MongoDB batches already carry the definition mapping needed by MongoDB v3
+- Postgres batches already carry `group_id`, database access, and parsed sync rules
+- resolving on the batch keeps table resolution, conflict detection, drops, truncates, snapshots, and row writes in one write-oriented API
+
+`SyncRulesBucketStorage.resolveTable` can either be removed after call sites migrate, or kept temporarily as a compatibility wrapper during the transition.
+
+### Resolution algorithm
+
+For each discovered physical table:
+
+1. Caller computes the matching sources for the physical table from schema/name, or `null` if fine-grained memberships are unavailable.
+2. Query existing `SourceTable` records matching the physical identity:
+   - same connection
+   - same schema/name
+   - same object identity when available
+   - same replica-id columns
+3. If matching sources are `null`, resolve or create one `SourceTable` for the physical identity.
+4. If matching sources are present, compare existing source memberships with those desired sources.
+5. Return existing records that cover any desired membership.
+6. If any desired membership is uncovered, create a new `SourceTable` record for the uncovered subset and return it too.
+7. Separately identify conflicting persisted records that should be dropped:
+   - same object identity with a different schema/name
+   - same schema/name with a different object identity
+   - same schema/name with different replica-id columns
+8. Snapshot all returned tables that are incomplete and relevant to active sync behavior.
+
+The resolver should use all current matching physical records to determine coverage, even if a record only covers part of the desired membership set.
+
+For Postgres and MongoDB v1, simplify this algorithm:
+
+1. Match the physical table to active patterns.
+2. Pass `matchingSources: null` to `resolveTables`.
+3. Resolve or create the single `SourceTable` for the physical identity.
+4. Detect conflicting persisted records for rename, replacement, or replica-id changes.
+5. Return the single table in `tables`, preserving the plural API shape.
+
+### Source membership storage
+
+MongoDB v3 already has explicit membership fields:
+
+- `bucket_data_source_ids`
+- `parameter_lookup_source_ids`
+
+Those IDs are used by MongoDB v3 storage and row processing to:
+
+- decide whether an existing `SourceTable` already covers a matched bucket data source or parameter lookup source
+- create a new `SourceTable` only for uncovered source memberships
+- evaluate only the sources owned by that `SourceTable` when writing source records
+- persist current-data/source-record entries with compact definition/index IDs
+- fetch bucket data and parameter lookups by those persisted definition/index IDs
+
+Postgres and MongoDB v1 should not add equivalent definition-id tracking as part of this refactor. For those storage versions, source membership is not part of the persisted `SourceTable` identity, and the resolver can keep the one-table-per-physical-source-row assumption.
+
+Event sources should not get persisted definition IDs as part of this refactor. They do not currently have definition IDs, and storage does not persist long-lived data scoped to individual event source queries. Event participation should remain derived from the active sync rules for each resolved `SourceTable`.
+
+Concretely:
+
+- `matchingSources` should cover bucket data sources and parameter lookup sources only.
+- `SourceTable.syncEvent` should be set by checking whether active event descriptors match the resolved table.
+- event emission should continue to select matching event descriptors at write time from active sync rules.
+- an event-only table should still resolve to a `SourceTable` so `syncAny` can trigger the required snapshot/CDC path, but it does not need a stable event membership ID.
+
+### Caller changes
+
+Replication streams and snapshotters should stop assuming one resolved table:
+
+- relation caches need to store multiple `SourceTable` records per physical relation/collection identity.
+- insert/update/delete handling must evaluate and save each resolved table independently.
+- snapshot decisions should iterate resolved tables.
+- mark snapshot done/progress APIs already accept arrays in several places; call sites should preserve per-table state when plural tables are returned.
+
+This should be a generic caller shape even when a storage implementation currently returns one table. That keeps CDC and snapshot code consistent while allowing MongoDB v3 to return multiple records.
+
+Provider-specific notes:
+
+- Postgres and MSSQL have stable object identities, so rename and replacement detection should remain object-id aware.
+- Postgres can keep resolving one `SourceTable` per physical source row; no definition-id persistence is needed unless we later want fine-grained incremental reprocessing there too.
+- MySQL object ids are synthesized from names in current code, so rename detection remains limited unless a better physical identity is introduced.
+- MongoDB v1 can keep resolving one `SourceTable` per physical source row.
+- MongoDB v3 is the storage version that uses definition IDs for plural membership resolution and fine-grained reprocessing.
+
+### Migration and compatibility plan
+
+Implement in stages:
+
+1. Keep source membership data model changes scoped to MongoDB v3.
+2. Add `resolveTables` to `BucketStorageBatch` with a compatibility path that returns a single table where matching sources are `null`.
+3. Move matching logic out of `resolveTable`: callers compute matching sources from schema/name and pass sources or `null`.
+4. Implement MongoDB v3 coverage detection and creation of missing `SourceTable` records.
+5. Keep conflict detection in `resolveTables` and return `dropTables` in the same result; keep the actual drop/truncate operation in the caller/batch.
+6. Update relation caches, snapshot loops, and row processing to handle multiple resolved tables.
+7. Remove or deprecate `SyncRulesBucketStorage.resolveTable` once stream and snapshot code resolve through the batch.
+8. Add focused tests for overlapping patterns, adding a new source to an existing physical table, replica-id changes, renames, and object replacement.
+
+### Test impact
+
+The expected test impact is moderate but mostly mechanical:
+
+- Storage implementations that implement `BucketStorageBatch` must add `resolveTables`, so TypeScript compilation will force the main changes.
+- Existing storage tests mostly create writers and use `save`, `truncate`, `drop`, and snapshot methods; they should not need broad rewrites unless they mock `BucketStorageBatch`.
+- Current tests do not appear to call `SyncRulesBucketStorage.resolveTable` directly, so moving call sites to `batch.resolveTables` should mainly affect replication stream tests and compile-time interfaces.
+- New tests should cover the resolver behavior directly on a batch, especially MongoDB v3 plural records and Postgres/MongoDB v1 single-record compatibility.
+- Existing helper `resolveTestTable(writer, ...)` already accepts a writer, so it can later be changed to call `writer.resolveTables` without changing most test call sites.
+
+### Drop table handling
+
+It is feasible and preferable to keep `dropTables` as part of the `resolveTables` result.
+
+Conflict detection uses the same physical identity inputs as table resolution:
+
+- connection
+- schema/name
+- object identity when available
+- replica-id columns
+
+Keeping this in the same storage step avoids a second query path that would repeat most of the resolver's lookup work. It also lets the storage implementation compute conflicts against the complete set of current resolved tables. This matters for MongoDB v3, where multiple current `SourceTable` records can share the same physical source row but own different definition IDs; those records must not be treated as conflicts with each other.
+
+The resolver should only identify conflicts. The caller or batch should still perform the actual `drop(result.dropTables)` operation, so operation ordering stays explicit next to cache updates and snapshot handling.
+
+Implementation detail: the conflict query should exclude all current valid `SourceTable` records returned by `resolveTables`, not just one table ID. That preserves existing rename/replacement/replica-id-change behavior while supporting plural resolution.

--- a/docs/resolve-tables-flow.md
+++ b/docs/resolve-tables-flow.md
@@ -7,36 +7,57 @@ This document explains the conceptual flow around `resolveTables`:
 3. Detect conflicts/differences with previously tracked records.
 4. Persist changes and snapshot state.
 
+_Partially AI-generated, manually reviewed and modified._
+
 ## Core concepts
 
 ### TablePattern
 
-A `TablePattern` is a sync-rule selector:
+A `TablePattern` is a sync query selector. This includes:
 
-- It describes which source tables should match (exact name or wildcard prefix).
-- It is scoped by connection/schema.
-- It is configuration-level and does not represent persisted runtime state.
+1. Connection tag. _We don't support multiple connections yet, but this caters for it in theory._
+2. Schema name.
+3. Table _pattern_.
 
-Think of it as: "which tables should we care about?"
+This is configuration-level only, and not used in persisted state.
 
 ### SourceTableRef
 
-A `SourceTableRef` describes the table of a source row as replicated.
+A `SourceTableRef` describes the table of a source row as replicated. This includes:
 
-We can do directy matching of `TablePattern.matches(SourceTableRef)`.
+1. Connection tag.
+2. Schema name.
+3. Table name.
+
+This is similar in structure to `TablePattern`, but uses specific names instead of wildcards.
+
+We can do directy matching of `TablePattern.matches(ref: SourceTableRef)`. This is what drives matching of replicated rows with specific sync queries.
+
+### SourceEntityDescriptor
+
+This is a SourceTableRef with additional metadata used for replication:
+
+1. objectId / relation id: The underlying id of the table/collection in the source database. This is used to track renames.
+2. replicaIdColumns: The columns and types representing the "replica identity" for the table.
 
 ### SourceTable
 
-A `SourceTable` is a concrete tracked runtime table with state:
+A `SourceTable` is a replicated table with state:
 
-- It represents one resolved physical source table identity.
-- It carries replication identity metadata (replica-id columns).
-- It tracks snapshot lifecycle state (complete/in-progress, progress markers).
-- It carries resolved sync participation flags (used for data, parameters, events).
+1. It has a specific `SourceTableRef`, but the same ref may have multiple `SourceTable`s.
+2. In stores the specific metadata from the `SourceEntityDescriptor` - any changes would result in a new `SourceTable`.
+3. It tracks snapshot lifecycle state (complete/in-progress, progress markers).
+4. It carries resolved sync participation flags (used for data, parameters, events).
+5. It tracks which sync stream / bucket definitions are used with it.
 
-Think of it as: "this exact table instance is now being tracked and replicated."
+There may now be multiple `SourceTable`s per `SourceTableRef`. Historically it was generally 1:1, but we now support multiple in preparation for incremental reprocessing: If a new data source or parameter index creator is added, we need to snapshot the source table. Instead of doing a re-snapshot of an existing SourceTable, we create a new SourceTable with the same SourceTableRef. The new snapshot then only affects the new data sources, not existing ones.
 
-There may be multiple SourceTables per SourceTableRef.
+`SourceTable` is also used to track changes that may require a re-snapshot:
+
+1. Renamed tables (same table name with different relationId or vice versa).
+2. Changes in replica indentity.
+
+These changes generally require "truncating" the outdated `SourceTable`, then snapshotting the new one.
 
 ## High-level flow
 
@@ -44,16 +65,10 @@ There may be multiple SourceTables per SourceTableRef.
 
 There are two entry paths:
 
-- CDC path: a relation/change event reveals a table at runtime.
-- Initial snapshot path: the snapshot process scans configured patterns and discovers existing tables before streaming catches up.
+1. CDC path: a relation/change event reveals a table at runtime.
+2. Initial snapshot path: the snapshot process scans configured patterns and discovers existing tables before streaming catches up.
 
-In both paths, discovery produces a physical table descriptor:
-
-- connection
-- schema
-- table name
-- object identity (when available)
-- replica-id columns
+These both produce a `SourceEntityDescriptor`, describing the table to replicate.
 
 ### 2. Match sync-rule patterns
 
@@ -65,35 +80,27 @@ Each matching pattern is resolved independently.
 
 ### 3. Resolve into tracked tables (`resolveTables`)
 
-For each matching pattern, `resolveTables` maps the discovered physical table to one or more `SourceTable` records.
+`resolveTables` maps the discovered physical table to one or more `SourceTable` records.
 
 Conceptually it does:
 
-- Look up existing tracked records that match the physical identity.
-- Determine which sync-rule sources are already covered.
-- Create missing tracked records when coverage is incomplete.
-- Return the current tracked records that should receive replicated data.
+1. Look up existing `SourceTable` records that match the physical identity.
+2. Determine which sync config sources are already covered.
+3. Create missing `SourceTable` records when coverage is incomplete.
+4. Return the `SourceTable` records that should receive replicated data.
 
-Important: one physical table can resolve to multiple tracked records when different sync-rule source sets are represented separately.
+Important: one physical table can resolve to multiple `SourceTable` records when sync config definitions have been added over time.
 
 ### 4. Detect differences/conflicts (`resolveTablesToDrop`)
 
-After resolution, the system identifies tracked records that conflict with the new definition and should be removed.
-
-Common conflict cases:
-
-- Rename: same physical object identity now has a different name.
-- Identity change: same table name but replica-id definition changed.
-- Object replacement: same schema/name now points at a different physical object identity.
-
-Those conflicting records are dropped/truncated so old state cannot leak into the new table identity.
+After resolution, the system identifies `SourceTable` records that conflict with the new definition and should be removed.
 
 ### 5. Decide whether to snapshot
 
 For each resolved `SourceTable`, snapshotting is needed when:
 
-- snapshot is not complete, and
-- the table is relevant to active sync behavior (data/parameters/events).
+1. Snapshot is not complete, and
+2. The table is relevant to active sync behavior (data/parameters/events).
 
 Newly discovered tables during CDC can trigger an inline or queued snapshot.
 Initial snapshot mode enqueues all unresolved tables first, then processes them.
@@ -122,188 +129,3 @@ Resolved `SourceTable` mappings are cached by relation identity for fast CDC rou
 Subsequent insert/update/delete events use those mappings to write bucket and parameter updates.
 
 If table metadata changes later, the same resolve + diff + drop cycle runs again.
-
-## Why this design exists
-
-This lifecycle guarantees:
-
-- New tables can be onboarded without restarting replication from scratch.
-- Renames and identity changes do not preserve stale state.
-- Snapshot progress is resumable and durable.
-- CDC and snapshot together converge to a consistent state after catch-up.
-
-## Refactor plan: plural table resolution
-
-Reference branch: `incremental-reprocessing`.
-
-The old branch has the core shape we want, but it is outdated around the surrounding writer/storage architecture. Use it as prior art for the `resolveTables` semantics, not as a direct patch source.
-
-### Current mismatch to fix
-
-The current storage API is singular:
-
-- `resolveTable(options)` returns one resolved `SourceTable`.
-- The same call also returns `dropTables`.
-- Callers cache and snapshot a single table per discovered source row.
-- `TablePattern` matching is mostly implicit inside `HydratedSyncRules.tableSyncsData/tableSyncsParameters/tableTriggersEvent`.
-
-The desired model is plural:
-
-- One physical source row/table can resolve to multiple `SourceTable` records.
-- In MongoDB v3, each `SourceTable` can represent the subset of sync-rule sources it owns.
-- In Postgres and MongoDB v1, we can assume one `SourceTable` per physical source row and keep source ownership implicit.
-- Pattern matching should happen before persistence resolution.
-- Persistence resolution should work with concrete source-table records, with storage-specific support for source memberships where needed.
-
-### Target concepts
-
-Keep a clear distinction between:
-
-- `TablePattern`: a sync-rule selector. It answers "does this rule source care about this physical table?"
-- physical source descriptor: the discovered table/collection identity from CDC or snapshot discovery.
-- `SourceTable`: a persisted runtime table record. It answers "which exact source table record should receive rows and snapshot state?"
-- source membership: for MongoDB v3 only, the set of bucket data sources and parameter lookup sources covered by a `SourceTable`.
-
-The important MongoDB v3 behavior is that adding a new sync-rule source for an already tracked physical table can create a new `SourceTable` for the uncovered source membership, without reprocessing unrelated existing memberships.
-
-For Postgres and MongoDB v1, the compatibility behavior can stay coarser: a physical source row resolves to one `SourceTable`, and row evaluation uses the active sync rules for that table.
-
-### API direction
-
-Introduce a plural resolver on `BucketStorageBatch`:
-
-- `resolveTables(options): Promise<ResolveTablesResult>`
-- `ResolveTablesResult` should contain `tables: SourceTable[]` and `dropTables: SourceTable[]`.
-- Options should include the physical `entity_descriptor`, connection metadata, and matching sources when available.
-- The caller should compute matching sources from the record table schema/name before calling `resolveTables`.
-- If matching sources are not available for the storage version or sync-rule context, the caller should pass `null`.
-- Avoid a generic requirement that every storage layer persists source membership IDs.
-
-The old branch passed a single `pattern` to `resolveTables` and used `rowProcessor.getMatchingSources(pattern)` to compute memberships. That is a useful reference, but the new boundary should pass the already-computed matching sources, or `null` when fine-grained memberships are not meaningful.
-
-Passing already computed source objects gives the cleanest split for MongoDB v3: stream/snapshot code handles matching `TablePattern`s from the record schema/name, while storage handles persisted `SourceTable` identity and translates memberships to storage-specific definition IDs. Postgres and MongoDB v1 should receive `null` because they do not split one physical source row across multiple persisted source memberships.
-
-Placing `resolveTables` on `BucketStorageBatch` is feasible and preferred:
-
-- replication and snapshot call sites already have a batch when they resolve discovered tables
-- the batch already owns the parsed sync rules used for row evaluation
-- MongoDB batches already carry the definition mapping needed by MongoDB v3
-- Postgres batches already carry `group_id`, database access, and parsed sync rules
-- resolving on the batch keeps table resolution, conflict detection, drops, truncates, snapshots, and row writes in one write-oriented API
-
-`SyncRulesBucketStorage.resolveTable` can either be removed after call sites migrate, or kept temporarily as a compatibility wrapper during the transition.
-
-### Resolution algorithm
-
-For each discovered physical table:
-
-1. Caller computes the matching sources for the physical table from schema/name, or `null` if fine-grained memberships are unavailable.
-2. Query existing `SourceTable` records matching the physical identity:
-   - same connection
-   - same schema/name
-   - same object identity when available
-   - same replica-id columns
-3. If matching sources are `null`, resolve or create one `SourceTable` for the physical identity.
-4. If matching sources are present, compare existing source memberships with those desired sources.
-5. Return existing records that cover any desired membership.
-6. If any desired membership is uncovered, create a new `SourceTable` record for the uncovered subset and return it too.
-7. Separately identify conflicting persisted records that should be dropped:
-   - same object identity with a different schema/name
-   - same schema/name with a different object identity
-   - same schema/name with different replica-id columns
-8. Snapshot all returned tables that are incomplete and relevant to active sync behavior.
-
-The resolver should use all current matching physical records to determine coverage, even if a record only covers part of the desired membership set.
-
-For Postgres and MongoDB v1, simplify this algorithm:
-
-1. Match the physical table to active patterns.
-2. Pass `matchingSources: null` to `resolveTables`.
-3. Resolve or create the single `SourceTable` for the physical identity.
-4. Detect conflicting persisted records for rename, replacement, or replica-id changes.
-5. Return the single table in `tables`, preserving the plural API shape.
-
-### Source membership storage
-
-MongoDB v3 already has explicit membership fields:
-
-- `bucket_data_source_ids`
-- `parameter_lookup_source_ids`
-
-Those IDs are used by MongoDB v3 storage and row processing to:
-
-- decide whether an existing `SourceTable` already covers a matched bucket data source or parameter lookup source
-- create a new `SourceTable` only for uncovered source memberships
-- evaluate only the sources owned by that `SourceTable` when writing source records
-- persist current-data/source-record entries with compact definition/index IDs
-- fetch bucket data and parameter lookups by those persisted definition/index IDs
-
-Postgres and MongoDB v1 should not add equivalent definition-id tracking as part of this refactor. For those storage versions, source membership is not part of the persisted `SourceTable` identity, and the resolver can keep the one-table-per-physical-source-row assumption.
-
-Event sources should not get persisted definition IDs as part of this refactor. They do not currently have definition IDs, and storage does not persist long-lived data scoped to individual event source queries. Event participation should remain derived from the active sync rules for each resolved `SourceTable`.
-
-Concretely:
-
-- `matchingSources` should cover bucket data sources and parameter lookup sources only.
-- `SourceTable.syncEvent` should be set by checking whether active event descriptors match the resolved table.
-- event emission should continue to select matching event descriptors at write time from active sync rules.
-- an event-only table should still resolve to a `SourceTable` so `syncAny` can trigger the required snapshot/CDC path, but it does not need a stable event membership ID.
-
-### Caller changes
-
-Replication streams and snapshotters should stop assuming one resolved table:
-
-- relation caches need to store multiple `SourceTable` records per physical relation/collection identity.
-- insert/update/delete handling must evaluate and save each resolved table independently.
-- snapshot decisions should iterate resolved tables.
-- mark snapshot done/progress APIs already accept arrays in several places; call sites should preserve per-table state when plural tables are returned.
-
-This should be a generic caller shape even when a storage implementation currently returns one table. That keeps CDC and snapshot code consistent while allowing MongoDB v3 to return multiple records.
-
-Provider-specific notes:
-
-- Postgres and MSSQL have stable object identities, so rename and replacement detection should remain object-id aware.
-- Postgres can keep resolving one `SourceTable` per physical source row; no definition-id persistence is needed unless we later want fine-grained incremental reprocessing there too.
-- MySQL object ids are synthesized from names in current code, so rename detection remains limited unless a better physical identity is introduced.
-- MongoDB v1 can keep resolving one `SourceTable` per physical source row.
-- MongoDB v3 is the storage version that uses definition IDs for plural membership resolution and fine-grained reprocessing.
-
-### Migration and compatibility plan
-
-Implement in stages:
-
-1. Keep source membership data model changes scoped to MongoDB v3.
-2. Add `resolveTables` to `BucketStorageBatch` with a compatibility path that returns a single table where matching sources are `null`.
-3. Move matching logic out of `resolveTable`: callers compute matching sources from schema/name and pass sources or `null`.
-4. Implement MongoDB v3 coverage detection and creation of missing `SourceTable` records.
-5. Keep conflict detection in `resolveTables` and return `dropTables` in the same result; keep the actual drop/truncate operation in the caller/batch.
-6. Update relation caches, snapshot loops, and row processing to handle multiple resolved tables.
-7. Remove or deprecate `SyncRulesBucketStorage.resolveTable` once stream and snapshot code resolve through the batch.
-8. Add focused tests for overlapping patterns, adding a new source to an existing physical table, replica-id changes, renames, and object replacement.
-
-### Test impact
-
-The expected test impact is moderate but mostly mechanical:
-
-- Storage implementations that implement `BucketStorageBatch` must add `resolveTables`, so TypeScript compilation will force the main changes.
-- Existing storage tests mostly create writers and use `save`, `truncate`, `drop`, and snapshot methods; they should not need broad rewrites unless they mock `BucketStorageBatch`.
-- Current tests do not appear to call `SyncRulesBucketStorage.resolveTable` directly, so moving call sites to `batch.resolveTables` should mainly affect replication stream tests and compile-time interfaces.
-- New tests should cover the resolver behavior directly on a batch, especially MongoDB v3 plural records and Postgres/MongoDB v1 single-record compatibility.
-- Existing helper `resolveTestTable(writer, ...)` already accepts a writer, so it can later be changed to call `writer.resolveTables` without changing most test call sites.
-
-### Drop table handling
-
-It is feasible and preferable to keep `dropTables` as part of the `resolveTables` result.
-
-Conflict detection uses the same physical identity inputs as table resolution:
-
-- connection
-- schema/name
-- object identity when available
-- replica-id columns
-
-Keeping this in the same storage step avoids a second query path that would repeat most of the resolver's lookup work. It also lets the storage implementation compute conflicts against the complete set of current resolved tables. This matters for MongoDB v3, where multiple current `SourceTable` records can share the same physical source row but own different definition IDs; those records must not be treated as conflicts with each other.
-
-The resolver should only identify conflicts. The caller or batch should still perform the actual `drop(result.dropTables)` operation, so operation ordering stays explicit next to cache updates and snapshot handling.
-
-Implementation detail: the conflict query should exclude all current valid `SourceTable` records returned by `resolveTables`, not just one table ID. That preserves existing rename/replacement/replica-id-change behavior while supporting plural resolution.

--- a/docs/resolve-tables-flow.md
+++ b/docs/resolve-tables-flow.md
@@ -45,7 +45,7 @@ This is a SourceTableRef with additional metadata used for replication:
 A `SourceTable` is a replicated table with state:
 
 1. It has a specific `SourceTableRef`, but the same ref may have multiple `SourceTable`s.
-2. In stores the specific metadata from the `SourceEntityDescriptor` - any changes would result in a new `SourceTable`.
+2. It stores the specific metadata from the `SourceEntityDescriptor` - any changes would result in a new `SourceTable`.
 3. It tracks snapshot lifecycle state (complete/in-progress, progress markers).
 4. It carries resolved sync participation flags (used for data, parameters, events).
 5. It tracks which sync stream / bucket definitions are used with it.
@@ -91,7 +91,7 @@ Conceptually it does:
 
 Important: one physical table can resolve to multiple `SourceTable` records when sync config definitions have been added over time.
 
-### 4. Detect differences/conflicts (`resolveTablesToDrop`)
+### 4. Detect differences/conflicts
 
 After resolution, the system identifies `SourceTable` records that conflict with the new definition and should be removed.
 

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -481,16 +481,10 @@ export abstract class MongoBucketBatch
       if (sourceTable.syncData) {
         const { results, errors: syncErrors } = this.sync_rules.evaluateRowWithErrors({
           record: after,
-          sourceTable
+          sourceTable,
+          bucketDataSources: sourceTable.bucketDataSources
         });
-        const allowedBucketSourceIds =
-          sourceTable.bucketDataSources == null
-            ? null
-            : new Set(sourceTable.bucketDataSources.map((source) => this.mapping.bucketSourceId(source)));
-        const evaluated =
-          allowedBucketSourceIds == null
-            ? results
-            : results.filter((result) => allowedBucketSourceIds.has(this.mapping.bucketSourceId(result.source)));
+        const evaluated = results;
 
         for (let error of syncErrors) {
           container.reporter.captureMessage(
@@ -521,17 +515,11 @@ export abstract class MongoBucketBatch
 
       if (sourceTable.syncParameters) {
         // Parameters
-        const { results, errors: paramErrors } = this.sync_rules.evaluateParameterRowWithErrors(sourceTable, after);
-        const allowedParameterLookupIds =
-          sourceTable.parameterLookupSources == null
-            ? null
-            : new Set(sourceTable.parameterLookupSources.map((source) => this.mapping.parameterLookupId(source)));
-        const paramEvaluated =
-          allowedParameterLookupIds == null
-            ? results
-            : results.filter((result) =>
-                allowedParameterLookupIds.has(this.mapping.parameterLookupId(result.lookup.source))
-              );
+        const { results: paramEvaluated, errors: paramErrors } = this.sync_rules.evaluateParameterRowWithErrors(
+          sourceTable,
+          after,
+          { parameterLookupSources: sourceTable.parameterLookupSources }
+        );
 
         for (let error of paramErrors) {
           container.reporter.captureMessage(

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -483,10 +483,14 @@ export abstract class MongoBucketBatch
           record: after,
           sourceTable
         });
-        const evaluated =
+        const allowedBucketSourceIds =
           sourceTable.bucketDataSources == null
+            ? null
+            : new Set(sourceTable.bucketDataSources.map((source) => this.mapping.bucketSourceId(source)));
+        const evaluated =
+          allowedBucketSourceIds == null
             ? results
-            : results.filter((result) => sourceTable.bucketDataSources!.includes(result.source));
+            : results.filter((result) => allowedBucketSourceIds.has(this.mapping.bucketSourceId(result.source)));
 
         for (let error of syncErrors) {
           container.reporter.captureMessage(
@@ -518,10 +522,16 @@ export abstract class MongoBucketBatch
       if (sourceTable.syncParameters) {
         // Parameters
         const { results, errors: paramErrors } = this.sync_rules.evaluateParameterRowWithErrors(sourceTable, after);
-        const paramEvaluated =
+        const allowedParameterLookupIds =
           sourceTable.parameterLookupSources == null
+            ? null
+            : new Set(sourceTable.parameterLookupSources.map((source) => this.mapping.parameterLookupId(source)));
+        const paramEvaluated =
+          allowedParameterLookupIds == null
             ? results
-            : results.filter((result) => sourceTable.parameterLookupSources!.includes(result.lookup.source));
+            : results.filter((result) =>
+                allowedParameterLookupIds.has(this.mapping.parameterLookupId(result.lookup.source))
+              );
 
         for (let error of paramErrors) {
           container.reporter.captureMessage(

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -56,6 +56,7 @@ export interface MongoBucketBatchOptions {
   skipExistingRows: boolean;
 
   markRecordUnavailable: BucketStorageMarkRecordUnavailable | undefined;
+  resolveTables: (options: storage.ResolveTablesOptions) => Promise<storage.ResolveTablesResult>;
 
   logger: Logger;
   tracer?: PerformanceTracer<'storage' | 'evaluate'>;
@@ -65,6 +66,7 @@ export abstract class MongoBucketBatch
   extends BaseObserver<storage.BucketBatchStorageListener>
   implements storage.BucketStorageBatch
 {
+  protected readonly options: MongoBucketBatchOptions;
   protected logger: Logger;
 
   private readonly client: mongo.MongoClient;
@@ -117,6 +119,7 @@ export abstract class MongoBucketBatch
   constructor(options: MongoBucketBatchOptions) {
     super();
     this.logger = options.logger;
+    this.options = options;
     this.client = options.db.client;
     this.db = options.db;
     this.group_id = options.groupId;
@@ -144,6 +147,10 @@ export abstract class MongoBucketBatch
 
   get lastCheckpointLsn() {
     return this.last_checkpoint_lsn;
+  }
+
+  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
+    return this.options.resolveTables(options);
   }
 
   protected abstract createPersistedBatch(writtenSize: number): PersistedBatch;
@@ -472,10 +479,14 @@ export abstract class MongoBucketBatch
     if (afterId && after && utils.isCompleteRow(this.storeCurrentData, after)) {
       // Insert or update
       if (sourceTable.syncData) {
-        const { results: evaluated, errors: syncErrors } = this.sync_rules.evaluateRowWithErrors({
+        const { results, errors: syncErrors } = this.sync_rules.evaluateRowWithErrors({
           record: after,
           sourceTable
         });
+        const evaluated =
+          sourceTable.bucketDataSources == null
+            ? results
+            : results.filter((result) => sourceTable.bucketDataSources!.includes(result.source));
 
         for (let error of syncErrors) {
           container.reporter.captureMessage(
@@ -506,10 +517,11 @@ export abstract class MongoBucketBatch
 
       if (sourceTable.syncParameters) {
         // Parameters
-        const { results: paramEvaluated, errors: paramErrors } = this.sync_rules.evaluateParameterRowWithErrors(
-          sourceTable,
-          after
-        );
+        const { results, errors: paramErrors } = this.sync_rules.evaluateParameterRowWithErrors(sourceTable, after);
+        const paramEvaluated =
+          sourceTable.parameterLookupSources == null
+            ? results
+            : results.filter((result) => sourceTable.parameterLookupSources!.includes(result.lookup.source));
 
         for (let error of paramErrors) {
           container.reporter.captureMessage(

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -56,9 +56,6 @@ export interface MongoBucketBatchOptions {
   skipExistingRows: boolean;
 
   markRecordUnavailable: BucketStorageMarkRecordUnavailable | undefined;
-  resolveTables: (
-    options: storage.ResolveTablesOptions & { syncRules: HydratedSyncRules }
-  ) => Promise<storage.ResolveTablesResult>;
 
   logger: Logger;
   tracer?: PerformanceTracer<'storage' | 'evaluate'>;
@@ -74,7 +71,7 @@ export abstract class MongoBucketBatch
   private readonly client: mongo.MongoClient;
   public readonly db: VersionedPowerSyncMongo;
   public readonly session: mongo.ClientSession;
-  private readonly sync_rules: HydratedSyncRules;
+  protected readonly sync_rules: HydratedSyncRules;
 
   protected readonly group_id: number;
 
@@ -151,9 +148,7 @@ export abstract class MongoBucketBatch
     return this.last_checkpoint_lsn;
   }
 
-  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
-    return this.options.resolveTables({ ...options, syncRules: options.syncRules ?? this.sync_rules });
-  }
+  abstract resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult>;
 
   protected abstract createPersistedBatch(writtenSize: number): PersistedBatch;
 

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -57,8 +57,7 @@ export interface MongoBucketBatchOptions {
 
   markRecordUnavailable: BucketStorageMarkRecordUnavailable | undefined;
   resolveTables: (
-    options: storage.ResolveTablesOptions,
-    syncRules: HydratedSyncRules
+    options: storage.ResolveTablesOptions & { syncRules: HydratedSyncRules }
   ) => Promise<storage.ResolveTablesResult>;
 
   logger: Logger;
@@ -153,7 +152,7 @@ export abstract class MongoBucketBatch
   }
 
   async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
-    return this.options.resolveTables(options, this.sync_rules);
+    return this.options.resolveTables({ ...options, syncRules: options.syncRules ?? this.sync_rules });
   }
 
   protected abstract createPersistedBatch(writtenSize: number): PersistedBatch;

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -56,7 +56,10 @@ export interface MongoBucketBatchOptions {
   skipExistingRows: boolean;
 
   markRecordUnavailable: BucketStorageMarkRecordUnavailable | undefined;
-  resolveTables: (options: storage.ResolveTablesOptions) => Promise<storage.ResolveTablesResult>;
+  resolveTables: (
+    options: storage.ResolveTablesOptions,
+    syncRules: HydratedSyncRules
+  ) => Promise<storage.ResolveTablesResult>;
 
   logger: Logger;
   tracer?: PerformanceTracer<'storage' | 'evaluate'>;
@@ -150,7 +153,7 @@ export abstract class MongoBucketBatch
   }
 
   async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
-    return this.options.resolveTables(options);
+    return this.options.resolveTables(options, this.sync_rules);
   }
 
   protected abstract createPersistedBatch(writtenSize: number): PersistedBatch;

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -484,7 +484,7 @@ export abstract class MongoBucketBatch
       if (sourceTable.syncData) {
         const { results, errors: syncErrors } = this.sync_rules.evaluateRowWithErrors({
           record: after,
-          sourceTable,
+          sourceTable: sourceTable.ref,
           bucketDataSources: sourceTable.bucketDataSources
         });
         const evaluated = results;
@@ -519,7 +519,7 @@ export abstract class MongoBucketBatch
       if (sourceTable.syncParameters) {
         // Parameters
         const { results: paramEvaluated, errors: paramErrors } = this.sync_rules.evaluateParameterRowWithErrors(
-          sourceTable,
+          sourceTable.ref,
           after,
           { parameterLookupSources: sourceTable.parameterLookupSources }
         );
@@ -869,7 +869,7 @@ export abstract class MongoBucketBatch
    */
   protected getTableEvents(table: storage.SourceTable): SqlEventDescriptor[] {
     return this.sync_rules.eventDescriptors.filter((evt) =>
-      [...evt.getSourceTables()].some((sourceTable) => sourceTable.matches(table))
+      [...evt.getSourceTables()].some((sourceTable) => sourceTable.matches(table.ref))
     );
   }
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -209,7 +209,8 @@ export abstract class MongoSyncBucketStorage
       markRecordUnavailable: options.markRecordUnavailable,
       syncConfigId: state.syncConfigId,
       tracer: options.tracer,
-      resolveTables: (resolveOptions: storage.ResolveTablesOptions) => this.resolveTables(resolveOptions)
+      resolveTables: (resolveOptions: storage.ResolveTablesOptions, syncRules: HydratedSyncRules) =>
+        this.resolveTables(resolveOptions, syncRules)
     };
     const writer = this.createWriterImpl(batchOptions);
     this.iterateListeners((cb) => cb.batchStarted?.(writer));
@@ -231,13 +232,17 @@ export abstract class MongoSyncBucketStorage
   protected abstract augmentCreatedSourceTableDocument(
     createDoc: CommonSourceTableDocument,
     options: storage.ResolveTablesOptions,
-    candidateSourceTable: storage.SourceTable
+    candidateSourceTable: storage.SourceTable,
+    syncRules: HydratedSyncRules
   ): void;
 
   protected abstract initializeResolvedSourceRecords(sourceTableId: bson.ObjectId): Promise<void>;
 
-  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
-    const { group_id, connection_id, connection_tag, entity_descriptor } = options;
+  async resolveTables(
+    options: storage.ResolveTablesOptions,
+    syncRules = this.getParsedSyncRules({ defaultSchema: options.entity_descriptor.schema })
+  ): Promise<storage.ResolveTablesResult> {
+    const { connection_id, connection_tag, entity_descriptor } = options;
 
     const { schema, name, objectId, replicaIdColumns } = entity_descriptor;
 
@@ -251,7 +256,7 @@ export abstract class MongoSyncBucketStorage
 
     const baseId = this.sourceTableBaseId();
     await this.db.client.withSession(async (session) => {
-      const col = this.db.commonSourceTables(group_id);
+      const col = this.db.commonSourceTables(this.group_id);
       let filter: Partial<CommonSourceTableDocument> = {
         ...baseId,
         connection_id: connection_id,
@@ -265,8 +270,9 @@ export abstract class MongoSyncBucketStorage
       }
       let doc = await col.findOne(filter, { session });
       if (doc == null) {
+        const id = options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId();
         const candidateSourceTable = new storage.SourceTable({
-          id: new bson.ObjectId(),
+          id,
           connectionTag: connection_tag,
           objectId: objectId,
           schema: schema,
@@ -275,7 +281,7 @@ export abstract class MongoSyncBucketStorage
           snapshotComplete: false
         });
         const createDoc: CommonSourceTableDocument = {
-          _id: candidateSourceTable.id as bson.ObjectId,
+          _id: id,
           ...(baseId as any),
           connection_id: connection_id,
           relation_id: objectId,
@@ -286,7 +292,7 @@ export abstract class MongoSyncBucketStorage
           snapshot_done: false,
           snapshot_status: undefined
         };
-        this.augmentCreatedSourceTableDocument(createDoc, options, candidateSourceTable);
+        this.augmentCreatedSourceTableDocument(createDoc, options, candidateSourceTable, syncRules);
         doc = createDoc;
 
         await col.insertOne(doc, { session });
@@ -301,9 +307,9 @@ export abstract class MongoSyncBucketStorage
         replicaIdColumns: replicaIdColumns,
         snapshotComplete: doc.snapshot_done ?? true
       });
-      sourceTable.syncEvent = options.sync_rules.tableTriggersEvent(sourceTable);
-      sourceTable.syncData = options.sync_rules.tableSyncsData(sourceTable);
-      sourceTable.syncParameters = options.sync_rules.tableSyncsParameters(sourceTable);
+      sourceTable.syncEvent = syncRules.tableTriggersEvent(sourceTable);
+      sourceTable.syncData = syncRules.tableSyncsData(sourceTable);
+      sourceTable.syncParameters = syncRules.tableSyncsParameters(sourceTable);
       sourceTable.snapshotStatus =
         doc.snapshot_status == null
           ? undefined

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -11,7 +11,6 @@ import {
   BroadcastIterable,
   CHECKPOINT_INVALIDATE_ALL,
   CheckpointChanges,
-  ColumnDescriptor,
   GetCheckpointChangesOptions,
   InternalOpId,
   mergeAsyncIterables,
@@ -22,12 +21,7 @@ import {
   utils,
   WatchWriteCheckpointOptions
 } from '@powersync/service-core';
-import {
-  HydratedSyncRules,
-  ParameterLookupRows,
-  ScopedParameterLookup,
-  SourceTableRef
-} from '@powersync/service-sync-rules';
+import { HydratedSyncRules, ParameterLookupRows, ScopedParameterLookup } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { LRUCache } from 'lru-cache';
 import * as timers from 'timers/promises';
@@ -35,7 +29,7 @@ import { retryOnMongoMaxTimeMSExpired } from '../../utils/util.js';
 import { MongoBucketStorage } from '../MongoBucketStorage.js';
 import { MongoSyncBucketStorageContext } from './common/MongoSyncBucketStorageContext.js';
 import type { VersionedPowerSyncMongo } from './db.js';
-import { CommonSourceTableDocument, StorageConfig } from './models.js';
+import { StorageConfig } from './models.js';
 import { MongoBucketBatchOptions } from './MongoBucketBatch.js';
 import { MongoChecksumOptions, MongoChecksums } from './MongoChecksums.js';
 import { MongoCompactOptions, MongoCompactor } from './MongoCompactor.js';
@@ -214,8 +208,7 @@ export abstract class MongoSyncBucketStorage
       skipExistingRows: options.skipExistingRows ?? false,
       markRecordUnavailable: options.markRecordUnavailable,
       syncConfigId: state.syncConfigId,
-      tracer: options.tracer,
-      resolveTables: this.resolveTables.bind(this)
+      tracer: options.tracer
     };
     const writer = this.createWriterImpl(batchOptions);
     this.iterateListeners((cb) => cb.batchStarted?.(writer));
@@ -230,137 +223,6 @@ export abstract class MongoSyncBucketStorage
     await callback(writer);
     await writer.flush();
     return writer.last_flushed_op != null ? { flushed_op: writer.last_flushed_op } : null;
-  }
-
-  protected abstract sourceTableBaseId(): Partial<CommonSourceTableDocument>;
-
-  protected abstract augmentCreatedSourceTableDocument(
-    createDoc: CommonSourceTableDocument,
-    options: storage.ResolveTablesOptions,
-    ref: SourceTableRef,
-    syncRules: HydratedSyncRules
-  ): void;
-
-  protected abstract initializeResolvedSourceRecords(sourceTableId: bson.ObjectId): Promise<void>;
-
-  async resolveTables(
-    options: storage.ResolveTablesOptions & { syncRules: HydratedSyncRules }
-  ): Promise<storage.ResolveTablesResult> {
-    const { connection_id, source, syncRules } = options;
-
-    const { schema: schema, name: name, objectId, replicaIdColumns, connectionTag } = source;
-
-    const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
-      name: column.name,
-      type: column.type,
-      type_oid: column.typeId
-    }));
-    let result: storage.ResolveTablesResult | null = null;
-    let initializeSourceRecordsFor: bson.ObjectId | null = null;
-
-    const baseId = this.sourceTableBaseId();
-    await this.db.client.withSession(async (session) => {
-      const col = this.db.commonSourceTables(this.group_id);
-      let filter: Partial<CommonSourceTableDocument> = {
-        ...baseId,
-        connection_id: connection_id,
-        schema_name: schema,
-        table_name: name,
-        replica_id_columns2: normalizedReplicaIdColumns
-      };
-
-      if (objectId != null) {
-        filter.relation_id = objectId;
-      }
-      let doc = await col.findOne(filter, { session });
-      if (doc == null) {
-        const id = options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId();
-        const createDoc: CommonSourceTableDocument = {
-          _id: id,
-          ...(baseId as any),
-          connection_id: connection_id,
-          relation_id: objectId,
-          schema_name: schema,
-          table_name: name,
-          replica_id_columns: null,
-          replica_id_columns2: normalizedReplicaIdColumns,
-          snapshot_done: false,
-          snapshot_status: undefined
-        };
-        this.augmentCreatedSourceTableDocument(createDoc, options, source, syncRules);
-        doc = createDoc;
-
-        await col.insertOne(doc, { session });
-        initializeSourceRecordsFor = doc._id;
-      }
-      const sourceTable = new storage.SourceTable({
-        id: doc._id,
-        ref: source,
-        objectId: objectId,
-        replicaIdColumns: replicaIdColumns,
-        snapshotComplete: doc.snapshot_done ?? true,
-        ...syncRules.getMatchingSources(source)
-      });
-      sourceTable.syncEvent = syncRules.tableTriggersEvent(source);
-      sourceTable.syncData = sourceTable.bucketDataSources.length > 0;
-      sourceTable.syncParameters = sourceTable.parameterLookupSources.length > 0;
-      sourceTable.snapshotStatus =
-        doc.snapshot_status == null
-          ? undefined
-          : {
-              lastKey: doc.snapshot_status.last_key?.buffer ?? null,
-              totalEstimatedCount: doc.snapshot_status.total_estimated_count,
-              replicatedCount: doc.snapshot_status.replicated_count
-            };
-
-      let dropTables: storage.SourceTable[] = [];
-      let truncateFilter = [{ schema_name: schema, table_name: name }] as any[];
-      if (objectId != null) {
-        truncateFilter.push({ relation_id: objectId });
-      }
-      const truncate = await col
-        .find(
-          {
-            ...baseId,
-            connection_id: connection_id,
-            _id: { $ne: doc._id },
-            $or: truncateFilter
-          },
-          { session }
-        )
-        .toArray();
-      dropTables = truncate.map((doc) => {
-        const ref = {
-          connectionTag,
-          schema: doc.schema_name,
-          name: doc.table_name
-        };
-        const dropTable = new storage.SourceTable({
-          id: doc._id,
-          ref,
-          objectId: doc.relation_id,
-          replicaIdColumns:
-            doc.replica_id_columns2?.map(
-              (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
-            ) ?? [],
-          snapshotComplete: doc.snapshot_done ?? true,
-          ...syncRules.getMatchingSources(ref)
-        });
-        dropTable.syncEvent = syncRules.tableTriggersEvent(ref);
-        dropTable.syncData = dropTable.bucketDataSources.length > 0;
-        dropTable.syncParameters = dropTable.parameterLookupSources.length > 0;
-        return dropTable;
-      });
-
-      result = {
-        tables: [sourceTable],
-        dropTables: dropTables
-      };
-    });
-    if (initializeSourceRecordsFor != null) {
-      await this.initializeResolvedSourceRecords(initializeSourceRecordsFor);
-    }
-    return result!;
   }
 
   protected abstract getParameterSetsImpl(

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -300,11 +300,12 @@ export abstract class MongoSyncBucketStorage
         ref: source,
         objectId: objectId,
         replicaIdColumns: replicaIdColumns,
-        snapshotComplete: doc.snapshot_done ?? true
+        snapshotComplete: doc.snapshot_done ?? true,
+        ...syncRules.getMatchingSources(source)
       });
       sourceTable.syncEvent = syncRules.tableTriggersEvent(source);
-      sourceTable.syncData = syncRules.tableSyncsData(source);
-      sourceTable.syncParameters = syncRules.tableSyncsParameters(source);
+      sourceTable.syncData = sourceTable.bucketDataSources.length > 0;
+      sourceTable.syncParameters = sourceTable.parameterLookupSources.length > 0;
       sourceTable.snapshotStatus =
         doc.snapshot_status == null
           ? undefined
@@ -330,23 +331,28 @@ export abstract class MongoSyncBucketStorage
           { session }
         )
         .toArray();
-      dropTables = truncate.map(
-        (doc) =>
-          new storage.SourceTable({
-            id: doc._id,
-            ref: {
-              connectionTag,
-              schema: doc.schema_name,
-              name: doc.table_name
-            },
-            objectId: doc.relation_id,
-            replicaIdColumns:
-              doc.replica_id_columns2?.map(
-                (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
-              ) ?? [],
-            snapshotComplete: doc.snapshot_done ?? true
-          })
-      );
+      dropTables = truncate.map((doc) => {
+        const ref = {
+          connectionTag,
+          schema: doc.schema_name,
+          name: doc.table_name
+        };
+        const dropTable = new storage.SourceTable({
+          id: doc._id,
+          ref,
+          objectId: doc.relation_id,
+          replicaIdColumns:
+            doc.replica_id_columns2?.map(
+              (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
+            ) ?? [],
+          snapshotComplete: doc.snapshot_done ?? true,
+          ...syncRules.getMatchingSources(ref)
+        });
+        dropTable.syncEvent = syncRules.tableTriggersEvent(ref);
+        dropTable.syncData = dropTable.bucketDataSources.length > 0;
+        dropTable.syncParameters = dropTable.parameterLookupSources.length > 0;
+        return dropTable;
+      });
 
       result = {
         tables: [sourceTable],

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -215,8 +215,7 @@ export abstract class MongoSyncBucketStorage
       markRecordUnavailable: options.markRecordUnavailable,
       syncConfigId: state.syncConfigId,
       tracer: options.tracer,
-      resolveTables: (resolveOptions: storage.ResolveTablesOptions, syncRules: HydratedSyncRules) =>
-        this.resolveTables(resolveOptions, syncRules)
+      resolveTables: this.resolveTables.bind(this)
     };
     const writer = this.createWriterImpl(batchOptions);
     this.iterateListeners((cb) => cb.batchStarted?.(writer));
@@ -245,10 +244,9 @@ export abstract class MongoSyncBucketStorage
   protected abstract initializeResolvedSourceRecords(sourceTableId: bson.ObjectId): Promise<void>;
 
   async resolveTables(
-    options: storage.ResolveTablesOptions,
-    syncRules = this.getParsedSyncRules({ defaultSchema: options.source.schema })
+    options: storage.ResolveTablesOptions & { syncRules: HydratedSyncRules }
   ): Promise<storage.ResolveTablesResult> {
-    const { connection_id, source } = options;
+    const { connection_id, source, syncRules } = options;
 
     const { schema: schema, name: name, objectId, replicaIdColumns, connectionTag } = source;
 

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -208,7 +208,8 @@ export abstract class MongoSyncBucketStorage
       skipExistingRows: options.skipExistingRows ?? false,
       markRecordUnavailable: options.markRecordUnavailable,
       syncConfigId: state.syncConfigId,
-      tracer: options.tracer
+      tracer: options.tracer,
+      resolveTables: (resolveOptions: storage.ResolveTablesOptions) => this.resolveTables(resolveOptions)
     };
     const writer = this.createWriterImpl(batchOptions);
     this.iterateListeners((cb) => cb.batchStarted?.(writer));
@@ -229,13 +230,13 @@ export abstract class MongoSyncBucketStorage
 
   protected abstract augmentCreatedSourceTableDocument(
     createDoc: CommonSourceTableDocument,
-    options: storage.ResolveTableOptions,
+    options: storage.ResolveTablesOptions,
     candidateSourceTable: storage.SourceTable
   ): void;
 
   protected abstract initializeResolvedSourceRecords(sourceTableId: bson.ObjectId): Promise<void>;
 
-  async resolveTable(options: storage.ResolveTableOptions): Promise<storage.ResolveTableResult> {
+  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
     const { group_id, connection_id, connection_tag, entity_descriptor } = options;
 
     const { schema, name, objectId, replicaIdColumns } = entity_descriptor;
@@ -245,7 +246,7 @@ export abstract class MongoSyncBucketStorage
       type: column.type,
       type_oid: column.typeId
     }));
-    let result: storage.ResolveTableResult | null = null;
+    let result: storage.ResolveTablesResult | null = null;
     let initializeSourceRecordsFor: bson.ObjectId | null = null;
 
     const baseId = this.sourceTableBaseId();
@@ -343,7 +344,7 @@ export abstract class MongoSyncBucketStorage
       );
 
       result = {
-        table: sourceTable,
+        tables: [sourceTable],
         dropTables: dropTables
       };
     });

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -21,7 +21,12 @@ import {
   utils,
   WatchWriteCheckpointOptions
 } from '@powersync/service-core';
-import { HydratedSyncRules, ParameterLookupRows, ScopedParameterLookup } from '@powersync/service-sync-rules';
+import {
+  HydratedSyncRules,
+  ParameterLookupRows,
+  ScopedParameterLookup,
+  SourceTableRef
+} from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { LRUCache } from 'lru-cache';
 import * as timers from 'timers/promises';
@@ -232,7 +237,7 @@ export abstract class MongoSyncBucketStorage
   protected abstract augmentCreatedSourceTableDocument(
     createDoc: CommonSourceTableDocument,
     options: storage.ResolveTablesOptions,
-    candidateSourceTable: storage.SourceTable,
+    ref: SourceTableRef,
     syncRules: HydratedSyncRules
   ): void;
 
@@ -240,11 +245,11 @@ export abstract class MongoSyncBucketStorage
 
   async resolveTables(
     options: storage.ResolveTablesOptions,
-    syncRules = this.getParsedSyncRules({ defaultSchema: options.entity_descriptor.schema })
+    syncRules = this.getParsedSyncRules({ defaultSchema: options.source.schema })
   ): Promise<storage.ResolveTablesResult> {
-    const { connection_id, connection_tag, entity_descriptor } = options;
+    const { connection_id, source } = options;
 
-    const { schema, name, objectId, replicaIdColumns } = entity_descriptor;
+    const { schema: schema, name: name, objectId, replicaIdColumns, connectionTag } = source;
 
     const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
       name: column.name,
@@ -271,15 +276,6 @@ export abstract class MongoSyncBucketStorage
       let doc = await col.findOne(filter, { session });
       if (doc == null) {
         const id = options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId();
-        const candidateSourceTable = new storage.SourceTable({
-          id,
-          connectionTag: connection_tag,
-          objectId: objectId,
-          schema: schema,
-          name: name,
-          replicaIdColumns: replicaIdColumns,
-          snapshotComplete: false
-        });
         const createDoc: CommonSourceTableDocument = {
           _id: id,
           ...(baseId as any),
@@ -292,7 +288,7 @@ export abstract class MongoSyncBucketStorage
           snapshot_done: false,
           snapshot_status: undefined
         };
-        this.augmentCreatedSourceTableDocument(createDoc, options, candidateSourceTable, syncRules);
+        this.augmentCreatedSourceTableDocument(createDoc, options, source, syncRules);
         doc = createDoc;
 
         await col.insertOne(doc, { session });
@@ -300,16 +296,14 @@ export abstract class MongoSyncBucketStorage
       }
       const sourceTable = new storage.SourceTable({
         id: doc._id,
-        connectionTag: connection_tag,
+        ref: source,
         objectId: objectId,
-        schema: schema,
-        name: name,
         replicaIdColumns: replicaIdColumns,
         snapshotComplete: doc.snapshot_done ?? true
       });
-      sourceTable.syncEvent = syncRules.tableTriggersEvent(sourceTable);
-      sourceTable.syncData = syncRules.tableSyncsData(sourceTable);
-      sourceTable.syncParameters = syncRules.tableSyncsParameters(sourceTable);
+      sourceTable.syncEvent = syncRules.tableTriggersEvent(source);
+      sourceTable.syncData = syncRules.tableSyncsData(source);
+      sourceTable.syncParameters = syncRules.tableSyncsParameters(source);
       sourceTable.snapshotStatus =
         doc.snapshot_status == null
           ? undefined
@@ -339,10 +333,12 @@ export abstract class MongoSyncBucketStorage
         (doc) =>
           new storage.SourceTable({
             id: doc._id,
-            connectionTag: connection_tag,
+            ref: {
+              connectionTag,
+              schema: doc.schema_name,
+              name: doc.table_name
+            },
             objectId: doc.relation_id,
-            schema: doc.schema_name,
-            name: doc.table_name,
             replicaIdColumns:
               doc.replica_id_columns2?.map((c) => ({ name: c.name, typeOid: c.type_oid, type: c.type })) ?? [],
             snapshotComplete: doc.snapshot_done ?? true

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -11,6 +11,7 @@ import {
   BroadcastIterable,
   CHECKPOINT_INVALIDATE_ALL,
   CheckpointChanges,
+  ColumnDescriptor,
   GetCheckpointChangesOptions,
   InternalOpId,
   mergeAsyncIterables,
@@ -340,7 +341,9 @@ export abstract class MongoSyncBucketStorage
             },
             objectId: doc.relation_id,
             replicaIdColumns:
-              doc.replica_id_columns2?.map((c) => ({ name: c.name, typeOid: c.type_oid, type: c.type })) ?? [],
+              doc.replica_id_columns2?.map(
+                (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
+              ) ?? [],
             snapshotComplete: doc.snapshot_done ?? true
           })
       );

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoBucketBatchV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoBucketBatchV1.ts
@@ -1,5 +1,6 @@
 import { ReplicationAssertionError } from '@powersync/lib-services-framework';
-import { SourceTable, storage } from '@powersync/service-core';
+import { ColumnDescriptor, SourceTable, storage } from '@powersync/service-core';
+import * as bson from 'bson';
 import { mongoTableId } from '../../../utils/util.js';
 import { calculateCheckpointState } from '../CheckpointState.js';
 import { MongoBucketBatch, MongoBucketBatchOptions } from '../MongoBucketBatch.js';
@@ -34,6 +35,112 @@ export class MongoBucketBatchV1 extends MongoBucketBatch {
 
   protected async cleanupDroppedSourceTables(_tables: SourceTable[]) {
     // No-op for V1: source records live in a shared collection.
+  }
+
+  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
+    const syncRules = options.syncRules ?? this.sync_rules;
+    const { connection_id, source } = options;
+    const { schema, name, objectId, replicaIdColumns, connectionTag } = source;
+
+    const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
+      name: column.name,
+      type: column.type,
+      type_oid: column.typeId
+    }));
+
+    let result: storage.ResolveTablesResult | null = null;
+    await this.db.client.withSession(async (session) => {
+      const col = this.db.commonSourceTables(this.group_id);
+      const filter: any = {
+        group_id: this.group_id,
+        connection_id,
+        schema_name: schema,
+        table_name: name,
+        replica_id_columns2: normalizedReplicaIdColumns
+      };
+      if (objectId != null) {
+        filter.relation_id = objectId;
+      }
+
+      let doc = await col.findOne(filter, { session });
+      if (doc == null) {
+        doc = {
+          _id: options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId(),
+          group_id: this.group_id,
+          connection_id,
+          relation_id: objectId,
+          schema_name: schema,
+          table_name: name,
+          replica_id_columns: null,
+          replica_id_columns2: normalizedReplicaIdColumns,
+          snapshot_done: false,
+          snapshot_status: undefined
+        };
+        await col.insertOne(doc, { session });
+      }
+
+      const sourceTable = new storage.SourceTable({
+        id: doc._id,
+        ref: source,
+        objectId,
+        replicaIdColumns,
+        snapshotComplete: doc.snapshot_done ?? true,
+        ...syncRules.getMatchingSources(source)
+      });
+      sourceTable.syncEvent = syncRules.tableTriggersEvent(source);
+      sourceTable.syncData = sourceTable.bucketDataSources.length > 0;
+      sourceTable.syncParameters = sourceTable.parameterLookupSources.length > 0;
+      sourceTable.snapshotStatus =
+        doc.snapshot_status == null
+          ? undefined
+          : {
+              lastKey: doc.snapshot_status.last_key?.buffer ?? null,
+              totalEstimatedCount: doc.snapshot_status.total_estimated_count,
+              replicatedCount: doc.snapshot_status.replicated_count
+            };
+
+      const truncateFilter = [{ schema_name: schema, table_name: name }] as any[];
+      if (objectId != null) {
+        truncateFilter.push({ relation_id: objectId });
+      }
+      const truncate = await col
+        .find(
+          {
+            group_id: this.group_id,
+            connection_id,
+            _id: { $ne: doc._id },
+            $or: truncateFilter
+          },
+          { session }
+        )
+        .toArray();
+      const dropTables = truncate.map((dropDoc) => {
+        const ref = {
+          connectionTag,
+          schema: dropDoc.schema_name,
+          name: dropDoc.table_name
+        };
+        const table = new storage.SourceTable({
+          id: dropDoc._id,
+          ref,
+          objectId: dropDoc.relation_id,
+          replicaIdColumns:
+            dropDoc.replica_id_columns2?.map(
+              (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
+            ) ?? [],
+          snapshotComplete: dropDoc.snapshot_done ?? true,
+          ...syncRules.getMatchingSources(ref)
+        });
+        table.syncEvent = syncRules.tableTriggersEvent(ref);
+        table.syncData = table.bucketDataSources.length > 0;
+        table.syncParameters = table.parameterLookupSources.length > 0;
+        return table;
+      });
+
+      result = { tables: [sourceTable], dropTables };
+    });
+
+    return result!;
   }
 
   async commit(lsn: string, options?: storage.BucketBatchCommitOptions): Promise<storage.CheckpointResult> {

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -18,6 +18,7 @@ import {
   HydratedSyncRules,
   ParameterLookupRows,
   ScopedParameterLookup,
+  SourceTableRef,
   SqliteJsonRow
 } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
@@ -192,7 +193,7 @@ export class MongoSyncBucketStorageV1 extends MongoSyncBucketStorage {
   protected augmentCreatedSourceTableDocument(
     _createDoc: CommonSourceTableDocument,
     _options: storage.ResolveTablesOptions,
-    _candidateSourceTable: storage.SourceTable,
+    _ref: SourceTableRef,
     _syncRules: HydratedSyncRules
   ): void {}
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -14,7 +14,12 @@ import {
   utils
 } from '@powersync/service-core';
 import { JSONBig } from '@powersync/service-jsonbig';
-import { ParameterLookupRows, ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
+import {
+  HydratedSyncRules,
+  ParameterLookupRows,
+  ScopedParameterLookup,
+  SqliteJsonRow
+} from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { idPrefixFilter, mapOpEntry, readSingleBatch, setSessionSnapshotTime } from '../../../utils/util.js';
 import { MongoBucketStorage } from '../../MongoBucketStorage.js';
@@ -187,7 +192,8 @@ export class MongoSyncBucketStorageV1 extends MongoSyncBucketStorage {
   protected augmentCreatedSourceTableDocument(
     _createDoc: CommonSourceTableDocument,
     _options: storage.ResolveTablesOptions,
-    _candidateSourceTable: storage.SourceTable
+    _candidateSourceTable: storage.SourceTable,
+    _syncRules: HydratedSyncRules
   ): void {}
 
   protected async initializeResolvedSourceRecords(_sourceTableId: bson.ObjectId): Promise<void> {}

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -186,7 +186,7 @@ export class MongoSyncBucketStorageV1 extends MongoSyncBucketStorage {
 
   protected augmentCreatedSourceTableDocument(
     _createDoc: CommonSourceTableDocument,
-    _options: storage.ResolveTableOptions,
+    _options: storage.ResolveTablesOptions,
     _candidateSourceTable: storage.SourceTable
   ): void {}
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -14,13 +14,7 @@ import {
   utils
 } from '@powersync/service-core';
 import { JSONBig } from '@powersync/service-jsonbig';
-import {
-  HydratedSyncRules,
-  ParameterLookupRows,
-  ScopedParameterLookup,
-  SourceTableRef,
-  SqliteJsonRow
-} from '@powersync/service-sync-rules';
+import { ParameterLookupRows, ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { idPrefixFilter, mapOpEntry, readSingleBatch, setSessionSnapshotTime } from '../../../utils/util.js';
 import { MongoBucketStorage } from '../../MongoBucketStorage.js';
@@ -28,7 +22,7 @@ import {
   MongoSyncBucketStorageCheckpoint,
   MongoSyncBucketStorageContext
 } from '../common/MongoSyncBucketStorageContext.js';
-import { CommonSourceTableDocument, SourceKey } from '../models.js';
+import { SourceKey } from '../models.js';
 import { MongoBucketBatchOptions } from '../MongoBucketBatch.js';
 import { MongoChecksums } from '../MongoChecksums.js';
 import { MongoCompactOptions, MongoCompactor } from '../MongoCompactor.js';
@@ -185,19 +179,6 @@ export class MongoSyncBucketStorageV1 extends MongoSyncBucketStorage {
   ): MongoParameterCompactor {
     return new MongoParameterCompactorV1(this.db, this.group_id, checkpoint, options);
   }
-
-  protected sourceTableBaseId(): Partial<CommonSourceTableDocument> {
-    return { group_id: this.group_id };
-  }
-
-  protected augmentCreatedSourceTableDocument(
-    _createDoc: CommonSourceTableDocument,
-    _options: storage.ResolveTablesOptions,
-    _ref: SourceTableRef,
-    _syncRules: HydratedSyncRules
-  ): void {}
-
-  protected async initializeResolvedSourceRecords(_sourceTableId: bson.ObjectId): Promise<void> {}
 
   protected override get versionContext(): MongoSyncBucketStorageContext<VersionedPowerSyncMongoV1> {
     return {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
@@ -1,6 +1,7 @@
 import * as lib_mongo from '@powersync/lib-service-mongodb';
 import { ReplicationAssertionError } from '@powersync/lib-services-framework';
-import { storage } from '@powersync/service-core';
+import { ColumnDescriptor, storage } from '@powersync/service-core';
+import { HydratedSyncRules, MatchingSources } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { mongoTableId } from '../../../utils/util.js';
 import { calculateCheckpointState } from '../CheckpointState.js';
@@ -11,7 +12,11 @@ import { SourceRecordStore } from '../common/SourceRecordStore.js';
 import { PersistedBatchV3 } from './PersistedBatchV3.js';
 import { SourceRecordStoreV3 } from './SourceRecordStoreV3.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
-import { ReplicationStreamDocumentV3 } from './models.js';
+import { ReplicationStreamDocumentV3, SourceTableDocumentV3 } from './models.js';
+
+function sameStringArray(left: string[], right: string[]) {
+  return left.length == right.length && left.every((value, index) => value == right[index]);
+}
 
 export class MongoBucketBatchV3 extends MongoBucketBatch {
   declare public readonly db: VersionedPowerSyncMongoV3;
@@ -52,6 +57,227 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
           throw error;
         });
     }
+  }
+
+  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
+    const ref = options.source;
+    const syncRules = options.syncRules ?? this.sync_rules;
+    const matchingSources = syncRules.getMatchingSources(ref);
+
+    const { connection_id, source } = options;
+    const { schema, name, objectId, replicaIdColumns, connectionTag } = source;
+    const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
+      name: column.name,
+      type: column.type,
+      type_oid: column.typeId
+    }));
+
+    let result: storage.ResolveTablesResult | null = null;
+    const initializeSourceRecordsFor: bson.ObjectId[] = [];
+
+    await this.db.client.withSession(async (session) => {
+      const col = this.db.commonSourceTables(this.group_id);
+      const exactFilter: Record<string, unknown> = {
+        connection_id,
+        schema_name: schema,
+        table_name: name,
+        replica_id_columns2: normalizedReplicaIdColumns
+      };
+      if (objectId != null) {
+        exactFilter.relation_id = objectId;
+      }
+
+      const exactDocs = (await col.find(exactFilter, { session }).toArray()) as SourceTableDocumentV3[];
+      const bucketSourceById = new Map(
+        matchingSources.bucketDataSources.map((source) => [this.mapping.bucketSourceId(source), source] as const)
+      );
+      const parameterLookupSourceById = new Map(
+        matchingSources.parameterLookupSources.map(
+          (source) => [this.mapping.parameterLookupId(source), source] as const
+        )
+      );
+      const desiredBucketIds = new Set(bucketSourceById.keys());
+      const desiredLookupIds = new Set(parameterLookupSourceById.keys());
+      const desiredHasMembership = desiredBucketIds.size > 0 || desiredLookupIds.size > 0;
+      const triggersEvent = syncRules.tableTriggersEvent(ref);
+
+      const coveredBucketIds = new Set<string>();
+      const coveredLookupIds = new Set<string>();
+      const retainedDocIds: bson.ObjectId[] = [];
+      const tables: storage.SourceTable[] = [];
+      let retainedEventOnlyTable = false;
+
+      for (const doc of exactDocs) {
+        const bucketDataSourceIds = doc.bucket_data_source_ids.filter((id) => desiredBucketIds.has(id));
+        const parameterLookupSourceIds = doc.parameter_lookup_source_ids.filter((id) => desiredLookupIds.has(id));
+        const coversDesiredMembership = bucketDataSourceIds.length > 0 || parameterLookupSourceIds.length > 0;
+        const coversEventOnlyTable = !desiredHasMembership && triggersEvent && !retainedEventOnlyTable;
+
+        for (const id of bucketDataSourceIds) {
+          coveredBucketIds.add(id);
+        }
+        for (const id of parameterLookupSourceIds) {
+          coveredLookupIds.add(id);
+        }
+
+        if (
+          !sameStringArray(doc.bucket_data_source_ids, bucketDataSourceIds) ||
+          !sameStringArray(doc.parameter_lookup_source_ids, parameterLookupSourceIds)
+        ) {
+          await col.updateOne(
+            { _id: doc._id },
+            {
+              $set: {
+                bucket_data_source_ids: bucketDataSourceIds,
+                parameter_lookup_source_ids: parameterLookupSourceIds
+              }
+            },
+            { session }
+          );
+        }
+
+        if (coversDesiredMembership || coversEventOnlyTable) {
+          if (coversEventOnlyTable) {
+            retainedEventOnlyTable = true;
+          }
+          retainedDocIds.push(doc._id);
+          tables.push(
+            this.sourceTableFromDocument(
+              {
+                ...doc,
+                bucket_data_source_ids: bucketDataSourceIds,
+                parameter_lookup_source_ids: parameterLookupSourceIds
+              },
+              connectionTag,
+              syncRules,
+              {
+                bucketDataSources: bucketDataSourceIds.map((id) => bucketSourceById.get(id)!),
+                parameterLookupSources: parameterLookupSourceIds.map((id) => parameterLookupSourceById.get(id)!)
+              }
+            )
+          );
+        }
+      }
+
+      const uncoveredBucketIds = [...desiredBucketIds].filter((id) => !coveredBucketIds.has(id));
+      const uncoveredLookupIds = [...desiredLookupIds].filter((id) => !coveredLookupIds.has(id));
+
+      if (uncoveredBucketIds.length > 0 || uncoveredLookupIds.length > 0 || (triggersEvent && tables.length == 0)) {
+        const id = options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId();
+        const sourceTable = new storage.SourceTable({
+          id,
+          ref,
+          objectId,
+          replicaIdColumns,
+          snapshotComplete: false,
+          bucketDataSources: uncoveredBucketIds.map((id) => bucketSourceById.get(id)!),
+          parameterLookupSources: uncoveredLookupIds.map((id) => parameterLookupSourceById.get(id)!)
+        });
+        sourceTable.syncData = uncoveredBucketIds.length > 0;
+        sourceTable.syncParameters = uncoveredLookupIds.length > 0;
+        sourceTable.syncEvent = triggersEvent;
+
+        const createDoc: SourceTableDocumentV3 = {
+          _id: id,
+          connection_id,
+          relation_id: objectId,
+          schema_name: schema,
+          table_name: name,
+          replica_id_columns: null,
+          replica_id_columns2: normalizedReplicaIdColumns,
+          snapshot_done: false,
+          snapshot_status: undefined,
+          bucket_data_source_ids: uncoveredBucketIds,
+          parameter_lookup_source_ids: uncoveredLookupIds
+        };
+
+        await col.insertOne(createDoc, { session });
+        initializeSourceRecordsFor.push(createDoc._id);
+        retainedDocIds.push(createDoc._id);
+        tables.push(sourceTable);
+      }
+
+      const conflictFilter = [{ schema_name: schema, table_name: name }] as Record<string, unknown>[];
+      if (objectId != null) {
+        conflictFilter.push({ relation_id: objectId });
+      }
+      const dropTables = await col
+        .find(
+          {
+            connection_id,
+            _id: { $nin: retainedDocIds },
+            $or: conflictFilter
+          },
+          { session }
+        )
+        .toArray();
+
+      result = {
+        tables,
+        dropTables: dropTables.map((doc) =>
+          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connectionTag, syncRules)
+        )
+      };
+    });
+
+    for (const sourceTableId of initializeSourceRecordsFor) {
+      await this.db.initializeSourceRecordsCollection(this.group_id, sourceTableId);
+    }
+
+    return result!;
+  }
+
+  private sourceTableFromDocument(
+    doc: SourceTableDocumentV3,
+    connectionTag: string,
+    syncRules: HydratedSyncRules,
+    memberships?: MatchingSources
+  ): storage.SourceTable {
+    const resolvedMemberships = memberships ?? this.sourceTableMembershipsFromDocument(doc, syncRules);
+    const table = new storage.SourceTable({
+      id: doc._id,
+      ref: {
+        connectionTag,
+        schema: doc.schema_name,
+        name: doc.table_name
+      },
+      objectId: doc.relation_id,
+      replicaIdColumns: doc.replica_id_columns2!.map(
+        (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
+      ),
+      snapshotComplete: doc.snapshot_done ?? true,
+      bucketDataSources: resolvedMemberships.bucketDataSources,
+      parameterLookupSources: resolvedMemberships.parameterLookupSources
+    });
+    table.syncData = table.bucketDataSources.length > 0;
+    table.syncParameters = table.parameterLookupSources.length > 0;
+    table.syncEvent = syncRules.tableTriggersEvent(table.ref);
+    table.snapshotStatus =
+      doc.snapshot_status == null
+        ? undefined
+        : {
+            lastKey: doc.snapshot_status.last_key?.buffer ?? null,
+            totalEstimatedCount: doc.snapshot_status.total_estimated_count,
+            replicatedCount: doc.snapshot_status.replicated_count
+          };
+    return table;
+  }
+
+  private sourceTableMembershipsFromDocument(
+    doc: SourceTableDocumentV3,
+    syncRules: HydratedSyncRules
+  ): MatchingSources {
+    const bucketDataSourceIds = new Set(doc.bucket_data_source_ids);
+    const parameterLookupSourceIds = new Set(doc.parameter_lookup_source_ids);
+
+    return {
+      bucketDataSources: syncRules.definition.bucketDataSources.filter((source) =>
+        bucketDataSourceIds.has(this.mapping.bucketSourceId(source))
+      ),
+      parameterLookupSources: syncRules.definition.bucketParameterLookupSources.filter((source) =>
+        parameterLookupSourceIds.has(this.mapping.parameterLookupId(source))
+      )
+    };
   }
 
   async commit(lsn: string, options?: storage.BucketBatchCommitOptions): Promise<storage.CheckpointResult> {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -3,6 +3,7 @@ import { mongo } from '@powersync/lib-service-mongodb';
 import { ServiceAssertionError } from '@powersync/lib-services-framework';
 import {
   CheckpointChanges,
+  ColumnDescriptor,
   GetCheckpointChangesOptions,
   InternalOpId,
   internalToExternalOpId,
@@ -426,8 +427,9 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       },
       objectId: doc.relation_id,
       replicaIdColumns:
-        doc.replica_id_columns2?.map((c) => ({ name: c.name, typeOid: c.type_oid, type: c.type })) ??
-        fallbackReplicaIdColumns,
+        doc.replica_id_columns2?.map(
+          (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
+        ) ?? fallbackReplicaIdColumns,
       snapshotComplete: doc.snapshot_done ?? true,
       bucketDataSources: memberships?.bucketDataSources ?? [],
       parameterLookupSources: memberships?.parameterLookupSources ?? []

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -54,6 +54,10 @@ import { MongoParameterCompactorV3 } from './MongoParameterCompactorV3.js';
 import { deserializeParameterLookupV3, serializeParameterLookupV3 } from './MongoParameterLookupV3.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
 
+function sameStringArray(left: string[], right: string[]) {
+  return left.length == right.length && left.every((value, index) => value == right[index]);
+}
+
 export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
   // Declare types to be more specific
   declare readonly db: VersionedPowerSyncMongoV3;
@@ -268,10 +272,10 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
   }
 
   async resolveTables(
-    options: storage.ResolveTablesOptions,
-    syncRules = this.getParsedSyncRules({ defaultSchema: options.source.schema })
+    options: storage.ResolveTablesOptions & { syncRules: HydratedSyncRules }
   ): Promise<storage.ResolveTablesResult> {
     const ref = options.source;
+    const syncRules = options.syncRules;
     const matchingSources = syncRules.getMatchingSources(ref);
 
     const { connection_id, source } = options;
@@ -309,19 +313,19 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       const desiredBucketIds = new Set(bucketSourceById.keys());
       const desiredLookupIds = new Set(parameterLookupSourceById.keys());
       const desiredHasMembership = desiredBucketIds.size > 0 || desiredLookupIds.size > 0;
+      const triggersEvent = syncRules.tableTriggersEvent(ref);
 
       const coveredBucketIds = new Set<string>();
       const coveredLookupIds = new Set<string>();
+      const retainedDocIds: bson.ObjectId[] = [];
       const tables: storage.SourceTable[] = [];
+      let retainedEventOnlyTable = false;
 
       for (const doc of exactDocs) {
         const bucketDataSourceIds = doc.bucket_data_source_ids.filter((id) => desiredBucketIds.has(id));
         const parameterLookupSourceIds = doc.parameter_lookup_source_ids.filter((id) => desiredLookupIds.has(id));
-        const coversDesiredMembership = bucketDataSourceIds.length > 0 || parameterLookupSourceIds.length > 0;
-        const coversEventOnlyTable =
-          !desiredHasMembership &&
-          doc.bucket_data_source_ids.length == 0 &&
-          doc.parameter_lookup_source_ids.length == 0;
+        const coversDesiredMembership: boolean = bucketDataSourceIds.length > 0 || parameterLookupSourceIds.length > 0;
+        const coversEventOnlyTable: boolean = !desiredHasMembership && triggersEvent && !retainedEventOnlyTable;
 
         for (const id of bucketDataSourceIds) {
           coveredBucketIds.add(id);
@@ -330,12 +334,41 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
           coveredLookupIds.add(id);
         }
 
+        if (
+          !sameStringArray(doc.bucket_data_source_ids, bucketDataSourceIds) ||
+          !sameStringArray(doc.parameter_lookup_source_ids, parameterLookupSourceIds)
+        ) {
+          await col.updateOne(
+            { _id: doc._id },
+            {
+              $set: {
+                bucket_data_source_ids: bucketDataSourceIds,
+                parameter_lookup_source_ids: parameterLookupSourceIds
+              }
+            },
+            { session }
+          );
+        }
+
         if (coversDesiredMembership || coversEventOnlyTable) {
+          if (coversEventOnlyTable) {
+            retainedEventOnlyTable = true;
+          }
+          retainedDocIds.push(doc._id);
           tables.push(
-            this.sourceTableFromDocument(doc, connectionTag, syncRules, {
-              bucketDataSources: bucketDataSourceIds.map((id) => bucketSourceById.get(id)!),
-              parameterLookupSources: parameterLookupSourceIds.map((id) => parameterLookupSourceById.get(id)!)
-            })
+            this.sourceTableFromDocument(
+              {
+                ...doc,
+                bucket_data_source_ids: bucketDataSourceIds,
+                parameter_lookup_source_ids: parameterLookupSourceIds
+              },
+              connectionTag,
+              syncRules,
+              {
+                bucketDataSources: bucketDataSourceIds.map((id) => bucketSourceById.get(id)!),
+                parameterLookupSources: parameterLookupSourceIds.map((id) => parameterLookupSourceById.get(id)!)
+              }
+            )
           );
         }
       }
@@ -343,7 +376,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       const uncoveredBucketIds = [...desiredBucketIds].filter((id) => !coveredBucketIds.has(id));
       const uncoveredLookupIds = [...desiredLookupIds].filter((id) => !coveredLookupIds.has(id));
 
-      if (uncoveredBucketIds.length > 0 || uncoveredLookupIds.length > 0 || tables.length == 0) {
+      if (uncoveredBucketIds.length > 0 || uncoveredLookupIds.length > 0 || (triggersEvent && tables.length == 0)) {
         const id = options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId();
         const sourceTable = new storage.SourceTable({
           id,
@@ -356,7 +389,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         });
         sourceTable.syncData = uncoveredBucketIds.length > 0;
         sourceTable.syncParameters = uncoveredLookupIds.length > 0;
-        sourceTable.syncEvent = syncRules.tableTriggersEvent(ref);
+        sourceTable.syncEvent = triggersEvent;
 
         const createDoc: SourceTableDocumentV3 = {
           _id: id,
@@ -374,10 +407,11 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 
         await col.insertOne(createDoc, { session });
         initializeSourceRecordsFor.push(createDoc._id);
+        retainedDocIds.push(createDoc._id);
         tables.push(sourceTable);
       }
 
-      const validIds = [...exactDocs.map((doc) => doc._id), ...initializeSourceRecordsFor];
+      const validIds = retainedDocIds;
       const conflictFilter = [{ schema_name: schema, table_name: name }] as mongo.Document[];
       if (objectId != null) {
         conflictFilter.push({ relation_id: objectId });

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -273,9 +273,6 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
   ): Promise<storage.ResolveTablesResult> {
     const ref = options.source;
     const matchingSources = syncRules.getMatchingSources(ref);
-    if (matchingSources.bucketDataSources.length == 0 && matchingSources.parameterLookupSources.length == 0) {
-      return super.resolveTables(options, syncRules);
-    }
 
     const { connection_id, source } = options;
     const { schema: schema, name: name, objectId, replicaIdColumns, connectionTag } = source;
@@ -335,7 +332,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 
         if (coversDesiredMembership || coversEventOnlyTable) {
           tables.push(
-            this.sourceTableFromDocument(doc, connectionTag, replicaIdColumns, syncRules, {
+            this.sourceTableFromDocument(doc, connectionTag, syncRules, {
               bucketDataSources: bucketDataSourceIds.map((id) => bucketSourceById.get(id)!),
               parameterLookupSources: parameterLookupSourceIds.map((id) => parameterLookupSourceById.get(id)!)
             })
@@ -399,7 +396,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       result = {
         tables,
         dropTables: dropTables.map((doc) =>
-          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connectionTag, [], syncRules)
+          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connectionTag, syncRules)
         )
       };
     });
@@ -414,10 +411,10 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
   private sourceTableFromDocument(
     doc: SourceTableDocumentV3,
     connectionTag: string,
-    fallbackReplicaIdColumns: storage.ColumnDescriptor[],
     syncRules: HydratedSyncRules,
     memberships?: MatchingSources
   ): storage.SourceTable {
+    const resolvedMemberships = memberships ?? this.sourceTableMembershipsFromDocument(doc, syncRules);
     const table = new storage.SourceTable({
       id: doc._id,
       ref: {
@@ -426,13 +423,12 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         name: doc.table_name
       },
       objectId: doc.relation_id,
-      replicaIdColumns:
-        doc.replica_id_columns2?.map(
-          (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
-        ) ?? fallbackReplicaIdColumns,
+      replicaIdColumns: doc.replica_id_columns2!.map(
+        (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
+      ),
       snapshotComplete: doc.snapshot_done ?? true,
-      bucketDataSources: memberships?.bucketDataSources ?? [],
-      parameterLookupSources: memberships?.parameterLookupSources ?? []
+      bucketDataSources: resolvedMemberships.bucketDataSources,
+      parameterLookupSources: resolvedMemberships.parameterLookupSources
     });
     table.syncData = table.bucketDataSources?.length != null && table.bucketDataSources.length > 0;
     table.syncParameters = table.parameterLookupSources?.length != null && table.parameterLookupSources.length > 0;
@@ -446,6 +442,24 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
             replicatedCount: doc.snapshot_status.replicated_count
           };
     return table;
+  }
+
+  private sourceTableMembershipsFromDocument(
+    doc: SourceTableDocumentV3,
+    syncRules: HydratedSyncRules
+  ): MatchingSources {
+    const bucketDataSourceIds = new Set(doc.bucket_data_source_ids);
+    const parameterLookupSourceIds = new Set(doc.parameter_lookup_source_ids);
+
+    // TODO: Should we rather do a looking by id from mapping directly?
+    return {
+      bucketDataSources: syncRules.definition.bucketDataSources.filter((source) =>
+        bucketDataSourceIds.has(this.mapping.bucketSourceId(source))
+      ),
+      parameterLookupSources: syncRules.definition.bucketParameterLookupSources.filter((source) =>
+        parameterLookupSourceIds.has(this.mapping.parameterLookupId(source))
+      )
+    };
   }
 
   protected augmentCreatedSourceTableDocument(

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -13,7 +13,12 @@ import {
   utils
 } from '@powersync/service-core';
 import { JSONBig } from '@powersync/service-jsonbig';
-import { ParameterLookupRows, ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
+import {
+  MatchingSources,
+  ParameterLookupRows,
+  ScopedParameterLookup,
+  SqliteJsonRow
+} from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { mapOpEntry, readSingleBatch, setSessionSnapshotTime } from '../../../utils/util.js';
 import { MongoBucketStorage } from '../../MongoBucketStorage.js';
@@ -36,6 +41,7 @@ import {
   BucketParameterDocumentV3,
   loadBucketDataDocumentV3,
   ReplicationStreamDocumentV3,
+  SourceTableDocumentV3,
   SyncRuleConfigStateV3
 } from './models.js';
 import { MongoBucketBatchV3 } from './MongoBucketBatchV3.js';
@@ -258,9 +264,183 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     return {};
   }
 
+  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
+    if (options.matchingSources == null) {
+      return super.resolveTables(options);
+    }
+
+    const { group_id, connection_id, connection_tag, entity_descriptor, matchingSources } = options;
+    const { schema, name, objectId, replicaIdColumns } = entity_descriptor;
+    const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
+      name: column.name,
+      type: column.type,
+      type_oid: column.typeId
+    }));
+
+    let result: storage.ResolveTablesResult | null = null;
+    const initializeSourceRecordsFor: bson.ObjectId[] = [];
+
+    await this.db.client.withSession(async (session) => {
+      const col = this.db.commonSourceTables(group_id);
+      const exactFilter: mongo.Filter<CommonSourceTableDocument> = {
+        connection_id,
+        schema_name: schema,
+        table_name: name,
+        replica_id_columns2: normalizedReplicaIdColumns
+      };
+      if (objectId != null) {
+        exactFilter.relation_id = objectId;
+      }
+
+      const exactDocs = (await col.find(exactFilter, { session }).toArray()) as SourceTableDocumentV3[];
+      const bucketSourceById = new Map(
+        matchingSources.bucketDataSources.map((source) => [this.mapping.bucketSourceId(source), source] as const)
+      );
+      const parameterLookupSourceById = new Map(
+        matchingSources.parameterLookupSources.map(
+          (source) => [this.mapping.parameterLookupId(source), source] as const
+        )
+      );
+      const desiredBucketIds = new Set(bucketSourceById.keys());
+      const desiredLookupIds = new Set(parameterLookupSourceById.keys());
+      const desiredHasMembership = desiredBucketIds.size > 0 || desiredLookupIds.size > 0;
+
+      const coveredBucketIds = new Set<string>();
+      const coveredLookupIds = new Set<string>();
+      const tables: storage.SourceTable[] = [];
+
+      for (const doc of exactDocs) {
+        const bucketDataSourceIds = doc.bucket_data_source_ids.filter((id) => desiredBucketIds.has(id));
+        const parameterLookupSourceIds = doc.parameter_lookup_source_ids.filter((id) => desiredLookupIds.has(id));
+        const coversDesiredMembership = bucketDataSourceIds.length > 0 || parameterLookupSourceIds.length > 0;
+        const coversEventOnlyTable =
+          !desiredHasMembership &&
+          doc.bucket_data_source_ids.length == 0 &&
+          doc.parameter_lookup_source_ids.length == 0;
+
+        for (const id of bucketDataSourceIds) {
+          coveredBucketIds.add(id);
+        }
+        for (const id of parameterLookupSourceIds) {
+          coveredLookupIds.add(id);
+        }
+
+        if (coversDesiredMembership || coversEventOnlyTable) {
+          tables.push(
+            this.sourceTableFromDocument(doc, connection_tag, replicaIdColumns, options, {
+              bucketDataSources: bucketDataSourceIds.map((id) => bucketSourceById.get(id)!),
+              parameterLookupSources: parameterLookupSourceIds.map((id) => parameterLookupSourceById.get(id)!)
+            })
+          );
+        }
+      }
+
+      const uncoveredBucketIds = [...desiredBucketIds].filter((id) => !coveredBucketIds.has(id));
+      const uncoveredLookupIds = [...desiredLookupIds].filter((id) => !coveredLookupIds.has(id));
+
+      if (uncoveredBucketIds.length > 0 || uncoveredLookupIds.length > 0 || tables.length == 0) {
+        const sourceTable = new storage.SourceTable({
+          id: new bson.ObjectId(),
+          connectionTag: connection_tag,
+          objectId,
+          schema,
+          name,
+          replicaIdColumns,
+          snapshotComplete: false,
+          bucketDataSources: uncoveredBucketIds.map((id) => bucketSourceById.get(id)!),
+          parameterLookupSources: uncoveredLookupIds.map((id) => parameterLookupSourceById.get(id)!)
+        });
+        sourceTable.syncData = uncoveredBucketIds.length > 0;
+        sourceTable.syncParameters = uncoveredLookupIds.length > 0;
+        sourceTable.syncEvent = options.sync_rules.tableTriggersEvent(sourceTable);
+
+        const createDoc: SourceTableDocumentV3 = {
+          _id: sourceTable.id as bson.ObjectId,
+          connection_id,
+          relation_id: objectId,
+          schema_name: schema,
+          table_name: name,
+          replica_id_columns: null,
+          replica_id_columns2: normalizedReplicaIdColumns,
+          snapshot_done: false,
+          snapshot_status: undefined,
+          bucket_data_source_ids: uncoveredBucketIds,
+          parameter_lookup_source_ids: uncoveredLookupIds
+        };
+
+        await col.insertOne(createDoc, { session });
+        initializeSourceRecordsFor.push(createDoc._id);
+        tables.push(sourceTable);
+      }
+
+      const validIds = [...exactDocs.map((doc) => doc._id), ...initializeSourceRecordsFor];
+      const conflictFilter = [{ schema_name: schema, table_name: name }] as mongo.Document[];
+      if (objectId != null) {
+        conflictFilter.push({ relation_id: objectId });
+      }
+      const dropTables = await col
+        .find(
+          {
+            connection_id,
+            _id: { $nin: validIds },
+            $or: conflictFilter
+          },
+          { session }
+        )
+        .toArray();
+
+      result = {
+        tables,
+        dropTables: dropTables.map((doc) =>
+          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connection_tag, [], options)
+        )
+      };
+    });
+
+    for (const sourceTableId of initializeSourceRecordsFor) {
+      await this.initializeResolvedSourceRecords(sourceTableId);
+    }
+
+    return result!;
+  }
+
+  private sourceTableFromDocument(
+    doc: SourceTableDocumentV3,
+    connectionTag: string,
+    fallbackReplicaIdColumns: storage.ColumnDescriptor[],
+    options: storage.ResolveTablesOptions,
+    memberships?: MatchingSources
+  ): storage.SourceTable {
+    const table = new storage.SourceTable({
+      id: doc._id,
+      connectionTag,
+      objectId: doc.relation_id,
+      schema: doc.schema_name,
+      name: doc.table_name,
+      replicaIdColumns:
+        doc.replica_id_columns2?.map((c) => ({ name: c.name, typeOid: c.type_oid, type: c.type })) ??
+        fallbackReplicaIdColumns,
+      snapshotComplete: doc.snapshot_done ?? true,
+      bucketDataSources: memberships?.bucketDataSources ?? [],
+      parameterLookupSources: memberships?.parameterLookupSources ?? []
+    });
+    table.syncData = table.bucketDataSources?.length != null && table.bucketDataSources.length > 0;
+    table.syncParameters = table.parameterLookupSources?.length != null && table.parameterLookupSources.length > 0;
+    table.syncEvent = options.sync_rules.tableTriggersEvent(table);
+    table.snapshotStatus =
+      doc.snapshot_status == null
+        ? undefined
+        : {
+            lastKey: doc.snapshot_status.last_key?.buffer ?? null,
+            totalEstimatedCount: doc.snapshot_status.total_estimated_count,
+            replicatedCount: doc.snapshot_status.replicated_count
+          };
+    return table;
+  }
+
   protected augmentCreatedSourceTableDocument(
     createDoc: CommonSourceTableDocument,
-    options: storage.ResolveTableOptions,
+    options: storage.ResolveTablesOptions,
     candidateSourceTable: storage.SourceTable
   ): void {
     const bucketDataSourceIds = options.sync_rules.definition.bucketDataSources

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -3,7 +3,6 @@ import { mongo } from '@powersync/lib-service-mongodb';
 import { ServiceAssertionError } from '@powersync/lib-services-framework';
 import {
   CheckpointChanges,
-  ColumnDescriptor,
   GetCheckpointChangesOptions,
   InternalOpId,
   internalToExternalOpId,
@@ -14,14 +13,7 @@ import {
   utils
 } from '@powersync/service-core';
 import { JSONBig } from '@powersync/service-jsonbig';
-import {
-  HydratedSyncRules,
-  MatchingSources,
-  ParameterLookupRows,
-  ScopedParameterLookup,
-  SourceTableRef,
-  SqliteJsonRow
-} from '@powersync/service-sync-rules';
+import { ParameterLookupRows, ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { mapOpEntry, readSingleBatch, setSessionSnapshotTime } from '../../../utils/util.js';
 import { MongoBucketStorage } from '../../MongoBucketStorage.js';
@@ -29,7 +21,6 @@ import {
   MongoSyncBucketStorageCheckpoint,
   MongoSyncBucketStorageContext
 } from '../common/MongoSyncBucketStorageContext.js';
-import { CommonSourceTableDocument } from '../models.js';
 import { MongoBucketBatchOptions } from '../MongoBucketBatch.js';
 import { MongoChecksums } from '../MongoChecksums.js';
 import { MongoCompactOptions, MongoCompactor } from '../MongoCompactor.js';
@@ -44,7 +35,6 @@ import {
   BucketParameterDocumentV3,
   loadBucketDataDocumentV3,
   ReplicationStreamDocumentV3,
-  SourceTableDocumentV3,
   SyncRuleConfigStateV3
 } from './models.js';
 import { MongoBucketBatchV3 } from './MongoBucketBatchV3.js';
@@ -53,10 +43,6 @@ import { MongoCompactorV3 } from './MongoCompactorV3.js';
 import { MongoParameterCompactorV3 } from './MongoParameterCompactorV3.js';
 import { deserializeParameterLookupV3, serializeParameterLookupV3 } from './MongoParameterLookupV3.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
-
-function sameStringArray(left: string[], right: string[]) {
-  return left.length == right.length && left.every((value, index) => value == right[index]);
-}
 
 export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
   // Declare types to be more specific
@@ -265,258 +251,6 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         arrayFilters: this.syncConfigArrayFilters()
       }
     );
-  }
-
-  protected sourceTableBaseId(): Partial<CommonSourceTableDocument> {
-    return {};
-  }
-
-  async resolveTables(
-    options: storage.ResolveTablesOptions & { syncRules: HydratedSyncRules }
-  ): Promise<storage.ResolveTablesResult> {
-    const ref = options.source;
-    const syncRules = options.syncRules;
-    const matchingSources = syncRules.getMatchingSources(ref);
-
-    const { connection_id, source } = options;
-    const { schema: schema, name: name, objectId, replicaIdColumns, connectionTag } = source;
-    const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
-      name: column.name,
-      type: column.type,
-      type_oid: column.typeId
-    }));
-
-    let result: storage.ResolveTablesResult | null = null;
-    const initializeSourceRecordsFor: bson.ObjectId[] = [];
-
-    await this.db.client.withSession(async (session) => {
-      const col = this.db.commonSourceTables(this.group_id);
-      const exactFilter: mongo.Filter<CommonSourceTableDocument> = {
-        connection_id,
-        schema_name: schema,
-        table_name: name,
-        replica_id_columns2: normalizedReplicaIdColumns
-      };
-      if (objectId != null) {
-        exactFilter.relation_id = objectId;
-      }
-
-      const exactDocs = (await col.find(exactFilter, { session }).toArray()) as SourceTableDocumentV3[];
-      const bucketSourceById = new Map(
-        matchingSources.bucketDataSources.map((source) => [this.mapping.bucketSourceId(source), source] as const)
-      );
-      const parameterLookupSourceById = new Map(
-        matchingSources.parameterLookupSources.map(
-          (source) => [this.mapping.parameterLookupId(source), source] as const
-        )
-      );
-      const desiredBucketIds = new Set(bucketSourceById.keys());
-      const desiredLookupIds = new Set(parameterLookupSourceById.keys());
-      const desiredHasMembership = desiredBucketIds.size > 0 || desiredLookupIds.size > 0;
-      const triggersEvent = syncRules.tableTriggersEvent(ref);
-
-      const coveredBucketIds = new Set<string>();
-      const coveredLookupIds = new Set<string>();
-      const retainedDocIds: bson.ObjectId[] = [];
-      const tables: storage.SourceTable[] = [];
-      let retainedEventOnlyTable = false;
-
-      for (const doc of exactDocs) {
-        const bucketDataSourceIds = doc.bucket_data_source_ids.filter((id) => desiredBucketIds.has(id));
-        const parameterLookupSourceIds = doc.parameter_lookup_source_ids.filter((id) => desiredLookupIds.has(id));
-        const coversDesiredMembership: boolean = bucketDataSourceIds.length > 0 || parameterLookupSourceIds.length > 0;
-        const coversEventOnlyTable: boolean = !desiredHasMembership && triggersEvent && !retainedEventOnlyTable;
-
-        for (const id of bucketDataSourceIds) {
-          coveredBucketIds.add(id);
-        }
-        for (const id of parameterLookupSourceIds) {
-          coveredLookupIds.add(id);
-        }
-
-        if (
-          !sameStringArray(doc.bucket_data_source_ids, bucketDataSourceIds) ||
-          !sameStringArray(doc.parameter_lookup_source_ids, parameterLookupSourceIds)
-        ) {
-          await col.updateOne(
-            { _id: doc._id },
-            {
-              $set: {
-                bucket_data_source_ids: bucketDataSourceIds,
-                parameter_lookup_source_ids: parameterLookupSourceIds
-              }
-            },
-            { session }
-          );
-        }
-
-        if (coversDesiredMembership || coversEventOnlyTable) {
-          if (coversEventOnlyTable) {
-            retainedEventOnlyTable = true;
-          }
-          retainedDocIds.push(doc._id);
-          tables.push(
-            this.sourceTableFromDocument(
-              {
-                ...doc,
-                bucket_data_source_ids: bucketDataSourceIds,
-                parameter_lookup_source_ids: parameterLookupSourceIds
-              },
-              connectionTag,
-              syncRules,
-              {
-                bucketDataSources: bucketDataSourceIds.map((id) => bucketSourceById.get(id)!),
-                parameterLookupSources: parameterLookupSourceIds.map((id) => parameterLookupSourceById.get(id)!)
-              }
-            )
-          );
-        }
-      }
-
-      const uncoveredBucketIds = [...desiredBucketIds].filter((id) => !coveredBucketIds.has(id));
-      const uncoveredLookupIds = [...desiredLookupIds].filter((id) => !coveredLookupIds.has(id));
-
-      if (uncoveredBucketIds.length > 0 || uncoveredLookupIds.length > 0 || (triggersEvent && tables.length == 0)) {
-        const id = options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId();
-        const sourceTable = new storage.SourceTable({
-          id,
-          ref,
-          objectId,
-          replicaIdColumns,
-          snapshotComplete: false,
-          bucketDataSources: uncoveredBucketIds.map((id) => bucketSourceById.get(id)!),
-          parameterLookupSources: uncoveredLookupIds.map((id) => parameterLookupSourceById.get(id)!)
-        });
-        sourceTable.syncData = uncoveredBucketIds.length > 0;
-        sourceTable.syncParameters = uncoveredLookupIds.length > 0;
-        sourceTable.syncEvent = triggersEvent;
-
-        const createDoc: SourceTableDocumentV3 = {
-          _id: id,
-          connection_id,
-          relation_id: objectId,
-          schema_name: schema,
-          table_name: name,
-          replica_id_columns: null,
-          replica_id_columns2: normalizedReplicaIdColumns,
-          snapshot_done: false,
-          snapshot_status: undefined,
-          bucket_data_source_ids: uncoveredBucketIds,
-          parameter_lookup_source_ids: uncoveredLookupIds
-        };
-
-        await col.insertOne(createDoc, { session });
-        initializeSourceRecordsFor.push(createDoc._id);
-        retainedDocIds.push(createDoc._id);
-        tables.push(sourceTable);
-      }
-
-      const validIds = retainedDocIds;
-      const conflictFilter = [{ schema_name: schema, table_name: name }] as mongo.Document[];
-      if (objectId != null) {
-        conflictFilter.push({ relation_id: objectId });
-      }
-      const dropTables = await col
-        .find(
-          {
-            connection_id,
-            _id: { $nin: validIds },
-            $or: conflictFilter
-          },
-          { session }
-        )
-        .toArray();
-
-      result = {
-        tables,
-        dropTables: dropTables.map((doc) =>
-          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connectionTag, syncRules)
-        )
-      };
-    });
-
-    for (const sourceTableId of initializeSourceRecordsFor) {
-      await this.initializeResolvedSourceRecords(sourceTableId);
-    }
-
-    return result!;
-  }
-
-  private sourceTableFromDocument(
-    doc: SourceTableDocumentV3,
-    connectionTag: string,
-    syncRules: HydratedSyncRules,
-    memberships?: MatchingSources
-  ): storage.SourceTable {
-    const resolvedMemberships = memberships ?? this.sourceTableMembershipsFromDocument(doc, syncRules);
-    const table = new storage.SourceTable({
-      id: doc._id,
-      ref: {
-        connectionTag,
-        schema: doc.schema_name,
-        name: doc.table_name
-      },
-      objectId: doc.relation_id,
-      replicaIdColumns: doc.replica_id_columns2!.map(
-        (c) => ({ name: c.name, typeId: c.type_oid, type: c.type }) satisfies ColumnDescriptor
-      ),
-      snapshotComplete: doc.snapshot_done ?? true,
-      bucketDataSources: resolvedMemberships.bucketDataSources,
-      parameterLookupSources: resolvedMemberships.parameterLookupSources
-    });
-    table.syncData = table.bucketDataSources?.length != null && table.bucketDataSources.length > 0;
-    table.syncParameters = table.parameterLookupSources?.length != null && table.parameterLookupSources.length > 0;
-    table.syncEvent = syncRules.tableTriggersEvent(table.ref);
-    table.snapshotStatus =
-      doc.snapshot_status == null
-        ? undefined
-        : {
-            lastKey: doc.snapshot_status.last_key?.buffer ?? null,
-            totalEstimatedCount: doc.snapshot_status.total_estimated_count,
-            replicatedCount: doc.snapshot_status.replicated_count
-          };
-    return table;
-  }
-
-  private sourceTableMembershipsFromDocument(
-    doc: SourceTableDocumentV3,
-    syncRules: HydratedSyncRules
-  ): MatchingSources {
-    const bucketDataSourceIds = new Set(doc.bucket_data_source_ids);
-    const parameterLookupSourceIds = new Set(doc.parameter_lookup_source_ids);
-
-    // TODO: Should we rather do a looking by id from mapping directly?
-    return {
-      bucketDataSources: syncRules.definition.bucketDataSources.filter((source) =>
-        bucketDataSourceIds.has(this.mapping.bucketSourceId(source))
-      ),
-      parameterLookupSources: syncRules.definition.bucketParameterLookupSources.filter((source) =>
-        parameterLookupSourceIds.has(this.mapping.parameterLookupId(source))
-      )
-    };
-  }
-
-  protected augmentCreatedSourceTableDocument(
-    createDoc: CommonSourceTableDocument,
-    _options: storage.ResolveTablesOptions,
-    ref: SourceTableRef,
-    syncRules: HydratedSyncRules
-  ): void {
-    const bucketDataSourceIds = syncRules.definition.bucketDataSources
-      .filter((source) => source.tableSyncsData(ref))
-      .map((source) => this.mapping.bucketSourceId(source));
-    const parameterLookupSourceIds = syncRules.definition.bucketParameterLookupSources
-      .filter((source) => source.tableSyncsParameters(ref))
-      .map((source) => this.mapping.parameterLookupId(source));
-
-    Object.assign(createDoc, {
-      bucket_data_source_ids: bucketDataSourceIds,
-      parameter_lookup_source_ids: parameterLookupSourceIds
-    });
-  }
-
-  protected async initializeResolvedSourceRecords(sourceTableId: bson.ObjectId): Promise<void> {
-    await this.db.initializeSourceRecordsCollection(this.group_id, sourceTableId);
   }
 
   protected override get versionContext(): MongoSyncBucketStorageContext<VersionedPowerSyncMongoV3> {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -18,6 +18,7 @@ import {
   MatchingSources,
   ParameterLookupRows,
   ScopedParameterLookup,
+  SourceTableRef,
   SqliteJsonRow
 } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
@@ -267,14 +268,16 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 
   async resolveTables(
     options: storage.ResolveTablesOptions,
-    syncRules = this.getParsedSyncRules({ defaultSchema: options.entity_descriptor.schema })
+    syncRules = this.getParsedSyncRules({ defaultSchema: options.source.schema })
   ): Promise<storage.ResolveTablesResult> {
-    if (options.matchingSources == null) {
+    const ref = options.source;
+    const matchingSources = syncRules.getMatchingSources(ref);
+    if (matchingSources.bucketDataSources.length == 0 && matchingSources.parameterLookupSources.length == 0) {
       return super.resolveTables(options, syncRules);
     }
 
-    const { connection_id, connection_tag, entity_descriptor, matchingSources } = options;
-    const { schema, name, objectId, replicaIdColumns } = entity_descriptor;
+    const { connection_id, source } = options;
+    const { schema: schema, name: name, objectId, replicaIdColumns, connectionTag } = source;
     const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
       name: column.name,
       type: column.type,
@@ -331,7 +334,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 
         if (coversDesiredMembership || coversEventOnlyTable) {
           tables.push(
-            this.sourceTableFromDocument(doc, connection_tag, replicaIdColumns, syncRules, {
+            this.sourceTableFromDocument(doc, connectionTag, replicaIdColumns, syncRules, {
               bucketDataSources: bucketDataSourceIds.map((id) => bucketSourceById.get(id)!),
               parameterLookupSources: parameterLookupSourceIds.map((id) => parameterLookupSourceById.get(id)!)
             })
@@ -346,10 +349,8 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         const id = options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId();
         const sourceTable = new storage.SourceTable({
           id,
-          connectionTag: connection_tag,
+          ref,
           objectId,
-          schema,
-          name,
           replicaIdColumns,
           snapshotComplete: false,
           bucketDataSources: uncoveredBucketIds.map((id) => bucketSourceById.get(id)!),
@@ -357,7 +358,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         });
         sourceTable.syncData = uncoveredBucketIds.length > 0;
         sourceTable.syncParameters = uncoveredLookupIds.length > 0;
-        sourceTable.syncEvent = syncRules.tableTriggersEvent(sourceTable);
+        sourceTable.syncEvent = syncRules.tableTriggersEvent(ref);
 
         const createDoc: SourceTableDocumentV3 = {
           _id: id,
@@ -397,7 +398,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       result = {
         tables,
         dropTables: dropTables.map((doc) =>
-          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connection_tag, [], syncRules)
+          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connectionTag, [], syncRules)
         )
       };
     });
@@ -418,10 +419,12 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
   ): storage.SourceTable {
     const table = new storage.SourceTable({
       id: doc._id,
-      connectionTag,
+      ref: {
+        connectionTag,
+        schema: doc.schema_name,
+        name: doc.table_name
+      },
       objectId: doc.relation_id,
-      schema: doc.schema_name,
-      name: doc.table_name,
       replicaIdColumns:
         doc.replica_id_columns2?.map((c) => ({ name: c.name, typeOid: c.type_oid, type: c.type })) ??
         fallbackReplicaIdColumns,
@@ -431,7 +434,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     });
     table.syncData = table.bucketDataSources?.length != null && table.bucketDataSources.length > 0;
     table.syncParameters = table.parameterLookupSources?.length != null && table.parameterLookupSources.length > 0;
-    table.syncEvent = syncRules.tableTriggersEvent(table);
+    table.syncEvent = syncRules.tableTriggersEvent(table.ref);
     table.snapshotStatus =
       doc.snapshot_status == null
         ? undefined
@@ -446,14 +449,14 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
   protected augmentCreatedSourceTableDocument(
     createDoc: CommonSourceTableDocument,
     _options: storage.ResolveTablesOptions,
-    candidateSourceTable: storage.SourceTable,
+    ref: SourceTableRef,
     syncRules: HydratedSyncRules
   ): void {
     const bucketDataSourceIds = syncRules.definition.bucketDataSources
-      .filter((source) => source.tableSyncsData(candidateSourceTable))
+      .filter((source) => source.tableSyncsData(ref))
       .map((source) => this.mapping.bucketSourceId(source));
     const parameterLookupSourceIds = syncRules.definition.bucketParameterLookupSources
-      .filter((source) => source.tableSyncsParameters(candidateSourceTable))
+      .filter((source) => source.tableSyncsParameters(ref))
       .map((source) => this.mapping.parameterLookupId(source));
 
     Object.assign(createDoc, {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -14,6 +14,7 @@ import {
 } from '@powersync/service-core';
 import { JSONBig } from '@powersync/service-jsonbig';
 import {
+  HydratedSyncRules,
   MatchingSources,
   ParameterLookupRows,
   ScopedParameterLookup,
@@ -264,12 +265,15 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     return {};
   }
 
-  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
+  async resolveTables(
+    options: storage.ResolveTablesOptions,
+    syncRules = this.getParsedSyncRules({ defaultSchema: options.entity_descriptor.schema })
+  ): Promise<storage.ResolveTablesResult> {
     if (options.matchingSources == null) {
-      return super.resolveTables(options);
+      return super.resolveTables(options, syncRules);
     }
 
-    const { group_id, connection_id, connection_tag, entity_descriptor, matchingSources } = options;
+    const { connection_id, connection_tag, entity_descriptor, matchingSources } = options;
     const { schema, name, objectId, replicaIdColumns } = entity_descriptor;
     const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
       name: column.name,
@@ -281,7 +285,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     const initializeSourceRecordsFor: bson.ObjectId[] = [];
 
     await this.db.client.withSession(async (session) => {
-      const col = this.db.commonSourceTables(group_id);
+      const col = this.db.commonSourceTables(this.group_id);
       const exactFilter: mongo.Filter<CommonSourceTableDocument> = {
         connection_id,
         schema_name: schema,
@@ -327,7 +331,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 
         if (coversDesiredMembership || coversEventOnlyTable) {
           tables.push(
-            this.sourceTableFromDocument(doc, connection_tag, replicaIdColumns, options, {
+            this.sourceTableFromDocument(doc, connection_tag, replicaIdColumns, syncRules, {
               bucketDataSources: bucketDataSourceIds.map((id) => bucketSourceById.get(id)!),
               parameterLookupSources: parameterLookupSourceIds.map((id) => parameterLookupSourceById.get(id)!)
             })
@@ -339,8 +343,9 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       const uncoveredLookupIds = [...desiredLookupIds].filter((id) => !coveredLookupIds.has(id));
 
       if (uncoveredBucketIds.length > 0 || uncoveredLookupIds.length > 0 || tables.length == 0) {
+        const id = options.idGenerator ? (options.idGenerator() as bson.ObjectId) : new bson.ObjectId();
         const sourceTable = new storage.SourceTable({
-          id: new bson.ObjectId(),
+          id,
           connectionTag: connection_tag,
           objectId,
           schema,
@@ -352,10 +357,10 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         });
         sourceTable.syncData = uncoveredBucketIds.length > 0;
         sourceTable.syncParameters = uncoveredLookupIds.length > 0;
-        sourceTable.syncEvent = options.sync_rules.tableTriggersEvent(sourceTable);
+        sourceTable.syncEvent = syncRules.tableTriggersEvent(sourceTable);
 
         const createDoc: SourceTableDocumentV3 = {
-          _id: sourceTable.id as bson.ObjectId,
+          _id: id,
           connection_id,
           relation_id: objectId,
           schema_name: schema,
@@ -392,7 +397,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       result = {
         tables,
         dropTables: dropTables.map((doc) =>
-          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connection_tag, [], options)
+          this.sourceTableFromDocument(doc as SourceTableDocumentV3, connection_tag, [], syncRules)
         )
       };
     });
@@ -408,7 +413,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     doc: SourceTableDocumentV3,
     connectionTag: string,
     fallbackReplicaIdColumns: storage.ColumnDescriptor[],
-    options: storage.ResolveTablesOptions,
+    syncRules: HydratedSyncRules,
     memberships?: MatchingSources
   ): storage.SourceTable {
     const table = new storage.SourceTable({
@@ -426,7 +431,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     });
     table.syncData = table.bucketDataSources?.length != null && table.bucketDataSources.length > 0;
     table.syncParameters = table.parameterLookupSources?.length != null && table.parameterLookupSources.length > 0;
-    table.syncEvent = options.sync_rules.tableTriggersEvent(table);
+    table.syncEvent = syncRules.tableTriggersEvent(table);
     table.snapshotStatus =
       doc.snapshot_status == null
         ? undefined
@@ -440,13 +445,14 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 
   protected augmentCreatedSourceTableDocument(
     createDoc: CommonSourceTableDocument,
-    options: storage.ResolveTablesOptions,
-    candidateSourceTable: storage.SourceTable
+    _options: storage.ResolveTablesOptions,
+    candidateSourceTable: storage.SourceTable,
+    syncRules: HydratedSyncRules
   ): void {
-    const bucketDataSourceIds = options.sync_rules.definition.bucketDataSources
+    const bucketDataSourceIds = syncRules.definition.bucketDataSources
       .filter((source) => source.tableSyncsData(candidateSourceTable))
       .map((source) => this.mapping.bucketSourceId(source));
-    const parameterLookupSourceIds = options.sync_rules.definition.bucketParameterLookupSources
+    const parameterLookupSourceIds = syncRules.definition.bucketParameterLookupSources
       .filter((source) => source.tableSyncsParameters(candidateSourceTable))
       .map((source) => this.mapping.parameterLookupId(source));
 

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -21,6 +21,36 @@ bucket_definitions:
       - SELECT id FROM test
 `;
 
+function sourceDescriptor(
+  name: string,
+  options: {
+    objectId?: string;
+    replicaIdColumns?: string[];
+  } = {}
+): storage.SourceEntityDescriptor {
+  return {
+    connectionTag: storage.SourceTable.DEFAULT_TAG,
+    objectId: options.objectId ?? name,
+    schema: 'public',
+    name,
+    replicaIdColumns: (options.replicaIdColumns ?? ['id']).map((column) => ({
+      name: column,
+      type: 'VARCHAR',
+      typeId: 25
+    }))
+  };
+}
+
+function objectIdGenerator(id: string) {
+  return () => new bson.ObjectId(id);
+}
+
+function hydratedRulesFor(syncRules: storage.PersistedSyncRulesContent, yaml: string, storageVersion: number) {
+  const parsed = updateSyncRulesFromYaml(yaml, { storageVersion }).config.parsed;
+  expect(parsed.errors).toEqual([]);
+  return parsed.config.hydrate({ hydrationState: syncRules.parsed(test_utils.PARSE_OPTIONS).hydrationState });
+}
+
 function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, storageVersion: number) {
   register.registerSyncTests(storageConfig.factory, {
     storageVersion,
@@ -165,6 +195,300 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
             .aggregate([{ $group: { _id: { $type: '$checksum' }, count: { $sum: 1 } } }])
             .toArray();
     expect(checksumTypes).toEqual([{ _id: 'long', count: 4 }]);
+  });
+
+  test('resolveTables populates matching data and parameter sources', async () => {
+    await using factory = await storageConfig.factory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+    bucket_definitions:
+      by_owner:
+        parameters:
+          - SELECT owner_id FROM test WHERE id = token_parameters.test_id
+        data:
+          - SELECT id, owner_id FROM test WHERE owner_id = bucket.owner_id
+    `,
+        { storageVersion }
+      )
+    );
+    const bucketStorage = factory.getInstance(syncRules);
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const sourceTable = await test_utils.resolveTestTable(writer, 'test', ['id'], INITIALIZED_MONGO_STORAGE_FACTORY);
+
+    expect(sourceTable.bucketDataSources).toHaveLength(1);
+    expect(sourceTable.parameterLookupSources).toHaveLength(1);
+    expect(sourceTable.syncData).toBe(true);
+    expect(sourceTable.syncParameters).toBe(true);
+    expect(sourceTable.syncEvent).toBe(false);
+  });
+
+  test('resolveTables drops old table when table name changes for the same objectId', async () => {
+    await using factory = await storageConfig.factory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+    bucket_definitions:
+      global:
+        data:
+          - SELECT id FROM "%"
+    `,
+        { storageVersion }
+      )
+    );
+    const bucketStorage = factory.getInstance(syncRules);
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const before = await writer.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('orders', { objectId: 'orders-relation' }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38342')
+    });
+    const after = await writer.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('renamed_orders', { objectId: 'orders-relation' }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38343')
+    });
+
+    expect(after.tables).toHaveLength(1);
+    expect(after.tables[0].id).not.toEqual(before.tables[0].id);
+    expect(after.tables[0].bucketDataSources).toHaveLength(1);
+    expect(after.tables[0].parameterLookupSources).toHaveLength(0);
+    expect(after.dropTables.map((table) => ({ id: table.id, name: table.name }))).toEqual([
+      { id: before.tables[0].id, name: 'orders' }
+    ]);
+    expect(after.dropTables[0].bucketDataSources).toHaveLength(1);
+    expect(after.dropTables[0].parameterLookupSources).toHaveLength(0);
+  });
+
+  test('resolveTables drops old table when objectId changes for the same table name', async () => {
+    await using factory = await storageConfig.factory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+    bucket_definitions:
+      global:
+        data:
+          - SELECT id FROM "%"
+    `,
+        { storageVersion }
+      )
+    );
+    const bucketStorage = factory.getInstance(syncRules);
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const before = await writer.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('accounts', { objectId: 'accounts-relation-old' }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38344')
+    });
+    const after = await writer.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('accounts', { objectId: 'accounts-relation-new' }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38345')
+    });
+
+    expect(after.tables).toHaveLength(1);
+    expect(after.tables[0].id).not.toEqual(before.tables[0].id);
+    expect(after.tables[0].bucketDataSources).toHaveLength(1);
+    expect(after.dropTables.map((table) => ({ id: table.id, objectId: table.objectId }))).toEqual([
+      { id: before.tables[0].id, objectId: 'accounts-relation-old' }
+    ]);
+    expect(after.dropTables[0].bucketDataSources).toHaveLength(1);
+  });
+
+  test('resolveTables drops old table when replica id columns change', async () => {
+    await using factory = await storageConfig.factory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+    bucket_definitions:
+      global:
+        data:
+          - SELECT id FROM "%"
+    `,
+        { storageVersion }
+      )
+    );
+    const bucketStorage = factory.getInstance(syncRules);
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const before = await writer.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('items', { objectId: 'items-relation', replicaIdColumns: ['id'] }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38346')
+    });
+    const after = await writer.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('items', { objectId: 'items-relation', replicaIdColumns: ['tenant_id', 'id'] }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38347')
+    });
+
+    expect(after.tables).toHaveLength(1);
+    expect(after.tables[0].id).not.toEqual(before.tables[0].id);
+    expect(after.tables[0].replicaIdColumns.map((column) => column.name)).toEqual(['tenant_id', 'id']);
+    expect(after.tables[0].bucketDataSources).toHaveLength(1);
+    expect(
+      after.dropTables.map((table) => ({ id: table.id, columns: table.replicaIdColumns.map((c) => c.name) }))
+    ).toEqual([{ id: before.tables[0].id, columns: ['id'] }]);
+    expect(after.dropTables[0].bucketDataSources).toHaveLength(1);
+  });
+
+  test.runIf(storageVersion >= 3)(
+    'resolveTables resolves v3 event-only tables without source memberships',
+    async () => {
+      await using factory = await storageConfig.factory();
+      const syncRules = await factory.updateSyncRules(
+        updateSyncRulesFromYaml(
+          `
+    bucket_definitions:
+      by_owner:
+        data:
+          - SELECT id FROM users
+
+    event_definitions:
+      write_checkpoints:
+        payloads:
+          - SELECT user_id, checkpoint FROM checkpoints
+    `,
+          { storageVersion }
+        )
+      );
+      const bucketStorage = factory.getInstance(syncRules);
+
+      await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+      const resolved = await writer.resolveTables({
+        connection_id: 1,
+        source: {
+          connectionTag: storage.SourceTable.DEFAULT_TAG,
+          objectId: 'checkpoints',
+          schema: 'public',
+          name: 'checkpoints',
+          replicaIdColumns: [{ name: 'id', type: 'VARCHAR', typeId: 25 }]
+        },
+        idGenerator: () => new bson.ObjectId('6544e3899293153fa7b38341')
+      });
+
+      expect(resolved.tables).toHaveLength(1);
+      expect(resolved.dropTables).toHaveLength(0);
+      expect(resolved.tables[0].bucketDataSources).toEqual([]);
+      expect(resolved.tables[0].parameterLookupSources).toEqual([]);
+      expect(resolved.tables[0].syncData).toBe(false);
+      expect(resolved.tables[0].syncParameters).toBe(false);
+      expect(resolved.tables[0].syncEvent).toBe(true);
+    }
+  );
+
+  test.runIf(storageVersion >= 3)('resolveTables handles v3 source membership additions and removals', async () => {
+    const fullRulesYaml = `
+    bucket_definitions:
+      by_owner:
+        parameters:
+          - SELECT owner_id FROM memberships WHERE id = token_parameters.test_id
+        data:
+          - SELECT id, owner_id FROM memberships WHERE owner_id = bucket.owner_id
+    `;
+    const dataOnlyRulesYaml = `
+    bucket_definitions:
+      by_owner:
+        data:
+          - SELECT id, owner_id FROM memberships WHERE owner_id = bucket.owner_id
+    `;
+    const parameterOnlyRulesYaml = `
+    bucket_definitions:
+      by_owner:
+        parameters:
+          - SELECT owner_id FROM memberships WHERE id = token_parameters.test_id
+    `;
+    const eventOnlyRulesYaml = `
+    bucket_definitions:
+      unrelated:
+        data:
+          - SELECT id FROM unrelated
+
+    event_definitions:
+      write_checkpoints:
+        payloads:
+          - SELECT id, owner_id FROM memberships
+    `;
+
+    await using factory = await storageConfig.factory();
+    const syncRules = await factory.updateSyncRules(updateSyncRulesFromYaml(fullRulesYaml, { storageVersion }));
+    const bucketStorage = factory.getInstance(syncRules) as MongoSyncBucketStorage;
+    const fullRules = syncRules.parsed(test_utils.PARSE_OPTIONS).hydratedSyncRules();
+    const dataOnlyRules = hydratedRulesFor(syncRules, dataOnlyRulesYaml, storageVersion);
+    const parameterOnlyRules = hydratedRulesFor(syncRules, parameterOnlyRulesYaml, storageVersion);
+    const eventOnlyRules = hydratedRulesFor(syncRules, eventOnlyRulesYaml, storageVersion);
+    const source = sourceDescriptor('memberships', { objectId: 'memberships-relation' });
+
+    const dataOnly = await bucketStorage.resolveTables(
+      {
+        connection_id: 1,
+        source,
+        idGenerator: objectIdGenerator('6544e3899293153fa7b38348')
+      },
+      dataOnlyRules
+    );
+    expect(dataOnly.tables).toHaveLength(1);
+    expect(dataOnly.tables[0].bucketDataSources).toHaveLength(1);
+    expect(dataOnly.tables[0].parameterLookupSources).toHaveLength(0);
+
+    const addedParameter = await bucketStorage.resolveTables(
+      {
+        connection_id: 1,
+        source,
+        idGenerator: objectIdGenerator('6544e3899293153fa7b38349')
+      },
+      fullRules
+    );
+    expect(addedParameter.tables).toHaveLength(2);
+    expect(addedParameter.dropTables).toHaveLength(0);
+    expect(addedParameter.tables.map((table) => table.bucketDataSources.length).sort()).toEqual([0, 1]);
+    expect(addedParameter.tables.map((table) => table.parameterLookupSources.length).sort()).toEqual([0, 1]);
+
+    const removedParameter = await bucketStorage.resolveTables(
+      {
+        connection_id: 1,
+        source,
+        idGenerator: () => {
+          throw new Error('data-only resolve should reuse existing v3 source table');
+        }
+      },
+      dataOnlyRules
+    );
+    expect(removedParameter.tables).toHaveLength(1);
+    expect(removedParameter.tables[0].bucketDataSources).toHaveLength(1);
+    expect(removedParameter.tables[0].parameterLookupSources).toHaveLength(0);
+
+    const removedData = await bucketStorage.resolveTables(
+      {
+        connection_id: 1,
+        source,
+        idGenerator: () => {
+          throw new Error('parameter-only resolve should reuse existing v3 source table');
+        }
+      },
+      parameterOnlyRules
+    );
+    expect(removedData.tables).toHaveLength(1);
+    expect(removedData.tables[0].bucketDataSources).toHaveLength(0);
+    expect(removedData.tables[0].parameterLookupSources).toHaveLength(1);
+
+    const eventOnly = await bucketStorage.resolveTables(
+      {
+        connection_id: 1,
+        source,
+        idGenerator: objectIdGenerator('6544e3899293153fa7b3834a')
+      },
+      eventOnlyRules
+    );
+    expect(eventOnly.tables).toHaveLength(1);
+    expect(eventOnly.tables[0].bucketDataSources).toHaveLength(0);
+    expect(eventOnly.tables[0].parameterLookupSources).toHaveLength(0);
+    expect(eventOnly.tables[0].syncData).toBe(false);
+    expect(eventOnly.tables[0].syncParameters).toBe(false);
+    expect(eventOnly.tables[0].syncEvent).toBe(true);
   });
 
   test.runIf(storageVersion >= 3)('uses v3 mongodb model shapes', async () => {

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -48,7 +48,9 @@ function objectIdGenerator(id: string) {
 function hydratedRulesFor(syncRules: storage.PersistedSyncRulesContent, yaml: string, storageVersion: number) {
   const parsed = updateSyncRulesFromYaml(yaml, { storageVersion }).config.parsed;
   expect(parsed.errors).toEqual([]);
-  return parsed.config.hydrate({ hydrationState: syncRules.parsed(test_utils.PARSE_OPTIONS).hydrationState });
+  return parsed.config.hydrate({
+    hydrationState: syncRules.parsed(test_utils.PARSE_OPTIONS).hydrationState
+  });
 }
 
 function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, storageVersion: number) {
@@ -392,6 +394,8 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
     const dataOnlyRulesYaml = `
     bucket_definitions:
       by_owner:
+        parameters:
+          - SELECT token_parameters.owner_id as owner_id
         data:
           - SELECT id, owner_id FROM memberships WHERE owner_id = bucket.owner_id
     `;
@@ -400,6 +404,7 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
       by_owner:
         parameters:
           - SELECT owner_id FROM memberships WHERE id = token_parameters.test_id
+        data: []
     `;
     const eventOnlyRulesYaml = `
     bucket_definitions:

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -1,6 +1,6 @@
 import { deserializeParameterLookup, JwtPayload, storage, updateSyncRulesFromYaml } from '@powersync/service-core';
 import { bucketRequest, register, test_utils } from '@powersync/service-core-tests';
-import { RequestParameters } from '@powersync/service-sync-rules';
+import { DEFAULT_HYDRATION_STATE, RequestParameters, SqlSyncRules } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { describe, expect, test } from 'vitest';
 import { MongoBucketStorage } from '../../src/storage/MongoBucketStorage.js';
@@ -42,15 +42,20 @@ function sourceDescriptor(
 }
 
 function objectIdGenerator(id: string) {
-  return () => new bson.ObjectId(id);
+  let used = false;
+  return () => {
+    if (used) {
+      throw new Error(`Can only generate a single id using ${id}`);
+    }
+    used = true;
+    return new bson.ObjectId(id);
+  };
 }
 
-function hydratedRulesFor(syncRules: storage.PersistedSyncRulesContent, yaml: string, storageVersion: number) {
-  const parsed = updateSyncRulesFromYaml(yaml, { storageVersion }).config.parsed;
+function hydratedRulesFor(yaml: string) {
+  const parsed = SqlSyncRules.fromYaml(yaml, test_utils.PARSE_OPTIONS);
   expect(parsed.errors).toEqual([]);
-  return parsed.config.hydrate({
-    hydrationState: syncRules.parsed(test_utils.PARSE_OPTIONS).hydrationState
-  });
+  return parsed.config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
 }
 
 function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, storageVersion: number) {
@@ -383,6 +388,12 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
   );
 
   test.runIf(storageVersion >= 3)('resolveTables handles v3 source membership additions and removals', async () => {
+    // Tests the behavior of resolveTables when bucket data sources and parameter index creators are added or removed.
+    // These are not end-to-end tests yet, since we don't have a full incremental reprocessing implementation.
+    // This just tests the specific resolveTables behavior.
+
+    // The same tests should work with sync streams, but legacy bucket_definitions make it easy
+    // to see the distinction between the parameter index queries and the data sources.
     const fullRulesYaml = `
     bucket_definitions:
       by_owner:
@@ -407,10 +418,7 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
         data: []
     `;
     const eventOnlyRulesYaml = `
-    bucket_definitions:
-      unrelated:
-        data:
-          - SELECT id FROM unrelated
+    bucket_definitions: {}
 
     event_definitions:
       write_checkpoints:
@@ -419,12 +427,15 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
     `;
 
     await using factory = await storageConfig.factory();
+    // This does not quite match what actual API usage would look like.
+    // Here we're persisting one sync config, then resolving tables with others.
+    // We're also using the default hydration state for them all.
     const syncRules = await factory.updateSyncRules(updateSyncRulesFromYaml(fullRulesYaml, { storageVersion }));
     const bucketStorage = factory.getInstance(syncRules) as MongoSyncBucketStorage;
-    const fullRules = syncRules.parsed(test_utils.PARSE_OPTIONS).hydratedSyncRules();
-    const dataOnlyRules = hydratedRulesFor(syncRules, dataOnlyRulesYaml, storageVersion);
-    const parameterOnlyRules = hydratedRulesFor(syncRules, parameterOnlyRulesYaml, storageVersion);
-    const eventOnlyRules = hydratedRulesFor(syncRules, eventOnlyRulesYaml, storageVersion);
+    const fullRules = hydratedRulesFor(fullRulesYaml);
+    const dataOnlyRules = hydratedRulesFor(dataOnlyRulesYaml);
+    const parameterOnlyRules = hydratedRulesFor(parameterOnlyRulesYaml);
+    const eventOnlyRules = hydratedRulesFor(eventOnlyRulesYaml);
     const source = sourceDescriptor('memberships', { objectId: 'memberships-relation' });
 
     const dataOnly = await bucketStorage.resolveTables(

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -432,74 +432,81 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
     // We're also using the default hydration state for them all.
     const syncRules = await factory.updateSyncRules(updateSyncRulesFromYaml(fullRulesYaml, { storageVersion }));
     const bucketStorage = factory.getInstance(syncRules) as MongoSyncBucketStorage;
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
     const fullRules = hydratedRulesFor(fullRulesYaml);
     const dataOnlyRules = hydratedRulesFor(dataOnlyRulesYaml);
     const parameterOnlyRules = hydratedRulesFor(parameterOnlyRulesYaml);
     const eventOnlyRules = hydratedRulesFor(eventOnlyRulesYaml);
     const source = sourceDescriptor('memberships', { objectId: 'memberships-relation' });
+    const dataOnlyTableId = new bson.ObjectId('6544e3899293153fa7b38348');
+    const addedParameterTableId = new bson.ObjectId('6544e3899293153fa7b38349');
+    const removedDataTableId = new bson.ObjectId('6544e3899293153fa7b3834a');
 
-    const dataOnly = await bucketStorage.resolveTables(
-      {
-        connection_id: 1,
-        source,
-        idGenerator: objectIdGenerator('6544e3899293153fa7b38348')
-      },
-      dataOnlyRules
-    );
-    expect(dataOnly.tables).toHaveLength(1);
+    const dataOnly = await writer.resolveTables({
+      connection_id: 1,
+      source,
+      idGenerator: () => dataOnlyTableId,
+      syncRules: dataOnlyRules
+    });
+    expect(dataOnly.tables.map((table) => table.id)).toEqual([dataOnlyTableId]);
+    expect(dataOnly.dropTables.map((table) => table.id)).toEqual([]);
     expect(dataOnly.tables[0].bucketDataSources).toHaveLength(1);
     expect(dataOnly.tables[0].parameterLookupSources).toHaveLength(0);
 
-    const addedParameter = await bucketStorage.resolveTables(
-      {
-        connection_id: 1,
-        source,
-        idGenerator: objectIdGenerator('6544e3899293153fa7b38349')
-      },
-      fullRules
-    );
-    expect(addedParameter.tables).toHaveLength(2);
-    expect(addedParameter.dropTables).toHaveLength(0);
+    const addedParameter = await writer.resolveTables({
+      connection_id: 1,
+      source,
+      idGenerator: () => addedParameterTableId,
+      syncRules: fullRules
+    });
+    // Adding a definition always creates a new SourceTable
+    expect(addedParameter.tables.map((table) => table.id)).toEqual([dataOnlyTableId, addedParameterTableId]);
     expect(addedParameter.tables.map((table) => table.bucketDataSources.length).sort()).toEqual([0, 1]);
     expect(addedParameter.tables.map((table) => table.parameterLookupSources.length).sort()).toEqual([0, 1]);
+    expect(addedParameter.dropTables.map((table) => table.id)).toEqual([]);
 
-    const removedParameter = await bucketStorage.resolveTables(
-      {
-        connection_id: 1,
-        source,
-        idGenerator: () => {
-          throw new Error('data-only resolve should reuse existing v3 source table');
-        }
+    const removedParameter = await writer.resolveTables({
+      connection_id: 1,
+      source,
+      idGenerator: () => {
+        throw new Error('data-only resolve should reuse existing v3 source table');
       },
-      dataOnlyRules
-    );
-    expect(removedParameter.tables).toHaveLength(1);
+      syncRules: dataOnlyRules
+    });
+    expect(removedParameter.tables.map((table) => table.id)).toEqual([dataOnlyTableId]);
+    // Now this sourceTable is unused & dropped
+    expect(removedParameter.dropTables.map((table) => table.id)).toEqual([addedParameterTableId]);
     expect(removedParameter.tables[0].bucketDataSources).toHaveLength(1);
     expect(removedParameter.tables[0].parameterLookupSources).toHaveLength(0);
+    await writer.drop(removedParameter.dropTables);
 
-    const removedData = await bucketStorage.resolveTables(
-      {
-        connection_id: 1,
-        source,
-        idGenerator: () => {
-          throw new Error('parameter-only resolve should reuse existing v3 source table');
-        }
-      },
-      parameterOnlyRules
-    );
-    expect(removedData.tables).toHaveLength(1);
+    const removedData = await writer.resolveTables({
+      connection_id: 1,
+      source,
+      idGenerator: () => removedDataTableId,
+      syncRules: parameterOnlyRules
+    });
+
+    // This goes from dataOnlyRules -> parameterOnlyRules, which adds one definition and removes another.
+    // This generates a new SourceTable again, and removes all others.
+    expect(removedData.tables.map((table) => table.id)).toEqual([removedDataTableId]);
+    expect(removedData.dropTables.map((table) => table.id)).toEqual([dataOnlyTableId]);
     expect(removedData.tables[0].bucketDataSources).toHaveLength(0);
     expect(removedData.tables[0].parameterLookupSources).toHaveLength(1);
+    await writer.drop(removedData.dropTables);
 
-    const eventOnly = await bucketStorage.resolveTables(
-      {
-        connection_id: 1,
-        source,
-        idGenerator: objectIdGenerator('6544e3899293153fa7b3834a')
+    const eventOnly = await writer.resolveTables({
+      connection_id: 1,
+      source,
+      idGenerator: () => {
+        throw new Error('resolve should reuse existing v3 source table');
       },
-      eventOnlyRules
-    );
-    expect(eventOnly.tables).toHaveLength(1);
+      syncRules: eventOnlyRules
+    });
+
+    // Event-only table can re-use any existing table.
+    expect(eventOnly.tables.map((table) => table.id)).toEqual([removedDataTableId]);
+    expect(eventOnly.dropTables.map((table) => table.id)).toEqual([]);
     expect(eventOnly.tables[0].bucketDataSources).toHaveLength(0);
     expect(eventOnly.tables[0].parameterLookupSources).toHaveLength(0);
     expect(eventOnly.tables[0].syncData).toBe(false);

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -137,12 +137,15 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
       if (tablePattern.isWildcard) {
         patternResult.tables = [];
         for (let collection of collections) {
+          const ref: sync_rules.SourceTableRef = {
+            connectionTag: this.connectionTag,
+            schema,
+            name: collection.name
+          };
           const sourceTable = new SourceTable({
             id: '', // not used
-            connectionTag: this.connectionTag,
+            ref,
             objectId: collection.name,
-            schema: schema,
-            name: collection.name,
             replicaIdColumns: [],
             snapshotComplete: true
           });
@@ -152,8 +155,8 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
           } else {
             errors.push(...validatePostImages(schema, collection));
           }
-          const syncData = sqlSyncRules.tableSyncsData(sourceTable);
-          const syncParameters = sqlSyncRules.tableSyncsParameters(sourceTable);
+          const syncData = sqlSyncRules.tableSyncsData(ref);
+          const syncParameters = sqlSyncRules.tableSyncsParameters(ref);
           patternResult.tables.push({
             schema,
             name: collection.name,
@@ -164,18 +167,21 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
           });
         }
       } else {
+        const ref: sync_rules.SourceTableRef = {
+          connectionTag: this.connectionTag,
+          schema,
+          name: tablePattern.name
+        };
         const sourceTable = new SourceTable({
           id: '', // not used
-          connectionTag: this.connectionTag,
+          ref,
           objectId: tablePattern.name,
-          schema: schema,
-          name: tablePattern.name,
           replicaIdColumns: [],
           snapshotComplete: true
         });
 
-        const syncData = sqlSyncRules.tableSyncsData(sourceTable);
-        const syncParameters = sqlSyncRules.tableSyncsParameters(sourceTable);
+        const syncData = sqlSyncRules.tableSyncsData(ref);
+        const syncParameters = sqlSyncRules.tableSyncsParameters(ref);
         const collection = collections[0];
 
         let errors: service_types.ReplicationError[] = [];

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -1,6 +1,6 @@
 import * as lib_mongo from '@powersync/lib-service-mongodb';
 import { mongo } from '@powersync/lib-service-mongodb';
-import { api, ParseSyncRulesOptions, ReplicationHeadCallback, SourceTable } from '@powersync/service-core';
+import { api, ParseSyncRulesOptions, ReplicationHeadCallback } from '@powersync/service-core';
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as service_types from '@powersync/service-types';
 
@@ -142,13 +142,6 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
             schema,
             name: collection.name
           };
-          const sourceTable = new SourceTable({
-            id: '', // not used
-            ref,
-            objectId: collection.name,
-            replicaIdColumns: [],
-            snapshotComplete: true
-          });
           let errors: service_types.ReplicationError[] = [];
           if (collection.type == 'view') {
             errors.push({ level: 'warning', message: `Collection ${schema}.${tablePattern.name} is a view` });
@@ -172,13 +165,6 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
           schema,
           name: tablePattern.name
         };
-        const sourceTable = new SourceTable({
-          id: '', // not used
-          ref,
-          objectId: tablePattern.name,
-          replicaIdColumns: [],
-          snapshotComplete: true
-        });
 
         const syncData = sqlSyncRules.tableSyncsData(ref);
         const syncParameters = sqlSyncRules.tableSyncsParameters(ref);

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -189,7 +189,7 @@ export class ChangeStream {
     for (let collection of collections) {
       const tables = await this.handleRelation(
         batch,
-        getMongoRelation({ db: schema, coll: collection.name }),
+        getMongoRelation({ db: schema, coll: collection.name }, this.connections.connectionTag),
         // This is done as part of the initial setup - snapshot is handled elsewhere
         { snapshot: false, collectionInfo: collection }
       );
@@ -614,12 +614,7 @@ export class ChangeStream {
     const snapshot = options.snapshot;
     const result = await batch.resolveTables({
       connection_id: this.connection_id,
-      connection_tag: this.connections.connectionTag,
-      entity_descriptor: descriptor,
-      matchingSources: this.sync_rules.getMatchingSources({
-        ...descriptor,
-        connectionTag: this.connections.connectionTag
-      })
+      source: descriptor
     });
     this.relationCache.updateAll(descriptor, result.tables);
 
@@ -1078,7 +1073,7 @@ export class ChangeStream {
                 waitForCheckpointLsn = await createCheckpoint(this.client, this.defaultDb, this.checkpointStreamId);
               }
 
-              const rel = getMongoRelation(changeDocument.ns);
+              const rel = getMongoRelation(changeDocument.ns, this.connections.connectionTag);
               const tables = await this.getRelations(batch, rel, {
                 // In most cases, we should not need to snapshot this. But if this is the first time we see the collection
                 // for whatever reason, then we do need to snapshot it.
@@ -1107,7 +1102,7 @@ export class ChangeStream {
                 }
               }
             } else if (changeDocument.operationType == 'drop') {
-              const rel = getMongoRelation(changeDocument.ns);
+              const rel = getMongoRelation(changeDocument.ns, this.connections.connectionTag);
               const tables = await this.getRelations(batch, rel, {
                 // We're "dropping" this collection, so never snapshot it.
                 snapshot: false
@@ -1118,8 +1113,8 @@ export class ChangeStream {
                 this.relationCache.delete(rel);
               }
             } else if (changeDocument.operationType == 'rename') {
-              const relFrom = getMongoRelation(changeDocument.ns);
-              const relTo = getMongoRelation(changeDocument.to);
+              const relFrom = getMongoRelation(changeDocument.ns, this.connections.connectionTag);
+              const relTo = getMongoRelation(changeDocument.to, this.connections.connectionTag);
               const tablesFrom = await this.getRelations(batch, relFrom, {
                 // We're "dropping" this collection, so never snapshot it.
                 snapshot: false

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -554,7 +554,7 @@ export class ChangeStream {
     options: { snapshot: boolean }
   ): Promise<SourceTable[]> {
     const existing = this.relationCache.getAll(descriptor);
-    if (existing.length > 0) {
+    if (existing != null) {
       return existing;
     }
 
@@ -623,7 +623,7 @@ export class ChangeStream {
         connectionTag: this.connections.connectionTag
       })
     });
-    this.relationCache.updateAll(result.tables);
+    this.relationCache.updateAll(descriptor, result.tables);
 
     // Drop conflicting collections.
     // This is generally not expected for MongoDB source dbs, so we log an error.
@@ -650,8 +650,10 @@ export class ChangeStream {
       const no_checkpoint_before_lsn = await createCheckpoint(this.client, this.defaultDb, STANDALONE_CHECKPOINT_ID);
 
       const doneTables = await batch.markTableSnapshotDone(snapshotCandidates, no_checkpoint_before_lsn);
-      this.relationCache.updateAll(doneTables);
-      return doneTables;
+      const snapshotDoneById = new Map(doneTables.map((table) => [table.id, table]));
+      const tables = result.tables.map((table) => snapshotDoneById.get(table.id) ?? table);
+      this.relationCache.updateAll(descriptor, tables);
+      return tables;
     }
 
     return result.tables;

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -187,14 +187,14 @@ export class ChangeStream {
     }
 
     for (let collection of collections) {
-      const table = await this.handleRelation(
+      const tables = await this.handleRelation(
         batch,
         getMongoRelation({ db: schema, coll: collection.name }),
         // This is done as part of the initial setup - snapshot is handled elsewhere
         { snapshot: false, collectionInfo: collection }
       );
 
-      result.push(table);
+      result.push(...tables);
     }
 
     return result;
@@ -548,13 +548,13 @@ export class ChangeStream {
     await nextChunkPromise;
   }
 
-  private async getRelation(
+  private async getRelations(
     batch: storage.BucketStorageBatch,
     descriptor: SourceEntityDescriptor,
     options: { snapshot: boolean }
-  ): Promise<SourceTable> {
-    const existing = this.relationCache.get(descriptor);
-    if (existing != null) {
+  ): Promise<SourceTable[]> {
+    const existing = this.relationCache.getAll(descriptor);
+    if (existing.length > 0) {
       return existing;
     }
 
@@ -612,14 +612,18 @@ export class ChangeStream {
     }
 
     const snapshot = options.snapshot;
-    const result = await this.storage.resolveTable({
+    const result = await batch.resolveTables({
       group_id: this.group_id,
       connection_id: this.connection_id,
       connection_tag: this.connections.connectionTag,
       entity_descriptor: descriptor,
-      sync_rules: this.sync_rules
+      sync_rules: this.sync_rules,
+      matchingSources: this.sync_rules.getMatchingSources({
+        ...descriptor,
+        connectionTag: this.connections.connectionTag
+      })
     });
-    this.relationCache.update(result.table);
+    this.relationCache.updateAll(result.tables);
 
     // Drop conflicting collections.
     // This is generally not expected for MongoDB source dbs, so we log an error.
@@ -634,20 +638,23 @@ export class ChangeStream {
     // 1. Snapshot is requested (false for initial snapshot, since that process handles it elsewhere)
     // 2. Snapshot is not already done, AND:
     // 3. The table is used in sync config.
-    const shouldSnapshot = snapshot && !result.table.snapshotComplete && result.table.syncAny;
-    if (shouldSnapshot) {
+    const snapshotCandidates = result.tables.filter((table) => snapshot && !table.snapshotComplete && table.syncAny);
+    if (snapshotCandidates.length > 0) {
       this.logger.info(`New collection: ${descriptor.schema}.${descriptor.name}`);
-      // Truncate this table, in case a previous snapshot was interrupted.
-      await batch.truncate([result.table]);
+      // Truncate tables, in case a previous snapshot was interrupted.
+      await batch.truncate(snapshotCandidates);
 
-      await this.snapshotTable(batch, result.table);
+      for (const tableToSnapshot of snapshotCandidates) {
+        await this.snapshotTable(batch, tableToSnapshot);
+      }
       const no_checkpoint_before_lsn = await createCheckpoint(this.client, this.defaultDb, STANDALONE_CHECKPOINT_ID);
 
-      const [table] = await batch.markTableSnapshotDone([result.table], no_checkpoint_before_lsn);
-      return table;
+      const doneTables = await batch.markTableSnapshotDone(snapshotCandidates, no_checkpoint_before_lsn);
+      this.relationCache.updateAll(doneTables);
+      return doneTables;
     }
 
-    return result.table;
+    return result.tables;
   }
 
   async writeChange(
@@ -1072,14 +1079,15 @@ export class ChangeStream {
               }
 
               const rel = getMongoRelation(changeDocument.ns);
-              const table = await this.getRelation(batch, rel, {
+              const tables = await this.getRelations(batch, rel, {
                 // In most cases, we should not need to snapshot this. But if this is the first time we see the collection
                 // for whatever reason, then we do need to snapshot it.
                 // This may result in some duplicate operations when a collection is created for the first time after
                 // sync config was deployed.
                 snapshot: true
               });
-              if (table.syncAny) {
+              const tablesToReplicate = tables.filter((table) => table.syncAny);
+              if (tablesToReplicate.length > 0) {
                 this.replicationLag.trackUncommittedChange(
                   changeDocument.clusterTime == null ? null : timestampToDate(changeDocument.clusterTime)
                 );
@@ -1094,27 +1102,31 @@ export class ChangeStream {
                   transactionsReplicatedMetric.add(1);
                 }
 
-                await this.writeChange(batch, table, changeDocument);
+                for (const table of tablesToReplicate) {
+                  await this.writeChange(batch, table, changeDocument);
+                }
               }
             } else if (changeDocument.operationType == 'drop') {
               const rel = getMongoRelation(changeDocument.ns);
-              const table = await this.getRelation(batch, rel, {
+              const tables = await this.getRelations(batch, rel, {
                 // We're "dropping" this collection, so never snapshot it.
                 snapshot: false
               });
-              if (table.syncAny) {
-                await batch.drop([table]);
-                this.relationCache.delete(table);
+              const tablesToDrop = tables.filter((table) => table.syncAny);
+              if (tablesToDrop.length > 0) {
+                await batch.drop(tablesToDrop);
+                this.relationCache.delete(rel);
               }
             } else if (changeDocument.operationType == 'rename') {
               const relFrom = getMongoRelation(changeDocument.ns);
               const relTo = getMongoRelation(changeDocument.to);
-              const tableFrom = await this.getRelation(batch, relFrom, {
+              const tablesFrom = await this.getRelations(batch, relFrom, {
                 // We're "dropping" this collection, so never snapshot it.
                 snapshot: false
               });
-              if (tableFrom.syncAny) {
-                await batch.drop([tableFrom]);
+              const tablesToDrop = tablesFrom.filter((table) => table.syncAny);
+              if (tablesToDrop.length > 0) {
+                await batch.drop(tablesToDrop);
                 this.relationCache.delete(relFrom);
               }
               // Here we do need to snapshot the new table

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -613,11 +613,9 @@ export class ChangeStream {
 
     const snapshot = options.snapshot;
     const result = await batch.resolveTables({
-      group_id: this.group_id,
       connection_id: this.connection_id,
       connection_tag: this.connections.connectionTag,
       entity_descriptor: descriptor,
-      sync_rules: this.sync_rules,
       matchingSources: this.sync_rules.getMatchingSources({
         ...descriptor,
         connectionTag: this.connections.connectionTag

--- a/modules/module-mongodb/src/replication/MongoRelation.ts
+++ b/modules/module-mongodb/src/replication/MongoRelation.ts
@@ -17,8 +17,12 @@ import { ErrorCode, ServiceError } from '@powersync/lib-services-framework';
 import { MongoLSN } from '../common/MongoLSN.js';
 import { CHECKPOINTS_COLLECTION } from './replication-utils.js';
 
-export function getMongoRelation(source: mongo.ChangeStreamNameSpace): storage.SourceEntityDescriptor {
+export function getMongoRelation(
+  source: mongo.ChangeStreamNameSpace,
+  connectionTag: string
+): storage.SourceEntityDescriptor {
   return {
+    connectionTag,
     name: source.coll,
     schema: source.db,
     // Not relevant for MongoDB - we use db + coll name as the identifier

--- a/modules/module-mssql/src/common/MSSQLSourceTable.ts
+++ b/modules/module-mssql/src/common/MSSQLSourceTable.ts
@@ -14,10 +14,29 @@ export class MSSQLSourceTable {
    */
   public captureInstance: CaptureInstance | null = null;
 
-  constructor(public sourceTable: SourceTable) {}
+  public sourceTables: SourceTable[];
+
+  constructor(sourceTables: SourceTable | SourceTable[]) {
+    this.sourceTables = Array.isArray(sourceTables) ? sourceTables : [sourceTables];
+  }
+
+  /**
+   * Primary SourceTable used for physical table metadata.
+   */
+  get sourceTable(): SourceTable {
+    return this.sourceTables[0];
+  }
 
   updateSourceTable(updated: SourceTable): void {
-    this.sourceTable = updated;
+    const index = this.sourceTables.findIndex((table) => table.id == updated.id);
+    if (index == -1) {
+      throw new ServiceAssertionError(`No SourceTable found for table: ${updated.id}`);
+    }
+    this.sourceTables[index] = updated;
+  }
+
+  getReplicatedSourceTables(): SourceTable[] {
+    return this.sourceTables.filter((sourceTable) => sourceTable.syncAny);
   }
 
   enabledForCDC(): boolean {

--- a/modules/module-mssql/src/common/MSSQLSourceTable.ts
+++ b/modules/module-mssql/src/common/MSSQLSourceTable.ts
@@ -1,4 +1,4 @@
-import { SourceTable } from '@powersync/service-core';
+import { SourceEntityDescriptor, SourceTable } from '@powersync/service-core';
 import { ServiceAssertionError } from '@powersync/service-errors';
 import { toQualifiedTableName } from '../utils/mssql.js';
 import { CaptureInstance } from './CaptureInstance.js';
@@ -8,23 +8,27 @@ import { CaptureInstance } from './CaptureInstance.js';
  */
 export const CDC_SCHEMA = 'cdc';
 
+/**
+ * Represents one underlying CDC capture instance.
+ *
+ * There could be multiple SourceTables associated with the same underlying capture instance.
+ */
 export class MSSQLSourceTable {
   /**
    *  The unique name of the CDC capture instance for this table
    */
   public captureInstance: CaptureInstance | null = null;
 
-  public sourceTables: SourceTable[];
-
-  constructor(sourceTables: SourceTable | SourceTable[]) {
-    this.sourceTables = Array.isArray(sourceTables) ? sourceTables : [sourceTables];
-  }
-
   /**
-   * Primary SourceTable used for physical table metadata.
+   * Can be 0, 1 or multiple SourceTables.
    */
-  get sourceTable(): SourceTable {
-    return this.sourceTables[0];
+  public readonly sourceTables: SourceTable[];
+
+  public readonly ref: SourceEntityDescriptor;
+
+  constructor(ref: SourceEntityDescriptor, sourceTables: SourceTable[]) {
+    this.sourceTables = sourceTables;
+    this.ref = ref;
   }
 
   updateSourceTable(updated: SourceTable): void {
@@ -53,14 +57,14 @@ export class MSSQLSourceTable {
 
   get allChangesFunction() {
     if (!this.captureInstance) {
-      throw new ServiceAssertionError(`No capture instance set for table: ${this.sourceTable.name}`);
+      throw new ServiceAssertionError(`No capture instance set for table: ${this.ref.name}`);
     }
     return `${CDC_SCHEMA}.fn_cdc_get_all_changes_${this.captureInstance.name}`;
   }
 
   get netChangesFunction() {
     if (!this.captureInstance) {
-      throw new ServiceAssertionError(`No capture instance set for table: ${this.sourceTable.name}`);
+      throw new ServiceAssertionError(`No capture instance set for table: ${this.ref.name}`);
     }
     return `${CDC_SCHEMA}.fn_cdc_get_net_changes_${this.captureInstance.name}`;
   }
@@ -70,13 +74,13 @@ export class MSSQLSourceTable {
    *  Object IDs in SQL Server are always numbers.
    */
   get objectId(): number {
-    return this.sourceTable.objectId as number;
+    return this.ref.objectId as number;
   }
 
   /**
    *  Escapes this source table's name and schema for use in MSSQL queries.
    */
   toQualifiedName(): string {
-    return toQualifiedTableName(this.sourceTable.schema, this.sourceTable.name);
+    return toQualifiedTableName(this.ref.schema, this.ref.name);
   }
 }

--- a/modules/module-mssql/src/common/MSSQLSourceTableCache.ts
+++ b/modules/module-mssql/src/common/MSSQLSourceTableCache.ts
@@ -6,7 +6,7 @@ export class MSSQLSourceTableCache {
   private cache = new Map<number | string, MSSQLSourceTable>();
 
   set(table: MSSQLSourceTable): void {
-    this.cache.set(table.sourceTable.objectId!, table);
+    this.cache.set(table.ref.objectId!, table);
   }
 
   /**

--- a/modules/module-mssql/src/replication/CDCPoller.ts
+++ b/modules/module-mssql/src/replication/CDCPoller.ts
@@ -5,7 +5,6 @@ import {
   Logger,
   ReplicationAssertionError
 } from '@powersync/lib-services-framework';
-import { SourceEntityDescriptor } from '@powersync/service-core';
 import { TablePattern } from '@powersync/service-sync-rules';
 import sql from 'mssql';
 import timers from 'timers/promises';
@@ -15,7 +14,7 @@ import { MSSQLSourceTable } from '../common/MSSQLSourceTable.js';
 import { AdditionalConfig } from '../types/types.js';
 import { isDeadlockError } from '../utils/deadlock.js';
 import { CaptureInstanceDetails, getCaptureInstances, incrementLSN, toQualifiedTableName } from '../utils/mssql.js';
-import { tableExists } from '../utils/schema.js';
+import { SourceTableChangeRef, tableExists } from '../utils/schema.js';
 import { MSSQLConnectionManager } from './MSSQLConnectionManager.js';
 
 enum Operation {
@@ -43,7 +42,7 @@ export interface SchemaChange {
   /**
    *  Populated for new tables or renames, but only if the new table matches a sync config source table.
    */
-  newTable?: Omit<SourceEntityDescriptor, 'replicaIdColumns'>;
+  newTable?: SourceTableChangeRef;
 
   newCaptureInstance?: CaptureInstance;
 }

--- a/modules/module-mssql/src/replication/CDCPoller.ts
+++ b/modules/module-mssql/src/replication/CDCPoller.ts
@@ -383,7 +383,7 @@ export class CDCPoller {
       }
 
       // One of the replicated tables has been renamed
-      if (table.sourceTable.name !== captureInstanceDetails.sourceTable.name) {
+      if (table.ref.name !== captureInstanceDetails.sourceTable.name) {
         const newTable = this.tableMatchesSyncRules(
           captureInstanceDetails.sourceTable.schema,
           captureInstanceDetails.sourceTable.name

--- a/modules/module-mssql/src/replication/CDCStream.ts
+++ b/modules/module-mssql/src/replication/CDCStream.ts
@@ -237,11 +237,9 @@ export class CDCStream {
       throw new ReplicationAssertionError(`objectId expected, got ${typeof table.objectId}`);
     }
     const resolved = await batch.resolveTables({
-      group_id: this.groupId,
       connection_id: this.connectionId,
       connection_tag: this.connectionTag,
       entity_descriptor: table,
-      sync_rules: this.syncRules,
       matchingSources: null
     });
     const primaryTable = resolved.tables[0];

--- a/modules/module-mssql/src/replication/CDCStream.ts
+++ b/modules/module-mssql/src/replication/CDCStream.ts
@@ -236,14 +236,16 @@ export class CDCStream {
     if (!table.objectId && typeof table.objectId != 'number') {
       throw new ReplicationAssertionError(`objectId expected, got ${typeof table.objectId}`);
     }
-    const resolved = await this.storage.resolveTable({
+    const resolved = await batch.resolveTables({
       group_id: this.groupId,
       connection_id: this.connectionId,
       connection_tag: this.connectionTag,
       entity_descriptor: table,
-      sync_rules: this.syncRules
+      sync_rules: this.syncRules,
+      matchingSources: null
     });
-    const resolvedTable = new MSSQLSourceTable(resolved.table);
+    const primaryTable = resolved.tables[0];
+    const resolvedTable = new MSSQLSourceTable(primaryTable);
 
     if (!captureInstance) {
       this.logger.warn(
@@ -261,15 +263,19 @@ export class CDCStream {
     // Snapshot if:
     // 1. The table is in the sync config and snapshot is requested, or not already done.
     // 2. AND the table is enabled for CDC with a valid capture instance.
-    const shouldSnapshot =
-      snapshot && !resolved.table.snapshotComplete && resolved.table.syncAny && resolvedTable.enabledForCDC();
+    const snapshotCandidates = resolved.tables.filter(
+      (candidate) => snapshot && !candidate.snapshotComplete && candidate.syncAny
+    );
+    const shouldSnapshot = snapshotCandidates.length > 0 && resolvedTable.enabledForCDC();
 
     if (shouldSnapshot) {
-      // Truncate this table in case a previous snapshot was interrupted.
-      await batch.truncate([resolved.table]);
+      // Truncate tables in case a previous snapshot was interrupted.
+      await batch.truncate(snapshotCandidates);
 
-      // Start the snapshot inside a transaction.
-      await this.snapshotTableInTx(batch, resolvedTable);
+      // Start the snapshot(s) inside a transaction.
+      for (const candidate of snapshotCandidates) {
+        await this.snapshotTableInTx(batch, new MSSQLSourceTable(candidate));
+      }
     }
 
     return resolvedTable;

--- a/modules/module-mssql/src/replication/CDCStream.ts
+++ b/modules/module-mssql/src/replication/CDCStream.ts
@@ -246,7 +246,7 @@ export class CDCStream {
       connection_id: this.connectionId,
       source: table
     });
-    const resolvedTable = new MSSQLSourceTable(resolved.tables);
+    const resolvedTable = new MSSQLSourceTable(table, resolved.tables);
 
     if (!captureInstance) {
       this.logger.warn(
@@ -497,7 +497,7 @@ export class CDCStream {
             for (const table of specificTablesToResnapshot!) {
               await batch.drop(table.getReplicatedSourceTables());
               // Update table in the table cache
-              await this.processTable(batch, this.sourceRefFromTable(table.sourceTable), table.captureInstance, false);
+              await this.processTable(batch, table.ref, table.captureInstance, false);
             }
             break;
           default:
@@ -755,7 +755,7 @@ export class CDCStream {
         await batch.drop(change.table!.getReplicatedSourceTables());
         this.tableCache.delete(change.table!.objectId);
 
-        await this.handleCreateOrUpdateTable(batch, change.table!.sourceTable, change.newCaptureInstance!);
+        await this.handleCreateOrUpdateTable(batch, change.table!.ref, change.newCaptureInstance!);
         break;
       case SchemaChangeType.TABLE_DROP:
         await batch.drop(change.table!.getReplicatedSourceTables());

--- a/modules/module-mssql/src/replication/CDCStream.ts
+++ b/modules/module-mssql/src/replication/CDCStream.ts
@@ -34,7 +34,12 @@ import {
   getLatestReplicatedLSN,
   isIColumnMetadata
 } from '../utils/mssql.js';
-import { getReplicationIdentityColumns, getTablesFromPattern, ResolvedTable } from '../utils/schema.js';
+import {
+  getReplicationIdentityColumns,
+  getTablesFromPattern,
+  ResolvedTable,
+  SourceTableChangeRef
+} from '../utils/schema.js';
 import { CDCEventHandler, CDCPoller, SchemaChange, SchemaChangeType } from './CDCPoller.js';
 import { MSSQLConnectionManager } from './MSSQLConnectionManager.js';
 import { BatchedSnapshotQuery, MSSQLSnapshotQuery, SimpleSnapshotQuery } from './MSSQLSnapshotQuery.js';
@@ -213,6 +218,7 @@ export class CDCStream {
       const table = await this.processTable(
         batch,
         {
+          connectionTag: this.connectionTag,
           name: matchedTable.name,
           schema: matchedTable.schema,
           objectId: matchedTable.objectId,
@@ -238,9 +244,7 @@ export class CDCStream {
     }
     const resolved = await batch.resolveTables({
       connection_id: this.connectionId,
-      connection_tag: this.connectionTag,
-      entity_descriptor: table,
-      matchingSources: null
+      source: table
     });
     const primaryTable = resolved.tables[0];
     const resolvedTable = new MSSQLSourceTable(primaryTable);
@@ -277,6 +281,16 @@ export class CDCStream {
     }
 
     return resolvedTable;
+  }
+
+  private sourceRefFromTable(table: storage.SourceTable): SourceEntityDescriptor {
+    return {
+      connectionTag: table.ref.connectionTag,
+      schema: table.ref.schema,
+      name: table.ref.name,
+      objectId: table.objectId,
+      replicaIdColumns: table.replicaIdColumns
+    };
   }
 
   private async snapshotTableInTx(batch: storage.BucketStorageBatch, table: MSSQLSourceTable): Promise<void> {
@@ -477,7 +491,7 @@ export class CDCStream {
             for (const table of specificTablesToResnapshot!) {
               await batch.drop([table.sourceTable]);
               // Update table in the table cache
-              await this.processTable(batch, table.sourceTable, table.captureInstance, false);
+              await this.processTable(batch, this.sourceRefFromTable(table.sourceTable), table.captureInstance, false);
             }
             break;
           default:
@@ -749,7 +763,7 @@ export class CDCStream {
 
   private async handleCreateOrUpdateTable(
     batch: storage.BucketStorageBatch,
-    table: Omit<SourceEntityDescriptor, 'replicaIdColumns'>,
+    table: SourceTableChangeRef,
     captureInstance: CaptureInstance
   ): Promise<void> {
     const replicaIdColumns = await getReplicationIdentityColumns({
@@ -761,6 +775,7 @@ export class CDCStream {
     await this.processTable(
       batch,
       {
+        connectionTag: this.connectionTag,
         name: table.name,
         schema: table.schema,
         objectId: table.objectId,

--- a/modules/module-mssql/src/replication/CDCStream.ts
+++ b/modules/module-mssql/src/replication/CDCStream.ts
@@ -246,8 +246,7 @@ export class CDCStream {
       connection_id: this.connectionId,
       source: table
     });
-    const primaryTable = resolved.tables[0];
-    const resolvedTable = new MSSQLSourceTable(primaryTable);
+    const resolvedTable = new MSSQLSourceTable(resolved.tables);
 
     if (!captureInstance) {
       this.logger.warn(
@@ -276,7 +275,7 @@ export class CDCStream {
 
       // Start the snapshot(s) inside a transaction.
       for (const candidate of snapshotCandidates) {
-        await this.snapshotTableInTx(batch, new MSSQLSourceTable(candidate));
+        await this.snapshotTableInTx(batch, resolvedTable, candidate);
       }
     }
 
@@ -293,14 +292,18 @@ export class CDCStream {
     };
   }
 
-  private async snapshotTableInTx(batch: storage.BucketStorageBatch, table: MSSQLSourceTable): Promise<void> {
+  private async snapshotTableInTx(
+    batch: storage.BucketStorageBatch,
+    physicalTable: MSSQLSourceTable,
+    sourceTable: storage.SourceTable
+  ): Promise<void> {
     // Note: We use the "Read Committed" isolation level here, not snapshot isolation.
     // The data may change during the transaction, but that is compensated for in the streaming
     // replication afterward.
     const transaction = await this.connections.createTransaction();
     await transaction.begin(sql.ISOLATION_LEVEL.READ_COMMITTED);
     try {
-      await this.snapshotTable(batch, transaction, table);
+      await this.snapshotTable(batch, transaction, physicalTable, sourceTable);
 
       // Get the current LSN.
       // The data will only be consistent once incremental replication has passed that point.
@@ -317,9 +320,9 @@ export class CDCStream {
       const postSnapshotLSN = await getLatestLSN(this.connections);
       // Side note: A ROLLBACK would probably also be fine here, since we only read in this transaction.
       await transaction.commit();
-      const [updatedSourceTable] = await batch.markTableSnapshotDone([table.sourceTable], postSnapshotLSN.toString());
+      const [updatedSourceTable] = await batch.markTableSnapshotDone([sourceTable], postSnapshotLSN.toString());
       this.logger.info(
-        `Snapshot of ${table.toQualifiedName()} completed. Post-snapshot LSN: ${postSnapshotLSN.toString()}`
+        `Snapshot of ${physicalTable.toQualifiedName()} completed. Post-snapshot LSN: ${postSnapshotLSN.toString()}`
       );
       this.tableCache.updateSourceTable(updatedSourceTable);
     } catch (e) {
@@ -331,39 +334,41 @@ export class CDCStream {
   private async snapshotTable(
     batch: storage.BucketStorageBatch,
     transaction: sql.Transaction,
-    table: MSSQLSourceTable
+    physicalTable: MSSQLSourceTable,
+    sourceTable: storage.SourceTable
   ) {
-    let totalEstimatedCount = table.sourceTable.snapshotStatus?.totalEstimatedCount;
-    let replicatedCount = table.sourceTable.snapshotStatus?.replicatedCount ?? 0;
+    let totalEstimatedCount = sourceTable.snapshotStatus?.totalEstimatedCount;
+    let replicatedCount = sourceTable.snapshotStatus?.replicatedCount ?? 0;
     let lastCountTime = 0;
     let query: MSSQLSnapshotQuery;
     // We do streaming on two levels:
     // 1. Coarse select from the entire table, stream rows 1 by one
     // 2. Fine level: Stream batches of rows with each fetch call
-    if (BatchedSnapshotQuery.supports(table)) {
+    if (BatchedSnapshotQuery.supports(sourceTable)) {
       // Single primary key - we can use the primary key for chunking
-      const orderByKey = table.sourceTable.replicaIdColumns[0];
+      const orderByKey = sourceTable.replicaIdColumns[0];
       query = new BatchedSnapshotQuery(
         transaction,
-        table,
+        physicalTable.toQualifiedName(),
+        sourceTable,
         this.snapshotBatchSize,
-        table.sourceTable.snapshotStatus?.lastKey ?? null
+        sourceTable.snapshotStatus?.lastKey ?? null
       );
-      if (table.sourceTable.snapshotStatus?.lastKey != null) {
+      if (sourceTable.snapshotStatus?.lastKey != null) {
         this.logger.info(
-          `Snapshotting ${table.toQualifiedName()} ${table.sourceTable.formatSnapshotProgress()} - resuming from ${orderByKey.name} > ${(query as BatchedSnapshotQuery).lastKey}`
+          `Snapshotting ${physicalTable.toQualifiedName()} ${sourceTable.formatSnapshotProgress()} - resuming from ${orderByKey.name} > ${(query as BatchedSnapshotQuery).lastKey}`
         );
       } else {
         this.logger.info(
-          `Snapshotting ${table.toQualifiedName()} ${table.sourceTable.formatSnapshotProgress()} - resumable`
+          `Snapshotting ${physicalTable.toQualifiedName()} ${sourceTable.formatSnapshotProgress()} - resumable`
         );
       }
     } else {
       // Fallback case - query the entire table
       this.logger.info(
-        `Snapshotting ${table.toQualifiedName()} ${table.sourceTable.formatSnapshotProgress()} - not resumable`
+        `Snapshotting ${physicalTable.toQualifiedName()} ${sourceTable.formatSnapshotProgress()} - not resumable`
       );
-      query = new SimpleSnapshotQuery(transaction, table);
+      query = new SimpleSnapshotQuery(transaction, physicalTable.toQualifiedName());
       replicatedCount = 0;
     }
     await query.initialize();
@@ -390,11 +395,11 @@ export class CDCStream {
           // This auto-flushes when the batch reaches its size limit
           await batch.save({
             tag: storage.SaveOperationTag.INSERT,
-            sourceTable: table.sourceTable,
+            sourceTable,
             before: undefined,
             beforeReplicaId: undefined,
             after: row,
-            afterReplicaId: getUuidReplicaIdentityBson(row, table.sourceTable.replicaIdColumns)
+            afterReplicaId: getUuidReplicaIdentityBson(row, sourceTable.replicaIdColumns)
           });
 
           replicatedCount++;
@@ -417,15 +422,16 @@ export class CDCStream {
         // the default "Read Committed" isolation level. This means we can get new data
         // within the transaction, so we re-estimate the count every 10 minutes when replicating
         // large tables.
-        totalEstimatedCount = await this.estimatedCountNumber(table, transaction);
+        totalEstimatedCount = await this.estimatedCountNumber(physicalTable, transaction);
         lastCountTime = performance.now();
       }
-      const updatedSourceTable = await batch.updateTableProgress(table.sourceTable, {
+      const updatedSourceTable = await batch.updateTableProgress(sourceTable, {
         lastKey: lastKey,
         replicatedCount: replicatedCount,
         totalEstimatedCount: totalEstimatedCount
       });
       this.tableCache.updateSourceTable(updatedSourceTable);
+      sourceTable = updatedSourceTable;
 
       if (this.abortSignal.aborted) {
         // We only abort after flushing
@@ -436,7 +442,7 @@ export class CDCStream {
       if (batchReplicatedCount < this.snapshotBatchSize) {
         hasRemainingData = false;
       } else {
-        this.logger.info(`Snapshotting ${table.toQualifiedName()} ${table.sourceTable.formatSnapshotProgress()}`);
+        this.logger.info(`Snapshotting ${physicalTable.toQualifiedName()} ${sourceTable.formatSnapshotProgress()}`);
       }
     }
   }
@@ -489,7 +495,7 @@ export class CDCStream {
             break;
           case SnapshotStatus.LIMITED_RESNAPSHOT:
             for (const table of specificTablesToResnapshot!) {
-              await batch.drop([table.sourceTable]);
+              await batch.drop(table.getReplicatedSourceTables());
               // Update table in the table cache
               await this.processTable(batch, this.sourceRefFromTable(table.sourceTable), table.captureInstance, false);
             }
@@ -498,9 +504,10 @@ export class CDCStream {
             throw new ReplicationAssertionError(`Unsupported snapshot status: ${status}`);
         }
 
-        const tablesToSnapshot: MSSQLSourceTable[] = [];
+        const tablesToSnapshot: { physicalTable: MSSQLSourceTable; sourceTable: storage.SourceTable }[] = [];
         for (const table of this.tableCache.getAll()) {
-          if (table.sourceTable.snapshotComplete) {
+          const sourceTablesToSnapshot = table.sourceTables.filter((sourceTable) => !sourceTable.snapshotComplete);
+          if (sourceTablesToSnapshot.length == 0) {
             this.logger.info(`Skipping table [${table.toQualifiedName()}] - snapshot already done.`);
             continue;
           }
@@ -511,15 +518,17 @@ export class CDCStream {
           }
 
           const count = await this.estimatedCountNumber(table);
-          const updatedSourceTable = await batch.updateTableProgress(table.sourceTable, {
-            totalEstimatedCount: count
-          });
-          this.tableCache.updateSourceTable(updatedSourceTable);
-          tablesToSnapshot.push(table);
+          for (const sourceTable of sourceTablesToSnapshot) {
+            const updatedSourceTable = await batch.updateTableProgress(sourceTable, {
+              totalEstimatedCount: count
+            });
+            this.tableCache.updateSourceTable(updatedSourceTable);
+            tablesToSnapshot.push({ physicalTable: table, sourceTable: updatedSourceTable });
+          }
         }
 
-        for (const table of tablesToSnapshot) {
-          await this.snapshotTableInTx(batch, table);
+        for (const { physicalTable, sourceTable } of tablesToSnapshot) {
+          await this.snapshotTableInTx(batch, physicalTable, sourceTable);
           this.touch();
         }
 
@@ -564,7 +573,9 @@ export class CDCStream {
 
     if (status.snapshot_done && status.checkpoint_lsn) {
       const additionalTablesToSnapshot: Set<MSSQLSourceTable> = new Set();
-      const newTables = this.tableCache.getAll().filter((table) => !table.sourceTable.snapshotComplete);
+      const newTables = this.tableCache
+        .getAll()
+        .filter((table) => table.sourceTables.some((sourceTable) => !sourceTable.snapshotComplete));
       if (newTables.length > 0) {
         this.logger.info(
           `Detected new table(s) [${newTables.map((table) => table.toQualifiedName()).join(', ')}] that have not been snapshotted yet.`
@@ -655,39 +666,45 @@ export class CDCStream {
     return {
       onInsert: async (row: any, table: MSSQLSourceTable, columns: sql.IColumnMetadata) => {
         const afterRow = this.toSqliteRow(row, columns);
-        await batch.save({
-          tag: storage.SaveOperationTag.INSERT,
-          sourceTable: table.sourceTable,
-          before: undefined,
-          beforeReplicaId: undefined,
-          after: afterRow,
-          afterReplicaId: getUuidReplicaIdentityBson(afterRow, table.sourceTable.replicaIdColumns)
-        });
+        for (const sourceTable of table.getReplicatedSourceTables()) {
+          await batch.save({
+            tag: storage.SaveOperationTag.INSERT,
+            sourceTable,
+            before: undefined,
+            beforeReplicaId: undefined,
+            after: afterRow,
+            afterReplicaId: getUuidReplicaIdentityBson(afterRow, sourceTable.replicaIdColumns)
+          });
+        }
         this.metrics.getCounter(ReplicationMetric.ROWS_REPLICATED).add(1);
       },
       onUpdate: async (rowAfter: any, rowBefore: any, table: MSSQLSourceTable, columns: sql.IColumnMetadata) => {
         const beforeRow = this.toSqliteRow(rowBefore, columns);
         const afterRow = this.toSqliteRow(rowAfter, columns);
-        await batch.save({
-          tag: storage.SaveOperationTag.UPDATE,
-          sourceTable: table.sourceTable,
-          before: beforeRow,
-          beforeReplicaId: getUuidReplicaIdentityBson(beforeRow, table.sourceTable.replicaIdColumns),
-          after: afterRow,
-          afterReplicaId: getUuidReplicaIdentityBson(afterRow, table.sourceTable.replicaIdColumns)
-        });
+        for (const sourceTable of table.getReplicatedSourceTables()) {
+          await batch.save({
+            tag: storage.SaveOperationTag.UPDATE,
+            sourceTable,
+            before: beforeRow,
+            beforeReplicaId: getUuidReplicaIdentityBson(beforeRow, sourceTable.replicaIdColumns),
+            after: afterRow,
+            afterReplicaId: getUuidReplicaIdentityBson(afterRow, sourceTable.replicaIdColumns)
+          });
+        }
         this.metrics.getCounter(ReplicationMetric.ROWS_REPLICATED).add(1);
       },
       onDelete: async (row: any, table: MSSQLSourceTable, columns: sql.IColumnMetadata) => {
         const beforeRow = this.toSqliteRow(row, columns);
-        await batch.save({
-          tag: storage.SaveOperationTag.DELETE,
-          sourceTable: table.sourceTable,
-          before: beforeRow,
-          beforeReplicaId: getUuidReplicaIdentityBson(beforeRow, table.sourceTable.replicaIdColumns),
-          after: undefined,
-          afterReplicaId: undefined
-        });
+        for (const sourceTable of table.getReplicatedSourceTables()) {
+          await batch.save({
+            tag: storage.SaveOperationTag.DELETE,
+            sourceTable,
+            before: beforeRow,
+            beforeReplicaId: getUuidReplicaIdentityBson(beforeRow, sourceTable.replicaIdColumns),
+            after: undefined,
+            afterReplicaId: undefined
+          });
+        }
         this.metrics.getCounter(ReplicationMetric.ROWS_REPLICATED).add(1);
       },
       onCommit: async (lsn: string, transactionCount: number) => {
@@ -716,7 +733,8 @@ export class CDCStream {
         );
 
         // Old table needs to be cleaned up
-        await batch.drop([fromTable.sourceTable]);
+        const fromTables = fromTable.getReplicatedSourceTables();
+        await batch.drop(fromTables);
         this.tableCache.delete(fromTable.objectId);
 
         if (change.newTable) {
@@ -734,13 +752,13 @@ export class CDCStream {
         this.logger.info(
           `New CDC capture instance detected for table ${change.table!.toQualifiedName()}. Re-snapshotting table...`
         );
-        await batch.drop([change.table!.sourceTable]);
+        await batch.drop(change.table!.getReplicatedSourceTables());
         this.tableCache.delete(change.table!.objectId);
 
         await this.handleCreateOrUpdateTable(batch, change.table!.sourceTable, change.newCaptureInstance!);
         break;
       case SchemaChangeType.TABLE_DROP:
-        await batch.drop([change.table!.sourceTable]);
+        await batch.drop(change.table!.getReplicatedSourceTables());
         this.tableCache.delete(change.table!.objectId);
         break;
       case SchemaChangeType.MISSING_CAPTURE_INSTANCE:

--- a/modules/module-mssql/src/replication/MSSQLSnapshotQuery.ts
+++ b/modules/module-mssql/src/replication/MSSQLSnapshotQuery.ts
@@ -1,7 +1,6 @@
 import { ServiceAssertionError } from '@powersync/lib-services-framework';
 import { bson, ColumnDescriptor, SourceTable } from '@powersync/service-core';
 import sql from 'mssql';
-import { MSSQLSourceTable } from '../common/MSSQLSourceTable.js';
 import { MSSQLBaseType } from '../types/mssql-data-types.js';
 import { escapeIdentifier } from '../utils/mssql.js';
 
@@ -23,7 +22,7 @@ export interface MSSQLSnapshotQuery {
 export class SimpleSnapshotQuery implements MSSQLSnapshotQuery {
   public constructor(
     private readonly transaction: sql.Transaction,
-    private readonly table: MSSQLSourceTable
+    private readonly qualifiedTableName: string
   ) {}
 
   public async initialize(): Promise<void> {}
@@ -36,7 +35,7 @@ export class SimpleSnapshotQuery implements MSSQLSnapshotQuery {
       metadataRequest.on('error', reject);
     });
 
-    metadataRequest.query(`SELECT TOP(0) * FROM ${this.table.toQualifiedName()}`);
+    metadataRequest.query(`SELECT TOP(0) * FROM ${this.qualifiedTableName}`);
 
     const columnMetadata: sql.IColumnMetadata = await metadataPromise;
     yield columnMetadata;
@@ -44,7 +43,7 @@ export class SimpleSnapshotQuery implements MSSQLSnapshotQuery {
     const request = this.transaction.request();
     const stream = request.toReadableStream();
 
-    request.query(`SELECT * FROM ${this.table.toQualifiedName()}`);
+    request.query(`SELECT * FROM ${this.qualifiedTableName}`);
 
     // MSSQL only streams one row at a time
     for await (const row of stream) {
@@ -84,8 +83,7 @@ export class BatchedSnapshotQuery implements MSSQLSnapshotQuery {
     MSSQLBaseType.BIGINT
   ];
 
-  static supports(table: SourceTable | MSSQLSourceTable): boolean {
-    const sourceTable = table instanceof MSSQLSourceTable ? table.sourceTable : table;
+  static supports(sourceTable: SourceTable): boolean {
     if (sourceTable.replicaIdColumns.length != 1) {
       return false;
     }
@@ -99,11 +97,12 @@ export class BatchedSnapshotQuery implements MSSQLSnapshotQuery {
 
   public constructor(
     private readonly transaction: sql.Transaction,
-    private readonly table: MSSQLSourceTable,
+    private readonly qualifiedTableName: string,
+    sourceTable: SourceTable,
     private readonly batchSize: number = 10_000,
     lastKeySerialized: Uint8Array | null
   ) {
-    this.key = table.sourceTable.replicaIdColumns[0];
+    this.key = sourceTable.replicaIdColumns[0];
 
     if (lastKeySerialized != null) {
       this.lastKey = this.deserializeKey(lastKeySerialized);
@@ -126,7 +125,7 @@ export class BatchedSnapshotQuery implements MSSQLSnapshotQuery {
       metadataRequest.on('recordset', resolve);
       metadataRequest.on('error', reject);
     });
-    metadataRequest.query(`SELECT TOP(0) * FROM ${this.table.toQualifiedName()}`);
+    metadataRequest.query(`SELECT TOP(0) * FROM ${this.qualifiedTableName}`);
 
     const columnMetadata: sql.IColumnMetadata = await metadataPromise;
 
@@ -142,7 +141,7 @@ export class BatchedSnapshotQuery implements MSSQLSnapshotQuery {
     const request = this.transaction.request();
     const stream = request.toReadableStream();
     if (this.lastKey == null) {
-      request.query(`SELECT TOP(${this.batchSize}) * FROM ${this.table.toQualifiedName()} ORDER BY ${escapedKeyName}`);
+      request.query(`SELECT TOP(${this.batchSize}) * FROM ${this.qualifiedTableName} ORDER BY ${escapedKeyName}`);
     } else {
       if (this.key.typeId == null) {
         throw new Error(`typeId required for primary key ${this.key.name}`);
@@ -150,7 +149,7 @@ export class BatchedSnapshotQuery implements MSSQLSnapshotQuery {
       request
         .input('lastKey', this.lastKey)
         .query(
-          `SELECT TOP(${this.batchSize}) * FROM ${this.table.toQualifiedName()} WHERE ${escapedKeyName} > @lastKey ORDER BY ${escapedKeyName}`
+          `SELECT TOP(${this.batchSize}) * FROM ${this.qualifiedTableName} WHERE ${escapedKeyName} > @lastKey ORDER BY ${escapedKeyName}`
         );
     }
 

--- a/modules/module-mssql/src/utils/mssql.ts
+++ b/modules/module-mssql/src/utils/mssql.ts
@@ -308,7 +308,7 @@ export async function getDebugTableInfo(options: GetDebugTableInfoOptions): Prom
   }
 
   const idColumns = idColumnsResult?.columns ?? [];
-  const sourceTable: sync_rules.SourceTableInterface = {
+  const sourceTable: sync_rules.SourceTableRef = {
     connectionTag: connectionManager.connectionTag,
     schema: schema,
     name: table.name

--- a/modules/module-mssql/src/utils/schema.ts
+++ b/modules/module-mssql/src/utils/schema.ts
@@ -1,5 +1,4 @@
 import { logger } from '@powersync/lib-services-framework';
-import { SourceEntityDescriptor } from '@powersync/service-core';
 import { TablePattern } from '@powersync/service-sync-rules';
 import sql from 'mssql';
 import { MSSQLConnectionManager } from '../replication/MSSQLConnectionManager.js';
@@ -139,7 +138,13 @@ export async function getReplicationIdentityColumns(
   };
 }
 
-export type ResolvedTable = Omit<SourceEntityDescriptor, 'replicaIdColumns'>;
+export interface SourceTableChangeRef {
+  objectId: number | string | undefined;
+  schema: string;
+  name: string;
+}
+
+export type ResolvedTable = SourceTableChangeRef;
 
 export async function getTablesFromPattern(
   connectionManager: MSSQLConnectionManager,

--- a/modules/module-mysql/src/api/MySQLRouteAPIAdapter.ts
+++ b/modules/module-mysql/src/api/MySQLRouteAPIAdapter.ts
@@ -1,4 +1,4 @@
-import { api, ParseSyncRulesOptions, ReplicationHeadCallback, storage } from '@powersync/service-core';
+import { api, ParseSyncRulesOptions, ReplicationHeadCallback } from '@powersync/service-core';
 
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as service_types from '@powersync/service-types';
@@ -220,20 +220,16 @@ export class MySQLRouteAPIAdapter implements api.RouteAPI {
     }
 
     const idColumns = idColumnsResult?.columns ?? [];
-    const sourceTable = new storage.SourceTable({
-      id: '', // not used
+    const ref: sync_rules.SourceTableRef = {
       connectionTag: this.config.tag,
-      objectId: tableName,
-      schema: schema,
-      name: tableName,
-      replicaIdColumns: idColumns,
-      snapshotComplete: true
-    });
-    const syncData = syncRules.tableSyncsData(sourceTable);
-    const syncParameters = syncRules.tableSyncsParameters(sourceTable);
+      schema,
+      name: tableName
+    };
+    const syncData = syncRules.tableSyncsData(ref);
+    const syncParameters = syncRules.tableSyncsParameters(ref);
 
     if (idColumns.length == 0 && idColumnsError == null) {
-      let message = `No replication id found for ${sourceTable.qualifiedName}. Replica identity: ${idColumnsResult?.identity}.`;
+      let message = `No replication id found for ${mysql_utils.qualifiedMySQLTable(ref)}. Replica identity: ${idColumnsResult?.identity}.`;
       if (idColumnsResult?.identity == 'default') {
         message += ' Configure a primary key on the table.';
       }
@@ -243,7 +239,7 @@ export class MySQLRouteAPIAdapter implements api.RouteAPI {
     let selectError: service_types.ReplicationError | null = null;
     try {
       await this.retriedQuery({
-        query: `SELECT * FROM ${sourceTable.name} LIMIT 1`
+        query: `SELECT * FROM ${mysql_utils.qualifiedMySQLTable(ref)} LIMIT 1`
       });
     } catch (e) {
       selectError = { level: 'fatal', message: e.message };

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -73,7 +73,7 @@ export class BinLogStream {
 
   private readonly logger: Logger;
 
-  private tableCache = new Map<string | number, storage.SourceTable>();
+  private tableCache = new Map<string | number, storage.SourceTable[]>();
 
   private replicationLag = new ReplicationLagTracker();
 
@@ -122,15 +122,17 @@ export class BinLogStream {
     return this.connections.databaseName;
   }
 
-  async handleRelation(batch: storage.BucketStorageBatch, source: storage.SourceEntityDescriptor, snapshot: boolean) {
+  async handleRelation(
+    batch: storage.BucketStorageBatch,
+    source: storage.SourceEntityDescriptor,
+    snapshot: boolean
+  ): Promise<storage.SourceTable[]> {
     const result = await batch.resolveTables({
       connection_id: this.connectionId,
       source
     });
-    for (const table of result.tables) {
-      // Since we create the objectId ourselves, this is always defined
-      this.tableCache.set(source.objectId!, table);
-    }
+    // Since we create the objectId ourselves, this is always defined.
+    this.tableCache.set(source.objectId!, result.tables);
 
     // Drop conflicting tables. In the MySQL case with ObjectIds created from the table name, renames cannot be detected by the storage.
     await batch.drop(result.dropTables);
@@ -166,11 +168,13 @@ export class BinLogStream {
         connection.release();
       }
       const doneTables = await batch.markTableSnapshotDone(snapshotCandidates, gtid.comparable);
-      const table = doneTables[doneTables.length - 1];
-      return table;
+      const doneTablesById = new Map(doneTables.map((table) => [table.id, table]));
+      const tables = result.tables.map((table) => doneTablesById.get(table.id) ?? table);
+      this.tableCache.set(source.objectId!, tables);
+      return tables;
     }
 
-    return result.tables[0];
+    return result.tables;
   }
 
   async getQualifiedTableNames(
@@ -189,7 +193,7 @@ export class BinLogStream {
     for (const matchedTable of matchedTables) {
       const replicaIdColumns = await this.getReplicaIdColumns(matchedTable, tablePattern.schema);
 
-      const table = await this.handleRelation(
+      const resolvedTables = await this.handleRelation(
         batch,
         {
           name: matchedTable,
@@ -201,7 +205,7 @@ export class BinLogStream {
         false
       );
 
-      tables.push(table);
+      tables.push(...resolvedTables);
     }
     return tables;
   }
@@ -391,14 +395,14 @@ export class BinLogStream {
     }
   }
 
-  private getTable(tableId: string): storage.SourceTable {
-    const table = this.tableCache.get(tableId);
-    if (table == null) {
+  private getTables(tableId: string): storage.SourceTable[] {
+    const tables = this.tableCache.get(tableId);
+    if (tables == null) {
       // We should always receive a replication message before the relation is used.
       // If we can't find it, it's a bug.
       throw new ReplicationAssertionError(`Missing relation cache for ${tableId}`);
     }
-    return table;
+    return tables;
   }
 
   async streamChanges() {
@@ -499,10 +503,10 @@ export class BinLogStream {
     if (change.type === SchemaChangeType.RENAME_TABLE) {
       const fromTableId = createTableId(change.schema, change.table);
 
-      const fromTable = this.tableCache.get(fromTableId);
+      const fromTables = this.tableCache.get(fromTableId);
       // Old table needs to be cleaned up
-      if (fromTable) {
-        await batch.drop([fromTable]);
+      if (fromTables) {
+        await batch.drop(fromTables);
         this.tableCache.delete(fromTableId);
       }
       // The new table matched a table in the sync config
@@ -512,7 +516,7 @@ export class BinLogStream {
     } else {
       const tableId = createTableId(change.schema, change.table);
 
-      const table = this.getTable(tableId);
+      const tables = this.getTables(tableId);
 
       switch (change.type) {
         case SchemaChangeType.ALTER_TABLE_COLUMN:
@@ -521,10 +525,10 @@ export class BinLogStream {
           await this.handleCreateOrUpdateTable(batch, change.table, change.schema);
           break;
         case SchemaChangeType.TRUNCATE_TABLE:
-          await batch.truncate([table]);
+          await batch.truncate(tables);
           break;
         case SchemaChangeType.DROP_TABLE:
-          await batch.drop([table]);
+          await batch.drop(tables);
           this.tableCache.delete(tableId);
           break;
         default:
@@ -550,7 +554,7 @@ export class BinLogStream {
     batch: storage.BucketStorageBatch,
     tableName: string,
     schema: string
-  ): Promise<SourceTable> {
+  ): Promise<SourceTable[]> {
     const replicaIdColumns = await this.getReplicaIdColumns(tableName, schema);
     return await this.handleRelation(
       batch,
@@ -577,23 +581,25 @@ export class BinLogStream {
     const columns = common.toColumnDescriptors(msg.tableEntry);
     const tableId = createTableId(msg.tableEntry.parentSchema, msg.tableEntry.tableName);
 
-    let table = this.tableCache.get(tableId);
-    if (table == null) {
+    let tables = this.tableCache.get(tableId);
+    if (tables == null) {
       // This is an insert for a new table that matches a table in the sync config
       // We need to create the table in the storage and cache it.
-      table = await this.handleCreateOrUpdateTable(batch, msg.tableEntry.tableName, msg.tableEntry.parentSchema);
+      tables = await this.handleCreateOrUpdateTable(batch, msg.tableEntry.tableName, msg.tableEntry.parentSchema);
     }
 
     for (const [index, row] of msg.rows.entries()) {
-      await this.writeChange(batch, {
-        type: msg.type,
-        database: msg.tableEntry.parentSchema,
-        sourceTable: table!,
-        table: msg.tableEntry.tableName,
-        columns: columns,
-        row: row,
-        previous_row: msg.rows_before?.[index]
-      });
+      for (const table of tables.filter((table) => table.syncAny)) {
+        await this.writeChange(batch, {
+          type: msg.type,
+          database: msg.tableEntry.parentSchema,
+          sourceTable: table,
+          table: msg.tableEntry.tableName,
+          columns: columns,
+          row: row,
+          previous_row: msg.rows_before?.[index]
+        });
+      }
     }
     return null;
   }

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -123,15 +123,18 @@ export class BinLogStream {
   }
 
   async handleRelation(batch: storage.BucketStorageBatch, entity: storage.SourceEntityDescriptor, snapshot: boolean) {
-    const result = await this.storage.resolveTable({
+    const result = await batch.resolveTables({
       group_id: this.groupId,
       connection_id: this.connectionId,
       connection_tag: this.connectionTag,
       entity_descriptor: entity,
-      sync_rules: this.syncRules
+      sync_rules: this.syncRules,
+      matchingSources: null
     });
-    // Since we create the objectId ourselves, this is always defined
-    this.tableCache.set(entity.objectId!, result.table);
+    for (const table of result.tables) {
+      // Since we create the objectId ourselves, this is always defined
+      this.tableCache.set(entity.objectId!, table);
+    }
 
     // Drop conflicting tables. In the MySQL case with ObjectIds created from the table name, renames cannot be detected by the storage.
     await batch.drop(result.dropTables);
@@ -140,11 +143,9 @@ export class BinLogStream {
     // 1. Snapshot is requested (false for initial snapshot, since that process handles it elsewhere)
     // 2. Snapshot is not done yet, AND:
     // 3. The table is used in sync config.
-    const shouldSnapshot = snapshot && !result.table.snapshotComplete && result.table.syncAny;
-
-    if (shouldSnapshot) {
-      // Truncate this table in case a previous snapshot was interrupted.
-      await batch.truncate([result.table]);
+    const snapshotCandidates = result.tables.filter((table) => snapshot && !table.snapshotComplete && table.syncAny);
+    if (snapshotCandidates.length > 0) {
+      await batch.truncate(snapshotCandidates);
 
       let gtid: common.ReplicatedGTID;
       // Start the snapshot inside a transaction.
@@ -157,7 +158,9 @@ export class BinLogStream {
         await promiseConnection.query('START TRANSACTION');
         try {
           gtid = await common.readExecutedGtid(promiseConnection);
-          await this.snapshotTable(connection as mysql.Connection, batch, result.table);
+          for (const table of snapshotCandidates) {
+            await this.snapshotTable(connection as mysql.Connection, batch, table);
+          }
           await promiseConnection.query('COMMIT');
         } catch (e) {
           await this.tryRollback(promiseConnection);
@@ -166,11 +169,12 @@ export class BinLogStream {
       } finally {
         connection.release();
       }
-      const [table] = await batch.markTableSnapshotDone([result.table], gtid.comparable);
+      const doneTables = await batch.markTableSnapshotDone(snapshotCandidates, gtid.comparable);
+      const table = doneTables[doneTables.length - 1];
       return table;
     }
 
-    return result.table;
+    return result.tables[0];
   }
 
   async getQualifiedTableNames(

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -122,16 +122,14 @@ export class BinLogStream {
     return this.connections.databaseName;
   }
 
-  async handleRelation(batch: storage.BucketStorageBatch, entity: storage.SourceEntityDescriptor, snapshot: boolean) {
+  async handleRelation(batch: storage.BucketStorageBatch, source: storage.SourceEntityDescriptor, snapshot: boolean) {
     const result = await batch.resolveTables({
       connection_id: this.connectionId,
-      connection_tag: this.connectionTag,
-      entity_descriptor: entity,
-      matchingSources: null
+      source
     });
     for (const table of result.tables) {
       // Since we create the objectId ourselves, this is always defined
-      this.tableCache.set(entity.objectId!, table);
+      this.tableCache.set(source.objectId!, table);
     }
 
     // Drop conflicting tables. In the MySQL case with ObjectIds created from the table name, renames cannot be detected by the storage.
@@ -196,6 +194,7 @@ export class BinLogStream {
         {
           name: matchedTable,
           schema: tablePattern.schema,
+          connectionTag: this.connectionTag,
           objectId: createTableId(tablePattern.schema, matchedTable),
           replicaIdColumns: replicaIdColumns
         },
@@ -307,11 +306,11 @@ export class BinLogStream {
     batch: storage.BucketStorageBatch,
     table: storage.SourceTable
   ) {
-    this.logger.info(`Replicating ${qualifiedMySQLTable(table)}`);
+    this.logger.info(`Replicating ${qualifiedMySQLTable(table.ref)}`);
     // TODO count rows and log progress at certain batch sizes
 
     // MAX_EXECUTION_TIME(0) hint disables execution timeout for this query
-    const query = connection.query(`SELECT /*+ MAX_EXECUTION_TIME(0) */ * FROM ${qualifiedMySQLTable(table)}`);
+    const query = connection.query(`SELECT /*+ MAX_EXECUTION_TIME(0) */ * FROM ${qualifiedMySQLTable(table.ref)}`);
     const stream = query.stream();
 
     let columns: Map<string, ColumnDescriptor> | undefined = undefined;
@@ -558,6 +557,7 @@ export class BinLogStream {
       {
         name: tableName,
         schema: schema,
+        connectionTag: this.connectionTag,
         objectId: createTableId(schema, tableName),
         replicaIdColumns: replicaIdColumns
       },

--- a/modules/module-mysql/src/replication/BinLogStream.ts
+++ b/modules/module-mysql/src/replication/BinLogStream.ts
@@ -124,11 +124,9 @@ export class BinLogStream {
 
   async handleRelation(batch: storage.BucketStorageBatch, entity: storage.SourceEntityDescriptor, snapshot: boolean) {
     const result = await batch.resolveTables({
-      group_id: this.groupId,
       connection_id: this.connectionId,
       connection_tag: this.connectionTag,
       entity_descriptor: entity,
-      sync_rules: this.syncRules,
       matchingSources: null
     });
     for (const table of result.tables) {

--- a/modules/module-mysql/src/utils/mysql-utils.ts
+++ b/modules/module-mysql/src/utils/mysql-utils.ts
@@ -1,5 +1,5 @@
 import { logger } from '@powersync/lib-services-framework';
-import { SourceEntityDescriptor } from '@powersync/service-core';
+import { SourceTableRef } from '@powersync/service-sync-rules';
 import mysql from 'mysql2';
 import mysqlPromise from 'mysql2/promise';
 import { coerce, gte, satisfies } from 'semver';
@@ -101,10 +101,10 @@ export function satisfiesVersion(version: string, targetVersion: string): boolea
   return satisfies(coercedVersion!, targetVersion!, { loose: true });
 }
 
-export function qualifiedMySQLTable(table: SourceEntityDescriptor): string;
+export function qualifiedMySQLTable(table: SourceTableRef): string;
 export function qualifiedMySQLTable(table: string, schema: string): string;
 
-export function qualifiedMySQLTable(table: SourceEntityDescriptor | string, schema?: string): string {
+export function qualifiedMySQLTable(table: SourceTableRef | string, schema?: string): string {
   if (typeof table === 'object') {
     return `\`${table.schema.replaceAll('`', '``')}\`.\`${table.name.replaceAll('`', '``')}\``;
   } else if (schema) {

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -4,6 +4,7 @@ import {
   BucketChecksum,
   CHECKPOINT_INVALIDATE_ALL,
   CheckpointChanges,
+  ColumnDescriptor,
   GetCheckpointChangesOptions,
   InternalOpId,
   internalToExternalOpId,
@@ -343,11 +344,14 @@ export class PostgresSyncRulesStorage
               },
               objectId: doc.relation_id?.object_id ?? 0,
               replicaIdColumns:
-                doc.replica_id_columns?.map((c) => ({
-                  name: c.name,
-                  typeOid: c.typeId,
-                  type: c.type
-                })) ?? [],
+                doc.replica_id_columns?.map(
+                  (c) =>
+                    ({
+                      name: c.name,
+                      typeId: c.typeId,
+                      type: c.type
+                    }) satisfies ColumnDescriptor
+                ) ?? [],
               snapshotComplete: doc.snapshot_done ?? true
             })
         )

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -276,7 +276,8 @@ export class PostgresSyncRulesStorage
         ref: source,
         objectId: objectId,
         replicaIdColumns: replicaIdColumns,
-        snapshotComplete: sourceTableRow!.snapshot_done ?? true
+        snapshotComplete: sourceTableRow!.snapshot_done ?? true,
+        ...syncRules.getMatchingSources(source)
       });
       if (!sourceTable.snapshotComplete) {
         sourceTable.snapshotStatus = {
@@ -286,8 +287,8 @@ export class PostgresSyncRulesStorage
         };
       }
       sourceTable.syncEvent = syncRules.tableTriggersEvent(source);
-      sourceTable.syncData = syncRules.tableSyncsData(source);
-      sourceTable.syncParameters = syncRules.tableSyncsParameters(source);
+      sourceTable.syncData = sourceTable.bucketDataSources.length > 0;
+      sourceTable.syncParameters = sourceTable.parameterLookupSources.length > 0;
 
       let truncatedTables: SourceTableDecoded[] = [];
       if (objectId != null) {
@@ -333,28 +334,33 @@ export class PostgresSyncRulesStorage
 
       return {
         tables: [sourceTable],
-        dropTables: truncatedTables.map(
-          (doc) =>
-            new storage.SourceTable({
-              id: doc.id,
-              ref: {
-                connectionTag,
-                schema: doc.schema_name,
-                name: doc.table_name
-              },
-              objectId: doc.relation_id?.object_id ?? 0,
-              replicaIdColumns:
-                doc.replica_id_columns?.map(
-                  (c) =>
-                    ({
-                      name: c.name,
-                      typeId: c.typeId,
-                      type: c.type
-                    }) satisfies ColumnDescriptor
-                ) ?? [],
-              snapshotComplete: doc.snapshot_done ?? true
-            })
-        )
+        dropTables: truncatedTables.map((doc) => {
+          const ref = {
+            connectionTag,
+            schema: doc.schema_name,
+            name: doc.table_name
+          };
+          const dropTable = new storage.SourceTable({
+            id: doc.id,
+            ref,
+            objectId: doc.relation_id?.object_id ?? 0,
+            replicaIdColumns:
+              doc.replica_id_columns?.map(
+                (c) =>
+                  ({
+                    name: c.name,
+                    typeId: c.typeId,
+                    type: c.type
+                  }) satisfies ColumnDescriptor
+              ) ?? [],
+            snapshotComplete: doc.snapshot_done ?? true,
+            ...syncRules.getMatchingSources(ref)
+          });
+          dropTable.syncEvent = syncRules.tableTriggersEvent(ref);
+          dropTable.syncData = dropTable.bucketDataSources.length > 0;
+          dropTable.syncParameters = dropTable.parameterLookupSources.length > 0;
+          return dropTable;
+        })
       };
     });
   }

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -188,7 +188,7 @@ export class PostgresSyncRulesStorage
     );
   }
 
-  async resolveTable(options: storage.ResolveTableOptions): Promise<storage.ResolveTableResult> {
+  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
     const { group_id, connection_id, connection_tag, entity_descriptor } = options;
 
     const { schema, name: table, objectId, replicaIdColumns } = entity_descriptor;
@@ -328,7 +328,7 @@ export class PostgresSyncRulesStorage
       }
 
       return {
-        table: sourceTable,
+        tables: [sourceTable],
         dropTables: truncatedTables.map(
           (doc) =>
             new storage.SourceTable({
@@ -380,7 +380,8 @@ export class PostgresSyncRulesStorage
       skip_existing_rows: options.skipExistingRows ?? false,
       batch_limits: this.options.batchLimits,
       markRecordUnavailable: options.markRecordUnavailable,
-      storageConfig: this.storageConfig
+      storageConfig: this.storageConfig,
+      resolveTables: (resolveOptions) => this.resolveTables(resolveOptions)
     });
     this.iterateListeners((cb) => cb.batchStarted?.(writer));
     return writer;

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -27,6 +27,7 @@ import { bigint, BIGINT_MAX } from '../types/codecs.js';
 import { models, RequiredOperationBatchLimits } from '../types/types.js';
 import { replicaIdToSubkey } from '../utils/bson.js';
 import { mapOpEntry } from '../utils/bucket-data.js';
+import { postgresTableId } from './table-id.js';
 
 import * as framework from '@powersync/lib-services-framework';
 import { StatementParam } from '@powersync/service-jpgwire';
@@ -188,8 +189,11 @@ export class PostgresSyncRulesStorage
     );
   }
 
-  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
-    const { group_id, connection_id, connection_tag, entity_descriptor } = options;
+  async resolveTables(
+    options: storage.ResolveTablesOptions,
+    syncRules = this.getParsedSyncRules({ defaultSchema: options.entity_descriptor.schema })
+  ): Promise<storage.ResolveTablesResult> {
+    const { connection_id, connection_tag, entity_descriptor } = options;
 
     const { schema, name: table, objectId, replicaIdColumns } = entity_descriptor;
 
@@ -208,7 +212,7 @@ export class PostgresSyncRulesStorage
           FROM
             source_tables
           WHERE
-            group_id = ${{ type: 'int4', value: group_id }}
+            group_id = ${{ type: 'int4', value: this.group_id }}
             AND connection_id = ${{ type: 'int4', value: connection_id }}
             AND relation_id = ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }}
             AND schema_name = ${{ type: 'varchar', value: schema }}
@@ -224,7 +228,7 @@ export class PostgresSyncRulesStorage
           FROM
             source_tables
           WHERE
-            group_id = ${{ type: 'int4', value: group_id }}
+            group_id = ${{ type: 'int4', value: this.group_id }}
             AND connection_id = ${{ type: 'int4', value: connection_id }}
             AND schema_name = ${{ type: 'varchar', value: schema }}
             AND table_name = ${{ type: 'varchar', value: table }}
@@ -235,6 +239,7 @@ export class PostgresSyncRulesStorage
       }
 
       if (sourceTableRow == null) {
+        const id = options.idGenerator ? postgresTableId(options.idGenerator()) : uuid.v4();
         const row = await db.sql`
           INSERT INTO
             source_tables (
@@ -248,8 +253,8 @@ export class PostgresSyncRulesStorage
             )
           VALUES
             (
-              ${{ type: 'varchar', value: uuid.v4() }},
-              ${{ type: 'int4', value: group_id }},
+              ${{ type: 'varchar', value: id }},
+              ${{ type: 'int4', value: this.group_id }},
               ${{ type: 'int4', value: connection_id }},
               --- The objectId can be string | number | undefined, we store it as jsonb value
               ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }},
@@ -281,9 +286,9 @@ export class PostgresSyncRulesStorage
           lastKey: sourceTableRow!.snapshot_last_key
         };
       }
-      sourceTable.syncEvent = options.sync_rules.tableTriggersEvent(sourceTable);
-      sourceTable.syncData = options.sync_rules.tableSyncsData(sourceTable);
-      sourceTable.syncParameters = options.sync_rules.tableSyncsParameters(sourceTable);
+      sourceTable.syncEvent = syncRules.tableTriggersEvent(sourceTable);
+      sourceTable.syncData = syncRules.tableSyncsData(sourceTable);
+      sourceTable.syncParameters = syncRules.tableSyncsParameters(sourceTable);
 
       let truncatedTables: SourceTableDecoded[] = [];
       if (objectId != null) {
@@ -294,7 +299,7 @@ export class PostgresSyncRulesStorage
           FROM
             source_tables
           WHERE
-            group_id = ${{ type: 'int4', value: group_id }}
+            group_id = ${{ type: 'int4', value: this.group_id }}
             AND connection_id = ${{ type: 'int4', value: connection_id }}
             AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
             AND (
@@ -315,7 +320,7 @@ export class PostgresSyncRulesStorage
           FROM
             source_tables
           WHERE
-            group_id = ${{ type: 'int4', value: group_id }}
+            group_id = ${{ type: 'int4', value: this.group_id }}
             AND connection_id = ${{ type: 'int4', value: connection_id }}
             AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
             AND (
@@ -381,7 +386,7 @@ export class PostgresSyncRulesStorage
       batch_limits: this.options.batchLimits,
       markRecordUnavailable: options.markRecordUnavailable,
       storageConfig: this.storageConfig,
-      resolveTables: (resolveOptions) => this.resolveTables(resolveOptions)
+      resolveTables: (resolveOptions, syncRules) => this.resolveTables(resolveOptions, syncRules)
     });
     this.iterateListeners((cb) => cb.batchStarted?.(writer));
     return writer;

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -191,11 +191,11 @@ export class PostgresSyncRulesStorage
 
   async resolveTables(
     options: storage.ResolveTablesOptions,
-    syncRules = this.getParsedSyncRules({ defaultSchema: options.entity_descriptor.schema })
+    syncRules = this.getParsedSyncRules({ defaultSchema: options.source.schema })
   ): Promise<storage.ResolveTablesResult> {
-    const { connection_id, connection_tag, entity_descriptor } = options;
+    const { connection_id, source } = options;
 
-    const { schema, name: table, objectId, replicaIdColumns } = entity_descriptor;
+    const { schema: schema, name: table, objectId, replicaIdColumns, connectionTag } = source;
 
     const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
       name: column.name,
@@ -272,10 +272,8 @@ export class PostgresSyncRulesStorage
 
       const sourceTable = new storage.SourceTable({
         id: sourceTableRow!.id,
-        connectionTag: connection_tag,
+        ref: source,
         objectId: objectId,
-        schema: schema,
-        name: table,
         replicaIdColumns: replicaIdColumns,
         snapshotComplete: sourceTableRow!.snapshot_done ?? true
       });
@@ -286,9 +284,9 @@ export class PostgresSyncRulesStorage
           lastKey: sourceTableRow!.snapshot_last_key
         };
       }
-      sourceTable.syncEvent = syncRules.tableTriggersEvent(sourceTable);
-      sourceTable.syncData = syncRules.tableSyncsData(sourceTable);
-      sourceTable.syncParameters = syncRules.tableSyncsParameters(sourceTable);
+      sourceTable.syncEvent = syncRules.tableTriggersEvent(source);
+      sourceTable.syncData = syncRules.tableSyncsData(source);
+      sourceTable.syncParameters = syncRules.tableSyncsParameters(source);
 
       let truncatedTables: SourceTableDecoded[] = [];
       if (objectId != null) {
@@ -338,10 +336,12 @@ export class PostgresSyncRulesStorage
           (doc) =>
             new storage.SourceTable({
               id: doc.id,
-              connectionTag: connection_tag,
+              ref: {
+                connectionTag,
+                schema: doc.schema_name,
+                name: doc.table_name
+              },
               objectId: doc.relation_id?.object_id ?? 0,
-              schema: doc.schema_name,
-              name: doc.table_name,
               replicaIdColumns:
                 doc.replica_id_columns?.map((c) => ({
                   name: c.name,

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -4,7 +4,6 @@ import {
   BucketChecksum,
   CHECKPOINT_INVALIDATE_ALL,
   CheckpointChanges,
-  ColumnDescriptor,
   GetCheckpointChangesOptions,
   InternalOpId,
   internalToExternalOpId,
@@ -23,18 +22,15 @@ import {
 import { JSONBig } from '@powersync/service-jsonbig';
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as timers from 'timers/promises';
-import * as uuid from 'uuid';
 import { bigint, BIGINT_MAX } from '../types/codecs.js';
 import { models, RequiredOperationBatchLimits } from '../types/types.js';
 import { replicaIdToSubkey } from '../utils/bson.js';
 import { mapOpEntry } from '../utils/bucket-data.js';
-import { postgresTableId } from './table-id.js';
 
 import * as framework from '@powersync/lib-services-framework';
 import { StatementParam } from '@powersync/service-jpgwire';
 import { wrapWithAbort } from 'ix/asynciterable/operators/withabort.js';
 import * as t from 'ts-codec';
-import { SourceTableDecoded, StoredRelationId } from '../types/models/SourceTable.js';
 import { pick } from '../utils/ts-codec.js';
 import { PostgresBucketBatch } from './batch/PostgresBucketBatch.js';
 import { PostgresWriteCheckpointAPI } from './checkpoints/PostgresWriteCheckpointAPI.js';
@@ -190,181 +186,6 @@ export class PostgresSyncRulesStorage
     );
   }
 
-  async resolveTables(
-    options: storage.ResolveTablesOptions,
-    syncRules = this.getParsedSyncRules({ defaultSchema: options.source.schema })
-  ): Promise<storage.ResolveTablesResult> {
-    const { connection_id, source } = options;
-
-    const { schema: schema, name: table, objectId, replicaIdColumns, connectionTag } = source;
-
-    const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
-      name: column.name,
-      type: column.type,
-      // The PGWire returns this as a BigInt. We want to store this as JSONB
-      type_oid: typeof column.typeId !== 'undefined' ? Number(column.typeId) : column.typeId
-    }));
-    return this.db.transaction(async (db) => {
-      let sourceTableRow: SourceTableDecoded | null;
-      if (objectId != null) {
-        sourceTableRow = await db.sql`
-          SELECT
-            *
-          FROM
-            source_tables
-          WHERE
-            group_id = ${{ type: 'int4', value: this.group_id }}
-            AND connection_id = ${{ type: 'int4', value: connection_id }}
-            AND relation_id = ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }}
-            AND schema_name = ${{ type: 'varchar', value: schema }}
-            AND table_name = ${{ type: 'varchar', value: table }}
-            AND replica_id_columns = ${{ type: 'jsonb', value: normalizedReplicaIdColumns }}
-        `
-          .decoded(models.SourceTable)
-          .first();
-      } else {
-        sourceTableRow = await db.sql`
-          SELECT
-            *
-          FROM
-            source_tables
-          WHERE
-            group_id = ${{ type: 'int4', value: this.group_id }}
-            AND connection_id = ${{ type: 'int4', value: connection_id }}
-            AND schema_name = ${{ type: 'varchar', value: schema }}
-            AND table_name = ${{ type: 'varchar', value: table }}
-            AND replica_id_columns = ${{ type: 'jsonb', value: normalizedReplicaIdColumns }}
-        `
-          .decoded(models.SourceTable)
-          .first();
-      }
-
-      if (sourceTableRow == null) {
-        const id = options.idGenerator ? postgresTableId(options.idGenerator()) : uuid.v4();
-        const row = await db.sql`
-          INSERT INTO
-            source_tables (
-              id,
-              group_id,
-              connection_id,
-              relation_id,
-              schema_name,
-              table_name,
-              replica_id_columns
-            )
-          VALUES
-            (
-              ${{ type: 'varchar', value: id }},
-              ${{ type: 'int4', value: this.group_id }},
-              ${{ type: 'int4', value: connection_id }},
-              --- The objectId can be string | number | undefined, we store it as jsonb value
-              ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }},
-              ${{ type: 'varchar', value: schema }},
-              ${{ type: 'varchar', value: table }},
-              ${{ type: 'jsonb', value: normalizedReplicaIdColumns }}
-            )
-          RETURNING
-            *
-        `
-          .decoded(models.SourceTable)
-          .first();
-        sourceTableRow = row;
-      }
-
-      const sourceTable = new storage.SourceTable({
-        id: sourceTableRow!.id,
-        ref: source,
-        objectId: objectId,
-        replicaIdColumns: replicaIdColumns,
-        snapshotComplete: sourceTableRow!.snapshot_done ?? true,
-        ...syncRules.getMatchingSources(source)
-      });
-      if (!sourceTable.snapshotComplete) {
-        sourceTable.snapshotStatus = {
-          totalEstimatedCount: Number(sourceTableRow!.snapshot_total_estimated_count ?? -1n),
-          replicatedCount: Number(sourceTableRow!.snapshot_replicated_count ?? 0n),
-          lastKey: sourceTableRow!.snapshot_last_key
-        };
-      }
-      sourceTable.syncEvent = syncRules.tableTriggersEvent(source);
-      sourceTable.syncData = sourceTable.bucketDataSources.length > 0;
-      sourceTable.syncParameters = sourceTable.parameterLookupSources.length > 0;
-
-      let truncatedTables: SourceTableDecoded[] = [];
-      if (objectId != null) {
-        // relation_id present - check for renamed tables
-        truncatedTables = await db.sql`
-          SELECT
-            *
-          FROM
-            source_tables
-          WHERE
-            group_id = ${{ type: 'int4', value: this.group_id }}
-            AND connection_id = ${{ type: 'int4', value: connection_id }}
-            AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
-            AND (
-              relation_id = ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }}
-              OR (
-                schema_name = ${{ type: 'varchar', value: schema }}
-                AND table_name = ${{ type: 'varchar', value: table }}
-              )
-            )
-        `
-          .decoded(models.SourceTable)
-          .rows();
-      } else {
-        // relation_id not present - only check for changed replica_id_columns
-        truncatedTables = await db.sql`
-          SELECT
-            *
-          FROM
-            source_tables
-          WHERE
-            group_id = ${{ type: 'int4', value: this.group_id }}
-            AND connection_id = ${{ type: 'int4', value: connection_id }}
-            AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
-            AND (
-              schema_name = ${{ type: 'varchar', value: schema }}
-              AND table_name = ${{ type: 'varchar', value: table }}
-            )
-        `
-          .decoded(models.SourceTable)
-          .rows();
-      }
-
-      return {
-        tables: [sourceTable],
-        dropTables: truncatedTables.map((doc) => {
-          const ref = {
-            connectionTag,
-            schema: doc.schema_name,
-            name: doc.table_name
-          };
-          const dropTable = new storage.SourceTable({
-            id: doc.id,
-            ref,
-            objectId: doc.relation_id?.object_id ?? 0,
-            replicaIdColumns:
-              doc.replica_id_columns?.map(
-                (c) =>
-                  ({
-                    name: c.name,
-                    typeId: c.typeId,
-                    type: c.type
-                  }) satisfies ColumnDescriptor
-              ) ?? [],
-            snapshotComplete: doc.snapshot_done ?? true,
-            ...syncRules.getMatchingSources(ref)
-          });
-          dropTable.syncEvent = syncRules.tableTriggersEvent(ref);
-          dropTable.syncData = dropTable.bucketDataSources.length > 0;
-          dropTable.syncParameters = dropTable.parameterLookupSources.length > 0;
-          return dropTable;
-        })
-      };
-    });
-  }
-
   async createWriter(options: storage.CreateWriterOptions): Promise<storage.BucketStorageBatch> {
     const syncRules = await this.db.sql`
       SELECT
@@ -395,8 +216,7 @@ export class PostgresSyncRulesStorage
       skip_existing_rows: options.skipExistingRows ?? false,
       batch_limits: this.options.batchLimits,
       markRecordUnavailable: options.markRecordUnavailable,
-      storageConfig: this.storageConfig,
-      resolveTables: (resolveOptions, syncRules) => this.resolveTables(resolveOptions, syncRules)
+      storageConfig: this.storageConfig
     });
     this.iterateListeners((cb) => cb.batchStarted?.(writer));
     return writer;

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -49,6 +49,7 @@ export interface PostgresBucketBatchOptions {
 
   markRecordUnavailable: BucketStorageMarkRecordUnavailable | undefined;
   storageConfig: storage.StorageVersionConfig;
+  resolveTables: (options: storage.ResolveTablesOptions) => Promise<storage.ResolveTablesResult>;
 }
 
 /**
@@ -137,6 +138,10 @@ export class PostgresBucketBatch
 
   async dispose() {
     await this[Symbol.asyncDispose]();
+  }
+
+  async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
+    return this.options.resolveTables(options);
   }
 
   async save(record: storage.SaveOptions): Promise<storage.FlushedResult | null> {

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -49,7 +49,10 @@ export interface PostgresBucketBatchOptions {
 
   markRecordUnavailable: BucketStorageMarkRecordUnavailable | undefined;
   storageConfig: storage.StorageVersionConfig;
-  resolveTables: (options: storage.ResolveTablesOptions) => Promise<storage.ResolveTablesResult>;
+  resolveTables: (
+    options: storage.ResolveTablesOptions,
+    syncRules: sync_rules.HydratedSyncRules
+  ) => Promise<storage.ResolveTablesResult>;
 }
 
 /**
@@ -141,7 +144,7 @@ export class PostgresBucketBatch
   }
 
   async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
-    return this.options.resolveTables(options);
+    return this.options.resolveTables(options, this.sync_rules);
   }
 
   async save(record: storage.SaveOptions): Promise<storage.FlushedResult | null> {

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -12,6 +12,7 @@ import {
 import {
   BucketStorageMarkRecordUnavailable,
   CheckpointResult,
+  ColumnDescriptor,
   deserializeReplicaId,
   InternalOpId,
   storage,
@@ -20,8 +21,10 @@ import {
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as timers from 'timers/promises';
 import * as t from 'ts-codec';
+import * as uuid from 'uuid';
 import { bigint } from '../../types/codecs.js';
 import { CurrentBucket, V3CurrentDataDecoded } from '../../types/models/CurrentData.js';
+import { SourceTableDecoded, StoredRelationId } from '../../types/models/SourceTable.js';
 import { models, RequiredOperationBatchLimits } from '../../types/types.js';
 import { NOTIFICATION_CHANNEL } from '../../utils/db.js';
 import { pick } from '../../utils/ts-codec.js';
@@ -49,10 +52,6 @@ export interface PostgresBucketBatchOptions {
 
   markRecordUnavailable: BucketStorageMarkRecordUnavailable | undefined;
   storageConfig: storage.StorageVersionConfig;
-  resolveTables: (
-    options: storage.ResolveTablesOptions,
-    syncRules: sync_rules.HydratedSyncRules
-  ) => Promise<storage.ResolveTablesResult>;
 }
 
 /**
@@ -144,7 +143,161 @@ export class PostgresBucketBatch
   }
 
   async resolveTables(options: storage.ResolveTablesOptions): Promise<storage.ResolveTablesResult> {
-    return this.options.resolveTables(options, this.sync_rules);
+    const syncRules = options.syncRules ?? this.sync_rules;
+    const { connection_id, source } = options;
+    const { schema, name: table, objectId, replicaIdColumns, connectionTag } = source;
+
+    const normalizedReplicaIdColumns = replicaIdColumns.map((column) => ({
+      name: column.name,
+      type: column.type,
+      type_oid: typeof column.typeId !== 'undefined' ? Number(column.typeId) : column.typeId
+    }));
+    return this.db.transaction(async (db) => {
+      let sourceTableRow: SourceTableDecoded | null;
+      if (objectId != null) {
+        sourceTableRow = await db.sql`
+          SELECT
+            *
+          FROM
+            source_tables
+          WHERE
+            group_id = ${{ type: 'int4', value: this.group_id }}
+            AND connection_id = ${{ type: 'int4', value: connection_id }}
+            AND relation_id = ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }}
+            AND schema_name = ${{ type: 'varchar', value: schema }}
+            AND table_name = ${{ type: 'varchar', value: table }}
+            AND replica_id_columns = ${{ type: 'jsonb', value: normalizedReplicaIdColumns }}
+        `
+          .decoded(models.SourceTable)
+          .first();
+      } else {
+        sourceTableRow = await db.sql`
+          SELECT
+            *
+          FROM
+            source_tables
+          WHERE
+            group_id = ${{ type: 'int4', value: this.group_id }}
+            AND connection_id = ${{ type: 'int4', value: connection_id }}
+            AND schema_name = ${{ type: 'varchar', value: schema }}
+            AND table_name = ${{ type: 'varchar', value: table }}
+            AND replica_id_columns = ${{ type: 'jsonb', value: normalizedReplicaIdColumns }}
+        `
+          .decoded(models.SourceTable)
+          .first();
+      }
+
+      if (sourceTableRow == null) {
+        const id = options.idGenerator ? postgresTableId(options.idGenerator()) : uuid.v4();
+        sourceTableRow = await db.sql`
+          INSERT INTO
+            source_tables (
+              id,
+              group_id,
+              connection_id,
+              relation_id,
+              schema_name,
+              table_name,
+              replica_id_columns
+            )
+          VALUES
+            (
+              ${{ type: 'varchar', value: id }},
+              ${{ type: 'int4', value: this.group_id }},
+              ${{ type: 'int4', value: connection_id }},
+              ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }},
+              ${{ type: 'varchar', value: schema }},
+              ${{ type: 'varchar', value: table }},
+              ${{ type: 'jsonb', value: normalizedReplicaIdColumns }}
+            )
+          RETURNING
+            *
+        `
+          .decoded(models.SourceTable)
+          .first();
+      }
+
+      const sourceTable = new storage.SourceTable({
+        id: sourceTableRow!.id,
+        ref: source,
+        objectId,
+        replicaIdColumns,
+        snapshotComplete: sourceTableRow!.snapshot_done ?? true,
+        ...syncRules.getMatchingSources(source)
+      });
+      if (!sourceTable.snapshotComplete) {
+        sourceTable.snapshotStatus = {
+          totalEstimatedCount: Number(sourceTableRow!.snapshot_total_estimated_count ?? -1n),
+          replicatedCount: Number(sourceTableRow!.snapshot_replicated_count ?? 0n),
+          lastKey: sourceTableRow!.snapshot_last_key
+        };
+      }
+      sourceTable.syncEvent = syncRules.tableTriggersEvent(source);
+      sourceTable.syncData = sourceTable.bucketDataSources.length > 0;
+      sourceTable.syncParameters = sourceTable.parameterLookupSources.length > 0;
+
+      let truncatedTables: SourceTableDecoded[] = [];
+      if (objectId != null) {
+        truncatedTables = await db.sql`
+          SELECT
+            *
+          FROM
+            source_tables
+          WHERE
+            group_id = ${{ type: 'int4', value: this.group_id }}
+            AND connection_id = ${{ type: 'int4', value: connection_id }}
+            AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
+            AND (
+              relation_id = ${{ type: 'jsonb', value: { object_id: objectId } satisfies StoredRelationId }}
+              OR (
+                schema_name = ${{ type: 'varchar', value: schema }}
+                AND table_name = ${{ type: 'varchar', value: table }}
+              )
+            )
+        `
+          .decoded(models.SourceTable)
+          .rows();
+      } else {
+        truncatedTables = await db.sql`
+          SELECT
+            *
+          FROM
+            source_tables
+          WHERE
+            group_id = ${{ type: 'int4', value: this.group_id }}
+            AND connection_id = ${{ type: 'int4', value: connection_id }}
+            AND id != ${{ type: 'varchar', value: sourceTableRow!.id }}
+            AND (
+              schema_name = ${{ type: 'varchar', value: schema }}
+              AND table_name = ${{ type: 'varchar', value: table }}
+            )
+        `
+          .decoded(models.SourceTable)
+          .rows();
+      }
+
+      return {
+        tables: [sourceTable],
+        dropTables: truncatedTables.map((doc) => {
+          const ref = { connectionTag, schema: doc.schema_name, name: doc.table_name };
+          const dropTable = new storage.SourceTable({
+            id: doc.id,
+            ref,
+            objectId: doc.relation_id?.object_id ?? 0,
+            replicaIdColumns:
+              doc.replica_id_columns?.map(
+                (c) => ({ name: c.name, typeId: c.typeId, type: c.type }) satisfies ColumnDescriptor
+              ) ?? [],
+            snapshotComplete: doc.snapshot_done ?? true,
+            ...syncRules.getMatchingSources(ref)
+          });
+          dropTable.syncEvent = syncRules.tableTriggersEvent(ref);
+          dropTable.syncData = dropTable.bucketDataSources.length > 0;
+          dropTable.syncParameters = dropTable.parameterLookupSources.length > 0;
+          return dropTable;
+        })
+      };
+    });
   }
 
   async save(record: storage.SaveOptions): Promise<storage.FlushedResult | null> {

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -908,7 +908,7 @@ export class PostgresBucketBatch
       if (sourceTable.syncData) {
         const { results: evaluated, errors: syncErrors } = this.sync_rules.evaluateRowWithErrors({
           record: after,
-          sourceTable
+          sourceTable: sourceTable.ref
         });
 
         for (const error of syncErrors) {
@@ -947,7 +947,7 @@ export class PostgresBucketBatch
       if (sourceTable.syncParameters) {
         // Parameters
         const { results: paramEvaluated, errors: paramErrors } = this.sync_rules.evaluateParameterRowWithErrors(
-          sourceTable,
+          sourceTable.ref,
           after
         );
 
@@ -1072,7 +1072,7 @@ export class PostgresBucketBatch
    */
   protected getTableEvents(table: storage.SourceTable): sync_rules.SqlEventDescriptor[] {
     return this.sync_rules.eventDescriptors.filter((evt) =>
-      [...evt.getSourceTables()].some((sourceTable) => sourceTable.matches(table))
+      [...evt.getSourceTables()].some((sourceTable) => sourceTable.matches(table.ref))
     );
   }
 

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -908,7 +908,8 @@ export class PostgresBucketBatch
       if (sourceTable.syncData) {
         const { results: evaluated, errors: syncErrors } = this.sync_rules.evaluateRowWithErrors({
           record: after,
-          sourceTable: sourceTable.ref
+          sourceTable: sourceTable.ref,
+          bucketDataSources: sourceTable.bucketDataSources
         });
 
         for (const error of syncErrors) {
@@ -948,7 +949,8 @@ export class PostgresBucketBatch
         // Parameters
         const { results: paramEvaluated, errors: paramErrors } = this.sync_rules.evaluateParameterRowWithErrors(
           sourceTable.ref,
-          after
+          after,
+          { parameterLookupSources: sourceTable.parameterLookupSources }
         );
 
         for (let error of paramErrors) {

--- a/modules/module-postgres/src/replication/PgRelation.ts
+++ b/modules/module-postgres/src/replication/PgRelation.ts
@@ -22,8 +22,9 @@ export function getRelId(source: PgoutputRelation): number {
   return relId;
 }
 
-export function getPgOutputRelation(source: PgoutputRelation): storage.SourceEntityDescriptor {
+export function getPgOutputRelation(source: PgoutputRelation, connectionTag: string): storage.SourceEntityDescriptor {
   return {
+    connectionTag,
     name: source.name,
     schema: source.schema,
     objectId: getRelId(source),

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -826,7 +826,7 @@ WHERE  oid = $1::regclass`,
       sync_rules: this.sync_rules,
       matchingSources: null
     });
-    this.relationCache.updateAll(result.tables);
+    this.relationCache.updateAll(descriptor.objectId as number, result.tables);
 
     // Drop conflicting tables. This includes for example renamed tables.
     await batch.drop(result.dropTables);
@@ -855,7 +855,7 @@ WHERE  oid = $1::regclass`,
         // After table snapshots, wait for replication to catch up.
         await sendKeepAlive(db);
         const tables = result.tables.map((table) => snapshotDoneById.get(table.id) ?? table);
-        this.relationCache.updateAll(tables);
+        this.relationCache.updateAll(descriptor.objectId as number, tables);
         return tables;
       } finally {
         await db.end();
@@ -903,7 +903,7 @@ WHERE  oid = $1::regclass`,
 
   private getTables(relationId: number): storage.SourceTable[] {
     const tables = this.relationCache.getAll(relationId);
-    if (tables.length == 0) {
+    if (tables == null) {
       // We should always receive a replication message before the relation is used.
       // If we can't find it, it's a bug.
       throw new ReplicationAssertionError(`Missing relation cache for ${relationId}`);

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -818,14 +818,17 @@ WHERE  oid = $1::regclass`,
     if (!descriptor.objectId && typeof descriptor.objectId != 'number') {
       throw new ReplicationAssertionError(`objectId expected, got ${typeof descriptor.objectId}`);
     }
-    const result = await this.storage.resolveTable({
+    const result = await batch.resolveTables({
       group_id: this.group_id,
       connection_id: this.connection_id,
       connection_tag: this.connections.connectionTag,
       entity_descriptor: descriptor,
-      sync_rules: this.sync_rules
+      sync_rules: this.sync_rules,
+      matchingSources: null
     });
-    this.relationCache.update(result.table);
+    for (const table of result.tables) {
+      this.relationCache.update(table);
+    }
 
     // Drop conflicting tables. This includes for example renamed tables.
     await batch.drop(result.dropTables);
@@ -837,28 +840,28 @@ WHERE  oid = $1::regclass`,
     // 1. Snapshot is requested (false for initial snapshot, since that process handles it elsewhere)
     // 2. Snapshot is not already done, AND:
     // 3. The table is used in sync config.
-    const shouldSnapshot = snapshot && !result.table.snapshotComplete && result.table.syncAny;
+    const snapshotCandidates = result.tables.filter((table) => snapshot && !table.snapshotComplete && table.syncAny);
 
-    if (shouldSnapshot) {
-      // Truncate this table, in case a previous snapshot was interrupted.
-      await batch.truncate([result.table]);
-
+    if (snapshotCandidates.length > 0) {
       // Start the snapshot inside a transaction.
       // We use a dedicated connection for this.
       const db = await this.connections.snapshotConnection();
       try {
-        const table = await this.snapshotTableInTx(batch, db, result.table);
-        // After the table snapshot, we wait for replication to catch up.
-        // To make sure there is actually something to replicate, we send a keepalive
-        // message.
+        let last: SourceTable = snapshotCandidates[0];
+        for (const table of snapshotCandidates) {
+          // Truncate this table, in case a previous snapshot was interrupted.
+          await batch.truncate([table]);
+          last = await this.snapshotTableInTx(batch, db, table);
+        }
+        // After table snapshots, wait for replication to catch up.
         await sendKeepAlive(db);
-        return table;
+        return last;
       } finally {
         await db.end();
       }
     }
 
-    return result.table;
+    return result.tables[0];
   }
 
   /**

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -819,11 +819,9 @@ WHERE  oid = $1::regclass`,
       throw new ReplicationAssertionError(`objectId expected, got ${typeof descriptor.objectId}`);
     }
     const result = await batch.resolveTables({
-      group_id: this.group_id,
       connection_id: this.connection_id,
       connection_tag: this.connections.connectionTag,
       entity_descriptor: descriptor,
-      sync_rules: this.sync_rules,
       matchingSources: null
     });
     this.relationCache.updateAll(descriptor.objectId as number, result.tables);

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -1087,7 +1087,13 @@ WHERE  oid = $1::regclass`,
 
     const markRecordUnavailable = (record: SaveUpdate) => {
       if (!IdSnapshotQuery.supports(record.sourceTable)) {
-        // If it's not supported, it's also safe to ignore
+        // We only have a targeted resnapshot implementation for tables supported by IdSnapshotQuery.
+        // For unsupported tables we cannot repair missing TOAST values here; leave the row unchanged
+        // and rely on a later full row update or a future full snapshot to correct it.
+        // FIXME: We should support resnapshot for any row.
+        this.logger.warn(
+          `Missing record for ${record.sourceTable.qualifiedName}: ${record.afterReplicaId} / ${record.after.id}`
+        );
         return;
       }
       let key: PrimaryKeyValue = {};

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -284,7 +284,7 @@ export class WalStream {
       const cresult = await getReplicationIdentityColumns(db, relid);
 
       const columnTypes = (JSON.parse(row.column_types) as string[]).map((e) => Number(e));
-      const table = await this.handleRelation({
+      const tables = await this.handleRelation({
         batch,
         descriptor: {
           name,
@@ -296,7 +296,7 @@ export class WalStream {
         referencedTypeIds: columnTypes
       });
 
-      result.push(table);
+      result.push(...tables);
     }
     return result;
   }
@@ -826,9 +826,7 @@ WHERE  oid = $1::regclass`,
       sync_rules: this.sync_rules,
       matchingSources: null
     });
-    for (const table of result.tables) {
-      this.relationCache.update(table);
-    }
+    this.relationCache.updateAll(result.tables);
 
     // Drop conflicting tables. This includes for example renamed tables.
     await batch.drop(result.dropTables);
@@ -847,21 +845,24 @@ WHERE  oid = $1::regclass`,
       // We use a dedicated connection for this.
       const db = await this.connections.snapshotConnection();
       try {
-        let last: SourceTable = snapshotCandidates[0];
+        const snapshotDoneById = new Map<storage.SourceTableId, SourceTable>();
         for (const table of snapshotCandidates) {
           // Truncate this table, in case a previous snapshot was interrupted.
           await batch.truncate([table]);
-          last = await this.snapshotTableInTx(batch, db, table);
+          const doneTable = await this.snapshotTableInTx(batch, db, table);
+          snapshotDoneById.set(doneTable.id, doneTable);
         }
         // After table snapshots, wait for replication to catch up.
         await sendKeepAlive(db);
-        return last;
+        const tables = result.tables.map((table) => snapshotDoneById.get(table.id) ?? table);
+        this.relationCache.updateAll(tables);
+        return tables;
       } finally {
         await db.end();
       }
     }
 
-    return result.tables[0];
+    return result.tables;
   }
 
   /**
@@ -900,14 +901,14 @@ WHERE  oid = $1::regclass`,
     }
   }
 
-  private getTable(relationId: number): storage.SourceTable {
-    const table = this.relationCache.get(relationId);
-    if (table == null) {
+  private getTables(relationId: number): storage.SourceTable[] {
+    const tables = this.relationCache.getAll(relationId);
+    if (tables.length == 0) {
       // We should always receive a replication message before the relation is used.
       // If we can't find it, it's a bug.
       throw new ReplicationAssertionError(`Missing relation cache for ${relationId}`);
     }
-    return table;
+    return tables;
   }
 
   private syncRulesRecord(row: SqliteInputRow): SqliteRow;
@@ -932,55 +933,70 @@ WHERE  oid = $1::regclass`,
       return null;
     }
     if (msg.tag == 'insert' || msg.tag == 'update' || msg.tag == 'delete') {
-      const table = this.getTable(getRelId(msg.relation));
-      if (!table.syncAny) {
-        this.logger.debug(`Table ${table.qualifiedName} not used in sync config - skipping`);
+      const tables = this.getTables(getRelId(msg.relation));
+      const tablesToReplicate = tables.filter((table) => table.syncAny);
+      if (tablesToReplicate.length == 0) {
+        this.logger.debug(`Table ${getRelId(msg.relation)} not used in sync config - skipping`);
         return null;
       }
 
       if (msg.tag == 'insert') {
         this.metrics.getCounter(ReplicationMetric.ROWS_REPLICATED).add(1);
         const baseRecord = this.syncRulesRecord(this.connections.types.constructAfterRecord(msg));
-        return await batch.save({
-          tag: storage.SaveOperationTag.INSERT,
-          sourceTable: table,
-          before: undefined,
-          beforeReplicaId: undefined,
-          after: baseRecord,
-          afterReplicaId: getUuidReplicaIdentityBson(baseRecord, table.replicaIdColumns)
-        });
+        let flushResult: storage.FlushedResult | null = null;
+        for (const table of tablesToReplicate) {
+          flushResult =
+            (await batch.save({
+              tag: storage.SaveOperationTag.INSERT,
+              sourceTable: table,
+              before: undefined,
+              beforeReplicaId: undefined,
+              after: baseRecord,
+              afterReplicaId: getUuidReplicaIdentityBson(baseRecord, table.replicaIdColumns)
+            })) ?? flushResult;
+        }
+        return flushResult;
       } else if (msg.tag == 'update') {
         this.metrics.getCounter(ReplicationMetric.ROWS_REPLICATED).add(1);
         // "before" may be null if the replica id columns are unchanged
         // It's fine to treat that the same as an insert.
         const before = this.syncRulesRecord(this.connections.types.constructBeforeRecord(msg));
         const after = this.toastableSyncRulesRecord(this.connections.types.constructAfterRecord(msg));
-        return await batch.save({
-          tag: storage.SaveOperationTag.UPDATE,
-          sourceTable: table,
-          before: before,
-          beforeReplicaId: before ? getUuidReplicaIdentityBson(before, table.replicaIdColumns) : undefined,
-          after: after,
-          afterReplicaId: getUuidReplicaIdentityBson(after, table.replicaIdColumns)
-        });
+        let flushResult: storage.FlushedResult | null = null;
+        for (const table of tablesToReplicate) {
+          flushResult =
+            (await batch.save({
+              tag: storage.SaveOperationTag.UPDATE,
+              sourceTable: table,
+              before: before,
+              beforeReplicaId: before ? getUuidReplicaIdentityBson(before, table.replicaIdColumns) : undefined,
+              after: after,
+              afterReplicaId: getUuidReplicaIdentityBson(after, table.replicaIdColumns)
+            })) ?? flushResult;
+        }
+        return flushResult;
       } else if (msg.tag == 'delete') {
         this.metrics.getCounter(ReplicationMetric.ROWS_REPLICATED).add(1);
         const before = this.syncRulesRecord(this.connections.types.constructBeforeRecord(msg)!);
 
-        return await batch.save({
-          tag: storage.SaveOperationTag.DELETE,
-          sourceTable: table,
-          before: before,
-          beforeReplicaId: getUuidReplicaIdentityBson(before, table.replicaIdColumns),
-          after: undefined,
-          afterReplicaId: undefined
-        });
+        let flushResult: storage.FlushedResult | null = null;
+        for (const table of tablesToReplicate) {
+          flushResult =
+            (await batch.save({
+              tag: storage.SaveOperationTag.DELETE,
+              sourceTable: table,
+              before: before,
+              beforeReplicaId: getUuidReplicaIdentityBson(before, table.replicaIdColumns),
+              after: undefined,
+              afterReplicaId: undefined
+            })) ?? flushResult;
+        }
+        return flushResult;
       }
     } else if (msg.tag == 'truncate') {
       let tables: storage.SourceTable[] = [];
       for (let relation of msg.relations) {
-        const table = this.getTable(getRelId(relation));
-        tables.push(table);
+        tables.push(...this.getTables(getRelId(relation)));
       }
       return await batch.truncate(tables);
     }

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -287,11 +287,12 @@ export class WalStream {
       const tables = await this.handleRelation({
         batch,
         descriptor: {
-          name,
-          schema,
+          connectionTag: this.connections.connectionTag,
+          name: name,
+          schema: schema,
           objectId: relid,
           replicaIdColumns: cresult.replicationColumns
-        } as SourceEntityDescriptor,
+        },
         snapshot: false,
         referencedTypeIds: columnTypes
       });
@@ -820,9 +821,7 @@ WHERE  oid = $1::regclass`,
     }
     const result = await batch.resolveTables({
       connection_id: this.connection_id,
-      connection_tag: this.connections.connectionTag,
-      entity_descriptor: descriptor,
-      matchingSources: null
+      source: descriptor
     });
     this.relationCache.updateAll(descriptor.objectId as number, result.tables);
 
@@ -1149,7 +1148,7 @@ WHERE  oid = $1::regclass`,
             if (msg.tag == 'relation') {
               await this.handleRelation({
                 batch,
-                descriptor: getPgOutputRelation(msg),
+                descriptor: getPgOutputRelation(msg, this.connections.connectionTag),
                 snapshot: true,
                 referencedTypeIds: referencedColumnTypeIds(msg)
               });

--- a/modules/module-postgres/src/replication/replication-utils.ts
+++ b/modules/module-postgres/src/replication/replication-utils.ts
@@ -278,17 +278,20 @@ export async function getDebugTablesInfo(options: GetDebugTablesInfoOptions): Pr
   for (const row of rows) {
     const tablePattern = tablePatterns[row.pattern_ord];
     const idColumns = JSON.parse(row.replication_id_json) as string[];
+    const ref: sync_rules.SourceTableRef = {
+      connectionTag,
+      schema: tablePattern.schema,
+      name: row.name
+    };
     const sourceTable = new storage.SourceTable({
       id: '',
-      connectionTag,
+      ref,
       objectId: row.relation_id ?? 0,
-      schema: tablePattern.schema,
-      name: row.name,
       replicaIdColumns: idColumns.map((name) => ({ name })),
       snapshotComplete: true
     });
-    const syncData = syncRules.tableSyncsData(sourceTable);
-    const syncParameters = syncRules.tableSyncsParameters(sourceTable);
+    const syncData = syncRules.tableSyncsData(ref);
+    const syncParameters = syncRules.tableSyncsParameters(ref);
 
     let errors: service_types.ReplicationError[];
     if (row.relation_id == null) {

--- a/modules/module-postgres/src/replication/replication-utils.ts
+++ b/modules/module-postgres/src/replication/replication-utils.ts
@@ -35,7 +35,7 @@ export async function getPrimaryKeyColumns(
   return attrRows.rows.map((row) => {
     return {
       name: row.decodeWithoutCustomTypes(0) as string,
-      typeId: row.decodeWithoutCustomTypes(1) as number
+      typeId: Number(row.decodeWithoutCustomTypes(1)) // source type can be a bigint, so always cast it
     } satisfies storage.ColumnDescriptor;
   });
 }

--- a/modules/module-postgres/src/replication/replication-utils.ts
+++ b/modules/module-postgres/src/replication/replication-utils.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 
 import * as lib_postgres from '@powersync/lib-service-postgres';
 import { ErrorCode, logger, ServiceAssertionError, ServiceError } from '@powersync/lib-services-framework';
-import { PatternResult, storage } from '@powersync/service-core';
+import { PatternResult, qualifiedName, storage } from '@powersync/service-core';
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as service_types from '@powersync/service-types';
 import { ReplicationIdentity } from './PgRelation.js';
@@ -283,25 +283,18 @@ export async function getDebugTablesInfo(options: GetDebugTablesInfoOptions): Pr
       schema: tablePattern.schema,
       name: row.name
     };
-    const sourceTable = new storage.SourceTable({
-      id: '',
-      ref,
-      objectId: row.relation_id ?? 0,
-      replicaIdColumns: idColumns.map((name) => ({ name })),
-      snapshotComplete: true
-    });
     const syncData = syncRules.tableSyncsData(ref);
     const syncParameters = syncRules.tableSyncsParameters(ref);
 
     let errors: service_types.ReplicationError[];
     if (row.relation_id == null) {
-      errors = [{ level: 'warning', message: `Table ${sourceTable.qualifiedName} not found.` }];
+      errors = [{ level: 'warning', message: `Table ${qualifiedName(ref)} not found.` }];
     } else {
       const idColumnsError =
         idColumns.length == 0 && row.replication_identity != 'nothing'
           ? {
               level: 'fatal' as const,
-              message: `No replication id found for ${sourceTable.qualifiedName}. Replica identity: ${row.replication_identity}.${row.replication_identity == 'default' ? ' Configure a primary key on the table.' : ''}`
+              message: `No replication id found for ${qualifiedName(ref)}. Replica identity: ${row.replication_identity}.${row.replication_identity == 'default' ? ' Configure a primary key on the table.' : ''}`
             }
           : null;
       const selectError = row.select_error == null ? null : { level: 'fatal' as const, message: row.select_error };
@@ -309,7 +302,7 @@ export async function getDebugTablesInfo(options: GetDebugTablesInfoOptions): Pr
         row.in_publication === false
           ? {
               level: 'fatal' as const,
-              message: `Table ${sourceTable.qualifiedName} is not part of publication '${publicationName}'. Run: \`ALTER PUBLICATION ${publicationName} ADD TABLE ${sourceTable.qualifiedName}\`.`
+              message: `Table ${qualifiedName(ref)} is not part of publication '${publicationName}'. Run: \`ALTER PUBLICATION ${publicationName} ADD TABLE ${qualifiedName(ref)}\`.`
             }
           : null;
       const rlsError =

--- a/modules/module-postgres/test/src/chunked_snapshots.test.ts
+++ b/modules/module-postgres/test/src/chunked_snapshots.test.ts
@@ -154,6 +154,7 @@ function defineBatchTests({ factory, storageVersion }: StorageVersionTestContext
     const reduced = reduceBucket(data);
 
     const movedRow = reduced.find((row) => row.object_id == String(options.moveToJs));
+    expect(movedRow).not.toBeUndefined();
     expect(movedRow?.data).toEqual(JSON.stringify({ id: options.moveToJs, description: largeDescription }));
 
     expect(reduced.length).toEqual(2001);

--- a/packages/service-core-tests/src/test-utils/general-utils.ts
+++ b/packages/service-core-tests/src/test-utils/general-utils.ts
@@ -31,7 +31,9 @@ export function makeTestTable(
     },
     objectId: relId,
     replicaIdColumns: (replicaIdColumns ?? ['id']).map((column) => ({ name: column, type: 'VARCHAR', typeId: 25 })),
-    snapshotComplete: true
+    snapshotComplete: true,
+    bucketDataSources: [],
+    parameterLookupSources: []
   });
 }
 /**

--- a/packages/service-core-tests/src/test-utils/general-utils.ts
+++ b/packages/service-core-tests/src/test-utils/general-utils.ts
@@ -24,10 +24,12 @@ export function makeTestTable(
     options?.tableIdStrings == false ? new bson.ObjectId('6544e3899293153fa7b38331') : '6544e3899293153fa7b38331';
   return new storage.SourceTable({
     id: id,
-    connectionTag: storage.SourceTable.DEFAULT_TAG,
+    ref: {
+      connectionTag: storage.SourceTable.DEFAULT_TAG,
+      schema: 'public',
+      name
+    },
     objectId: relId,
-    schema: 'public',
-    name: name,
     replicaIdColumns: (replicaIdColumns ?? ['id']).map((column) => ({ name: column, type: 'VARCHAR', typeId: 25 })),
     snapshotComplete: true
   });
@@ -54,17 +56,16 @@ export async function resolveTestTable(
   const id = options.tableIdStrings == false ? new bson.ObjectId(idString) : idString;
   let didGenerateId = false;
 
-  const descriptor: storage.SourceEntityDescriptor = {
+  const source: storage.SourceEntityDescriptor = {
+    connectionTag: storage.SourceTable.DEFAULT_TAG,
     objectId: relId,
     schema: 'public',
-    name,
+    name: name,
     replicaIdColumns: (replicaIdColumns ?? ['id']).map((column) => ({ name: column, type: 'VARCHAR', typeId: 25 }))
   };
   const resolved = await writer.resolveTables({
     connection_id: 1,
-    connection_tag: storage.SourceTable.DEFAULT_TAG,
-    entity_descriptor: descriptor,
-    matchingSources: null,
+    source,
     idGenerator: () => {
       if (didGenerateId) {
         throw new Error('idGenerator called multiple times - not supported in tests');
@@ -76,7 +77,7 @@ export async function resolveTestTable(
 
   const table = resolved.tables[0];
   if (table == null) {
-    throw new Error(`Failed to resolve test table ${descriptor.schema}.${descriptor.name}`);
+    throw new Error(`Failed to resolve test table ${source.schema}.${source.name}`);
   }
   return table;
 }

--- a/packages/service-core-tests/src/test-utils/general-utils.ts
+++ b/packages/service-core-tests/src/test-utils/general-utils.ts
@@ -38,26 +38,47 @@ export function makeTestTable(
  * This prepares for it.
  */
 export async function resolveTestTable(
-  _writer: storage.BucketStorageBatch,
+  writer: storage.BucketStorageBatch,
   name: string,
   replicaIdColumns: string[] | undefined,
   options: { tableIdStrings: boolean },
   idIndex: number = 1
 ) {
+  void idIndex;
+  void options;
+
   const relId = utils.hashData('table', name, (replicaIdColumns ?? ['id']).join(','));
-  // Generate unique ids per test table (if idIndex is specified), without completely
-  // breaking all the existing tests.
+  // Semi-hardcoded id for tests, to get consistent output.
+  // If the same test uses multiple tables, pass idIndex to get different ids.
   const idString = '6544e3899293153fa7b383' + (30 + idIndex).toString().padStart(2, '0');
   const id = options.tableIdStrings == false ? new bson.ObjectId(idString) : idString;
-  return new storage.SourceTable({
-    id: id,
-    connectionTag: storage.SourceTable.DEFAULT_TAG,
+  let didGenerateId = false;
+
+  const descriptor: storage.SourceEntityDescriptor = {
     objectId: relId,
     schema: 'public',
-    name: name,
-    replicaIdColumns: (replicaIdColumns ?? ['id']).map((column) => ({ name: column, type: 'VARCHAR', typeId: 25 })),
-    snapshotComplete: true
+    name,
+    replicaIdColumns: (replicaIdColumns ?? ['id']).map((column) => ({ name: column, type: 'VARCHAR', typeId: 25 }))
+  };
+  const resolved = await writer.resolveTables({
+    connection_id: 1,
+    connection_tag: storage.SourceTable.DEFAULT_TAG,
+    entity_descriptor: descriptor,
+    matchingSources: null,
+    idGenerator: () => {
+      if (didGenerateId) {
+        throw new Error('idGenerator called multiple times - not supported in tests');
+      }
+      didGenerateId = true;
+      return id;
+    }
   });
+
+  const table = resolved.tables[0];
+  if (table == null) {
+    throw new Error(`Failed to resolve test table ${descriptor.schema}.${descriptor.name}`);
+  }
+  return table;
 }
 
 export function getBatchData(

--- a/packages/service-core-tests/src/test-utils/general-utils.ts
+++ b/packages/service-core-tests/src/test-utils/general-utils.ts
@@ -14,32 +14,8 @@ export const BATCH_OPTIONS: storage.CreateWriterOptions = {
   storeCurrentData: true
 };
 
-export function makeTestTable(
-  name: string,
-  replicaIdColumns?: string[] | undefined,
-  options?: { tableIdStrings: boolean }
-) {
-  const relId = utils.hashData('table', name, (replicaIdColumns ?? ['id']).join(','));
-  const id =
-    options?.tableIdStrings == false ? new bson.ObjectId('6544e3899293153fa7b38331') : '6544e3899293153fa7b38331';
-  return new storage.SourceTable({
-    id: id,
-    ref: {
-      connectionTag: storage.SourceTable.DEFAULT_TAG,
-      schema: 'public',
-      name
-    },
-    objectId: relId,
-    replicaIdColumns: (replicaIdColumns ?? ['id']).map((column) => ({ name: column, type: 'VARCHAR', typeId: 25 })),
-    snapshotComplete: true,
-    bucketDataSources: [],
-    parameterLookupSources: []
-  });
-}
 /**
- * With incremental reprocessing, we need actual test tables, resolved via the writer.
- *
- * This prepares for it.
+ * With newer storage versions, we need actual test tables, resolved via the writer.
  */
 export async function resolveTestTable(
   writer: storage.BucketStorageBatch,

--- a/packages/service-core-tests/src/tests/register-data-storage-data-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-data-tests.ts
@@ -826,7 +826,7 @@ bucket_definitions:
     const bucketStorage = factory.getInstance(syncRules);
 
     await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
-    const sourceTable = test_utils.makeTestTable('test', ['id', 'description'], config);
+    const sourceTable = await test_utils.resolveTestTable(writer, 'test', ['id', 'description'], config);
 
     // Pre-setup
     await writer.markAllSnapshotDone('1/1');
@@ -939,7 +939,7 @@ bucket_definitions:
     const bucketStorage = factory.getInstance(syncRules);
 
     await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
-    const sourceTable = test_utils.makeTestTable('test', ['id', 'description'], config);
+    const sourceTable = await test_utils.resolveTestTable(writer, 'test', ['id', 'description'], config);
 
     // Pre-setup
     await writer.markAllSnapshotDone('1/1');

--- a/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
@@ -786,7 +786,6 @@ streams:
         return parameter_sets;
       }
     });
-    console.log('whatabuckets', buckets);
     expect(buckets).toHaveLength(1);
     expect(buckets).toMatchObject([
       {
@@ -999,8 +998,8 @@ streams:
     const syncConfig = parsedSyncRules.sync_rules.config;
 
     await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
-    const paramATable = await test_utils.resolveTestTable(writer, 'param_a', ['id'], config);
-    const paramBTable = await test_utils.resolveTestTable(writer, 'param_b', ['id'], config);
+    const paramATable = await test_utils.resolveTestTable(writer, 'param_a', ['id'], config, 1);
+    const paramBTable = await test_utils.resolveTestTable(writer, 'param_b', ['id'], config, 2);
     const replicaId = test_utils.rid('id');
 
     // Insert the same row into param_a and param_b
@@ -1095,8 +1094,8 @@ streams:
     const sync_rules = syncRules.parsed(test_utils.PARSE_OPTIONS).hydratedSyncRules();
 
     await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
-    const tableB = await test_utils.resolveTestTable(writer, 'b', ['id'], config);
-    const tableC = await test_utils.resolveTestTable(writer, 'c', ['id'], config);
+    const tableB = await test_utils.resolveTestTable(writer, 'b', ['id'], config, 1);
+    const tableC = await test_utils.resolveTestTable(writer, 'c', ['id'], config, 2);
 
     await writer.markAllSnapshotDone('1/1');
     await writer.save({

--- a/packages/service-core-tests/src/tests/util.ts
+++ b/packages/service-core-tests/src/tests/util.ts
@@ -1,10 +1,5 @@
 import { storage } from '@powersync/service-core';
-import {
-  ParameterIndexLookupCreator,
-  SourceTableInterface,
-  SqliteRow,
-  TablePattern
-} from '@powersync/service-sync-rules';
+import { ParameterIndexLookupCreator, SourceTableRef, SqliteRow, TablePattern } from '@powersync/service-sync-rules';
 import { ParameterLookupScope } from '@powersync/service-sync-rules/src/HydrationState.js';
 import { bucketRequest } from '../test-utils/general-utils.js';
 
@@ -36,10 +31,10 @@ const EMPTY_LOOKUP_SOURCE: ParameterIndexLookupCreator = {
   getSourceTables(): Set<TablePattern> {
     return new Set();
   },
-  evaluateParameterRow(_sourceTable: SourceTableInterface, _row: SqliteRow) {
+  evaluateParameterRow(_sourceTable: SourceTableRef, _row: SqliteRow) {
     return [];
   },
-  tableSyncsParameters(_table: SourceTableInterface): boolean {
+  tableSyncsParameters(_table: SourceTableRef): boolean {
     return false;
   }
 };

--- a/packages/service-core/src/api/diagnostics.ts
+++ b/packages/service-core/src/api/diagnostics.ts
@@ -1,5 +1,5 @@
 import { logger } from '@powersync/lib-services-framework';
-import { DEFAULT_TAG, SourceTableInterface, SyncConfigWithErrors } from '@powersync/service-sync-rules';
+import { DEFAULT_TAG, SourceTableRef, SyncConfigWithErrors } from '@powersync/service-sync-rules';
 import { ReplicationError, SyncRulesStatus, TableInfo } from '@powersync/service-types';
 
 import * as storage from '../storage/storage-index.js';
@@ -116,7 +116,7 @@ export async function getSyncRulesStatus(
           errors: [{ level: 'fatal', message: 'connection failed', ts: now }]
         };
       } else {
-        const source: SourceTableInterface = {
+        const source: SourceTableRef = {
           connectionTag: tag,
           schema: pattern.schema,
           name: pattern.tablePattern

--- a/packages/service-core/src/replication/RelationCache.ts
+++ b/packages/service-core/src/replication/RelationCache.ts
@@ -8,6 +8,9 @@ export class RelationCache<T> {
     this.idFunction = idFunction;
   }
 
+  /**
+   * Update a single table in-place - use when the snapshot status of the table has changed.
+   */
   update(table: SourceTable) {
     const id = this.idFunction(table);
     const existing = this.cache.get(id) ?? [];
@@ -21,24 +24,20 @@ export class RelationCache<T> {
     }
   }
 
-  updateAll(tables: SourceTable[]) {
-    if (tables.length == 0) {
-      return;
-    }
-    const id = this.idFunction(tables[0]);
+  /**
+   * Set the full set of tables for a specific reference.
+   */
+  updateAll(ref: T, tables: SourceTable[]) {
+    const id = this.idFunction(ref);
     this.cache.set(id, tables);
   }
 
-  get(source: T | SourceTable): SourceTable | undefined {
-    return this.getAll(source)[0];
-  }
-
-  getAll(source: T | SourceTable): SourceTable[] {
+  getAll(source: T | SourceTable): SourceTable[] | undefined {
     const id = this.idFunction(source);
-    return this.cache.get(id) ?? [];
+    return this.cache.get(id);
   }
 
-  delete(source: T | SourceTable): boolean {
+  delete(source: T): boolean {
     const id = this.idFunction(source);
     return this.cache.delete(id);
   }

--- a/packages/service-core/src/replication/RelationCache.ts
+++ b/packages/service-core/src/replication/RelationCache.ts
@@ -1,7 +1,7 @@
 import { SourceTable } from '../storage/SourceTable.js';
 
 export class RelationCache<T> {
-  private cache = new Map<string | number, SourceTable>();
+  private cache = new Map<string | number, SourceTable[]>();
   private idFunction: (item: T | SourceTable) => string | number;
 
   constructor(idFunction: (item: T | SourceTable) => string | number) {
@@ -10,12 +10,32 @@ export class RelationCache<T> {
 
   update(table: SourceTable) {
     const id = this.idFunction(table);
-    this.cache.set(id, table);
+    const existing = this.cache.get(id) ?? [];
+    const replacementIndex = existing.findIndex((candidate) => candidate.id == table.id);
+    if (replacementIndex == -1) {
+      this.cache.set(id, [...existing, table]);
+    } else {
+      const next = [...existing];
+      next[replacementIndex] = table;
+      this.cache.set(id, next);
+    }
+  }
+
+  updateAll(tables: SourceTable[]) {
+    if (tables.length == 0) {
+      return;
+    }
+    const id = this.idFunction(tables[0]);
+    this.cache.set(id, tables);
   }
 
   get(source: T | SourceTable): SourceTable | undefined {
+    return this.getAll(source)[0];
+  }
+
+  getAll(source: T | SourceTable): SourceTable[] {
     const id = this.idFunction(source);
-    return this.cache.get(id);
+    return this.cache.get(id) ?? [];
   }
 
   delete(source: T | SourceTable): boolean {

--- a/packages/service-core/src/storage/BucketStorageBatch.ts
+++ b/packages/service-core/src/storage/BucketStorageBatch.ts
@@ -5,6 +5,7 @@ import { InternalOpId } from '../util/utils.js';
 import { ReplicationEventPayload } from './ReplicationEventPayload.js';
 import { SourceTable, TableSnapshotStatus } from './SourceTable.js';
 import { BatchedCustomWriteCheckpointOptions } from './storage-index.js';
+import { ResolveTablesOptions, ResolveTablesResult } from './SyncRulesBucketStorage.js';
 
 export const DEFAULT_BUCKET_BATCH_COMMIT_OPTIONS: ResolvedBucketBatchCommitOptions = {
   createEmptyCheckpoints: true,
@@ -94,6 +95,8 @@ export interface BucketStorageBatch extends ObserverClient<BucketBatchStorageLis
   markAllSnapshotDone(no_checkpoint_before_lsn: string): Promise<void>;
 
   updateTableProgress(table: SourceTable, progress: Partial<TableSnapshotStatus>): Promise<SourceTable>;
+
+  resolveTables(options: ResolveTablesOptions): Promise<ResolveTablesResult>;
 
   /**
    * Queues the creation of a custom Write Checkpoint. This will be persisted after operations are flushed.

--- a/packages/service-core/src/storage/BucketStorageFactory.ts
+++ b/packages/service-core/src/storage/BucketStorageFactory.ts
@@ -170,6 +170,11 @@ export interface UpdateSyncRulesOptions {
   };
   lock?: boolean;
   storageVersion?: number;
+
+  /**
+   * Only relevant if the result is used. This does not affect the persisted config.
+   */
+  defaultSchema?: string;
 }
 
 export interface SerializedSyncPlan {
@@ -196,7 +201,7 @@ export function updateSyncRulesFromYaml(
   const config = SqlSyncRules.fromYaml(content, {
     // No schema-based validation at this point
     schema: undefined,
-    defaultSchema: 'not_applicable', // Not needed for validation
+    defaultSchema: options?.defaultSchema ?? 'not_applicable', // Not needed for validation
     throwOnError: options?.validate ?? false
   });
 

--- a/packages/service-core/src/storage/SourceEntity.ts
+++ b/packages/service-core/src/storage/SourceEntity.ts
@@ -1,3 +1,5 @@
+import { SourceTableRef } from '@powersync/service-sync-rules';
+
 export interface ColumnDescriptor {
   name: string;
   /**
@@ -10,7 +12,7 @@ export interface ColumnDescriptor {
   typeId?: number;
 }
 
-export interface SourceEntityDescriptor {
+export interface SourceEntityDescriptor extends SourceTableRef {
   /**
    * The internal id of the source entity structure in the database.
    * If undefined, the schema and name are used as the identifier.

--- a/packages/service-core/src/storage/SourceTable.ts
+++ b/packages/service-core/src/storage/SourceTable.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TAG } from '@powersync/service-sync-rules';
+import { BucketDataSource, DEFAULT_TAG, ParameterIndexLookupCreator } from '@powersync/service-sync-rules';
 import { bson } from '../index.js';
 import * as util from '../util/util-index.js';
 import { ColumnDescriptor, SourceEntityDescriptor } from './SourceEntity.js';
@@ -16,6 +16,8 @@ export interface SourceTableOptions {
   name: string;
   replicaIdColumns: ColumnDescriptor[];
   snapshotComplete: boolean;
+  bucketDataSources?: BucketDataSource[];
+  parameterLookupSources?: ParameterIndexLookupCreator[];
 }
 
 export interface TableSnapshotStatus {
@@ -90,6 +92,14 @@ export class SourceTable implements SourceEntityDescriptor {
     return this.options.replicaIdColumns;
   }
 
+  get bucketDataSources() {
+    return this.options.bucketDataSources;
+  }
+
+  get parameterLookupSources() {
+    return this.options.parameterLookupSources;
+  }
+
   /**
    *  Sanitized name of the entity in the format of "{schema}.{entity name}"
    *  Suitable for safe use in Postgres queries.
@@ -113,10 +123,13 @@ export class SourceTable implements SourceEntityDescriptor {
       schema: this.schema,
       name: this.name,
       replicaIdColumns: this.replicaIdColumns,
-      snapshotComplete: this.snapshotComplete
+      snapshotComplete: this.snapshotComplete,
+      bucketDataSources: this.bucketDataSources,
+      parameterLookupSources: this.parameterLookupSources
     });
     copy.syncData = this.syncData;
     copy.syncParameters = this.syncParameters;
+    copy.syncEvent = this.syncEvent;
     copy.snapshotStatus = this.snapshotStatus;
     return copy;
   }

--- a/packages/service-core/src/storage/SourceTable.ts
+++ b/packages/service-core/src/storage/SourceTable.ts
@@ -19,8 +19,8 @@ export interface SourceTableOptions {
   objectId: number | string | undefined;
   replicaIdColumns: ColumnDescriptor[];
   snapshotComplete: boolean;
-  bucketDataSources?: BucketDataSource[];
-  parameterLookupSources?: ParameterIndexLookupCreator[];
+  bucketDataSources: BucketDataSource[];
+  parameterLookupSources: ParameterIndexLookupCreator[];
 }
 
 export interface TableSnapshotStatus {

--- a/packages/service-core/src/storage/SourceTable.ts
+++ b/packages/service-core/src/storage/SourceTable.ts
@@ -1,7 +1,12 @@
-import { BucketDataSource, DEFAULT_TAG, ParameterIndexLookupCreator } from '@powersync/service-sync-rules';
+import {
+  BucketDataSource,
+  DEFAULT_TAG,
+  ParameterIndexLookupCreator,
+  SourceTableRef
+} from '@powersync/service-sync-rules';
 import { bson } from '../index.js';
 import * as util from '../util/util-index.js';
-import { ColumnDescriptor, SourceEntityDescriptor } from './SourceEntity.js';
+import { ColumnDescriptor } from './SourceEntity.js';
 
 /**
  * Format of the id depends on the bucket storage module. It should be consistent within the module.
@@ -10,10 +15,8 @@ export type SourceTableId = string | bson.ObjectId;
 
 export interface SourceTableOptions {
   id: SourceTableId;
-  connectionTag: string;
+  ref: SourceTableRef;
   objectId: number | string | undefined;
-  schema: string;
-  name: string;
   replicaIdColumns: ColumnDescriptor[];
   snapshotComplete: boolean;
   bucketDataSources?: BucketDataSource[];
@@ -26,7 +29,13 @@ export interface TableSnapshotStatus {
   lastKey: Uint8Array | null;
 }
 
-export class SourceTable implements SourceEntityDescriptor {
+/**
+ * Represents a resolved source table.
+ *
+ * There could be multiple of these for the same SourceTableRef.
+ * For that reason, we do not implement the SourceTableRef interface, to ensure that the two are not used interchangably.
+ */
+export class SourceTable {
   static readonly DEFAULT_TAG = DEFAULT_TAG;
 
   /**
@@ -73,19 +82,19 @@ export class SourceTable implements SourceEntityDescriptor {
     return this.options.id;
   }
 
-  get connectionTag() {
-    return this.options.connectionTag;
-  }
-
   get objectId() {
     return this.options.objectId;
   }
 
   get schema() {
-    return this.options.schema;
+    return this.options.ref.schema;
   }
   get name() {
-    return this.options.name;
+    return this.options.ref.name;
+  }
+
+  get ref() {
+    return this.options.ref;
   }
 
   get replicaIdColumns() {
@@ -101,11 +110,11 @@ export class SourceTable implements SourceEntityDescriptor {
   }
 
   /**
-   *  Sanitized name of the entity in the format of "{schema}.{entity name}"
-   *  Suitable for safe use in Postgres queries.
+   * Sanitized name of the entity in the format of "{schema}.{entity name}".
+   * Suitable for safe use in Postgres queries.
    */
   get qualifiedName() {
-    return `${util.escapeIdentifier(this.schema)}.${util.escapeIdentifier(this.name)}`;
+    return util.qualifiedName(this.ref);
   }
 
   get syncAny() {
@@ -118,10 +127,8 @@ export class SourceTable implements SourceEntityDescriptor {
   clone() {
     const copy = new SourceTable({
       id: this.id,
-      connectionTag: this.connectionTag,
+      ref: this.options.ref,
       objectId: this.objectId,
-      schema: this.schema,
-      name: this.name,
       replicaIdColumns: this.replicaIdColumns,
       snapshotComplete: this.snapshotComplete,
       bucketDataSources: this.bucketDataSources,

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -2,7 +2,6 @@ import { Logger, ObserverClient } from '@powersync/lib-services-framework';
 import {
   BucketDataSource,
   HydratedSyncRules,
-  MatchingSources,
   ParameterLookupRows,
   ScopedParameterLookup
 } from '@powersync/service-sync-rules';
@@ -158,10 +157,7 @@ export interface SyncRuleStatus {
 }
 export interface ResolveTablesOptions {
   connection_id: number;
-  connection_tag: string;
-  entity_descriptor: SourceEntityDescriptor;
-
-  matchingSources: MatchingSources | null;
+  source: SourceEntityDescriptor;
   /**
    * For tests only - custom id generator for stable ids.
    */

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -27,8 +27,6 @@ export interface SyncRulesBucketStorage
   readonly factory: BucketStorageFactory;
   readonly logger: Logger;
 
-  resolveTables(options: ResolveTablesOptions): Promise<ResolveTablesResult>;
-
   /**
    * Create a new writer.
    *

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -6,6 +6,7 @@ import {
   ParameterLookupRows,
   ScopedParameterLookup
 } from '@powersync/service-sync-rules';
+import * as bson from 'bson';
 import { PerformanceTracer } from '../tracing/PerformanceTracer.js';
 import * as util from '../util/util-index.js';
 import { BucketStorageBatch, FlushedResult, SaveUpdate } from './BucketStorageBatch.js';
@@ -156,13 +157,15 @@ export interface SyncRuleStatus {
   snapshot_lsn: string | null;
 }
 export interface ResolveTablesOptions {
-  group_id: number;
   connection_id: number;
   connection_tag: string;
   entity_descriptor: SourceEntityDescriptor;
 
-  sync_rules: HydratedSyncRules;
   matchingSources: MatchingSources | null;
+  /**
+   * For tests only - custom id generator for stable ids.
+   */
+  idGenerator?: () => string | bson.ObjectId;
 }
 
 export interface ResolveTablesResult {

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -162,6 +162,10 @@ export interface ResolveTablesOptions {
    * For tests only - custom id generator for stable ids.
    */
   idGenerator?: () => string | bson.ObjectId;
+  /**
+   * For tests only - override the sync rules used.
+   */
+  syncRules?: HydratedSyncRules;
 }
 
 export interface ResolveTablesResult {

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -2,6 +2,7 @@ import { Logger, ObserverClient } from '@powersync/lib-services-framework';
 import {
   BucketDataSource,
   HydratedSyncRules,
+  MatchingSources,
   ParameterLookupRows,
   ScopedParameterLookup
 } from '@powersync/service-sync-rules';
@@ -26,10 +27,7 @@ export interface SyncRulesBucketStorage
   readonly factory: BucketStorageFactory;
   readonly logger: Logger;
 
-  /**
-   * Resolve a table, keeping track of it internally.
-   */
-  resolveTable(options: ResolveTableOptions): Promise<ResolveTableResult>;
+  resolveTables(options: ResolveTablesOptions): Promise<ResolveTablesResult>;
 
   /**
    * Create a new writer.
@@ -157,17 +155,18 @@ export interface SyncRuleStatus {
   snapshot_done: boolean;
   snapshot_lsn: string | null;
 }
-export interface ResolveTableOptions {
+export interface ResolveTablesOptions {
   group_id: number;
   connection_id: number;
   connection_tag: string;
   entity_descriptor: SourceEntityDescriptor;
 
   sync_rules: HydratedSyncRules;
+  matchingSources: MatchingSources | null;
 }
 
-export interface ResolveTableResult {
-  table: SourceTable;
+export interface ResolveTablesResult {
+  tables: SourceTable[];
   dropTables: SourceTable[];
 }
 

--- a/packages/service-core/src/util/utils.ts
+++ b/packages/service-core/src/util/utils.ts
@@ -39,6 +39,14 @@ export function escapeIdentifier(identifier: string) {
   return `"${identifier.replace(/"/g, '""').replace(/\./g, '"."')}"`;
 }
 
+/**
+ *  Sanitized name of the entity in the format of "{schema}.{entity name}"
+ *  Suitable for safe use in Postgres queries and in log output.
+ */
+export function qualifiedName(ref: sync_rules.SourceTableRef) {
+  return `${escapeIdentifier(ref.schema)}.${escapeIdentifier(ref.name)}`;
+}
+
 export function hashData(type: string, id: string, data: string): number {
   const hash = crypto.createHash('sha256');
   hash.update(`put.${type}.${id}.${data}`);

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -18,7 +18,7 @@ import {
   ParameterIndexLookupCreator,
   ParameterLookupRows,
   ScopedParameterLookup,
-  SourceTableInterface,
+  SourceTableRef,
   SqliteRow,
   SqlSyncRules,
   TablePattern,
@@ -39,10 +39,10 @@ describe('BucketChecksumState', () => {
     getSourceTables(): Set<TablePattern> {
       return new Set();
     },
-    evaluateParameterRow(_sourceTable: SourceTableInterface, _row: SqliteRow) {
+    evaluateParameterRow(_sourceTable: SourceTableRef, _row: SqliteRow) {
       return [];
     },
-    tableSyncsParameters(_table: SourceTableInterface): boolean {
+    tableSyncsParameters(_table: SourceTableRef): boolean {
       return false;
     }
   };

--- a/packages/sync-rules/src/BaseSqlDataQuery.ts
+++ b/packages/sync-rules/src/BaseSqlDataQuery.ts
@@ -2,7 +2,7 @@ import { SelectedColumn } from 'pgsql-ast-parser';
 import { idFromData } from './cast.js';
 import { SqlRuleError } from './errors.js';
 import { ColumnDefinition } from './ExpressionType.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { AvailableTable, SqlTools } from './sql_filters.js';
 import { TablePattern } from './TablePattern.js';
 import {
@@ -23,7 +23,7 @@ export interface RowValueExtractor {
 }
 
 export interface EvaluateRowOptions {
-  table: SourceTableInterface;
+  table: SourceTableRef;
   row: SqliteRow;
   serializedBucketParameters: (params: QueryParameters) => string[];
 }
@@ -94,11 +94,11 @@ export class BaseSqlDataQuery {
     this.errors = options.errors ?? [];
   }
 
-  applies(table: SourceTableInterface) {
+  applies(table: SourceTableRef) {
     return this.sourceTable.matches(table);
   }
 
-  addSpecialParameters(table: SourceTableInterface, row: SqliteRow) {
+  addSpecialParameters(table: SourceTableRef, row: SqliteRow) {
     if (this.sourceTable.isWildcard) {
       return {
         ...row,

--- a/packages/sync-rules/src/BucketSource.ts
+++ b/packages/sync-rules/src/BucketSource.ts
@@ -6,7 +6,7 @@ import {
 } from './BucketParameterQuerier.js';
 import { ColumnDefinition } from './ExpressionType.js';
 import { DEFAULT_HYDRATION_STATE, HydrationState, ParameterLookupScope } from './HydrationState.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { GetQuerierOptions } from './SqlSyncRules.js';
 import { TablePattern } from './TablePattern.js';
 import {
@@ -80,10 +80,7 @@ export interface HydratedBucketSource extends BucketParameterQuerierSource {
 }
 
 export type ScopedEvaluateRow = (options: EvaluateRowOptions) => EvaluationResult[];
-export type ScopedEvaluateParameterRow = (
-  sourceTable: SourceTableInterface,
-  row: SqliteRow
-) => EvaluatedParametersResult[];
+export type ScopedEvaluateParameterRow = (sourceTable: SourceTableRef, row: SqliteRow) => EvaluatedParametersResult[];
 
 /**
  * Encodes a static definition of a bucket source, as parsed from sync rules or stream definitions.
@@ -105,7 +102,7 @@ export interface BucketDataSource {
   readonly bucketParameters: string[];
 
   getSourceTables(): Set<TablePattern>;
-  tableSyncsData(table: SourceTableInterface): boolean;
+  tableSyncsData(table: SourceTableRef): boolean;
 
   /**
    * Given a row as it appears in a table that affects sync data, return buckets, logical table names and transformed
@@ -146,10 +143,10 @@ export interface ParameterIndexLookupCreator {
    * The returned {@link UnscopedParameterLookup} can be referenced by {@link pushBucketParameterQueriers} to allow the storage
    * system to find buckets.
    */
-  evaluateParameterRow(sourceTable: SourceTableInterface, row: SqliteRow): UnscopedEvaluatedParametersResult[];
+  evaluateParameterRow(sourceTable: SourceTableRef, row: SqliteRow): UnscopedEvaluatedParametersResult[];
 
   /** Whether the table possibly affects the buckets resolved by this source. */
-  tableSyncsParameters(table: SourceTableInterface): boolean;
+  tableSyncsParameters(table: SourceTableRef): boolean;
 }
 
 export interface DebugMergedSource extends HydratedBucketSource {
@@ -190,7 +187,7 @@ export function hydrateEvaluateParameterRow(
   source: ParameterIndexLookupCreator
 ): ScopedEvaluateParameterRow {
   const scope = hydrationState.getParameterIndexLookupScope(source);
-  return (sourceTable: SourceTableInterface, row: SqliteRow): EvaluatedParametersResult[] => {
+  return (sourceTable: SourceTableRef, row: SqliteRow): EvaluatedParametersResult[] => {
     return source.evaluateParameterRow(sourceTable, row).map((result) => {
       if (isEvaluationError(result)) {
         return result;
@@ -221,7 +218,7 @@ export function mergeParameterIndexLookupCreators(
 ): { evaluateParameterRow: ScopedEvaluateParameterRow } {
   const withScope = sources.map((source) => hydrateEvaluateParameterRow(hydrationState, source));
   return {
-    evaluateParameterRow(sourceTable: SourceTableInterface, row: SqliteRow): EvaluatedParametersResult[] {
+    evaluateParameterRow(sourceTable: SourceTableRef, row: SqliteRow): EvaluatedParametersResult[] {
       return withScope.flatMap((source) => source(sourceTable, row));
     }
   };

--- a/packages/sync-rules/src/HydratedSyncRules.ts
+++ b/packages/sync-rules/src/HydratedSyncRules.ts
@@ -45,6 +45,11 @@ export class HydratedSyncRules {
   private readonly innerEvaluateRow: ScopedEvaluateRow;
   private readonly innerEvaluateParameterRow: ScopedEvaluateParameterRow;
   private readonly hydrationState: HydrationState;
+  private mergedEvaluatorCache = new WeakMap<BucketDataSource[], { evaluateRow: ScopedEvaluateRow }>();
+  private mergedParameterIndexCreatorCache = new WeakMap<
+    ParameterIndexLookupCreator[],
+    { evaluateParameterRow: ScopedEvaluateParameterRow }
+  >();
 
   constructor(params: {
     definition: SyncConfig;
@@ -126,9 +131,14 @@ export class HydratedSyncRules {
   evaluateRowWithErrors(options: EvaluateRowOptions): { results: EvaluatedRow[]; errors: EvaluationError[] } {
     let rawResults: EvaluationResult[];
     if (options.bucketDataSources != null) {
-      // TODO: cache these?
-      const e = mergeDataSources(this.hydrationState, options.bucketDataSources);
-      rawResults = e.evaluateRow(options);
+      // This array is generally expected to be stable, so makes for a good cache key.
+      // It is not a strict requirement to use stable arrays, but it can help for performance.
+      let merged = this.mergedEvaluatorCache.get(options.bucketDataSources);
+      if (merged == null) {
+        merged = mergeDataSources(this.hydrationState, options.bucketDataSources);
+        this.mergedEvaluatorCache.set(options.bucketDataSources, merged);
+      }
+      rawResults = merged.evaluateRow(options);
     } else {
       rawResults = this.innerEvaluateRow(options);
     }
@@ -160,9 +170,14 @@ export class HydratedSyncRules {
   ): { results: EvaluatedParameters[]; errors: EvaluationError[] } {
     let rawResults: EvaluatedParametersResult[];
     if (options?.parameterLookupSources != null) {
-      // TODO: cache these?
-      const e = mergeParameterIndexLookupCreators(this.hydrationState, options.parameterLookupSources);
-      rawResults = e.evaluateParameterRow(table, row);
+      // This array is generally expected to be stable, so makes for a good cache key.
+      // It is not a strict requirement to use stable arrays, but it can help for performance.
+      let merged = this.mergedParameterIndexCreatorCache.get(options.parameterLookupSources);
+      if (merged == null) {
+        merged = mergeParameterIndexLookupCreators(this.hydrationState, options.parameterLookupSources);
+        this.mergedParameterIndexCreatorCache.set(options.parameterLookupSources, merged);
+      }
+      rawResults = merged.evaluateParameterRow(table, row);
     } else {
       rawResults = this.innerEvaluateParameterRow(table, row);
     }

--- a/packages/sync-rules/src/HydratedSyncRules.ts
+++ b/packages/sync-rules/src/HydratedSyncRules.ts
@@ -7,6 +7,7 @@ import {
   EvaluationError,
   GetBucketParameterQuerierResult,
   GetQuerierOptions,
+  HydrationState,
   isEvaluatedParameters,
   isEvaluatedRow,
   isEvaluationError,
@@ -43,6 +44,7 @@ export class HydratedSyncRules {
 
   private readonly innerEvaluateRow: ScopedEvaluateRow;
   private readonly innerEvaluateParameterRow: ScopedEvaluateParameterRow;
+  private readonly hydrationState: HydrationState;
 
   constructor(params: {
     definition: SyncConfig;
@@ -53,6 +55,7 @@ export class HydratedSyncRules {
     compatibility?: CompatibilityContext;
   }) {
     const hydrationState = params.createParams.hydrationState;
+    this.hydrationState = hydrationState;
 
     this.definition = params.definition;
     this.innerEvaluateRow = mergeDataSources(hydrationState, params.bucketDataSources).evaluateRow;
@@ -116,7 +119,14 @@ export class HydratedSyncRules {
   }
 
   evaluateRowWithErrors(options: EvaluateRowOptions): { results: EvaluatedRow[]; errors: EvaluationError[] } {
-    const rawResults: EvaluationResult[] = this.innerEvaluateRow(options);
+    let rawResults: EvaluationResult[];
+    if (options.bucketDataSources != null) {
+      // TODO: cache these?
+      const e = mergeDataSources(this.hydrationState, options.bucketDataSources);
+      rawResults = e.evaluateRow(options);
+    } else {
+      rawResults = this.innerEvaluateRow(options);
+    }
     const results = rawResults.filter(isEvaluatedRow) as EvaluatedRow[];
     const errors = rawResults.filter(isEvaluationError) as EvaluationError[];
 
@@ -126,8 +136,12 @@ export class HydratedSyncRules {
   /**
    * Throws errors.
    */
-  evaluateParameterRow(table: SourceTableInterface, row: SqliteRow): EvaluatedParameters[] {
-    const { results, errors } = this.evaluateParameterRowWithErrors(table, row);
+  evaluateParameterRow(
+    table: SourceTableInterface,
+    row: SqliteRow,
+    options?: { parameterLookupSources?: ParameterIndexLookupCreator[] }
+  ): EvaluatedParameters[] {
+    const { results, errors } = this.evaluateParameterRowWithErrors(table, row, options);
     if (errors.length > 0) {
       throw new Error(errors[0].error);
     }
@@ -136,9 +150,17 @@ export class HydratedSyncRules {
 
   evaluateParameterRowWithErrors(
     table: SourceTableInterface,
-    row: SqliteRow
+    row: SqliteRow,
+    options?: { parameterLookupSources?: ParameterIndexLookupCreator[] }
   ): { results: EvaluatedParameters[]; errors: EvaluationError[] } {
-    const rawResults: EvaluatedParametersResult[] = this.innerEvaluateParameterRow(table, row);
+    let rawResults: EvaluatedParametersResult[];
+    if (options?.parameterLookupSources != null) {
+      // TODO: cache these?
+      const e = mergeParameterIndexLookupCreators(this.hydrationState, options.parameterLookupSources);
+      rawResults = e.evaluateParameterRow(table, row);
+    } else {
+      rawResults = this.innerEvaluateParameterRow(table, row);
+    }
     const results = rawResults.filter(isEvaluatedParameters) as EvaluatedParameters[];
     const errors = rawResults.filter(isEvaluationError) as EvaluationError[];
     return { results, errors };

--- a/packages/sync-rules/src/HydratedSyncRules.ts
+++ b/packages/sync-rules/src/HydratedSyncRules.ts
@@ -23,7 +23,7 @@ import {
   SqliteValue,
   SyncConfig
 } from './index.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { EvaluatedParametersResult, EvaluateRowOptions, EvaluationResult, SqliteRow } from './types.js';
 
 export interface MatchingSources {
@@ -80,19 +80,24 @@ export class HydratedSyncRules {
     return this.definition.getSourceTables();
   }
 
-  tableTriggersEvent(table: SourceTableInterface): boolean {
+  tableTriggersEvent(table: SourceTableRef): boolean {
     return this.definition.tableTriggersEvent(table);
   }
 
-  tableSyncsData(table: SourceTableInterface): boolean {
+  tableSyncsData(table: SourceTableRef): boolean {
     return this.definition.tableSyncsData(table);
   }
 
-  tableSyncsParameters(table: SourceTableInterface): boolean {
+  tableSyncsParameters(table: SourceTableRef): boolean {
     return this.definition.tableSyncsParameters(table);
   }
 
-  getMatchingSources(table: SourceTableInterface): MatchingSources {
+  getMatchingSources(source: SourceTableRef): MatchingSources {
+    const table: SourceTableRef = {
+      connectionTag: source.connectionTag,
+      schema: source.schema,
+      name: source.name
+    };
     return {
       bucketDataSources: this.definition.bucketDataSources.filter((source) => source.tableSyncsData(table)),
       parameterLookupSources: this.definition.bucketParameterLookupSources.filter((source) =>
@@ -137,7 +142,7 @@ export class HydratedSyncRules {
    * Throws errors.
    */
   evaluateParameterRow(
-    table: SourceTableInterface,
+    table: SourceTableRef,
     row: SqliteRow,
     options?: { parameterLookupSources?: ParameterIndexLookupCreator[] }
   ): EvaluatedParameters[] {
@@ -149,7 +154,7 @@ export class HydratedSyncRules {
   }
 
   evaluateParameterRowWithErrors(
-    table: SourceTableInterface,
+    table: SourceTableRef,
     row: SqliteRow,
     options?: { parameterLookupSources?: ParameterIndexLookupCreator[] }
   ): { results: EvaluatedParameters[]; errors: EvaluationError[] } {

--- a/packages/sync-rules/src/HydratedSyncRules.ts
+++ b/packages/sync-rules/src/HydratedSyncRules.ts
@@ -25,6 +25,11 @@ import {
 import { SourceTableInterface } from './SourceTableInterface.js';
 import { EvaluatedParametersResult, EvaluateRowOptions, EvaluationResult, SqliteRow } from './types.js';
 
+export interface MatchingSources {
+  bucketDataSources: BucketDataSource[];
+  parameterLookupSources: ParameterIndexLookupCreator[];
+}
+
 /**
  * Hydrated sync config is sync config definitions along with persisted state. Currently, the persisted state
  * specifically affects bucket names.
@@ -82,6 +87,15 @@ export class HydratedSyncRules {
 
   tableSyncsParameters(table: SourceTableInterface): boolean {
     return this.definition.tableSyncsParameters(table);
+  }
+
+  getMatchingSources(table: SourceTableInterface): MatchingSources {
+    return {
+      bucketDataSources: this.definition.bucketDataSources.filter((source) => source.tableSyncsData(table)),
+      parameterLookupSources: this.definition.bucketParameterLookupSources.filter((source) =>
+        source.tableSyncsParameters(table)
+      )
+    };
   }
 
   applyRowContext<MaybeToast extends undefined = never>(

--- a/packages/sync-rules/src/SourceTableInterface.ts
+++ b/packages/sync-rules/src/SourceTableInterface.ts
@@ -1,5 +1,1 @@
-export interface SourceTableInterface {
-  readonly connectionTag: string;
-  readonly schema: string;
-  readonly name: string;
-}
+export { SourceTableRef as SourceRowTableInterface, SourceTableRef as SourceTableInterface } from './SourceTableRef.js';

--- a/packages/sync-rules/src/SourceTableInterface.ts
+++ b/packages/sync-rules/src/SourceTableInterface.ts
@@ -1,1 +1,0 @@
-export { SourceTableRef as SourceRowTableInterface, SourceTableRef as SourceTableInterface } from './SourceTableRef.js';

--- a/packages/sync-rules/src/SourceTableRef.ts
+++ b/packages/sync-rules/src/SourceTableRef.ts
@@ -1,0 +1,8 @@
+/**
+ * Reference to a source table associated with a replicated row.
+ */
+export interface SourceTableRef {
+  readonly connectionTag: string;
+  readonly schema: string;
+  readonly name: string;
+}

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -8,7 +8,7 @@ import {
 } from './BucketSource.js';
 import { ColumnDefinition } from './ExpressionType.js';
 import { IdSequence } from './IdSequence.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { SqlDataQuery } from './SqlDataQuery.js';
 import { SqlParameterQuery } from './SqlParameterQuery.js';
 import { GetQuerierOptions, SyncRulesOptions } from './SqlSyncRules.js';
@@ -198,7 +198,7 @@ export class BucketDefinitionDataSource implements BucketDataSource {
     return result;
   }
 
-  tableSyncsData(table: SourceTableInterface): boolean {
+  tableSyncsData(table: SourceTableRef): boolean {
     for (let query of this.descriptor.dataQueries) {
       if (query.applies(table)) {
         return true;

--- a/packages/sync-rules/src/SqlDataQuery.ts
+++ b/packages/sync-rules/src/SqlDataQuery.ts
@@ -4,7 +4,7 @@ import { BaseSqlDataQuery, BaseSqlDataQueryOptions, RowValueExtractor } from './
 import { CompatibilityContext } from './compatibility.js';
 import { SqlRuleError } from './errors.js';
 import { ExpressionType } from './ExpressionType.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { AvailableTable, SqlTools } from './sql_filters.js';
 import { checkUnsupportedFeatures, isClauseError } from './sql_support.js';
 import { SyncRulesOptions } from './SqlSyncRules.js';
@@ -190,7 +190,7 @@ export class SqlDataQuery extends BaseSqlDataQuery {
     this.filter = options.filter;
   }
 
-  evaluateRow(table: SourceTableInterface, row: SqliteRow): UnscopedEvaluationResult[] {
+  evaluateRow(table: SourceTableRef, row: SqliteRow): UnscopedEvaluationResult[] {
     return this.evaluateRowWithOptions({
       table,
       row,

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -23,7 +23,7 @@ import {
   UnscopedEvaluatedParameters,
   UnscopedEvaluatedParametersResult
 } from './index.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { AvailableTable, SqlTools } from './sql_filters.js';
 import { checkUnsupportedFeatures, isClauseError } from './sql_support.js';
 import { StaticSqlParameterQuery } from './StaticSqlParameterQuery.js';
@@ -343,7 +343,7 @@ export class SqlParameterQuery implements ParameterIndexLookupCreator {
     };
   }
 
-  tableSyncsParameters(table: SourceTableInterface): boolean {
+  tableSyncsParameters(table: SourceTableRef): boolean {
     return this.sourceTable.matches(table);
   }
 
@@ -367,7 +367,7 @@ export class SqlParameterQuery implements ParameterIndexLookupCreator {
   /**
    * Given a replicated row, results an array of bucket parameter rows to persist.
    */
-  evaluateParameterRow(sourceTable: SourceTableInterface, row: SqliteRow): UnscopedEvaluatedParametersResult[] {
+  evaluateParameterRow(sourceTable: SourceTableRef, row: SqliteRow): UnscopedEvaluatedParametersResult[] {
     if (!this.tableSyncsParameters(sourceTable)) {
       return [];
     }

--- a/packages/sync-rules/src/StaticSchema.ts
+++ b/packages/sync-rules/src/StaticSchema.ts
@@ -1,5 +1,5 @@
 import { ColumnDefinition, ExpressionType, expressionTypeFromPostgresType, SqliteType } from './ExpressionType.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { TablePattern } from './TablePattern.js';
 import { SourceSchema, SourceSchemaTable } from './types.js';
 
@@ -43,7 +43,7 @@ export interface SourceConnectionDefinition {
   schemas: SourceSchemaDefinition[];
 }
 
-class SourceTableDetails implements SourceTableInterface, SourceSchemaTable {
+class SourceTableDetails implements SourceTableRef, SourceSchemaTable {
   readonly connectionTag: string;
   readonly schema: string;
   readonly name: string;

--- a/packages/sync-rules/src/StaticSqlParameterQuery.ts
+++ b/packages/sync-rules/src/StaticSqlParameterQuery.ts
@@ -5,7 +5,7 @@ import { CreateSourceParams } from './BucketSource.js';
 import { SqlRuleError } from './errors.js';
 import { BucketDataScope } from './HydrationState.js';
 import { BucketDataSource, BucketParameterQuerierSource, GetQuerierOptions, resolvedBucket } from './index.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { AvailableTable, SqlTools } from './sql_filters.js';
 import { checkUnsupportedFeatures, isClauseError, sqliteBool } from './sql_support.js';
 import { TablePattern } from './TablePattern.js';
@@ -171,7 +171,7 @@ export class StaticSqlParameterQuery {
     return new Set<TablePattern>();
   }
 
-  tableSyncsParameters(_table: SourceTableInterface): boolean {
+  tableSyncsParameters(_table: SourceTableRef): boolean {
     return false;
   }
 

--- a/packages/sync-rules/src/SyncConfig.ts
+++ b/packages/sync-rules/src/SyncConfig.ts
@@ -3,7 +3,7 @@ import { CompatibilityContext } from './compatibility.js';
 import { YamlError } from './errors.js';
 import { SqlEventDescriptor } from './events/SqlEventDescriptor.js';
 import { HydratedSyncRules } from './HydratedSyncRules.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { TablePattern } from './TablePattern.js';
 import { SqliteInputValue, SqliteRow, SqliteValue } from './types.js';
 import { applyRowContext } from './utils.js';
@@ -101,15 +101,15 @@ export abstract class SyncConfig {
     return [...eventTables.values()];
   }
 
-  tableTriggersEvent(table: SourceTableInterface): boolean {
+  tableTriggersEvent(table: SourceTableRef): boolean {
     return this.eventDescriptors.some((bucket) => bucket.tableTriggersEvent(table));
   }
 
-  tableSyncsData(table: SourceTableInterface): boolean {
+  tableSyncsData(table: SourceTableRef): boolean {
     return this.bucketDataSources.some((b) => b.tableSyncsData(table));
   }
 
-  tableSyncsParameters(table: SourceTableInterface): boolean {
+  tableSyncsParameters(table: SourceTableRef): boolean {
     return this.bucketParameterLookupSources.some((b) => b.tableSyncsParameters(table));
   }
 

--- a/packages/sync-rules/src/TablePattern.ts
+++ b/packages/sync-rules/src/TablePattern.ts
@@ -1,5 +1,5 @@
 import { Equatable, StableHasher } from './compiler/equality.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 
 export const DEFAULT_TAG = 'default';
 
@@ -92,7 +92,7 @@ export class TablePattern extends ImplicitSchemaTablePattern {
     return this.tablePattern.substring(0, this.tablePattern.length - 1);
   }
 
-  matches(table: SourceTableInterface) {
+  matches(table: SourceTableRef) {
     if (this.connectionTag != table.connectionTag || this.schema != table.schema) {
       return false;
     }

--- a/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
+++ b/packages/sync-rules/src/TableValuedFunctionSqlParameterQuery.ts
@@ -10,7 +10,7 @@ import {
   GetQuerierOptions,
   PendingQueriers
 } from './index.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { AvailableTable, SqlTools } from './sql_filters.js';
 import { checkUnsupportedFeatures, isClauseError, sqliteBool } from './sql_support.js';
 import { TablePattern } from './TablePattern.js';
@@ -227,7 +227,7 @@ export class TableValuedFunctionSqlParameterQuery {
     return new Set<TablePattern>();
   }
 
-  tableSyncsParameters(_table: SourceTableInterface): boolean {
+  tableSyncsParameters(_table: SourceTableRef): boolean {
     return false;
   }
 

--- a/packages/sync-rules/src/events/SqlEventDescriptor.ts
+++ b/packages/sync-rules/src/events/SqlEventDescriptor.ts
@@ -1,6 +1,6 @@
 import { CompatibilityContext } from '../compatibility.js';
 import { SqlRuleError } from '../errors.js';
-import { SourceTableInterface } from '../SourceTableInterface.js';
+import { SourceTableRef } from '../SourceTableRef.js';
 import { QueryParseResult } from '../SqlBucketDescriptor.js';
 import { SyncRulesOptions } from '../SqlSyncRules.js';
 import { TablePattern } from '../TablePattern.js';
@@ -61,7 +61,7 @@ export class SqlEventDescriptor {
     return result;
   }
 
-  tableTriggersEvent(table: SourceTableInterface): boolean {
+  tableTriggersEvent(table: SourceTableRef): boolean {
     return this.sourceQueries.some((query) => query.applies(table));
   }
 }

--- a/packages/sync-rules/src/events/SqlEventSourceQuery.ts
+++ b/packages/sync-rules/src/events/SqlEventSourceQuery.ts
@@ -3,7 +3,7 @@ import { BaseSqlDataQuery, BaseSqlDataQueryOptions, RowValueExtractor } from '..
 import { CompatibilityContext } from '../compatibility.js';
 import { SqlRuleError } from '../errors.js';
 import { ExpressionType } from '../ExpressionType.js';
-import { SourceTableInterface } from '../SourceTableInterface.js';
+import { SourceTableRef } from '../SourceTableRef.js';
 import { AvailableTable, SqlTools } from '../sql_filters.js';
 import { checkUnsupportedFeatures, isClauseError } from '../sql_support.js';
 import { SyncRulesOptions } from '../SqlSyncRules.js';
@@ -133,7 +133,7 @@ export class SqlEventSourceQuery extends BaseSqlDataQuery {
     super(options);
   }
 
-  evaluateRowWithErrors(table: SourceTableInterface, row: SqliteRow): EvaluatedEventRowWithErrors {
+  evaluateRowWithErrors(table: SourceTableRef, row: SqliteRow): EvaluatedEventRowWithErrors {
     try {
       const tables = { [this.table!.nameInSchema]: this.addSpecialParameters(table, row) };
 

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -14,6 +14,7 @@ export * from './json_schema.js';
 export * from './request_functions.js';
 export * from './schema-generators/schema-generators.js';
 export * from './SourceTableInterface.js';
+export * from './SourceTableRef.js';
 export * from './sql_filters.js';
 export * from './sql_functions.js';
 export * from './sql_support.js';

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -13,7 +13,6 @@ export * from './IdSequence.js';
 export * from './json_schema.js';
 export * from './request_functions.js';
 export * from './schema-generators/schema-generators.js';
-export * from './SourceTableInterface.js';
 export * from './SourceTableRef.js';
 export * from './sql_filters.js';
 export * from './sql_functions.js';

--- a/packages/sync-rules/src/streams/filter.ts
+++ b/packages/sync-rules/src/streams/filter.ts
@@ -17,7 +17,7 @@ import { isJsonValue, normalizeParameterValue } from '../utils.js';
 import { NodeLocation } from 'pgsql-ast-parser';
 import { ParameterIndexLookupCreator } from '../BucketSource.js';
 import { HydrationState, ParameterLookupScope } from '../HydrationState.js';
-import { SourceTableInterface } from '../SourceTableInterface.js';
+import { SourceTableRef } from '../SourceTableRef.js';
 import { SubqueryEvaluator } from './parameter.js';
 import { cartesianProduct } from './utils.js';
 import { StreamVariant } from './variant.js';
@@ -566,7 +566,7 @@ export class SubqueryParameterLookupSource implements ParameterIndexLookupCreato
    * @param sourceTable A table we depend on in a subquery.
    * @param row Row data to index.
    */
-  evaluateParameterRow(sourceTable: SourceTableInterface, row: SqliteRow): UnscopedEvaluatedParametersResult[] {
+  evaluateParameterRow(sourceTable: SourceTableRef, row: SqliteRow): UnscopedEvaluatedParametersResult[] {
     if (this.parameterTable.matches(sourceTable)) {
       // Theoretically we're doing duplicate work by doing this for each innerVariant in a subquery.
       // In practice, we don't have more than one innerVariant per subquery right now, so this is fine.
@@ -592,7 +592,7 @@ export class SubqueryParameterLookupSource implements ParameterIndexLookupCreato
     return [];
   }
 
-  tableSyncsParameters(table: SourceTableInterface): boolean {
+  tableSyncsParameters(table: SourceTableRef): boolean {
     return this.parameterTable.matches(table);
   }
 }

--- a/packages/sync-rules/src/streams/stream.ts
+++ b/packages/sync-rules/src/streams/stream.ts
@@ -10,7 +10,7 @@ import {
   ParameterIndexLookupCreator
 } from '../BucketSource.js';
 import { ColumnDefinition } from '../ExpressionType.js';
-import { SourceTableInterface } from '../SourceTableInterface.js';
+import { SourceTableRef } from '../SourceTableRef.js';
 import { TablePattern } from '../TablePattern.js';
 import { EvaluateRowOptions, SourceSchema, TableRow, UnscopedEvaluationResult } from '../types.js';
 import { StreamVariant } from './variant.js';
@@ -100,7 +100,7 @@ export class SyncStreamDataSource implements BucketDataSource {
     return new Set<TablePattern>([this.data.sourceTable]);
   }
 
-  tableSyncsData(table: SourceTableInterface): boolean {
+  tableSyncsData(table: SourceTableRef): boolean {
     return this.data.applies(table);
   }
 

--- a/packages/sync-rules/src/sync_plan/evaluator/bucket_data_source.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/bucket_data_source.ts
@@ -1,7 +1,7 @@
 import { BucketDataSource } from '../../BucketSource.js';
 import { idFromData } from '../../cast.js';
 import { ColumnDefinition } from '../../ExpressionType.js';
-import { SourceTableInterface } from '../../SourceTableInterface.js';
+import { SourceTableRef } from '../../SourceTableRef.js';
 import { TablePattern } from '../../TablePattern.js';
 import {
   EvaluateRowOptions,
@@ -58,7 +58,7 @@ export class PreparedStreamBucketDataSource implements BucketDataSource {
     return this.sourceTables;
   }
 
-  private *sourcesForTable(table: SourceTableInterface) {
+  private *sourcesForTable(table: SourceTableRef) {
     for (const source of this.sources) {
       if (source.tablePattern.matches(table)) {
         yield source;
@@ -66,7 +66,7 @@ export class PreparedStreamBucketDataSource implements BucketDataSource {
     }
   }
 
-  tableSyncsData(table: SourceTableInterface): boolean {
+  tableSyncsData(table: SourceTableRef): boolean {
     return !this.sourcesForTable(table).next().done;
   }
 

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
@@ -1,7 +1,7 @@
 import { UnscopedParameterLookup } from '../../BucketParameterQuerier.js';
 import { ParameterIndexLookupCreator } from '../../BucketSource.js';
 import { ParameterLookupScope } from '../../HydrationState.js';
-import { SourceTableInterface } from '../../SourceTableInterface.js';
+import { SourceTableRef } from '../../SourceTableRef.js';
 import { TablePattern } from '../../TablePattern.js';
 import { SqliteJsonValue, SqliteParameterValue, SqliteRow, UnscopedEvaluatedParametersResult } from '../../types.js';
 import { ScalarExpressionEvaluator } from '../engine/scalar_expression_engine.js';
@@ -47,7 +47,7 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
     return set;
   }
 
-  evaluateParameterRow(sourceTable: SourceTableInterface, row: SqliteRow): UnscopedEvaluatedParametersResult[] {
+  evaluateParameterRow(sourceTable: SourceTableRef, row: SqliteRow): UnscopedEvaluatedParametersResult[] {
     const results: UnscopedEvaluatedParametersResult[] = [];
     if (!this.sourceTable.matches(sourceTable)) {
       return results;
@@ -117,7 +117,7 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
     return results;
   }
 
-  tableSyncsParameters(table: SourceTableInterface): boolean {
+  tableSyncsParameters(table: SourceTableRef): boolean {
     return this.sourceTable.matches(table);
   }
 }

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -376,7 +376,7 @@ export interface EvaluateRowOptions extends TableRow {
   /**
    * Optional: List the specific sources to use.
    *
-   * If not provided, uses all matching sources in the sync config.
+   * If not provided, uses all matching sources in the sync config. This path is primarily intended for tests.
    *
    * If provided, use only these sources.
    */

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -372,7 +372,16 @@ export interface InputParameter {
   parametersToLookupValue(parameters: ParameterValueSet): SqliteValue;
 }
 
-export interface EvaluateRowOptions extends TableRow {}
+export interface EvaluateRowOptions extends TableRow {
+  /**
+   * Optional: List the specific sources to use.
+   *
+   * If not provided, uses all matching sources in the sync config.
+   *
+   * If provided, use only these sources.
+   */
+  bucketDataSources?: BucketDataSource[];
+}
 
 /**
  * A row associated with the table it's coming from.

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -5,7 +5,7 @@ import { BucketDataSource } from './BucketSource.js';
 import { CompatibilityContext } from './compatibility.js';
 import { ColumnDefinition } from './ExpressionType.js';
 import { RequestFunctionCall } from './request_functions.js';
-import { SourceTableInterface } from './SourceTableInterface.js';
+import { SourceTableRef } from './SourceTableRef.js';
 import { SyncRulesOptions } from './SqlSyncRules.js';
 import { TablePattern } from './TablePattern.js';
 import { CustomSqliteValue } from './types/custom_sqlite_value.js';
@@ -387,7 +387,7 @@ export interface EvaluateRowOptions extends TableRow {
  * A row associated with the table it's coming from.
  */
 export interface TableRow<R = SqliteRow> {
-  sourceTable: SourceTableInterface;
+  sourceTable: SourceTableRef;
   record: R;
 }
 

--- a/packages/sync-rules/src/types.ts
+++ b/packages/sync-rules/src/types.ts
@@ -374,11 +374,13 @@ export interface InputParameter {
 
 export interface EvaluateRowOptions extends TableRow {
   /**
-   * Optional: List the specific sources to use.
+   * Recommended: List the specific sources to use.
    *
    * If not provided, uses all matching sources in the sync config. This path is primarily intended for tests.
    *
    * If provided, use only these sources.
+   *
+   * The array identity is used for caching, so it is recommended to use stable arrays here (e.g. from the bucket source definition) for better performance.
    */
   bucketDataSources?: BucketDataSource[];
 }

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -8,7 +8,7 @@ import {
   ParameterLookupScope,
   QuerierError,
   ScopedParameterLookup,
-  SourceTableInterface,
+  SourceTableRef,
   SqlParameterQuery,
   UnscopedParameterLookup
 } from '../../src/index.js';
@@ -24,7 +24,7 @@ import {
 } from './util.js';
 
 describe('parameter queries', () => {
-  const table = (name: string): SourceTableInterface => ({
+  const table = (name: string): SourceTableRef => ({
     connectionTag: 'default',
     name,
     schema: PARSE_OPTIONS.defaultSchema

--- a/packages/sync-rules/test/src/streams.test.ts
+++ b/packages/sync-rules/test/src/streams.test.ts
@@ -16,7 +16,7 @@ import {
   ParameterLookupRows,
   QuerierError,
   ScopedParameterLookup,
-  SourceTableInterface,
+  SourceTableRef,
   SqliteRow,
   StaticSchema,
   StreamParseOptions,
@@ -1180,7 +1180,7 @@ const options: StreamParseOptions = {
 
 const hydrationParams: CreateSourceParams = { hydrationState: versionedHydrationState(1) };
 
-function evaluateBucketIds(stream: SyncStream, sourceTable: SourceTableInterface, record: SqliteRow) {
+function evaluateBucketIds(stream: SyncStream, sourceTable: SourceTableRef, record: SqliteRow) {
   return bucketIds(debugHydratedMergedSource(stream, hydrationParams).evaluateRow({ sourceTable, record }));
 }
 

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -5,7 +5,7 @@ import {
   ParameterLookupRows,
   PrecompiledSyncConfig,
   ScopedParameterLookup,
-  SourceTableInterface,
+  SourceTableRef,
   SqliteRow,
   SqliteValue
 } from '../../../../src/index.js';
@@ -1170,7 +1170,7 @@ streams:
   });
 });
 
-function evaluateBucketIds(source: HydratedSyncRules, sourceTable: SourceTableInterface, record: SqliteRow) {
+function evaluateBucketIds(source: HydratedSyncRules, sourceTable: SourceTableRef, record: SqliteRow) {
   return source.evaluateRow({ sourceTable, record }).map((r) => r.bucket);
 }
 

--- a/packages/sync-rules/test/src/util.ts
+++ b/packages/sync-rules/test/src/util.ts
@@ -14,12 +14,12 @@ import {
   RequestParameters,
   ScopedParameterLookup,
   SourceSchema,
-  SourceTableInterface,
+  SourceTableRef,
   StaticSchema,
   TablePattern
 } from '../../src/index.js';
 
-export class TestSourceTable implements SourceTableInterface {
+export class TestSourceTable implements SourceTableRef {
   readonly connectionTag = DEFAULT_TAG;
   readonly schema = 'test_schema';
 
@@ -100,7 +100,7 @@ export const EMPTY_DATA_SOURCE: BucketDataSource = {
   evaluateRow(options) {
     throw new Error('Function not implemented.');
   },
-  tableSyncsData: function (table: SourceTableInterface): boolean {
+  tableSyncsData: function (table: SourceTableRef): boolean {
     throw new Error('Function not implemented.');
   },
   resolveResultSets: function (schema: SourceSchema, tables: Record<string, Record<string, ColumnDefinition>>): void {


### PR DESCRIPTION
This is in preparation for incremental reprocessing.

This builds on #619. While the two PRs are mostly focusing on different aspects, there is some overlap that would cause conflicts if I split them into independent PRs.

### Multiple tables

Previously, `resolveTable` would always return a single `SourceTable`. This changes it to `resolveTables` that may return more than one.

The specific use case here is for adding new sync streams (new BucketDataSource and/or ParameterIndexLookupCreator). If we have other sources referencing the same source table, we already have a `SourceTable` entry with a completed snapshot. But for the new source, we need a new snapshot. To avoid that new snapshot affecting the existing sources, we create a new `SourceTable` for that. Only storage v3 supports this - v1 storage does not support adding or removing sync streams on existing replication streams.

For reference, everything under `source_records`, `bucket_data` and `parameter_index` collections are scoped to specific `SourceTable`s - either directly or indirectly.

On each `SourceTable` we specifically keep track of the individual data sources and parameter index definitions. As mentioned above, we never add new definitions to an existing table, but we do remove definitions from existing `SourceTables`.

More details on the storage structure are available in `docs/storage-v3.md`.

We now also supporting returning zero `SourceTables` for tables not referenced in sync queries. This is roughly equivalent to the case of `table.syncAny == false`, but avoids keeping track of the table at all.

### Source module updates

Each source replication implementation is updated to handle the multiple source tables. For the most part it just affects the caching logic, and routes writes separately for each `SourceTable`.

### Filtered definitions per table

Each `SourceTable` now has this:

```
bucketDataSources: BucketDataSource[];
parameterLookupSources: ParameterIndexLookupCreator[];
```

For storage V3, those are persisted with the tables. This ensures specific sources are only used with the specific `SourceTable`s they were assigned to.

For storage V1, each `SourceTable` applies to all matching definitions. This change still computes the specific list of sources for the table upfront (when `resolveTables` is called), which can speed up replication when replicating dozens or hundreds of tables.

### SourceTableInterface restructuring

This introduces a clean split between `TablePattern`, `SourceTableRef` (new term for `SourceTableInterface`) and `SourceTable`.

Since we no longer have a 1:1 mapping between the underlying source table (as encapsulated by `SourceTableRef`) and the persisted `SourceTable`, using those interchangably in calls introduced some issues. These are now split, with `SourceTable` no longer matching the `SourceTableRef` interface. Instead, we can use `SourceTable.ref` when we need it.

More details on this split are documented in `docs/resolve-tables-flow.md`.

### Other restructuring

1. We now avoid creating an entire SourceTable instance where a SourceTableRef is sufficient, such as in the API adapters.
2. In tests we avoid mocking SourceTable, instead using the actual `resolveTables` call. Only a small number of tests were still using the old `makeTestTable` function.
3. This fixes some cases where `ColumnDescriptor` was constructed incorrectly - `typeId` vs `typeOid`, and bigint instead of number. This did not appear to cause any issues before, but it started causing issues after some of these refactorings.

### AI Usage

This PR was AI-assisted: A large portion of the code was written using Codex, but manually directed, and manually reviewed and tested.

