### PR TITLE
Include requested lookup for parameter results

### DIFF
--- a/.changeset/gold-hats-sit.md
+++ b/.changeset/gold-hats-sit.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-postgres-storage': minor
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-sync-rules': minor
+'@powersync/service-core': patch
+---
+
+When querying parameter rows, track which lookups resulted in which rows.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -22,7 +22,7 @@ import {
   utils,
   WatchWriteCheckpointOptions
 } from '@powersync/service-core';
-import { HydratedSyncRules, ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
+import { HydratedSyncRules, ParameterLookupRows, ScopedParameterLookup } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { LRUCache } from 'lru-cache';
 import * as timers from 'timers/promises';
@@ -362,13 +362,13 @@ export abstract class MongoSyncBucketStorage
     checkpoint: MongoReplicationCheckpoint,
     lookups: ScopedParameterLookup[],
     limit: number
-  ): Promise<SqliteJsonRow[]>;
+  ): Promise<ParameterLookupRows[]>;
 
   async getParameterSets(
     checkpoint: MongoReplicationCheckpoint,
     lookups: ScopedParameterLookup[],
     limit: number
-  ): Promise<SqliteJsonRow[]> {
+  ): Promise<ParameterLookupRows[]> {
     return this.getParameterSetsImpl(checkpoint, lookups, limit);
   }
 
@@ -783,7 +783,7 @@ class MongoReplicationCheckpoint implements ReplicationCheckpoint {
     this.#storage = storage;
   }
 
-  async getParameterSets(lookups: ScopedParameterLookup[], limit: number): Promise<SqliteJsonRow[]> {
+  async getParameterSets(lookups: ScopedParameterLookup[], limit: number): Promise<ParameterLookupRows[]> {
     return this.#storage.getParameterSets(this, lookups, limit);
   }
 }
