### PR TITLE
Fix replicating parameter rows with multiple outputs

### DIFF
--- a/.changeset/slow-swans-vanish.md
+++ b/.changeset/slow-swans-vanish.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix incorrect replication of parameter rows contributing multiple parameter instantiations for Sync Streams.

--- a/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
@@ -840,73 +840,123 @@ config:
   edition: 3
 streams:
   chat:
-    accept_potentially_dangerous_queries: true
+    auto_subscribe: true
     query: |
-      SELECT users.*
-      FROM users
-      JOIN conversations
-      JOIN json_each(conversations.members) AS members
-      WHERE users.id = members.value
-        AND conversations.id = subscription.parameter('chat')
+      SELECT a.*
+      FROM a, b, json_each(b.x) x, json_each(b.y) y
+      WHERE a.x = x.value AND y.value = auth.user_id()
     `)
     );
     const bucketStorage = factory.getInstance(syncRules);
     const sync_rules = syncRules.parsed(test_utils.PARSE_OPTIONS).hydratedSyncRules();
 
     await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
-    const conversationsTable = await test_utils.resolveTestTable(writer, 'conversations', ['id'], config);
+    const tableB = await test_utils.resolveTestTable(writer, 'b', ['id'], config);
+    const firstState = {
+      id: 'id0',
+      x: JSON.stringify(['x1', 'x2']),
+      y: JSON.stringify(['y1', 'y2'])
+    };
+    const secondState = {
+      id: 'id0',
+      x: JSON.stringify(['x2']),
+      y: JSON.stringify(['y1', 'y2'])
+    };
+    const thirdState = {
+      id: 'id0',
+      x: JSON.stringify(['x2']),
+      y: JSON.stringify(['y2'])
+    };
+    const replicaId = test_utils.rid('id0');
+
     await writer.markAllSnapshotDone('1/1');
     await writer.save({
-      sourceTable: conversationsTable,
+      sourceTable: tableB,
       tag: storage.SaveOperationTag.INSERT,
-      after: {
-        id: 'chat-1',
-        members: JSON.stringify(['user-1', 'user-2'])
-      },
-      afterReplicaId: test_utils.rid('chat-1')
+      after: firstState,
+      afterReplicaId: replicaId
     });
 
     await writer.commit('1/1');
 
-    const checkpoint = await bucketStorage.getCheckpoint();
-    const parameters = new RequestParameters(new JwtPayload({ sub: 'unused' }), {});
+    let checkpoint = await bucketStorage.getCheckpoint();
+    const parameters = new RequestParameters(new JwtPayload({ sub: 'y1' }), {});
     const querier = sync_rules.getBucketParameterQuerier({
-      ...test_utils.querierOptions(parameters),
-      streams: {
-        chat: [
-          {
-            priorityOverride: null,
-            parameters: { chat: 'chat-1' },
-            opaque_id: 123
-          }
-        ]
-      }
+      ...test_utils.querierOptions(parameters)
     }).querier;
 
-    const buckets = await querier.queryDynamicBucketDescriptions({
+    let buckets = await querier.queryDynamicBucketDescriptions({
       async getParameterSets(lookups) {
-        expect(lookups.map((l) => l.indexKey)).toEqual([['chat-1']]);
+        expect(lookups.map((l) => l.indexKey)).toEqual([['y1']]);
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
 
-        expect(parameter_sets).toEqual([{ '0': 'user-1' }, { '0': 'user-2' }]);
+        expect(parameter_sets).toEqual([{ '0': 'x1' }, { '0': 'x2' }]);
         return parameter_sets;
       }
     });
 
     expect(buckets).toMatchObject([
       {
-        bucket: expect.stringMatching(/chat.*\["user-1"\]$/),
+        bucket: expect.stringMatching(/chat.*\["x1"\]$/),
         definition: 'chat',
-        inclusion_reasons: [{ subscription: 123 }],
+        inclusion_reasons: ['default'],
         priority: 3
       },
       {
-        bucket: expect.stringMatching(/chat.*\["user-2"\]$/),
+        bucket: expect.stringMatching(/chat.*\["x2"\]$/),
         definition: 'chat',
-        inclusion_reasons: [{ subscription: 123 }],
+        inclusion_reasons: ['default'],
         priority: 3
       }
     ]);
+
+    // Make the x2 bucket inaccessible
+    await writer.save({
+      sourceTable: tableB,
+      tag: storage.SaveOperationTag.UPDATE,
+      before: firstState,
+      after: secondState,
+      beforeReplicaId: replicaId,
+      afterReplicaId: replicaId
+    });
+    await writer.commit('1/2');
+
+    checkpoint = await bucketStorage.getCheckpoint();
+    buckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups) {
+        expect(lookups.map((l) => l.indexKey)).toEqual([['y1']]);
+
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
+
+        expect(parameter_sets).toEqual([{ '0': 'x2' }]);
+        return parameter_sets;
+      }
+    });
+    expect(buckets.map((bkt) => bkt.bucket)).toStrictEqual([expect.stringContaining('x2')]);
+
+    // Second update, remove user from inputs
+    await writer.save({
+      sourceTable: tableB,
+      tag: storage.SaveOperationTag.UPDATE,
+      before: secondState,
+      after: thirdState,
+      beforeReplicaId: replicaId,
+      afterReplicaId: replicaId
+    });
+    await writer.commit('1/3');
+
+    checkpoint = await bucketStorage.getCheckpoint();
+    buckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups) {
+        expect(lookups.map((l) => l.indexKey)).toEqual([['y1']]);
+
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
+
+        expect(parameter_sets).toHaveLength(0);
+        return parameter_sets;
+      }
+    });
+    expect(buckets).toHaveLength(0);
   });
 }

--- a/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
@@ -831,4 +831,82 @@ streams:
       })
     ).rejects.toThrow('Too many parameter results (limit was 5)');
   });
+
+  test('sync streams store multiple parameter outputs for a single source row and lookup', async () => {
+    await using factory = await generateStorageFactory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(`
+config:
+  edition: 3
+streams:
+  chat:
+    accept_potentially_dangerous_queries: true
+    query: |
+      SELECT users.*
+      FROM users
+      JOIN conversations
+      JOIN json_each(conversations.members) AS members
+      WHERE users.id = members.value
+        AND conversations.id = subscription.parameter('chat')
+    `)
+    );
+    const bucketStorage = factory.getInstance(syncRules);
+    const sync_rules = syncRules.parsed(test_utils.PARSE_OPTIONS).hydratedSyncRules();
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const conversationsTable = await test_utils.resolveTestTable(writer, 'conversations', ['id'], config);
+    await writer.markAllSnapshotDone('1/1');
+    await writer.save({
+      sourceTable: conversationsTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'chat-1',
+        members: JSON.stringify(['user-1', 'user-2'])
+      },
+      afterReplicaId: test_utils.rid('chat-1')
+    });
+
+    await writer.commit('1/1');
+
+    const checkpoint = await bucketStorage.getCheckpoint();
+    const parameters = new RequestParameters(new JwtPayload({ sub: 'unused' }), {});
+    const querier = sync_rules.getBucketParameterQuerier({
+      ...test_utils.querierOptions(parameters),
+      streams: {
+        chat: [
+          {
+            priorityOverride: null,
+            parameters: { chat: 'chat-1' },
+            opaque_id: 123
+          }
+        ]
+      }
+    }).querier;
+
+    const buckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups) {
+        expect(lookups.map((l) => l.indexKey)).toEqual([['chat-1']]);
+
+        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
+
+        expect(parameter_sets).toEqual([{ '0': 'user-1' }, { '0': 'user-2' }]);
+        return parameter_sets;
+      }
+    });
+
+    expect(buckets).toMatchObject([
+      {
+        bucket: expect.stringMatching(/chat.*\["user-1"\]$/),
+        definition: 'chat',
+        inclusion_reasons: [{ subscription: 123 }],
+        priority: 3
+      },
+      {
+        bucket: expect.stringMatching(/chat.*\["user-2"\]$/),
+        definition: 'chat',
+        inclusion_reasons: [{ subscription: 123 }],
+        priority: 3
+      }
+    ]);
+  });
 }

--- a/packages/sync-rules/src/TableValuedFunctions.ts
+++ b/packages/sync-rules/src/TableValuedFunctions.ts
@@ -24,6 +24,7 @@ function jsonEachImplementation(fixedJsonBehavior: boolean): TableValuedFunction
       }
       let values: SqliteJsonValue[] = [];
       try {
+        // FIXME: This should use JsonBig to parse integers as bigints.
         values = JSON.parse(valueString);
       } catch (e) {
         throw new Error('Expected JSON string');

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
@@ -3,7 +3,7 @@ import { ParameterIndexLookupCreator } from '../../BucketSource.js';
 import { ParameterLookupScope } from '../../HydrationState.js';
 import { SourceTableInterface } from '../../SourceTableInterface.js';
 import { TablePattern } from '../../TablePattern.js';
-import { SqliteJsonValue, SqliteRow, UnscopedEvaluatedParametersResult } from '../../types.js';
+import { SqliteJsonValue, SqliteParameterValue, SqliteRow, UnscopedEvaluatedParametersResult } from '../../types.js';
 import { ScalarExpressionEvaluator } from '../engine/scalar_expression_engine.js';
 import * as plan from '../plan.js';
 import { StreamEvaluationContext } from './index.js';
@@ -53,8 +53,43 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
       return results;
     }
 
+    interface PendingLookup {
+      partitionValues: SqliteParameterValue[];
+      bucketParameters: Record<string, SqliteJsonValue>[];
+    }
+
+    function parametersEqual(a: SqliteParameterValue[], b: SqliteParameterValue[]) {
+      if (a.length != b.length) return false;
+
+      return a.every((val, idx) => val === b[idx]);
+    }
+
     try {
       const inputInstantiation = this.evaluatorInputs.map((input) => row[input.column]);
+
+      // In almost all cases, lookups generate at most one output with exactly one bucket parameter. This is the case
+      // for all lookups without a table-valued function, e.g. `SELECT * FROM foo, bar ON foo.x = bar.x AND bar.x y = auth.user_id()`
+      // which generates a lookup from `bar.y` to `bar.x`. However, it's also possible for:
+      //
+      //  - a single row with one partition value to generate multiple outputs, which would yield a lookup with multiple
+      //    entries in bucketParameters.
+      //  - a single row to generate multiple partition vlaues, which would yield multiple lookup entries.
+      //  - a combination of those two, if multiple table-valued functions are used in the parameter result set.
+      const lookups: PendingLookup[] = [];
+
+      function resolveLookup(entries: SqliteParameterValue[]) {
+        // The lookups array could be a hash map, but since we don't expect rows to generate many lookups, a hash map
+        // would likely be more expensive.
+        for (const existing of lookups) {
+          if (parametersEqual(existing.partitionValues, entries)) {
+            return existing;
+          }
+        }
+
+        const created: PendingLookup = { partitionValues: entries, bucketParameters: [] };
+        lookups.push(created);
+        return created;
+      }
 
       for (const outputRow of this.evaluator.evaluate(inputInstantiation)) {
         if (!isValidParameterValueRow(outputRow)) {
@@ -68,8 +103,12 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
 
         // source is [...outputs, ...partitionValues]
         const partitionValues = outputRow.splice(this.numberOfOutputs, this.numberOfParameters);
-        const lookup = UnscopedParameterLookup.normalized(partitionValues);
-        results.push({ lookup, bucketParameters: [outputs] });
+        const pendingLookup = resolveLookup(partitionValues);
+        pendingLookup.bucketParameters.push(outputs);
+      }
+
+      for (const { partitionValues, bucketParameters } of lookups) {
+        results.push({ lookup: UnscopedParameterLookup.normalized(partitionValues), bucketParameters });
       }
     } catch (e) {
       results.push({ error: e.message });

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
@@ -68,18 +68,18 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
       const inputInstantiation = this.evaluatorInputs.map((input) => row[input.column]);
 
       // In almost all cases, lookups generate at most one output with exactly one bucket parameter. This is the case
-      // for all lookups without a table-valued function, e.g. `SELECT * FROM foo, bar ON foo.x = bar.x AND bar.x y = auth.user_id()`
-      // which generates a lookup from `bar.y` to `bar.x`. However, it's also possible for:
+      // for all lookups without a table-valued function, e.g. `SELECT foo.* FROM foo, bar ON foo.x = bar.x AND
+      // bar.y = auth.user_id()` which generates a lookup from `bar.y` to `bar.x`. However, it's also possible for:
       //
       //  - a single row with one partition value to generate multiple outputs, which would yield a lookup with multiple
       //    entries in bucketParameters.
