### PR TITLE
Upgrade to pnpm 11

### DIFF
--- a/.github/workflows/packages_release.yaml
+++ b/.github/workflows/packages_release.yaml
@@ -87,7 +87,7 @@ jobs:
           # If no changesets are available the status check will fail
           # We should not continue if there are no changesets    
           pnpm changeset status
-          pnpm changeset version --no-git-tag --snapshot dev
+          pnpm changeset version --snapshot dev
           pnpm changeset publish --tag dev
 
   release-docker-image:

--- a/package.json
+++ b/package.json
@@ -50,5 +50,5 @@
     "vitest": "catalog:",
     "ws": "^8.2.3"
   },
-  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
+  "packageManager": "pnpm@11.0.9"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,9 @@ allowBuilds:
   # These need install scripts to download/build native modules
   '@mongodb-js/zstd': true
 
+  # We don't need to run these checks: https://github.com/protobufjs/protobuf.js/blob/master/scripts/postinstall.js
+  protobufjs: false
+
 overrides:
   # Override to remove vitest production dependency
   # Remove once this is released: https://github.com/journeyapps-labs/common/pull/15


### PR DESCRIPTION
This upgrades to pnpm version 11 (see [release notes](https://pnpm.io/blog/releases/11.0)) and a [migration guide](https://pnpm.io/migration) for details.

A breaking change that affects us here is that `pnpm install` seems to error if we have a dependency with an install script for which we haven't made an explicit decision. This affects `protobufjs` here, I've disabled that package's build script.

An interesting change is that `pnpm publish` is now implemented in pnpm instead of using `npm publish` as a subcommand. I've triggered a dev release to make sure things are still working.