@@ -792,7 +792,7 @@ class EmptyReplicationCheckpoint implements ReplicationCheckpoint {
   readonly checkpoint: InternalOpId = 0n;
   readonly lsn: string | null = null;
 
-  async getParameterSets(_lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
+  async getParameterSets(_lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
     return [];
   }
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -12,7 +12,7 @@ import {
   utils
 } from '@powersync/service-core';
 import { JSONBig } from '@powersync/service-jsonbig';
-import { ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
+import { ParameterLookupRows, ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { idPrefixFilter, mapOpEntry, readSingleBatch, setSessionSnapshotTime } from '../../../utils/util.js';
 import { MongoBucketStorage } from '../../MongoBucketStorage.js';
@@ -99,7 +99,7 @@ export class MongoSyncBucketStorageV1 extends MongoSyncBucketStorage {
     checkpoint: MongoSyncBucketStorageCheckpoint,
     lookups: ScopedParameterLookup[],
     limit: number
-  ): Promise<SqliteJsonRow[]> {
+  ): Promise<ParameterLookupRows[]> {
     return getParameterSetsV1(this.versionContext, checkpoint, lookups, limit);
   }
 
@@ -199,20 +199,29 @@ export async function getParameterSetsV1(
   checkpoint: MongoSyncBucketStorageCheckpoint,
   lookups: ScopedParameterLookup[],
   limit: number
-): Promise<SqliteJsonRow[]> {
+): Promise<ParameterLookupRows[]> {
   return ctx.db.client.withSession({ snapshot: true }, async (session) => {
     setSessionSnapshotTime(session, checkpoint.snapshotTime);
     const lookupFilter = lookups.map((lookup) => {
       return storage.serializeLookup(lookup);
     });
     const rows = await ctx.db.parameterIndexV1
-      .aggregate(
+      .aggregate<{ index: number; bucket_parameters: SqliteJsonRow }>(
         [
           {
             $match: {
               'key.g': ctx.group_id,
-              lookup: { $in: lookupFilter },
               _id: { $lte: checkpoint.checkpoint }
+            }
+          },
+          {
+            $addFields: {
+              index: { $indexOfArray: [lookupFilter, '$lookup'] }
+            }
+          },
+          {
+            $match: {
+              index: { $gte: 0 }
             }
           },
           {
@@ -222,10 +231,17 @@ export async function getParameterSetsV1(
           },
           {
             $group: {
-              _id: { key: '$key', lookup: '$lookup' },
+              _id: { key: '$key', index: '$index' },
               bucket_parameters: {
                 $first: '$bucket_parameters'
               }
+            }
+          },
+          {
+            $project: {
+              _id: 0,
+              bucket_parameters: 1,
+              index: '$_id.index'
             }
           },
           { $unwind: '$bucket_parameters' },
@@ -244,10 +260,13 @@ export async function getParameterSetsV1(
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
       });
 
-    const results = rows.map((row) => row.bucket_parameters);
-    if (results.length > limit) {
+    if (rows.length > limit) {
       throw new ParameterSetLimitExceededError(limit);
     }
+
+    const byLookup = Map.groupBy(rows, (row) => lookups[row.index]);
+    const results: ParameterLookupRows[] = [];
+    byLookup.forEach((value, lookup) => results.push({ lookup, rows: value.map((r) => r.bucket_parameters) }));
     return results;
   });
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -202,59 +202,71 @@ export async function getParameterSetsV1(
 ): Promise<ParameterLookupRows[]> {
   return ctx.db.client.withSession({ snapshot: true }, async (session) => {
     setSessionSnapshotTime(session, checkpoint.snapshotTime);
+    const parameterIndexCollection = ctx.db.parameterIndexV1;
     const lookupFilter = lookups.map((lookup) => {
       return storage.serializeLookup(lookup);
     });
-    const rows = await ctx.db.parameterIndexV1
-      .aggregate<{ index: number; bucket_parameters: SqliteJsonRow }>(
-        [
-          {
-            $match: {
-              'key.g': ctx.group_id,
-              _id: { $lte: checkpoint.checkpoint }
-            }
-          },
-          {
-            $addFields: {
-              index: { $indexOfArray: [lookupFilter, '$lookup'] }
-            }
-          },
-          {
-            $match: {
-              index: { $gte: 0 }
-            }
-          },
-          {
-            $sort: {
-              _id: -1
-            }
-          },
-          {
-            $group: {
-              _id: { key: '$key', index: '$index' },
-              bucket_parameters: {
-                $first: '$bucket_parameters'
-              }
-            }
-          },
-          {
-            $project: {
-              _id: 0,
-              bucket_parameters: 1,
-              index: '$_id.index'
-            }
-          },
-          { $unwind: '$bucket_parameters' },
-          {
-            $limit: limit + 1
-          }
-        ],
+
+    function pipelineForLookup(lookup: ScopedParameterLookup, index: number) {
+      const filter = storage.serializeLookup(lookup);
+      return parameterIndexCollection.aggregate<{ index: number; bucket_parameters: SqliteJsonRow[] }>([
         {
-          session,
-          readConcern: 'snapshot',
-          maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
+          $match: {
+            'key.g': ctx.group_id,
+            lookup: { $eq: filter },
+            _id: { $lte: checkpoint.checkpoint }
+          }
+        },
+        {
+          $sort: {
+            _id: -1
+          }
+        },
+        {
+          $group: {
+            _id: { key: '$key', lookup: '$lookup' },
+            bucket_parameters: {
+              $first: '$bucket_parameters'
+            }
+          }
+        },
+        {
+          $project: {
+            _id: 0,
+            bucket_parameters: 1,
+            index: { $literal: index }
+          }
         }
-      )
+      ]);
+    }
+
+    const [firstLookup, ...remainingLookups] = lookups;
+    const firstQuery = firstLookup == null ? null : pipelineForLookup(firstLookup, 0);
+    if (firstQuery == null) {
+      return [];
+    }
+
+    const pipeline: mongo.Document[] = [
+      ...firstQuery.pipeline,
+      ...remainingLookups.map((lookup, indexInRemaining) => {
+        const query = pipelineForLookup(lookup, indexInRemaining + 1);
+        return {
+          $unionWith: {
+            coll: parameterIndexCollection.collectionName,
+            pipeline: query.pipeline
+          }
+        };
+      }),
+      { $unwind: '$bucket_parameters' },
+      { $limit: limit + 1 }
+    ];
+
+    const rows = await ctx.db.parameterIndexV1
+      .aggregate<{ index: number; bucket_parameters: SqliteJsonRow }>(pipeline, {
+        session,
+        readConcern: 'snapshot',
+        maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
+      })
       .toArray()
       .catch((e) => {
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -202,71 +202,56 @@ export async function getParameterSetsV1(
 ): Promise<ParameterLookupRows[]> {
   return ctx.db.client.withSession({ snapshot: true }, async (session) => {
     setSessionSnapshotTime(session, checkpoint.snapshotTime);
-    const parameterIndexCollection = ctx.db.parameterIndexV1;
     const lookupFilter = lookups.map((lookup) => {
       return storage.serializeLookup(lookup);
     });
 
-    function pipelineForLookup(lookup: ScopedParameterLookup, index: number) {
-      const filter = storage.serializeLookup(lookup);
-      return parameterIndexCollection.aggregate<{ index: number; bucket_parameters: SqliteJsonRow[] }>([
-        {
-          $match: {
-            'key.g': ctx.group_id,
-            lookup: { $eq: filter },
-            _id: { $lte: checkpoint.checkpoint }
-          }
-        },
-        {
-          $sort: {
-            _id: -1
-          }
-        },
-        {
-          $group: {
-            _id: { key: '$key', lookup: '$lookup' },
-            bucket_parameters: {
-              $first: '$bucket_parameters'
-            }
-          }
-        },
-        {
-          $project: {
-            _id: 0,
-            bucket_parameters: 1,
-            index: { $literal: index }
-          }
-        }
-      ]);
-    }
-
-    const [firstLookup, ...remainingLookups] = lookups;
-    const firstQuery = firstLookup == null ? null : pipelineForLookup(firstLookup, 0);
-    if (firstQuery == null) {
-      return [];
-    }
-
-    const pipeline: mongo.Document[] = [
-      ...firstQuery.pipeline,
-      ...remainingLookups.map((lookup, indexInRemaining) => {
-        const query = pipelineForLookup(lookup, indexInRemaining + 1);
-        return {
-          $unionWith: {
-            coll: parameterIndexCollection.collectionName,
-            pipeline: query.pipeline
-          }
-        };
-      }),
-      { $unwind: '$bucket_parameters' },
-      { $limit: limit + 1 }
-    ];
-
     const rows = await ctx.db.parameterIndexV1
-      .aggregate<{ index: number; bucket_parameters: SqliteJsonRow }>(pipeline, {
-        session,
-        readConcern: 'snapshot',
-        maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
-      })
+      .aggregate<{ lookup: number; bucket_parameters: SqliteJsonRow }>(
+        [
+          {
+            $match: {
+              'key.g': ctx.group_id,
+              lookup: { $in: lookupFilter },
+              _id: { $lte: checkpoint.checkpoint }
+            }
+          },
+          {
+            $set: {
+              index: { $indexOfArray: [lookupFilter, '$lookup'] }
+            }
+          },
+          {
+            $sort: {
+              _id: -1
+            }
+          },
+          {
+            $group: {
+              _id: { key: '$key', lookup: '$index' },
+              bucket_parameters: {
+                $first: '$bucket_parameters'
+              }
+            }
+          },
+          {
+            $project: {
+              _id: false,
+              lookup: '$_id.lookup',
+              bucket_parameters: true
+            }
+          },
+          { $unwind: '$bucket_parameters' },
+          {
+            $limit: limit + 1
+          }
+        ],
+        {
+          session,
+          readConcern: 'snapshot',
+          maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
+        }
+      )
       .toArray()
       .catch((e) => {
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
@@ -276,7 +261,7 @@ export async function getParameterSetsV1(
       throw new ParameterSetLimitExceededError(limit);
     }
 
-    const byLookup = Map.groupBy(rows, (row) => lookups[row.index]);
+    const byLookup = Map.groupBy(rows, (row) => lookups[row.lookup]);
     const results: ParameterLookupRows[] = [];
     byLookup.forEach((value, lookup) => results.push({ lookup, rows: value.map((r) => r.bucket_parameters) }));
     return results;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -11,7 +11,7 @@ import {
   utils
 } from '@powersync/service-core';
 import { JSONBig } from '@powersync/service-jsonbig';
-import { ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
+import { ParameterLookupRows, ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
 import { mapOpEntry, readSingleBatch, setSessionSnapshotTime } from '../../../utils/util.js';
 import { MongoBucketStorage } from '../../MongoBucketStorage.js';
@@ -138,7 +138,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     checkpoint: MongoSyncBucketStorageCheckpoint,
     lookups: ScopedParameterLookup[],
     limit: number
-  ): Promise<SqliteJsonRow[]> {
+  ): Promise<ParameterLookupRows[]> {
     return getParameterSetsV3(this.versionContext, checkpoint, lookups, limit);
   }
 
@@ -210,12 +210,13 @@ export async function getParameterSetsV3(
   checkpoint: MongoSyncBucketStorageCheckpoint,
   lookups: ScopedParameterLookup[],
   limit: number
-): Promise<SqliteJsonRow[]> {
+): Promise<ParameterLookupRows[]> {
   return ctx.db.client.withSession({ snapshot: true }, async (session) => {
     setSessionSnapshotTime(session, checkpoint.snapshotTime);
 
     const buildLookupPipeline = (
-      lookup: ScopedParameterLookup
+      lookup: ScopedParameterLookup,
+      index: number
     ): {
       collection: mongo.Collection<BucketParameterDocumentV3>;
       pipeline: mongo.Document[];
@@ -252,7 +253,8 @@ export async function getParameterSetsV3(
           {
             $project: {
               _id: 0,
-              bucket_parameters: 1
+              bucket_parameters: 1,
+              index: { $literal: index }
             }
           }
         ]
@@ -260,15 +262,15 @@ export async function getParameterSetsV3(
     };
 
     const [firstLookup, ...remainingLookups] = lookups;
-    const firstQuery = firstLookup == null ? null : buildLookupPipeline(firstLookup);
+    const firstQuery = firstLookup == null ? null : buildLookupPipeline(firstLookup, 0);
     if (firstQuery == null) {
       return [];
     }
 
     const pipeline: mongo.Document[] = [
       ...firstQuery.pipeline,
-      ...remainingLookups.map((lookup) => {
-        const query = buildLookupPipeline(lookup);
+      ...remainingLookups.map((lookup, indexInRemaining) => {
+        const query = buildLookupPipeline(lookup, indexInRemaining + 1);
         return {
           $unionWith: {
             coll: query.collection.collectionName,
@@ -281,7 +283,7 @@ export async function getParameterSetsV3(
     ];
 
     const rows = await firstQuery.collection
-      .aggregate<{ bucket_parameters: SqliteJsonRow }>(pipeline, {
+      .aggregate<{ index: number; bucket_parameters: SqliteJsonRow }>(pipeline, {
         session,
         readConcern: 'snapshot',
         maxTimeMS: lib_mongo.db.MONGO_OPERATION_TIMEOUT_MS
@@ -291,12 +293,15 @@ export async function getParameterSetsV3(
         throw lib_mongo.mapQueryError(e, 'while evaluating parameter queries');
       });
 
-    const expandedRows = rows.map((row) => row.bucket_parameters);
-    if (expandedRows.length > limit) {
+    if (rows.length > limit) {
       throw new ParameterSetLimitExceededError(limit);
     }
 
-    return expandedRows;
+    const byLookup = Map.groupBy(rows, (row) => lookups[row.index]);
+
+    const results: ParameterLookupRows[] = [];
+    byLookup.forEach((value, lookup) => results.push({ lookup, rows: value.map((r) => r.bucket_parameters) }));
+    return results;
   });
 }
 

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -199,7 +199,7 @@ function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, stor
         expect(lookups[0].indexId).toEqual('1');
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
-        expect(parameter_sets).toEqual([{ owner_id: 'user-1' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ owner_id: 'user-1' }] }]);
         return parameter_sets;
       }
     });

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -31,6 +31,7 @@ import { mapOpEntry } from '../utils/bucket-data.js';
 import * as framework from '@powersync/lib-services-framework';
 import { StatementParam } from '@powersync/service-jpgwire';
 import { wrapWithAbort } from 'ix/asynciterable/operators/withabort.js';
+import * as t from 'ts-codec';
 import { SourceTableDecoded, StoredRelationId } from '../types/models/SourceTable.js';
 import { pick } from '../utils/ts-codec.js';
 import { PostgresBucketBatch } from './batch/PostgresBucketBatch.js';
@@ -402,37 +403,29 @@ export class PostgresSyncRulesStorage
     checkpoint: ReplicationCheckpoint,
     lookups: sync_rules.ScopedParameterLookup[],
     limit: number
-  ): Promise<sync_rules.SqliteJsonRow[]> {
+  ): Promise<sync_rules.ParameterLookupRows[]> {
     const rows = await this.db.sql`
       WITH
         rows AS (
           SELECT DISTINCT
-            ON (lookup, source_table, source_key) lookup,
-            source_table,
-            source_key,
-            id,
+            ON (requested.index) requested.index - 1 AS index,
             bucket_parameters
           FROM
-            bucket_parameters
-          WHERE
-            group_id = ${{ type: 'int4', value: this.group_id }}
-            AND lookup = ANY (
-              SELECT
-                decode((FILTER ->> 0)::text, 'hex') -- Decode the hex string to bytea
-              FROM
-                jsonb_array_elements(${{
+            bucket_parameters,
+            jsonb_array_elements(${{
         type: 'jsonb',
         value: lookups.map((l) => storage.serializeLookupBuffer(l).toString('hex'))
-      }}) AS FILTER
-            )
+      }}) WITH ORDINALITY AS requested
+          WHERE
+            group_id = ${{ type: 'int4', value: this.group_id }}
+            AND lookup = decode((requested.value ->> 0)::text, 'hex') -- Decode the hex string to bytea
             AND id <= ${{ type: 'int8', value: checkpoint.checkpoint }}
           ORDER BY
             lookup,
-            source_table,
-            source_key,
             id DESC
         )
       SELECT
+        index,
         bucket_parameters
       FROM
         rows
@@ -441,16 +434,21 @@ export class PostgresSyncRulesStorage
       LIMIT
         ${{ type: 'int4', value: limit + 1 }}
     `
-      .decoded(pick(models.BucketParameters, ['bucket_parameters']))
+      .decoded(parameterSetsRow)
       .rows();
 
-    const parameters = rows
-      .map((row) => {
-        return JSONBig.parse(row.bucket_parameters) as sync_rules.SqliteJsonRow[];
-      })
-      .flat();
+    let totalRows = 0;
+    const parameters = rows.map((row) => {
+      const parameterRows = JSONBig.parse(row.bucket_parameters) as sync_rules.SqliteJsonRow[];
+      totalRows += parameterRows.length;
 
-    if (parameters.length > limit) {
+      return {
+        lookup: lookups[row.index],
+        rows: parameterRows
+      } satisfies sync_rules.ParameterLookupRows;
+    });
+
+    if (totalRows > limit) {
       // Note that the LIMIT in the query allows more rows than parameters (because each row stores an array of
       // parameter results). That array is very small though, and it doesn't allow fewer rows (due to the != []), so
       // the SQL limit is good enough.
@@ -923,7 +921,15 @@ class PostgresReplicationCheckpoint implements storage.ReplicationCheckpoint {
     public readonly lsn: string | null
   ) {}
 
-  getParameterSets(lookups: sync_rules.ScopedParameterLookup[], limit: number): Promise<sync_rules.SqliteJsonRow[]> {
+  getParameterSets(
+    lookups: sync_rules.ScopedParameterLookup[],
+    limit: number
+  ): Promise<sync_rules.ParameterLookupRows[]> {
     return this.storage.getParameterSets(this, lookups, limit);
   }
 }
+
+const parameterSetsRow = t.object({
+  index: t.number,
+  bucket_parameters: t.string
+});

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -23,7 +23,7 @@ import { JSONBig } from '@powersync/service-jsonbig';
 import * as sync_rules from '@powersync/service-sync-rules';
 import * as timers from 'timers/promises';
 import * as uuid from 'uuid';
-import { BIGINT_MAX } from '../types/codecs.js';
+import { bigint, BIGINT_MAX } from '../types/codecs.js';
 import { models, RequiredOperationBatchLimits } from '../types/types.js';
 import { replicaIdToSubkey } from '../utils/bson.js';
 import { mapOpEntry } from '../utils/bucket-data.js';
@@ -408,20 +408,22 @@ export class PostgresSyncRulesStorage
       WITH
         rows AS (
           SELECT DISTINCT
-            ON (requested.index) requested.index - 1 AS index,
+            ON (lookup, source_table, source_key) requested.index - 1 AS index,
             bucket_parameters
           FROM
             bucket_parameters,
             jsonb_array_elements(${{
         type: 'jsonb',
         value: lookups.map((l) => storage.serializeLookupBuffer(l).toString('hex'))
-      }}) WITH ORDINALITY AS requested
+      }}) WITH ORDINALITY AS requested (value, index)
           WHERE
             group_id = ${{ type: 'int4', value: this.group_id }}
             AND lookup = decode((requested.value ->> 0)::text, 'hex') -- Decode the hex string to bytea
             AND id <= ${{ type: 'int8', value: checkpoint.checkpoint }}
           ORDER BY
             lookup,
+            source_table,
+            source_key,
             id DESC
         )
       SELECT
@@ -438,15 +440,20 @@ export class PostgresSyncRulesStorage
       .rows();
 
     let totalRows = 0;
-    const parameters = rows.map((row) => {
+    const resultsByLookup = new Map<sync_rules.ScopedParameterLookup, sync_rules.SqliteJsonRow[]>();
+    for (const row of rows) {
       const parameterRows = JSONBig.parse(row.bucket_parameters) as sync_rules.SqliteJsonRow[];
+      const lookup = lookups[Number(row.index)];
       totalRows += parameterRows.length;
 
-      return {
-        lookup: lookups[row.index],
-        rows: parameterRows
-      } satisfies sync_rules.ParameterLookupRows;
-    });
+      const existingResults = resultsByLookup.get(lookup);
+      const decodedParameters = JSONBig.parse(row.bucket_parameters) as sync_rules.SqliteJsonRow[];
+      if (existingResults != null) {
+        existingResults.push(...decodedParameters);
+      } else {
+        resultsByLookup.set(lookup, decodedParameters);
+      }
+    }
 
     if (totalRows > limit) {
       // Note that the LIMIT in the query allows more rows than parameters (because each row stores an array of
@@ -454,7 +461,10 @@ export class PostgresSyncRulesStorage
       // the SQL limit is good enough.
       throw new ParameterSetLimitExceededError(limit);
     }
-    return parameters;
+
+    const results: sync_rules.ParameterLookupRows[] = [];
+    resultsByLookup.forEach((rows, lookup) => results.push({ lookup, rows }));
+    return results;
   }
 
   async *getBucketDataBatch(
@@ -930,6 +940,6 @@ class PostgresReplicationCheckpoint implements storage.ReplicationCheckpoint {
 }
 
 const parameterSetsRow = t.object({
-  index: t.number,
+  index: bigint,
   bucket_parameters: t.string
 });

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -447,11 +447,10 @@ export class PostgresSyncRulesStorage
       totalRows += parameterRows.length;
 
       const existingResults = resultsByLookup.get(lookup);
-      const decodedParameters = JSONBig.parse(row.bucket_parameters) as sync_rules.SqliteJsonRow[];
       if (existingResults != null) {
-        existingResults.push(...decodedParameters);
+        existingResults.push(...parameterRows);
       } else {
-        resultsByLookup.set(lookup, decodedParameters);
+        resultsByLookup.set(lookup, parameterRows);
       }
     }
 

--- a/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
@@ -76,7 +76,7 @@ bucket_definitions:
         expect(lookups.map((l) => l.indexKey)).toEqual([['user1']]);
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
-        expect(parameter_sets).toEqual([{ group_id: 'group1a' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ group_id: 'group1a' }] }]);
         return parameter_sets;
       }
     });
@@ -137,7 +137,7 @@ bucket_definitions:
         expect(lookups.map((l) => l.indexKey)).toEqual([['user1']]);
 
         const parameter_sets = await checkpoint1.getParameterSets(lookups, 1000);
-        expect(parameter_sets).toEqual([{ group_id: 'group1' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ group_id: 'group1' }] }]);
         return parameter_sets;
       }
     });
@@ -148,7 +148,7 @@ bucket_definitions:
         expect(lookups.map((l) => l.indexKey)).toEqual([['user1']]);
 
         const parameter_sets = await checkpoint2.getParameterSets(lookups, 1000);
-        expect(parameter_sets).toEqual([{ group_id: 'group2' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ group_id: 'group2' }] }]);
         return parameter_sets;
       }
     });
@@ -226,12 +226,13 @@ bucket_definitions:
       async getParameterSets(lookups) {
         expect(lookups.map((l) => JSON.stringify(l.indexKey)).sort()).toEqual(['["list1"]', '["list2"]']);
 
-        const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
-        expect(parameter_sets.sort((a, b) => (a.todo_id as string).localeCompare(b.todo_id as string))).toEqual([
+        const results = await checkpoint.getParameterSets(lookups, 1000);
+        const allRows = results.flatMap(({ rows }) => rows);
+        expect(allRows.sort((a, b) => (a.todo_id as string).localeCompare(b.todo_id as string))).toEqual([
           { todo_id: 'todo1' },
           { todo_id: 'todo2' }
         ]);
-        return parameter_sets;
+        return results;
       }
     });
 
@@ -286,7 +287,11 @@ bucket_definitions:
       return await querier.queryDynamicBucketDescriptions({
         async getParameterSets(lookups) {
           const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
-          expect(parameter_sets).toEqual(expectedParameterSets);
+          if (expectedParameterSets.length == 0) {
+            expect(parameter_sets).toEqual([]);
+          } else {
+            expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: expectedParameterSets }]);
+          }
           return parameter_sets;
         }
       });
@@ -364,7 +369,7 @@ bucket_definitions:
         expect(lookups.map((l) => l.indexKey)).toEqual([[n1]]);
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
-        expect(parameter_sets).toEqual([{ group_id: 'group1' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ group_id: 'group1' }] }]);
         return parameter_sets;
       }
     });
@@ -416,7 +421,7 @@ bucket_definitions:
         expect(lookups.map((l) => l.indexKey)).toEqual([['u1']]);
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
-        expect(parameter_sets).toEqual([{ workspace_id: 'workspace1' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ workspace_id: 'workspace1' }] }]);
         return parameter_sets;
       }
     });