-      //  - a single row to generate multiple partition vlaues, which would yield multiple lookup entries.
+      //  - a single row to generate multiple partition values, which would yield multiple lookup entries.
       //  - a combination of those two, if multiple table-valued functions are used in the parameter result set.
       const lookups: PendingLookup[] = [];
 
       function resolveLookup(entries: SqliteParameterValue[]) {
         // The lookups array could be a hash map, but since we don't expect rows to generate many lookups, a hash map
-        // would likely be more expensive.
+        // would likely be more expensive than this linear search.
         for (const existing of lookups) {
           if (parametersEqual(existing.partitionValues, entries)) {
             return existing;

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -232,6 +232,115 @@ streams:
     ]);
   });
 
+  syncTest('multiple inputs for parameter row', ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+streams:
+  chat:
+    query: |
+      SELECT messages.*
+      FROM messages
+      JOIN conversations ON conversations.id = messages.conversation
+      JOIN json_each(conversations.members) AS members
+      WHERE auth.user_id() = members.value
+`);
+
+    // This generates multiple parameter lookups (one for each member) with a single output (the conversation id). A
+    // querier would use the connecting user's id to find bucket parameters.
+    const conversations = new TestSourceTable('conversations');
+    expect(
+      desc.evaluateParameterRow(conversations, { id: 'c', members: JSON.stringify(['a', 'b', 'c']) })
+    ).toStrictEqual(
+      ['a', 'b', 'c'].map((id) => ({
+        lookup: ScopedParameterLookup.direct(lookupScope('lookup', '0'), [id]),
+        bucketParameters: [
+          {
+            '0': 'c'
+          }
+        ]
+      }))
+    );
+  });
+
+  syncTest('multiple outputs for parameter row', ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+streams:
+  chat:
+    accept_potentially_dangerous_queries: true
+    query: |
+      SELECT users.*
+      FROM users
+      JOIN conversations
+      JOIN json_each(conversations.members) AS members
+      WHERE users.id = members.value
+        AND conversations.id = subscription.parameter('chat')
+`);
+
+    // On the other hand, this must generate a single lookup with multiple outputs. The chat is the input as part of
+    // the key, and we output one parameter for each member.
+    const conversations = new TestSourceTable('conversations');
+    expect(
+      desc.evaluateParameterRow(conversations, { id: 'chat', members: JSON.stringify(['a', 'b', 'c']) })
+    ).toStrictEqual([
+      {
+        lookup: ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['chat']),
+        bucketParameters: [
+          {
+            '0': 'a'
+          },
+          {
+            '0': 'b'
+          },
+          {
+            '0': 'c'
+          }
+        ]
+      }
+    ]);
+  });
+
+  syncTest('multiple inputs and outputs for parameter row', ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+streams:
+  chat:
+    query: |
+      SELECT a.*
+      FROM a, b, json_each(b.x) x, json_each(b.y) y
+      WHERE a.x = x.value AND y.value = auth.user_id()
+`);
+
+    const outputs = desc.evaluateParameterRow(new TestSourceTable('b'), { x: '[1,2]', y: '["a", "b"]' });
+    expect(outputs).toStrictEqual([
+      {
+        lookup: ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['a']),
+        bucketParameters: [
+          {
+            '0': 1
+          },
+          {
+            '0': 2
+          }
+        ]
+      },
+      {
+        lookup: ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['b']),
+        bucketParameters: [
+          {
+            '0': 1
+          },
+          {
+            '0': 2
+          }
+        ]
+      }
+    ]);
+  });
+
   syncTest('skips null and binary values', ({ sync }) => {
     const desc = sync.prepareSyncStreams(`
 config:

--- a/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
@@ -59,12 +59,7 @@ streams:
         bucketParameters: [
           {
             '0': 'user'
-          }
-        ]
-      },
-      {
-        lookup: ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['chat']),
-        bucketParameters: [
+          },
           {
             '0': 'another'
           }


