### PR TITLE
Correlate parameters if they originate from the same logical result set

### DIFF
--- a/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-parameter-tests.ts
@@ -1067,4 +1067,87 @@ streams:
     expect(foundLookupA).toBeTruthy();
     expect(foundLookupB).toBeTruthy();
   });
+
+  test('sync streams preserve duplicate downstream lookups with different provenance', async () => {
+    await using factory = await generateStorageFactory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+streams:
+  stream:
+    auto_subscribe: true
+    query: |
+      SELECT a.*
+      FROM a, b, c
+      WHERE a.x = b.x
+        AND a.z = c.z
+        AND b.y = c.y
+        AND c.u = auth.user_id()
+    `,
+        {
+          storageVersion
+        }
+      )
+    );
+    const bucketStorage = factory.getInstance(syncRules);
+    const sync_rules = syncRules.parsed(test_utils.PARSE_OPTIONS).hydratedSyncRules();
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const tableB = await test_utils.resolveTestTable(writer, 'b', ['id'], config);
+    const tableC = await test_utils.resolveTestTable(writer, 'c', ['id'], config);
+
+    await writer.markAllSnapshotDone('1/1');
+    await writer.save({
+      sourceTable: tableB,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'b1',
+        y: 'shared-y',
+        x: 'x-from-shared-y'
+      },
+      afterReplicaId: test_utils.rid('b1')
+    });
+    await writer.save({
+      sourceTable: tableC,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'c1',
+        u: 'user1',
+        y: 'shared-y',
+        z: 'z1'
+      },
+      afterReplicaId: test_utils.rid('c1')
+    });
+    await writer.save({
+      sourceTable: tableC,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'c2',
+        u: 'user1',
+        y: 'shared-y',
+        z: 'z2'
+      },
+      afterReplicaId: test_utils.rid('c2')
+    });
+    await writer.commit('1/1');
+
+    const checkpoint = await bucketStorage.getCheckpoint();
+    const parameters = new RequestParameters(new JwtPayload({ sub: 'user1' }), {});
+    const querier = sync_rules.getBucketParameterQuerier({
+      ...test_utils.querierOptions(parameters)
+    }).querier;
+
+    const buckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups) {
+        return checkpoint.getParameterSets(lookups, 1000);
+      }
+    });
+
+    expect(buckets.map((bucket) => bucket.bucket).sort()).toStrictEqual([
+      expect.stringMatching(/stream.*\["x-from-shared-y","z1"\]$/),
+      expect.stringMatching(/stream.*\["x-from-shared-y","z2"\]$/)
+    ]);
+  });
 }

--- a/packages/sync-rules/src/compiler/equality.ts
+++ b/packages/sync-rules/src/compiler/equality.ts
@@ -1,3 +1,5 @@
+import { SqliteParameterValue } from '../types.js';
+
 /**
  * Stable value-based hashcodes for JavaScript. The sync streams compiler uses hashmaps derived from this to efficiently
  * de-duplicate equivalent expressions and lookups.
@@ -71,6 +73,43 @@ export class StableHasher {
   };
 
   static readonly defaultListEquality = listEquality(this.defaultEquality);
+
+  static readonly parameterValueEquality: Equality<SqliteParameterValue> = (() => {
+    const buf = new DataView(new ArrayBuffer(8));
+
+    return {
+      equals: function (a: SqliteParameterValue, b: SqliteParameterValue): boolean {
+        // Allowed values are numbers, string, and bigint. All of them compare correctly with ===
+        return a === b;
+      },
+      hash: function (hasher: StableHasher, value: SqliteParameterValue): void {
+        switch (typeof value) {
+          case 'string':
+            hasher.addString(value);
+            break;
+          case 'number':
+            const normalized = value || 0; // Ensure 0 and -0 have the same hash code.
+            buf.setFloat64(0, value, true);
+            hasher.addHash(buf.getUint32(0, true));
+            hasher.addHash(buf.getUint32(4, true));
+            break;
+          case 'bigint':
+            // Most bigints we're dealing with fit in 64 bits. Truncating is fine, we're building hashes anyway.
+            buf.setBigInt64(0, value, true);
+            hasher.addHash(buf.getUint32(0, true));
+            hasher.addHash(buf.getUint32(4, true));
+          case 'boolean':
+            hasher.addHash(value ? 0 : 1);
+            break;
+          case 'symbol':
+          case 'undefined':
+          case 'object':
+          case 'function':
+            throw new Error(`Not a parameter value: ${value}`);
+        }
+      }
+    };
+  })();
 }
 
 /**

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -294,7 +294,7 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
     if (current.type === 'cached') {
       return current.values;
     } else if (current.type === 'intersection') {
-      let intersection: Map<SqliteParameterValue, (VirtualSourceRow | null)[]> | null = null;
+      let intersection: Map<SqliteParameterValue, VirtualSourceRow[]> | null = null;
       for (let i = 0; i < current.values.length; i++) {
         const evaluated = this.parameterSync(current.values, i);
         if (evaluated == null) {
@@ -353,7 +353,7 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
         ? [
             {
               value,
-              provenance: [null]
+              provenance: []
             }
           ]
         : [];
@@ -400,13 +400,10 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
     if (lookup.type == 'parameter') {
       const scope = this.input.hydrationState.getParameterIndexLookupScope(lookup.lookup);
       const resolvedLookup = lookup.lookup as PreparedParameterIndexLookupCreator;
-      const lookupsToProvenance = new Map<
-        ScopedParameterLookup,
-        { origin: (VirtualSourceRow | null)[]; symbol: symbol }
-      >();
+      const lookupsToProvenance = new Map<ScopedParameterLookup, { origin: VirtualSourceRow[]; symbol: symbol }>();
 
       for (const values of this.resolveInputs(lookup.instantiation)) {
-        const provenance: (VirtualSourceRow | null)[] = [];
+        const provenance: VirtualSourceRow[] = [];
         for (const value of values) {
           provenance.push(...value.provenance);
         }
@@ -433,7 +430,13 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
 
           for (let i = 0; i < length; i++) {
             const value = row[i.toString()] as SqliteParameterValue;
-            asArray.push({ value, provenance: [...origin, { resultSet: symbol, row: rowid }] });
+            asArray.push({
+              value,
+              // Note: Not tracking provenance for parameters with just a single output is purely a performance
+              // optimization. If there's just a single value, we don't need to correlate it with other columns in the
+              // row. Not adding provenance saves some work in mergeValueCombinations.
+              provenance: length > 1 ? [...origin, { resultSet: symbol, row: rowid }] : origin
+            });
           }
           return asArray;
         });
@@ -469,11 +472,47 @@ export type PreparedParameterValue =
 
 interface ParameterValueWithRow {
   value: SqliteParameterValue;
-  provenance: (VirtualSourceRow | null)[];
+
+  /**
+   * Information on how this value was resolved.
+   *
+   * We track how a parameter value was resolved to be able to merge parameters correctly. A Sync Stream with multiple
+   * independent parameters generates their cartesian product as buckets. When multiple parameters are resolved from the
+   * same row though, we can't use the full cartesian product. As an example, consider this stream:
+   *
+   * ```sql
+   * SELECT products.* FROM products, stores
+   *   WHERE stores.name = products.store_name
+   *     AND stores.region = products.region
+   *     AND stores.id = subscription.parameter('store');
+   * ```
+   *
+   * Here, the bucket shape consists of two parameters (`store_name` and `region`). But since they're derived from the
+   * same `stores` row, we can't combine them freely. For each parameter, `store_name` and `region` must come from the
+   * same row. Here, the `provenance` would have a single entry and both parameters would have the same
+   * {@link VirtualSourceRow.resultSet}.
+   *
+   * For static values, such as constants or scalar values derived from request parameters, this array is empty. It's
+   * also possible for this to contain more than one entry, though:
+   *
+   *  1. For intersection values, we track the provenance of all input values.
+   *  2. It's possible to nest parameters. For instance, in the query `SELECT data.* FROM data, a, b WHERE a.a = data.a
+   *     AND b.b = a.b AND data.c = b.c`, we have to parameters (`a` and `c`). `a` can be resolved from a lookup in
+   *     table `a`, but we need to go through a second lookup to resolve `c`. Here, we can only combine value `c` with
+   *     value `a` if the two were derived from the same row in `a`. So, the row `b` derived through `a` would include
+   *     provenance elements of row `a` here.
+   */
+  provenance: VirtualSourceRow[];
 }
 
 interface VirtualSourceRow {
+  /**
+   * An opaque identifier for the result set this row was derived from.
+   */
   resultSet: symbol;
+  /**
+   * A number uniquely identifying this row in its result set.
+   */
   row: number;
 }
 
@@ -525,11 +564,20 @@ function* filterParameterRows(rows: SqliteValue[][]): Generator<SqliteParameterV
   }
 }
 
-function* mergeValueCombinations(valuesByParameter: ParameterValueWithRow[][]) {
-  const usedRows = new Map<symbol, number>();
+/**
+ * Builds a cartesian product of parameter instantiations, taking {@link ParameterValueWithRow.provenance} into account
+ * to avoid combining values from different rows of the same result set.
+ *
+ * @param valuesByParameter An array containing possible instantiations for each parameter.
+ * @returns All allowed instantiations.
+ */
+function* mergeValueCombinations(valuesByParameter: ParameterValueWithRow[][]): Generator<ParameterValueWithRow[]> {
+  // Partial backtracking results, the current instantiation is fixed for 0..nextParameter in generateCombinations.
   const partialResults = new Array(valuesByParameter.length);
+  // A map from result sets to roows used in the partial instantiation.
+  const usedRows = new Map<symbol, number>();
 
-  function installRowOrFail(value: ParameterValueWithRow): [boolean, symbol[]] {
+  function installRowIfNoConflict(value: ParameterValueWithRow): [boolean, symbol[]] {
     const addedResultSets: symbol[] = [];
 
     for (const origin of value.provenance) {
@@ -566,7 +614,7 @@ function* mergeValueCombinations(valuesByParameter: ParameterValueWithRow[][]) {
 
     const availableValues = valuesByParameter[nextParameter];
     for (const available of availableValues) {
-      const [canUse, addedResultSets] = installRowOrFail(available);
+      const [canUse, addedResultSets] = installRowIfNoConflict(available);
       if (canUse) {
         partialResults[nextParameter] = available;
         yield* generateCombinations(nextParameter + 1);

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -330,7 +330,8 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
       // Eliminate rows with conflicting values.
       for (const column of columns) {
         nextValue: for (const value of column) {
-          for (const row of value.provenance) {
+          const row = value.directOrigin;
+          if (row) {
             let forResultSet = valuesByResultSet.get(row.resultSet);
             if (forResultSet == null) {
               forResultSet = new Map();
@@ -350,12 +351,14 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
       }
 
       function shouldSkipValue(value: ParameterValueWithRow): boolean {
-        for (const { resultSet, row } of value.provenance) {
+        if (value.directOrigin) {
+          const { resultSet, row } = value.directOrigin;
+
           const ignoredRowIds = completedRows.get(resultSet);
           if (ignoredRowIds?.has(row)) return true;
 
           const valuesForResultSet = valuesByResultSet.get(resultSet);
-          if (valuesForResultSet == null) continue;
+          if (valuesForResultSet == null) return false;
 
           if (valuesForResultSet.get(row) != value.value) return true;
         }
@@ -455,8 +458,9 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
       // We can evaluate this table-valued function already.
       const resultSetMarker = Symbol();
       const values = lookup.read(this.input.request).map((values, rowid) => {
-        const provenance: [VirtualSourceRow] = [{ resultSet: resultSetMarker, row: rowid }];
-        return values.map((value) => ({ value, provenance }) satisfies ParameterValueWithRow);
+        const directOrigin: VirtualSourceRow = { resultSet: resultSetMarker, row: rowid };
+        const provenance: [VirtualSourceRow] = [directOrigin];
+        return values.map((value) => ({ value, provenance, directOrigin }) satisfies ParameterValueWithRow);
       });
 
       this.evaluators.lookupStages[stage][index] = { type: 'cached', values };
@@ -514,12 +518,15 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
 
           for (let i = 0; i < length; i++) {
             const value = row[i.toString()] as SqliteParameterValue;
+            const directOrigin = length > 1 ? { resultSet: symbol, row: rowid } : undefined;
+
             asArray.push({
               value,
               // Note: Not tracking provenance for parameters with just a single output is purely a performance
               // optimization. If there's just a single value, we don't need to correlate it with other columns in the
               // row. Not adding provenance saves some work in mergeValueCombinations.
-              provenance: length > 1 ? [...origin, { resultSet: symbol, row: rowid }] : origin
+              provenance: directOrigin != null ? [...origin, directOrigin] : origin,
+              directOrigin
             });
           }
           return asArray;
@@ -587,6 +594,8 @@ interface ParameterValueWithRow {
    *     provenance elements of row `a` here.
    */
   provenance: VirtualSourceRow[];
+  // If set, must be contained in provenance
+  directOrigin?: VirtualSourceRow;
 }
 
 interface VirtualSourceRow {
@@ -658,26 +667,24 @@ function* filterParameterRows(rows: SqliteValue[][]): Generator<SqliteParameterV
 function* mergeValueCombinations(valuesByParameter: ParameterValueWithRow[][]): Generator<ParameterValueWithRow[]> {
   // Partial backtracking results, the current instantiation is fixed for 0..nextParameter in generateCombinations.
   const partialResults = new Array(valuesByParameter.length);
-  // A map from result sets to roows used in the partial instantiation.
+  // A map from result sets to rows used in the partial instantiation.
   const usedRows = new Map<symbol, number>();
 
   function installRowIfNoConflict(value: ParameterValueWithRow): [boolean, symbol[]] {
     const addedResultSets: symbol[] = [];
 
     for (const origin of value.provenance) {
-      if (origin != null) {
-        const { resultSet, row } = origin;
-        const existingRow = usedRows.get(resultSet);
-        if (existingRow === undefined) {
-          addedResultSets.push(resultSet);
-          usedRows.set(resultSet, row);
-        } else if (existingRow == row) {
-          continue;
-        } else {
-          // The current instantiation already constains a value from the same result set but derived from a different
-          // row. So we must ignore this parameter value.
-          return [false, addedResultSets];
-        }
+      const { resultSet, row } = origin;
+      const existingRow = usedRows.get(resultSet);
+      if (existingRow === undefined) {
+        addedResultSets.push(resultSet);
+        usedRows.set(resultSet, row);
+      } else if (existingRow == row) {
+        continue;
+      } else {
+        // The current instantiation already contains a value from the same result set but derived from a different
+        // row. So we must ignore this parameter value.
+        return [false, addedResultSets];
       }
     }
 

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -294,30 +294,110 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
     if (current.type === 'cached') {
       return current.values;
     } else if (current.type === 'intersection') {
-      let intersection: Map<SqliteParameterValue, VirtualSourceRow[]> | null = null;
+      const columns: ParameterValueWithRow[][] = [];
       for (let i = 0; i < current.values.length; i++) {
         const evaluated = this.parameterSync(current.values, i);
         if (evaluated == null) {
           return undefined; // Can't evaluate sub-parameter
         }
+        columns.push(evaluated);
+      }
 
+      // For the most part, this just needs to find an intersection of values present in all columns. It gets more
+      // complicated for rows with provenance, however. For those. we need to ensure we find an intersection of values
+      // with compatible source rows. For example, consider an intersection of the same parameter lookup with columns
+      // `c1` and `c2`, and assume that we had the following rows:
+      //
+      //   1. Row {c1: 'a', c2: 'a'}
+      //   2. Row {c1: 'a', c2: 'b'}
+      //
+      // The intersection of this has one value: `a`, with a provenance of Row 1.  To achieve this, we re-create rows
+      // by tracking a canonical value per row. If we see another value in the same row, we know that row can't
+      // contribute to the intersection because it has different values for `c1` and `c2`.
+      const poison = Symbol('poison');
+      const valuesByResultSet = new Map<symbol, Map<number, SqliteParameterValue | typeof poison>>();
+      const completedRows = new Map<symbol, Set<number>>();
+      function markRowAsCompleted(resultSet: symbol, rowid: number) {
+        let rowids = completedRows.get(resultSet);
+        if (rowids == null) {
+          rowids = new Set();
+          completedRows.set(resultSet, rowids);
+        }
+
+        rowids.add(rowid);
+      }
+
+      // Eliminate rows with conflicting values.
+      for (const column of columns) {
+        nextValue: for (const value of column) {
+          for (const row of value.provenance) {
+            let forResultSet = valuesByResultSet.get(row.resultSet);
+            if (forResultSet == null) {
+              forResultSet = new Map();
+              valuesByResultSet.set(row.resultSet, forResultSet);
+            }
+
+            const existingValue = forResultSet.get(row.row);
+            if (existingValue != null && existingValue != value.value) {
+              forResultSet.set(row.row, poison);
+              markRowAsCompleted(row.resultSet, row.row);
+              continue nextValue;
+            } else {
+              forResultSet.set(row.row, value.value);
+            }
+          }
+        }
+      }
+
+      function shouldSkipValue(value: ParameterValueWithRow): boolean {
+        for (const { resultSet, row } of value.provenance) {
+          const ignoredRowIds = completedRows.get(resultSet);
+          if (ignoredRowIds?.has(row)) return true;
+
+          const valuesForResultSet = valuesByResultSet.get(resultSet);
+          if (valuesForResultSet == null) continue;
+
+          if (valuesForResultSet.get(row) != value.value) return true;
+        }
+
+        return false;
+      }
+
+      let intersection: Map<SqliteParameterValue, VirtualSourceRow[][]> | null = null;
+      for (const column of columns) {
         if (intersection == null) {
           intersection = new Map();
-          for (const { value, provenance } of evaluated) {
-            intersection.set(value, provenance);
+
+          for (const value of column) {
+            if (shouldSkipValue(value)) continue;
+
+            const existing = intersection.get(value.value);
+            if (existing != null) {
+              existing.push(value.provenance);
+            } else {
+              intersection.set(value.value, [value.provenance]);
+            }
+
+            for (const { resultSet, row } of value.provenance) {
+              // Any other value derived from this row must have the same value (otherwise we would have eliminated it).
+              // So we don't have to consider this row again.
+              markRowAsCompleted(resultSet, row);
+            }
           }
         } else {
           const unmatchedValues = new Set(intersection.keys());
 
-          for (const { value, provenance } of evaluated) {
-            const existing = intersection.get(value);
+          for (const value of column) {
+            const existing = intersection.get(value.value);
             if (existing == null) {
               // Value not in intersection, ignore.
             } else {
-              unmatchedValues.delete(value);
+              unmatchedValues.delete(value.value);
 
-              // An intersection value is derived from all inputs, so we track them all as provenance.
-              existing.push(...provenance);
+              if (!shouldSkipValue(value)) {
+                // An intersection value is derived from all inputs, so we track them all as provenance.
+                existing.push(value.provenance);
+              }
             }
           }
 
@@ -335,7 +415,11 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
 
       let values: ParameterValueWithRow[] = [];
       if (intersection) {
-        intersection.forEach((provenance, value) => values.push({ value, provenance }));
+        intersection.forEach((provenances, value) => {
+          for (const provenance of provenances) {
+            values.push({ value, provenance });
+          }
+        });
       }
 
       parent[index] = { type: 'cached', values };

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -1,5 +1,6 @@
 import { ParameterLookupSource, ScopedParameterLookup, UnscopedParameterLookup } from '../../BucketParameterQuerier.js';
 import { ParameterIndexLookupCreator } from '../../BucketSource.js';
+import { HashMap, listEquality, StableHasher } from '../../compiler/equality.js';
 import { HydrationState } from '../../HydrationState.js';
 import { RequestParameters, SqliteParameterValue, SqliteValue } from '../../types.js';
 import { isValidParameterValue } from '../../utils.js';
@@ -488,7 +489,18 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
     if (lookup.type == 'parameter') {
       const scope = this.input.hydrationState.getParameterIndexLookupScope(lookup.lookup);
       const resolvedLookup = lookup.lookup as PreparedParameterIndexLookupCreator;
-      const lookupsToProvenance = new Map<ScopedParameterLookup, { origin: VirtualSourceRow[]; symbol: symbol }>();
+
+      interface PendingLookup {
+        lookup: ScopedParameterLookup;
+        provenance: { origin: VirtualSourceRow[]; symbol: symbol }[];
+      }
+
+      // It's possible that we'll have the same logical lookup with multiple provenance values. For instance, if the
+      // outputs of another lookup with two columns (where only one column is an input to this lookup) are passed into
+      // this, we can have two lookups with identical keys but different provenances. This hash map de-duplicates keys.
+      const pendingLookups = new HashMap<SqliteParameterValue[], PendingLookup>(
+        FullInstantiator.parameterArrayEquality
+      );
 
       for (const values of this.resolveInputs(lookup.instantiation)) {
         const provenance: VirtualSourceRow[] = [];
@@ -496,11 +508,23 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
           provenance.push(...value.provenance);
         }
 
-        const lookup = ScopedParameterLookup.normalized(
-          scope,
-          UnscopedParameterLookup.normalized(withoutProvenance(values))
-        );
-        lookupsToProvenance.set(lookup, { origin: provenance, symbol: Symbol(`lookup ${stage}.${index}`) });
+        const directValues = withoutProvenance(values);
+        pendingLookups.setOrUpdate(directValues, (old) => {
+          if (old == null) {
+            return {
+              lookup: ScopedParameterLookup.normalized(scope, UnscopedParameterLookup.normalized(directValues)),
+              provenance: [{ origin: provenance, symbol: Symbol(`lookup ${stage}.${index}`) }]
+            };
+          } else {
+            old.provenance.push({ origin: provenance, symbol: Symbol(`lookup ${stage}.${index}`) });
+            return old;
+          }
+        });
+      }
+
+      const lookupsToProvenance = new Map<ScopedParameterLookup, { origin: VirtualSourceRow[]; symbol: symbol }[]>();
+      for (const [_, { lookup, provenance }] of pendingLookups.entries) {
+        lookupsToProvenance.set(lookup, provenance);
       }
 
       const outputs = await this.input.source.getParameterSets(
@@ -510,26 +534,26 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
 
       // Stream parameters generate an output row like {0: <expr>, 1: <expr>, ...}.
       const values = outputs.flatMap(({ lookup, rows }) => {
-        const { symbol, origin } = lookupsToProvenance.get(lookup)!;
+        return lookupsToProvenance.get(lookup)!.flatMap(({ symbol, origin }) => {
+          return rows.map((row, rowid) => {
+            const length = Object.entries(row).length;
+            const asArray: ParameterValueWithRow[] = [];
 
-        return rows.map((row, rowid) => {
-          const length = Object.entries(row).length;
-          const asArray: ParameterValueWithRow[] = [];
+            for (let i = 0; i < length; i++) {
+              const value = row[i.toString()] as SqliteParameterValue;
+              const directOrigin = length > 1 ? { resultSet: symbol, row: rowid } : undefined;
 
-          for (let i = 0; i < length; i++) {
-            const value = row[i.toString()] as SqliteParameterValue;
-            const directOrigin = length > 1 ? { resultSet: symbol, row: rowid } : undefined;
-
-            asArray.push({
-              value,
-              // Note: Not tracking provenance for parameters with just a single output is purely a performance
-              // optimization. If there's just a single value, we don't need to correlate it with other columns in the
-              // row. Not adding provenance saves some work in mergeValueCombinations.
-              provenance: directOrigin != null ? [...origin, directOrigin] : origin,
-              directOrigin
-            });
-          }
-          return asArray;
+              asArray.push({
+                value,
+                // Note: Not tracking provenance for parameters with just a single output is purely a performance
+                // optimization. If there's just a single value, we don't need to correlate it with other columns in the
+                // row. Not adding provenance saves some work in mergeValueCombinations.
+                provenance: directOrigin != null ? [...origin, directOrigin] : origin,
+                directOrigin
+              });
+            }
+            return asArray;
+          });
         });
       });
 
@@ -543,6 +567,8 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
     }
     return other;
   }
+
+  private static readonly parameterArrayEquality = listEquality(StableHasher.parameterValueEquality);
 }
 
 export type PreparedExpandingLookup =

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -1,7 +1,6 @@
 import { ParameterLookupSource, ScopedParameterLookup, UnscopedParameterLookup } from '../../BucketParameterQuerier.js';
 import { ParameterIndexLookupCreator } from '../../BucketSource.js';
 import { HydrationState } from '../../HydrationState.js';
-import { cartesianProduct } from '../../streams/utils.js';
 import { RequestParameters, SqliteParameterValue, SqliteValue } from '../../types.js';
 import { isValidParameterValue } from '../../utils.js';
 import {
@@ -120,7 +119,7 @@ export class RequestParameterEvaluators {
       stage.forEach((_, indexInStage) => helper.expandingLookupSync(stageIndex, indexInStage));
     });
 
-    return helper.tryResolveInstantiation(this.parameterValues);
+    return helper.tryResolveInstantiation(this.parameterValues)?.map(withoutProvenance);
   }
 
   /**
@@ -138,7 +137,7 @@ export class RequestParameterEvaluators {
 
     // At this point, all lookups have been resolved and we can synchronously evaluate parameters which might depend on
     // those lookups.
-    return helper.resolveInstantiation(this.parameterValues);
+    return helper.resolveInstantiation(this.parameterValues).map(withoutProvenance);
   }
 
   /**
@@ -241,7 +240,7 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
     protected readonly evaluators: RequestParameterEvaluators
   ) {}
 
-  tryResolveInstantiation(params: PreparedParameterValue[]): SqliteParameterValue[][] | undefined {
+  tryResolveInstantiation(params: PreparedParameterValue[]): ParameterValueWithRow[][] | undefined {
     const stages = this.evaluators.lookupStages;
     let hasUninstantiatedStage = false;
     for (let stageIndex = 0; stageIndex < stages.length; stageIndex++) {
@@ -273,7 +272,7 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
     return [...this.resolveInputs(params)];
   }
 
-  protected *resolveInputs(params: PreparedParameterValue[]): Generator<SqliteParameterValue[]> {
+  protected *resolveInputs(params: PreparedParameterValue[]): Generator<ParameterValueWithRow[]> {
     const parameterValues = params.map((_, index) => {
       const cached = this.parameterSync(params, index);
       if (cached == null) {
@@ -283,19 +282,19 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
       return cached;
     });
 
-    yield* cartesianProduct(...parameterValues);
+    yield* mergeValueCombinations(parameterValues);
   }
 
   /**
    * If possible, evaluates an element in an array of parameter values and replaces the parameter with a marker
    * indicating it as cached.
    */
-  parameterSync(parent: PreparedParameterValue[], index: number): SqliteParameterValue[] | undefined {
+  parameterSync(parent: PreparedParameterValue[], index: number): ParameterValueWithRow[] | undefined {
     const current = parent[index];
     if (current.type === 'cached') {
       return current.values;
     } else if (current.type === 'intersection') {
-      let intersection: Set<SqliteParameterValue> | null = null;
+      let intersection: Map<SqliteParameterValue, (VirtualSourceRow | null)[]> | null = null;
       for (let i = 0; i < current.values.length; i++) {
         const evaluated = this.parameterSync(current.values, i);
         if (evaluated == null) {
@@ -303,21 +302,40 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
         }
 
         if (intersection == null) {
-          intersection = new Set(evaluated);
+          intersection = new Map();
+          for (const { value, provenance } of evaluated) {
+            intersection.set(value, provenance);
+          }
         } else {
-          // TODO: Remove as any once we can use ES2025 in TypeScript
-          intersection = (intersection as any).intersection(new Set(evaluated)) as Set<SqliteParameterValue>;
+          const unmatchedValues = new Set(intersection.keys());
+
+          for (const { value, provenance } of evaluated) {
+            const existing = intersection.get(value);
+            if (existing == null) {
+              // Value not in intersection, ignore.
+            } else {
+              unmatchedValues.delete(value);
+
+              // An intersection value is derived from all inputs, so we track them all as provenance.
+              existing.push(...provenance);
+            }
+          }
+
+          for (const unmatched of unmatchedValues) {
+            // Values in intersection before, but not in evaluated
+            intersection.delete(unmatched);
+          }
         }
 
-        if (intersection.size == 0) {
+        if (intersection!.size == 0) {
           // Empty intersection, we don't even need to evaluate the rest.
           break;
         }
       }
 
-      let values: SqliteParameterValue[] = [];
+      let values: ParameterValueWithRow[] = [];
       if (intersection) {
-        values.push(...intersection.keys());
+        intersection.forEach((provenance, value) => values.push({ value, provenance }));
       }
 
       parent[index] = { type: 'cached', values };
@@ -331,7 +349,14 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
       }
     } else if (current.type === 'request') {
       const value = current.read(this.input.request);
-      const values: SqliteParameterValue[] = isValidParameterValue(value) ? [value] : [];
+      const values: ParameterValueWithRow[] = isValidParameterValue(value)
+        ? [
+            {
+              value,
+              provenance: [null]
+            }
+          ]
+        : [];
 
       parent[index] = { type: 'cached', values };
       return values;
@@ -340,11 +365,16 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
     return undefined;
   }
 
-  expandingLookupSync(stage: number, index: number): SqliteParameterValue[][] | undefined {
+  expandingLookupSync(stage: number, index: number): ParameterValueWithRow[][] | undefined {
     const lookup = this.evaluators.lookupStages[stage][index];
     if (lookup.type == 'table_valued') {
       // We can evaluate this table-valued function already.
-      const values = lookup.read(this.input.request);
+      const resultSetMarker = Symbol();
+      const values = lookup.read(this.input.request).map((values, rowid) => {
+        const provenance: [VirtualSourceRow] = [{ resultSet: resultSetMarker, row: rowid }];
+        return values.map((value) => ({ value, provenance }) satisfies ParameterValueWithRow);
+      });
+
       this.evaluators.lookupStages[stage][index] = { type: 'cached', values };
       return values;
     } else if (lookup.type == 'cached') {
@@ -356,7 +386,7 @@ class PartialInstantiator<I extends PartialInstantiationInput = PartialInstantia
 }
 
 class FullInstantiator extends PartialInstantiator<InstantiationInput> {
-  resolveInstantiation(params: PreparedParameterValue[]): SqliteParameterValue[][] {
+  resolveInstantiation(params: PreparedParameterValue[]): ParameterValueWithRow[][] {
     const resolved = this.tryResolveInstantiation(params);
     if (resolved == null) {
       throw new Error('internal error: Should have been able to resolve instantiation after instantiating stages.');
@@ -365,30 +395,49 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
     return resolved;
   }
 
-  async expandingLookup(stage: number, index: number): Promise<SqliteParameterValue[][]> {
+  async expandingLookup(stage: number, index: number): Promise<ParameterValueWithRow[][]> {
     const lookup = this.evaluators.lookupStages[stage][index];
     if (lookup.type == 'parameter') {
       const scope = this.input.hydrationState.getParameterIndexLookupScope(lookup.lookup);
       const resolvedLookup = lookup.lookup as PreparedParameterIndexLookupCreator;
+      const lookupsToProvenance = new Map<
+        ScopedParameterLookup,
+        { origin: (VirtualSourceRow | null)[]; symbol: symbol }
+      >();
+
+      for (const values of this.resolveInputs(lookup.instantiation)) {
+        const provenance: (VirtualSourceRow | null)[] = [];
+        for (const value of values) {
+          provenance.push(...value.provenance);
+        }
+
+        const lookup = ScopedParameterLookup.normalized(
+          scope,
+          UnscopedParameterLookup.normalized(withoutProvenance(values))
+        );
+        lookupsToProvenance.set(lookup, { origin: provenance, symbol: Symbol(`lookup ${stage}.${index}`) });
+      }
+
       const outputs = await this.input.source.getParameterSets(
-        [...this.resolveInputs(lookup.instantiation)].map((instantiation) =>
-          ScopedParameterLookup.normalized(scope, UnscopedParameterLookup.normalized(instantiation))
-        ),
+        [...lookupsToProvenance.keys()],
         `Stream ${this.evaluators.stream.name} evaluating parameter on ${resolvedLookup.sourceTable.name}`
       );
 
       // Stream parameters generate an output row like {0: <expr>, 1: <expr>, ...}.
-      const values = outputs.flatMap(({ rows }) =>
-        rows.map((row) => {
+      const values = outputs.flatMap(({ lookup, rows }) => {
+        const { symbol, origin } = lookupsToProvenance.get(lookup)!;
+
+        return rows.map((row, rowid) => {
           const length = Object.entries(row).length;
-          const asArray: SqliteParameterValue[] = [];
+          const asArray: ParameterValueWithRow[] = [];
 
           for (let i = 0; i < length; i++) {
-            asArray.push(row[i.toString()] as SqliteParameterValue);
+            const value = row[i.toString()] as SqliteParameterValue;
+            asArray.push({ value, provenance: [...origin, { resultSet: symbol, row: rowid }] });
           }
           return asArray;
-        })
-      );
+        });
+      });
 
       this.evaluators.lookupStages[stage][index] = { type: 'cached', values };
       return values;
@@ -405,7 +454,7 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
 export type PreparedExpandingLookup =
   | { type: 'parameter'; lookup: ParameterIndexLookupCreator; instantiation: PreparedParameterValue[] }
   | { type: 'table_valued'; read(request: RequestParameters): SqliteParameterValue[][] }
-  | { type: 'cached'; values: SqliteParameterValue[][] };
+  | { type: 'cached'; values: ParameterValueWithRow[][] };
 
 /**
  * A {@link plan.ParameterValue} that can be evaluated against request parameters.
@@ -416,7 +465,21 @@ export type PreparedParameterValue =
   | { type: 'request'; read(request: RequestParameters): SqliteValue }
   | { type: 'lookup'; lookup: { stage: number; index: number }; resultIndex: number }
   | { type: 'intersection'; values: PreparedParameterValue[] }
-  | { type: 'cached'; values: SqliteParameterValue[] };
+  | { type: 'cached'; values: ParameterValueWithRow[] };
+
+interface ParameterValueWithRow {
+  value: SqliteParameterValue;
+  provenance: (VirtualSourceRow | null)[];
+}
+
+interface VirtualSourceRow {
+  resultSet: symbol;
+  row: number;
+}
+
+function withoutProvenance(source: ParameterValueWithRow[]): SqliteParameterValue[] {
+  return source.map(({ value }) => value);
+}
 
 export interface PartialInstantiationInput {
   request: RequestParameters;
@@ -460,4 +523,58 @@ function* filterParameterRows(rows: SqliteValue[][]): Generator<SqliteParameterV
       yield row;
     }
   }
+}
+
+function* mergeValueCombinations(valuesByParameter: ParameterValueWithRow[][]) {
+  const usedRows = new Map<symbol, number>();
+  const partialResults = new Array(valuesByParameter.length);
+
+  function installRowOrFail(value: ParameterValueWithRow): [boolean, symbol[]] {
+    const addedResultSets: symbol[] = [];
+
+    for (const origin of value.provenance) {
+      if (origin != null) {
+        const { resultSet, row } = origin;
+        const existingRow = usedRows.get(resultSet);
+        if (existingRow === undefined) {
+          addedResultSets.push(resultSet);
+          usedRows.set(resultSet, row);
+        } else if (existingRow == row) {
+          continue;
+        } else {
+          // The current instantiation already constains a value from the same result set but derived from a different
+          // row. So we must ignore this parameter value.
+          return [false, addedResultSets];
+        }
+      }
+    }
+
+    return [true, addedResultSets];
+  }
+
+  function uninstallResultSets(resultSets: symbol[]) {
+    for (const rs of resultSets) {
+      usedRows.delete(rs);
+    }
+  }
+
+  function* generateCombinations(nextParameter: number): Generator<ParameterValueWithRow[]> {
+    if (nextParameter >= valuesByParameter.length) {
+      yield [...partialResults];
+      return;
+    }
+
+    const availableValues = valuesByParameter[nextParameter];
+    for (const available of availableValues) {
+      const [canUse, addedResultSets] = installRowOrFail(available);
+      if (canUse) {
+        partialResults[nextParameter] = available;
+        yield* generateCombinations(nextParameter + 1);
+      }
+
+      uninstallResultSets(addedResultSets);
+    }
+  }
+
+  yield* generateCombinations(0);
 }

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect } from 'vitest';
 import {
+  DEFAULT_HYDRATION_STATE,
   HydratedSyncRules,
   ParameterLookupRows,
+  PrecompiledSyncConfig,
   ScopedParameterLookup,
   SourceTableInterface,
   SqliteRow,
@@ -549,6 +551,286 @@ streams:
     expect(buckets.map((b) => b.bucket)).toStrictEqual(['stream|0["issue"]']);
   });
 
+  syncTest('preserves correlation across lookup output columns', async ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      # Buckets are parameterized by the joined a.c1/a.c2 values. The b table is
+      # only used to discover which pairs are visible to the current user.
+      query: SELECT a.* FROM a, b WHERE a.c1 = b.c1 AND a.c2 = b.c2 AND b.u = auth.user_id()
+`);
+
+    const { querier, errors } = desc.getBucketParameterQuerier({
+      globalParameters: requestParameters({ sub: 'user1' }),
+      hasDefaultStreams: false,
+      streams: {
+        stream: [{ priorityOverride: null, opaque_id: 0, parameters: {} }]
+      }
+    });
+    expect(errors).toStrictEqual([]);
+
+    const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups): Promise<ParameterLookupRows[]> {
+        // Equivalent source data:
+        //
+        //   b.c1 | b.c2 | b.u
+        //   -----+------+------
+        //   A    | 1    | user1
+        //   B    | 2    | user1
+        //
+        // getParameterSets() returns the two output columns for each matching b
+        // row. These values must stay grouped per row: (A, 1) and (B, 2).
+        // Treating column 0 and column 1 as independent value sets would create
+        // impossible pairs such as (A, 2) or (B, 1).
+        expect(lookups.map((l) => l.values)).toEqual([['lookup', '0', 'user1']]);
+        return [
+          {
+            lookup: lookups[0],
+            rows: [
+              { '0': 'A', '1': 1 },
+              { '0': 'B', '1': 2 }
+            ]
+          }
+        ];
+      }
+    });
+
+    // Bucket parameter order is c2, c1 for this compiled plan, so the two valid
+    // joined pairs above become [1, "A"] and [2, "B"].
+    expect(dynamicBuckets.map((bucket) => bucket.bucket)).toStrictEqual(['stream|0[1,"A"]', 'stream|0[2,"B"]']);
+  });
+
+  syncTest('preserves correlation across lookup stages', async ({ sync }) => {
+    const compiled = sync.prepareWithoutHydration(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      query: SELECT a.* FROM a, b, c WHERE a.id1 = b.id1 AND a.c1 = c.c1 AND b.c1 = c.c1 AND b.c2 = c.c2 AND c.u = auth.user_id()
+`) as PrecompiledSyncConfig;
+    const desc = compiled.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+
+    const { querier, errors } = desc.getBucketParameterQuerier({
+      globalParameters: requestParameters({ sub: 'user1' }),
+      hasDefaultStreams: false,
+      streams: {
+        stream: [{ priorityOverride: null, opaque_id: 0, parameters: {} }]
+      }
+    });
+    expect(errors).toStrictEqual([]);
+
+    const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups): Promise<ParameterLookupRows[]> {
+        const results: ParameterLookupRows[] = [];
+
+        for (const lookup of lookups) {
+          const lookupId = Number(lookup.values[1]);
+          const definition = compiled.plan.parameterIndexes[lookupId];
+
+          if (definition.sourceTable.name === 'c') {
+            // On table c: Output c1, c2 values
+            results.push({
+              lookup,
+              rows: [
+                { '0': 'c1-1', '1': 'c2-1' },
+                { '0': 'c1-2', '1': 'c2-2' },
+                { '0': 'c1-3', '1': 'c2-3' }
+              ]
+            });
+          } else if (definition.sourceTable.name === 'b') {
+            // On table b: Output id1 value which we copy from table c
+            const [c1, c2] = lookup.values.slice(2) as string[];
+            // Inputs should be a valid (c1-x, c2-x) pair.
+            expect(c1.charAt(3)).toStrictEqual(c2.charAt(3));
+
+            results.push({ lookup, rows: [{ '0': `id-${c1.charAt(3)}` }] });
+          } else {
+            throw new Error('unexpected lookup');
+          }
+        }
+
+        return results;
+      }
+    });
+
+    // Duplicates do not need to be removed here, but they must not make lookup
+    // columns independent and create impossible pairs like [2, "A"].
+    expect(dynamicBuckets.map((bucket) => bucket.bucket)).toStrictEqual([
+      'stream|0["id-1","c1-1"]',
+      'stream|0["id-2","c1-2"]',
+      'stream|0["id-3","c1-3"]'
+    ]);
+  });
+
+  syncTest('preserves correlation across duplicate lookup output rows', async ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      query: SELECT a.* FROM a, b WHERE a.c1 = b.c1 AND a.c2 = b.c2 AND b.u = auth.user_id()
+`);
+
+    const { querier, errors } = desc.getBucketParameterQuerier({
+      globalParameters: requestParameters({ sub: 'user1' }),
+      hasDefaultStreams: false,
+      streams: {
+        stream: [{ priorityOverride: null, opaque_id: 0, parameters: {} }]
+      }
+    });
+    expect(errors).toStrictEqual([]);
+
+    const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups) {
+        expect(lookups).toHaveLength(1);
+        return [
+          {
+            lookup: lookups[0],
+            rows: [
+              { '0': 'A', '1': 1 },
+              { '0': 'A', '1': 1 },
+              { '0': 'B', '1': 2 }
+            ]
+          }
+        ];
+      }
+    });
+
+    // Duplicates do not need to be removed here, but they must not make lookup
+    // columns independent and create impossible pairs like [2, "A"].
+    expect(dynamicBuckets.map((bucket) => bucket.bucket)).toStrictEqual([
+      'stream|0[1,"A"]',
+      'stream|0[1,"A"]',
+      'stream|0[2,"B"]'
+    ]);
+  });
+
+  syncTest('preserves correlation across bigint lookup output columns', async ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      query: SELECT a.* FROM a, b WHERE a.c1 = b.c1 AND a.c2 = b.c2 AND b.u = auth.user_id()
+`);
+
+    const { querier, errors } = desc.getBucketParameterQuerier({
+      globalParameters: requestParameters({ sub: 'user1' }),
+      hasDefaultStreams: false,
+      streams: {
+        stream: [{ priorityOverride: null, opaque_id: 0, parameters: {} }]
+      }
+    });
+    expect(errors).toStrictEqual([]);
+
+    const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups) {
+        expect(lookups).toHaveLength(1);
+        return [
+          {
+            lookup: lookups[0],
+            rows: [
+              { '0': 'A', '1': 9007199254740993n },
+              { '0': 'B', '1': 9007199254740995n }
+            ]
+          }
+        ];
+      }
+    });
+
+    expect(dynamicBuckets.map((bucket) => bucket.bucket)).toStrictEqual([
+      'stream|0[9007199254740993,"A"]',
+      'stream|0[9007199254740995,"B"]'
+    ]);
+  });
+
+  syncTest('preserves lookup row bindings inside intersections', async ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      query: SELECT a.* FROM a, b WHERE a.c1 = b.c1 AND a.c1 = b.c2 AND b.u = auth.user_id()
+`);
+
+    const { querier, errors } = desc.getBucketParameterQuerier({
+      globalParameters: requestParameters({ sub: 'user1' }),
+      hasDefaultStreams: false,
+      streams: {
+        stream: [{ priorityOverride: null, opaque_id: 0, parameters: {} }]
+      }
+    });
+    expect(errors).toStrictEqual([]);
+
+    const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups) {
+        // Column-wise intersection would see c1 values {A, B} and c2 values
+        // {B, A}, then incorrectly emit A and B. There is no single b row where
+        // both values are equal, so no a.c1 bucket can satisfy the join.
+        expect(lookups).toHaveLength(1);
+        return [
+          {
+            lookup: lookups[0],
+            rows: [
+              { '0': 'A', '1': 'B' },
+              { '0': 'B', '1': 'A' }
+            ]
+          }
+        ];
+      }
+    });
+
+    expect(dynamicBuckets).toStrictEqual([]);
+  });
+
+  syncTest('cross-combines independent lookup output rows', async ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      query: SELECT a.* FROM a, b, c WHERE a.c1 = b.c1 AND a.c2 = c.c2 AND b.u = auth.user_id() AND c.u = auth.user_id()
+`);
+
+    const { querier, errors } = desc.getBucketParameterQuerier({
+      globalParameters: requestParameters({ sub: 'user1' }),
+      hasDefaultStreams: false,
+      streams: {
+        stream: [{ priorityOverride: null, opaque_id: 0, parameters: {} }]
+      }
+    });
+    expect(errors).toStrictEqual([]);
+
+    const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+      async getParameterSets(lookups, debugDefinition): Promise<ParameterLookupRows[]> {
+        expect(lookups).toHaveLength(1);
+
+        if (debugDefinition.endsWith(' on b')) {
+          return [{ lookup: lookups[0], rows: [{ '0': 'A' }, { '0': 'B' }] }];
+        } else if (debugDefinition.endsWith(' on c')) {
+          return [{ lookup: lookups[0], rows: [{ '0': 1 }, { '0': 2 }] }];
+        }
+
+        throw new Error(`Unexpected lookup: ${debugDefinition}`);
+      }
+    });
+
+    expect(dynamicBuckets.map((bucket) => bucket.bucket).sort()).toStrictEqual([
+      'stream|0[1,"A"]',
+      'stream|0[1,"B"]',
+      'stream|0[2,"A"]',
+      'stream|0[2,"B"]'
+    ]);
+  });
+
   syncTest('multiple IN operators', ({ sync }) => {
     const desc = sync.prepareSyncStreams(`
 config:
@@ -697,7 +979,7 @@ streams:
             await querier.queryDynamicBucketDescriptions({
               getParameterSets: async function (lookups: ScopedParameterLookup[]): Promise<ParameterLookupRows[]> {
                 expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['user'])]);
-                return [{ lookup: lookups[0], rows: hasLookupResult ? [{}] : [] }];
+                return [{ lookup: lookups[0], rows: hasLookupResult ? [{ '0': 'post_id' }] : [] }];
               }
             })
           ).toHaveLength(hasLookupResult ? 1 : 0);

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -877,6 +877,66 @@ streams:
     ]);
   });
 