@@ -496,8 +501,12 @@ bucket_definitions:
         expect(lookups.map((l) => l.indexKey)).toEqual([[]]);
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
-        parameter_sets.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
-        expect(parameter_sets).toEqual([{ workspace_id: 'workspace1' }, { workspace_id: 'workspace3' }]);
+        expect(parameter_sets).toHaveLength(1);
+
+        const [{ lookup, rows }] = parameter_sets;
+        expect(lookup).toEqual(lookups[0]);
+        rows.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+        expect(rows).toEqual([{ workspace_id: 'workspace1' }, { workspace_id: 'workspace3' }]);
         return parameter_sets;
       }
     });
@@ -602,7 +611,10 @@ bucket_definitions:
         async getParameterSets(lookups) {
           foundLookups.push(...lookups);
           const output = await checkpoint.getParameterSets(lookups, 1000);
-          parameter_sets.push(...output);
+          for (const { rows } of output) {
+            parameter_sets.push(...rows);
+          }
+
           return output;
         }
       })
@@ -764,7 +776,7 @@ streams:
         expect(lookups.map((l) => l.indexKey)).toEqual([['baz']]);
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
-        expect(parameter_sets).toEqual([{ '0': 'bar' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ '0': 'bar' }] }]);
         return parameter_sets;
       }
     });