### PR DESCRIPTION
Typically, parameter indexes generate at most one set of bucket parameters per output row:

```sql
-- Prepares a parameter index from projects.owner -> projects.id.
-- A row with a null value in owner or id generates zero lookups, otherwise it generates one lookup result.
SELECT tasks.* FROM tasks INNER JOIN projects on tasks.project = projects.id AND projects.owner = auth.user_id()
```

Thanks to `IN` and table-valued functions, it's also possible to have parameter indexes generate multiple lookup results per row:

```sql
-- Assuming projects.id is non-null, this generates one lookup for each value in projects.owners (interpreted as a JSON array)
SELECT tasks.* FROM tasks INNER JOIN projects on tasks.project = projects.id AND auth.user_id() IN projects.owners
```

Both of these cases work correctly. However, there's a third possible topology that's currently broken: A parameter row can generate a lookup with multiple output values:

```sql
-- Assuming a non-null owner value, generates a single lookup (with the owner) with multiple output parameters (one per task id).
SELECT tasks.* FROM tasks INNER JOIN projects WHERE tasks.id IN projects.task_ids AND projects.owner = auth.user_id()
```

(multiple `IN` and `json_each` calls can also be combined to generate multiple lookups with multiple output parameters each)

The third case currently generates multiple lookups with the same key, which bucket storage implementations interpret as multiple revisions from different database states. Only the last lookup would be used in this case, which is incorret! This fixes evaluating parameters to generate a single lookup with multiple outputs in that case.