+  syncTest(
+    'preserves valid intersection when duplicate lookup values have overlapping provenance',
+    async ({ sync }) => {
+      const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      query: SELECT a.* FROM a, b, c WHERE a.c1 = b.c1 AND a.c1 = b.c2 AND b.x = c.x AND a.y = c.y
+`);
+
+      const { querier, errors } = desc.getBucketParameterQuerier({
+        globalParameters: requestParameters({ sub: 'user1' }),
+        hasDefaultStreams: false,
+        streams: {
+          stream: [{ priorityOverride: null, opaque_id: 0, parameters: {} }]
+        }
+      });
+      expect(errors).toStrictEqual([]);
+
+      async function checkWithParameters(...results: { c1: string; c2: string }[]): Promise<string[]> {
+        const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+          async getParameterSets(lookups, debugContext) {
+            if (debugContext.endsWith('on c')) {
+              expect(lookups).toHaveLength(1);
+
+              return [
+                {
+                  lookup: lookups[0],
+                  rows: [{ '0': 'x', '1': 'y' }]
+                }
+              ];
+            }
+
+            expect(lookups).toHaveLength(1);
+            return [
+              {
+                lookup: lookups[0],
+                rows: results.map(({ c1, c2 }) => ({ '0': c1, '1': c2 }))
+              }
+            ];
+          }
+        });
+
+        return dynamicBuckets.map((bucket) => bucket.bucket);
+      }
+
+      expect(await checkWithParameters({ c1: 'A', c2: 'A' })).toStrictEqual(['stream|0["y","A"]']);
+      expect(await checkWithParameters({ c1: 'A', c2: 'B' })).toStrictEqual([]);
+      expect(await checkWithParameters({ c1: 'A', c2: 'A' }, { c1: 'A', c2: 'B' })).toStrictEqual([
+        'stream|0["y","A"]'
+      ]);
+      expect(await checkWithParameters({ c1: 'A', c2: 'C' }, { c1: 'A', c2: 'B' })).toStrictEqual([]);
+      expect(await checkWithParameters({ c1: 'A', c2: 'A' }, { c1: 'A', c2: 'B' }, { c1: 'B', c2: 'B' })).toStrictEqual(
+        ['stream|0["y","A"]', 'stream|0["y","B"]']
+      );
+    }
+  );
+
   syncTest('multiple IN operators', ({ sync }) => {
     const desc = sync.prepareSyncStreams(`
 config:

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -831,6 +831,52 @@ streams:
     ]);
   });
 