@@ -891,7 +903,7 @@ streams:
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
 
-        expect(parameter_sets).toEqual([{ '0': 'x1' }, { '0': 'x2' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ '0': 'x1' }, { '0': 'x2' }] }]);
         return parameter_sets;
       }
     });
@@ -929,7 +941,7 @@ streams:
 
         const parameter_sets = await checkpoint.getParameterSets(lookups, 1000);
 
-        expect(parameter_sets).toEqual([{ '0': 'x2' }]);
+        expect(parameter_sets).toEqual([{ lookup: lookups[0], rows: [{ '0': 'x2' }] }]);
         return parameter_sets;
       }
     });

--- a/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
@@ -1,5 +1,11 @@
 import { CURRENT_STORAGE_VERSION, JwtPayload, storage, updateSyncRulesFromYaml } from '@powersync/service-core';
-import { RequestParameters, ScopedParameterLookup, SqliteJsonRow } from '@powersync/service-sync-rules';
+import {
+  ParameterIndexLookupCreator,
+  RequestParameters,
+  ScopedParameterLookup,
+  SqliteJsonRow,
+  UnscopedParameterLookup
+} from '@powersync/service-sync-rules';
 import { expect, test } from 'vitest';
 import * as test_utils from '../test-utils/test-utils-index.js';
 import { bucketRequest } from '../test-utils/test-utils-index.js';
@@ -970,5 +976,95 @@ streams:
       }
     });
     expect(buckets).toHaveLength(0);
+  });
+
+  test('can request multiple lookups at once', async () => {
+    await using factory = await generateStorageFactory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(`
+config:
+  edition: 3
+streams:
+  a:
+    auto_subscribe: true
+    query: SELECT * FROM a WHERE p IN (SELECT id FROM param_a WHERE u = auth.user_id())
+  b:
+    auto_subscribe: true
+    query: SELECT * FROM b WHERE p IN (SELECT id FROM param_b WHERE u = auth.user_id())
+    `)
+    );
+    const bucketStorage = factory.getInstance(syncRules);
+    const parsedSyncRules = syncRules.parsed(test_utils.PARSE_OPTIONS);
+    const hydrationState = parsedSyncRules.hydrationState;
+    const syncConfig = parsedSyncRules.sync_rules.config;
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const paramATable = await test_utils.resolveTestTable(writer, 'param_a', ['id'], config);
+    const paramBTable = await test_utils.resolveTestTable(writer, 'param_b', ['id'], config);
+    const replicaId = test_utils.rid('id');
+
+    // Insert the same row into param_a and param_b
+    await writer.markAllSnapshotDone('1/1');
+    await writer.save({
+      sourceTable: paramATable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'id',
+        u: 'user'
+      },
+      afterReplicaId: replicaId
+    });
+    await writer.save({
+      sourceTable: paramBTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'id',
+        u: 'user'
+      },
+      afterReplicaId: replicaId
+    });
+    await writer.commit('1/1');
+
+    function findParameterOnTable(name: string): ParameterIndexLookupCreator {
+      for (const source of syncConfig.bucketParameterLookupSources) {
+        for (const param of source.getSourceTables()) {
+          if (param.name == name) return source;
+        }
+      }
+
+      throw new Error(`Expected parameter index on ${name}`);
+    }
+
+    // Run two lookups on separate parameter indexes.
+    const lookupA = ScopedParameterLookup.normalized(
+      hydrationState.getParameterIndexLookupScope(findParameterOnTable('param_a')),
+      UnscopedParameterLookup.normalized(['user'])
+    );
+    const lookupB = ScopedParameterLookup.normalized(
+      hydrationState.getParameterIndexLookupScope(findParameterOnTable('param_b')),
+      UnscopedParameterLookup.normalized(['user'])
+    );
+
+    const checkpoint = await bucketStorage.getCheckpoint();
+    const parameterSets = await checkpoint.getParameterSets([lookupA, lookupB], 1000);
+    const expectedRow = { '0': 'id' };
+    let foundLookupA = false,
+      foundLookupB = false;
+
+    // We should get the same row on both, with information on which lookup contributed which row.
+    for (const { lookup, rows } of parameterSets) {
+      if (lookup === lookupA) {
+        foundLookupA = true;
+        expect(rows).toStrictEqual([expectedRow]);
+      } else if (lookup === lookupB) {
+        foundLookupB = true;
+        expect(rows).toStrictEqual([expectedRow]);
+      } else {
+        throw new Error('unexpected lookup in results');
+      }
+    }
+
+    expect(foundLookupA).toBeTruthy();
+    expect(foundLookupB).toBeTruthy();
   });
 }

--- a/packages/service-core-tests/src/tests/register-parameter-compacting-tests.ts
+++ b/packages/service-core-tests/src/tests/register-parameter-compacting-tests.ts
@@ -45,7 +45,7 @@ bucket_definitions:
 
     const checkpoint1 = await bucketStorage.getCheckpoint();
     const parameters1 = await checkpoint1.getParameterSets([lookup], 1000);