+  syncTest('preserves valid intersection when duplicate lookup values have different provenance', async ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      query: SELECT a.* FROM a, b WHERE a.c1 = b.c1 AND a.c1 = b.c2 AND b.u = auth.user_id()
+`);
+
+    const { querier, errors } = desc.getBucketParameterQuerier({
+      globalParameters: requestParameters({ sub: 'user1' }),
+      hasDefaultStreams: false,
+      streams: {
+        stream: [{ priorityOverride: null, opaque_id: 0, parameters: {} }]
+      }
+    });
+    expect(errors).toStrictEqual([]);
+
+    async function checkWithParameters(...results: { c1: string; c2: string }[]): Promise<string[]> {
+      const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+        async getParameterSets(lookups) {
+          expect(lookups).toHaveLength(1);
+
+          return [
+            {
+              lookup: lookups[0],
+              rows: results.map(({ c1, c2 }) => ({ '0': c1, '1': c2 }))
+            }
+          ];
+        }
+      });
+
+      return dynamicBuckets.map((bucket) => bucket.bucket);
+    }
+
+    expect(await checkWithParameters({ c1: 'A', c2: 'A' })).toStrictEqual(['stream|0["A"]']);
+    expect(await checkWithParameters({ c1: 'A', c2: 'B' })).toStrictEqual([]);
+    expect(await checkWithParameters({ c1: 'A', c2: 'A' }, { c1: 'A', c2: 'B' })).toStrictEqual(['stream|0["A"]']);
+    expect(await checkWithParameters({ c1: 'A', c2: 'C' }, { c1: 'A', c2: 'B' })).toStrictEqual([]);
+    expect(await checkWithParameters({ c1: 'A', c2: 'A' }, { c1: 'A', c2: 'B' }, { c1: 'B', c2: 'B' })).toStrictEqual([
+      'stream|0["A"]',
+      'stream|0["B"]'
+    ]);
+  });
+
   syncTest('multiple IN operators', ({ sync }) => {
     const desc = sync.prepareSyncStreams(`
 config:


### PR DESCRIPTION
Sorry for the noise, I closed https://github.com/powersync-ja/powersync-service/pull/632 by mistake with a careless rebase.

Starting from https://github.com/powersync-ja/powersync-service/pull/608 (which hasn't been released yet), it's possible for Sync Streams to use compound keys as parameters, e.g. in:

```sql
SELECT products.* FROM products, stores
  WHERE stores.name = products.store_name
    AND stores.region = products.region
    AND stores.id = subscription.parameter('store');
```

The way this is replicated is fairly obvious: When we encounter a `stores` row, we populate a parameter index from `id` to `name` and `region`. When building a querier, we use these two outputs as parameters. Unfortunately, that is not quite correct because we then build the cartesian product of all parameters as buckets. So, if we had two rows in `stores` with `{name: 'foo', region: 'us'}` and `{name: 'bar', region: 'eu'}`, we'd generate four buckets: `[foo,us], [foo, eu], [bar, us], [bar, eu]`. Oops.

To implement join semantics correctly, we also need to track which logical row in a joined result set a parameter value was derived from. This is implemented here by tracking:

1. The result set, as an opaque unique symbol instance.
2. The row in a result set, as an incrementing number.

When we build the cartesian product for parameter instantiations, we keep track of which result sets have already appeared in partial instantiations. When we discover a new value from a covered result set with a different row, we skip it.

This fixes an issue introduced in https://github.com/powersync-ja/powersync-service/pull/608 (which hasn't been released yet, hence no changeset entry).

## AI usage disclaimer

Ralf originally found this issue with Codex security scanning. This builds ontop of 37f42ea2125ee0591fcba2534912d461f778e731, which contains a fix and tests generated by Codex. The implementation was rewritten manually for clarity and to fix this across multiple lookup stages too.