-    expect(parameters1).toEqual([{ id: 't1' }]);
+    expect(parameters1).toEqual([{ lookup, rows: [{ id: 't1' }] }]);
 
     await writer.save({
       sourceTable: testTable,
@@ -79,7 +79,7 @@ bucket_definitions:
     // Check consistency
     const parameters1b = await checkpoint1.getParameterSets([lookup], 1000);
     const parameters2b = await checkpoint2.getParameterSets([lookup], 1000);
-    expect(parameters1b).toEqual([{ id: 't1' }]);
+    expect(parameters1b).toEqual([{ lookup, rows: [{ id: 't1' }] }]);
     expect(parameters2b).toEqual([]);
 
     // Check storage size

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -2,8 +2,8 @@ import { Logger, ObserverClient } from '@powersync/lib-services-framework';
 import {
   BucketDataSource,
   HydratedSyncRules,
-  ScopedParameterLookup,
-  SqliteJsonRow
+  ParameterLookupRows,
+  ScopedParameterLookup
 } from '@powersync/service-sync-rules';
 import { PerformanceTracer } from '../tracing/PerformanceTracer.js';
 import * as util from '../util/util-index.js';
@@ -330,7 +330,7 @@ export interface ReplicationCheckpoint {
    * @throws {@link ParameterSetLimitExceededError}
    * Thrown if resolved lookups in bucket storage exceed the `limit` parameter.
    */
-  getParameterSets(lookups: ScopedParameterLookup[], limit: number): Promise<SqliteJsonRow[]>;
+  getParameterSets(lookups: ScopedParameterLookup[], limit: number): Promise<ParameterLookupRows[]>;
 }
 
 /**

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -624,11 +624,13 @@ export class BucketParameterState {
           }
 
           try {
-            const rows = await checkpoint.base.getParameterSets(lookups, remainingBudget);
-            lookupLog.push({ definition, resultsOrLimit: rows.length, didExceedLimit: false });
-            remainingBudget -= rows.length;
-            usedParameterResults += rows.length;
-            return rows;
+            const results = await checkpoint.base.getParameterSets(lookups, remainingBudget);
+            const numRows = results.reduce((a, b) => a + b.rows.length, 0);
+
+            lookupLog.push({ definition, resultsOrLimit: numRows, didExceedLimit: false });
+            remainingBudget -= numRows;
+            usedParameterResults += numRows;
+            return results;
           } catch (e: unknown) {
             if (e instanceof ParameterSetLimitExceededError) {
               lookupLog.push({ definition, resultsOrLimit: remainingBudget, didExceedLimit: true });

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -16,9 +16,9 @@ import {
 import { JSONBig } from '@powersync/service-jsonbig';
 import {
   ParameterIndexLookupCreator,
+  ParameterLookupRows,
   ScopedParameterLookup,
   SourceTableInterface,
-  SqliteJsonRow,
   SqliteRow,
   SqlSyncRules,
   TablePattern,
@@ -546,7 +546,7 @@ bucket_definitions:
     const line = (await state.buildNextCheckpointLine({
       base: storage.makeCheckpoint(1n, (lookups) => {
         expect(lookups).toEqual([ScopedParameterLookup.direct(lookupScope('by_project', '1'), ['u1'])]);
-        return [{ id: 1 }, { id: 2 }];
+        return [{ lookup: lookups[0], rows: [{ id: 1 }, { id: 2 }] }];
       }),
       writeCheckpoint: null,
       update: CHECKPOINT_INVALIDATE_ALL
@@ -607,7 +607,7 @@ bucket_definitions:
     const line2 = (await state.buildNextCheckpointLine({
       base: storage.makeCheckpoint(2n, (lookups) => {
         expect(lookups).toEqual([ScopedParameterLookup.direct(lookupScope('by_project', '1'), ['u1'])]);
-        return [{ id: 1 }, { id: 2 }, { id: 3 }];
+        return [{ lookup: lookups[0], rows: [{ id: 1 }, { id: 2 }, { id: 3 }] }];
       }),
       writeCheckpoint: null,
       update: {
@@ -890,7 +890,8 @@ config:
 
       const line = (await state.buildNextCheckpointLine({
         base: storage.makeCheckpoint(1n, (lookups) => {
-          return [{ id: 1 }, { id: 2 }, { id: 3 }];
+          expect(lookups).toHaveLength(1);
+          return [{ lookup: lookups[0], rows: [{ id: 1 }, { id: 2 }, { id: 3 }] }];
         }),
         writeCheckpoint: null,
         update: CHECKPOINT_INVALIDATE_ALL
@@ -969,7 +970,7 @@ streams:
             if (count > limit) {
               throw new ParameterSetLimitExceededError(limit);
             }
-            return Array.from({ length: count }, (_, i) => ({ '0': BigInt(i) }));
+            return [{ lookup: lookups[0], rows: Array.from({ length: count }, (_, i) => ({ '0': BigInt(i) })) }];
           }),
           writeCheckpoint: null,
           update: CHECKPOINT_INVALIDATE_ALL
@@ -1061,18 +1062,13 @@ streams:
         logger: mockLogger as any
       });
 
-      let invokedParameterQueries = 0;
       await expect(
         state.buildNextCheckpointLine({
-          base: storage.makeCheckpoint(1n, () => {
-            invokedParameterQueries++;
-            return [{ '0': 'user' }];
-          }),
+          base: storage.makeCheckpoint(1n),
           writeCheckpoint: null,
           update: CHECKPOINT_INVALIDATE_ALL
         })
       ).rejects.toThrow('Too many buckets: 60 (limit of 50');
-      expect(invokedParameterQueries).toStrictEqual(0);
 
       // Verify error log includes breakdown
       expect(errorMessages[0]).toContain('Buckets by definition:');
@@ -1139,9 +1135,7 @@ streams:
 
       await expect(
         state.buildNextCheckpointLine({
-          base: storage.makeCheckpoint(1n, (lookups) => {
-            return [{ '0': 'user' }];
-          }),
+          base: storage.makeCheckpoint(1n),
           writeCheckpoint: null,
           update: CHECKPOINT_INVALIDATE_ALL
         })
@@ -1191,7 +1185,7 @@ class MockBucketChecksumStateStorage implements BucketChecksumStateStorage {
 
   makeCheckpoint(
     opId: InternalOpId,
-    parameters?: (lookups: ScopedParameterLookup[], limit: number) => SqliteJsonRow[]
+    parameters?: (lookups: ScopedParameterLookup[], limit: number) => ParameterLookupRows[]
   ): ReplicationCheckpoint {
     return {
       checkpoint: opId,

--- a/packages/sync-rules/src/BucketParameterQuerier.ts
+++ b/packages/sync-rules/src/BucketParameterQuerier.ts
@@ -76,7 +76,18 @@ export interface PendingQueriers {
 }
 
 export interface ParameterLookupSource {
-  getParameterSets: (lookups: ScopedParameterLookup[], debugDefinition: string) => Promise<SqliteJsonRow[]>;
+  getParameterSets: (lookups: ScopedParameterLookup[], debugDefinition: string) => Promise<ParameterLookupRows[]>;
+}
+
+export interface ParameterLookupRows {
+  /**
+   * A lookup passed to {@link ParameterLookupSource.getParameterSets}.
+   */
+  lookup: ScopedParameterLookup;
+  /**
+   * Rows returned from the {@link lookup}.
+   */
+  rows: SqliteJsonRow[];
 }
 
 export interface QueryBucketDescriptorOptions extends ParameterLookupSource {

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -545,7 +545,8 @@ export class SqlParameterQuery implements ParameterIndexLookupCreator {
       staticBuckets: [],
       hasDynamicBuckets: true,
       queryDynamicBucketDescriptions: async (source: ParameterLookupSource) => {
-        const bucketParameters = await source.getParameterSets(lookups, debugName);
+        const lookupResults = await source.getParameterSets(lookups, debugName);
+        const bucketParameters = lookupResults.flatMap(({ rows }) => rows);
         return this.resolveBucketDescriptions(bucketParameters, requestParameters, bucketDataScope).map((bucket) => {
           return resolvedBucket(bucket, { definition: this.descriptorName, inclusion_reasons: reasons });
         });

--- a/packages/sync-rules/src/streams/variant.ts
+++ b/packages/sync-rules/src/streams/variant.ts
@@ -185,12 +185,12 @@ export class StreamVariant {
         // Evaluate subqueries
         const subqueryResults = new Map<SubqueryEvaluator, SqliteJsonValue[]>();
         for (const [subquery, lookups] of subqueryToLookups.entries()) {
-          const rows = await source.getParameterSets(
+          const results = await source.getParameterSets(
             lookups,
             `variant ${variant.id} of legacy Sync Stream ${stream.name}`
           );
           // The result column used in parameter sets is always named result, see pushParameterRowEvaluation
-          const values = rows.map((r) => r.result);
+          const values = results.flatMap(({ rows }) => rows.map((r) => r.result));
           subqueryResults.set(subquery, values);
         }
 

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -378,15 +378,17 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
       );
 
       // Stream parameters generate an output row like {0: <expr>, 1: <expr>, ...}.
-      const values = outputs.map((row) => {
-        const length = Object.entries(row).length;
-        const asArray: SqliteParameterValue[] = [];
+      const values = outputs.flatMap(({ rows }) =>
+        rows.map((row) => {
+          const length = Object.entries(row).length;
+          const asArray: SqliteParameterValue[] = [];
 
-        for (let i = 0; i < length; i++) {
-          asArray.push(row[i.toString()] as SqliteParameterValue);
-        }
-        return asArray;
-      });
+          for (let i = 0; i < length; i++) {
+            asArray.push(row[i.toString()] as SqliteParameterValue);
+          }
+          return asArray;
+        })
+      );
 
       this.evaluators.lookupStages[stage][index] = { type: 'cached', values };
       return values;

--- a/packages/sync-rules/test/src/streams.test.ts
+++ b/packages/sync-rules/test/src/streams.test.ts
@@ -13,10 +13,10 @@ import {
   GetBucketParameterQuerierResult,
   GetQuerierOptions,
   mergeBucketParameterQueriers,
+  ParameterLookupRows,
   QuerierError,
   ScopedParameterLookup,
   SourceTableInterface,
-  SqliteJsonRow,
   SqliteRow,
   StaticSchema,
   StreamParseOptions,
@@ -137,8 +137,8 @@ describe('streams', () => {
     expect(querier.staticBuckets[0].source).toBe(desc.dataSources[0]);
 
     const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
-      async getParameterSets() {
-        return [{ result: 'i1' }];
+      async getParameterSets(lookups) {
+        return [{ lookup: lookups[0], rows: [{ result: 'i1' }] }];
       }
     });
     expect(dynamicBuckets).toHaveLength(1);
@@ -289,7 +289,7 @@ describe('streams', () => {
       function getParameterSets(lookups: ScopedParameterLookup[]) {
         expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, ['u1'])]);
 
-        return [{ result: 'i1' }];
+        return [{ lookup: lookups[0], rows: [{ result: 'i1' }] }];
       }
       expect(
         await queryBucketIds(desc, { tokenPayload: { sub: 'u1', is_admin: false }, getParameterSets })
@@ -328,7 +328,7 @@ describe('streams', () => {
           getParameterSets(lookups) {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, ['user1'])]);
 
-            return [{ result: 'issue_id' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'issue_id' }] }];
           }
         })
       ).toStrictEqual(['1#stream|0["issue_id"]']);
@@ -359,7 +359,7 @@ describe('streams', () => {
           tokenPayload: { sub: 'u' },
           getParameterSets: (lookups: ScopedParameterLookup[]) => {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, ['u'])]);
-            return [{ result: 'u' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'u' }] }];
           }
         })
       ).toStrictEqual(['1#stream|0[]']);
@@ -416,7 +416,7 @@ describe('streams', () => {
           return [];
         } else {
           expect(lookup).toStrictEqual(ScopedParameterLookup.direct(STREAM_1, ['a']));
-          return [{ result: 'b' }];
+          return [{ lookup, rows: [{ result: 'b' }] }];
         }
       }
 
@@ -456,7 +456,7 @@ describe('streams', () => {
             expect(lookups).toHaveLength(1);
             const [lookup] = lookups;
             expect(lookup).toStrictEqual(ScopedParameterLookup.direct(STREAM_0, ['a']));
-            return [{ result: 'i1' }, { result: 'i2' }];
+            return [{ lookup, rows: [{ result: 'i1' }, { result: 'i2' }] }];
           }
         })
       ).toStrictEqual([
@@ -517,7 +517,7 @@ describe('streams', () => {
           getParameterSets(lookups) {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, ['user1'])]);
 
-            return [{ result: 'issue_id' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'issue_id' }] }];
           }
         })
       ).toStrictEqual(['1#stream|0["issue_id"]']);
@@ -677,7 +677,7 @@ describe('streams', () => {
           getParameterSets(lookups) {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, ['user1'])]);
 
-            return [{ result: 'issue_id' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'issue_id' }] }];
           }
         })
       ).toStrictEqual(['1#stream|0["issue_id"]']);
@@ -732,7 +732,7 @@ describe('streams', () => {
           getParameterSets(lookups) {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, ['user1'])]);
 
-            return [{ result: 'issue_id' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'issue_id' }] }];
           }
         })
       ).toStrictEqual(['1#stream|0["issue_id"]']);
@@ -742,7 +742,7 @@ describe('streams', () => {
           getParameterSets(lookups) {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, ['user1'])]);
 
-            return [{ result: 'issue_id' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'issue_id' }] }];
           }
         })
       ).toStrictEqual(['1#stream|1[]', '1#stream|0["issue_id"]']);
@@ -801,7 +801,7 @@ describe('streams', () => {
           parameters: {},
           getParameterSets(lookups) {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('account_member', '0'), ['id'])]);
-            return [{ result: 'account_id' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'account_id' }] }];
           }
         })
       ).toStrictEqual(['1#account_member|0["account_id"]']);
@@ -895,7 +895,7 @@ WHERE
           parameters: { project: 'foo' },
           getParameterSets(lookups) {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, [1n, 'foo'])]);
-            return [{ result: 'foo' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'foo' }] }];
           }
         })
       ).toStrictEqual(['1#stream|0["foo"]']);
@@ -992,7 +992,7 @@ WHERE
           globalParameters: { team_id: 'team' },
           getParameterSets(lookups) {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(STREAM_0, ['team'])]);
-            return [{ result: 'user' }];
+            return [{ lookup: lookups[0], rows: [{ result: 'user' }] }];
           }
         })
       ).toStrictEqual(['1#stream|0["user"]']);
@@ -1071,14 +1071,14 @@ WHERE
       }
     ]);
 
-    function getParameterSets(lookups: ScopedParameterLookup[]) {
+    function getParameterSets(lookups: ScopedParameterLookup[]): ParameterLookupRows[] {
       return lookups.flatMap((lookup) => {
         if (JSON.stringify(lookup.values) == JSON.stringify(['stream.test', '1.test', null])) {
           return [];
         } else if (JSON.stringify(lookup.values) == JSON.stringify(['stream.test', '0.test', 'u1'])) {
-          return [{ result: 'i1' }];
+          return [{ lookup, rows: [{ result: 'i1' }] }];
         } else if (JSON.stringify(lookup.values) == JSON.stringify(['stream.test', '1.test', 'myname'])) {
-          return [{ result: 'i2' }];
+          return [{ lookup, rows: [{ result: 'i2' }] }];
         } else {
           throw new Error(`Unexpected lookup: ${JSON.stringify(lookup.values)}`);
         }
@@ -1181,7 +1181,7 @@ interface TestQuerierOptions {
   tokenPayload?: Record<string, any>;
   globalParameters?: Record<string, any>;
   parameters?: Record<string, any>;
-  getParameterSets?: (lookups: ScopedParameterLookup[]) => SqliteJsonRow[];
+  getParameterSets?: (lookups: ScopedParameterLookup[]) => ParameterLookupRows[];
   hydrationState?: HydrationState;
 }
 async function createQueriers(
@@ -1210,7 +1210,7 @@ async function queryBucketIds(stream: SyncStream, options?: TestQuerierOptions) 
   const { querier, errors } = await createQueriers(stream, options);
   expect(errors).toHaveLength(0);
 
-  async function getParameterSets(lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
+  async function getParameterSets(lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
     const provided = options?.getParameterSets;
     if (provided) {
       return provided(lookups);

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect } from 'vitest';
 import {
   HydratedSyncRules,
+  ParameterLookupRows,
   ScopedParameterLookup,
   SourceTableInterface,
-  SqliteJsonRow,
   SqliteRow,
   SqliteValue
 } from '../../../../src/index.js';
@@ -420,8 +420,8 @@ streams:
     expect(querier.staticBuckets[0].source).toBe(streamSource.dataSources[0]);
 
     const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
-      async getParameterSets() {
-        return [{ '0': 'i1' }];
+      async getParameterSets(lookups) {
+        return [{ lookup: lookups[0], rows: [{ '0': 'i1' }] }];
       }
     });
     expect(dynamicBuckets).toHaveLength(1);
@@ -530,17 +530,17 @@ streams:
     expect(querier.staticBuckets.map((e) => e.bucket)).toStrictEqual([]);
     let call = 0;
     const buckets = await querier.queryDynamicBucketDescriptions({
-      getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
+      getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
         if (call == 0) {
           // First call. Lookup from users.id => users.name
           call++;
           expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['user'])]);
-          return [{ '0': 'name' }];
+          return [{ lookup: lookups[0], rows: [{ '0': 'name' }] }];
         } else if (call == 1) {
           // Second call. Lookup from issues.owned_by => issues.id
           call++;
           expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('lookup', '1'), ['name'])]);
-          return [{ '0': 'issue' }];
+          return [{ lookup: lookups[0], rows: [{ '0': 'issue' }] }];
         }
 
         throw new Error('Function not implemented.');
@@ -601,7 +601,7 @@ streams:
       // Should not return any streams if the synced_table lookup is empty.
       expect(
         await querier.queryDynamicBucketDescriptions({
-          getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
+          getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['user'])]);
             return [];
           }
@@ -610,9 +610,9 @@ streams:
 
       expect(
         await querier.queryDynamicBucketDescriptions({
-          getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
+          getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
             expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['user'])]);
-            return [{}];
+            return [{ lookup: lookups[0], rows: [{}] }];
           }
         })
       ).toStrictEqual([
@@ -695,9 +695,9 @@ streams:
         for (const hasLookupResult of [false, true]) {
           expect(
             await querier.queryDynamicBucketDescriptions({
-              getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
+              getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
                 expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['user'])]);
-                return hasLookupResult ? [{}] : [];
+                return [{ lookup: lookups[0], rows: hasLookupResult ? [{}] : [] }];
               }
             })
           ).toHaveLength(hasLookupResult ? 1 : 0);
@@ -754,20 +754,20 @@ streams:
 
       expect(
         await querier.queryDynamicBucketDescriptions({
-          getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
-            for (const lookup of lookups) {
+          getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
+            return lookups.flatMap((lookup) => {
               expect(lookup.values[0]).toStrictEqual('lookup');
               switch (lookup.values[1]) {
                 case '0':
-                  return [{ '0': 'c3', '1': 'c4' }];
+                  return [{ lookup, rows: [{ '0': 'c3', '1': 'c4' }] }];
                 case '1':
-                  return [{ '0': 'c2' }];
+                  return [{ lookup, rows: [{ '0': 'c2' }] }];
                 case '2':
-                  return [{ '0': 'c1' }];
+                  return [{ lookup, rows: [{ '0': 'c1' }] }];
+                default:
+                  return [];
               }
-            }
-
-            return [];
+            });
           }
         })
       ).toStrictEqual([

--- a/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
@@ -2,9 +2,9 @@ import { describe, expect } from 'vitest';
 import {
   deserializeSyncPlan,
   ImplicitSchemaTablePattern,
+  ParameterLookupRows,
   ScopedParameterLookup,
   serializeSyncPlan,
-  SqliteJsonRow,
   StreamDataSource,
   TableProcessorTableValuedFunction
 } from '../../../../src/index.js';
@@ -76,10 +76,10 @@ streams:
     });
 
     const buckets = await querier.queryDynamicBucketDescriptions({
-      getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<SqliteJsonRow[]> {
+      getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
         expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['chat'])]);
 
-        return [{ '0': 'user' }, { '0': 'another' }];
+        return [{ lookup: lookups[0], rows: [{ '0': 'user' }, { '0': 'another' }] }];
       }
     });
 


### PR DESCRIPTION
When querying for parameters, we provide a `ScopedParameterLookup[]` array and currently get a `SqliteJsonRow[]` of results in response. The response is a union of parameter rows found for all lookups in the input array, we don't know which lookup resuled in which rows.

Returning all results in a single array blocks two improvements:

1. An implementation of Sync Streams might want to pass multiple `ScopedParameterLookup` values for different parameter indexes into a single `getParameterSets` call for efficiency. This is not currently possible since we wouldn't be able to inspect which output was generated by which parameter.
2. In complex cases where a parameter has multiple outputs which are passed into a different parameter, we need to track how rows from the first parameter influence the second to implement `JOIN` semantics correctly.

(neither of those two things is currently implemented, but since this is a non-trivial change on its own it helps to have it in a separate PR).

## AI usage disclaimer

Most test changes in this PR were migrated using Claude after I've updated a few tests by hand.