### PR TITLE
Warn on unreferenced common table expressions

### DIFF
--- a/.changeset/grumpy-socks-tease.md
+++ b/.changeset/grumpy-socks-tease.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Emit a warning for unused common table expressions.

--- a/packages/sync-rules/src/compiler/compiler.ts
+++ b/packages/sync-rules/src/compiler/compiler.ts
@@ -10,7 +10,7 @@ import { StreamQueryParser } from './parser.js';
 import { QuerierGraphBuilder } from './querier_graph.js';
 import { PointLookup, RowEvaluator } from './rows.js';
 import { SqlScope } from './scope.js';
-import { PreparedSubquery } from './sqlite.js';
+import { CommonTableExpression, PreparedSubquery } from './sqlite.js';
 
 export interface SyncStreamsCompilerOptions {
   /**
@@ -145,7 +145,7 @@ export interface IndividualSyncStreamCompiler {
    * Makes a common table expression prepared through {@link SyncStreamsCompiler.commonTableExpression} available when
    * parsing queries for this stream.
    */
-  registerCommonTableExpression(name: string, cte: PreparedSubquery): void;
+  registerCommonTableExpression(name: string, cte: CommonTableExpression): void;
 
   /**
    * Validates and adds a parameter query to this stream.

--- a/packages/sync-rules/src/compiler/scope.ts
+++ b/packages/sync-rules/src/compiler/scope.ts
@@ -1,5 +1,5 @@
 import { ParsingErrorListener } from './compiler.js';
-import { PreparedSubquery } from './sqlite.js';
+import { CommonTableExpression, PreparedSubquery } from './sqlite.js';
 import { SyntacticResultSetSource } from './table.js';
 
 /**
@@ -10,7 +10,7 @@ import { SyntacticResultSetSource } from './table.js';
 export class SqlScope {
   readonly parent?: SqlScope;
   private readonly nameToResultSet = new Map<string, SyntacticResultSetSource>();
-  private readonly commonTableExpressions = new Map<string, PreparedSubquery>();
+  private readonly commonTableExpressions = new Map<string, CommonTableExpression>();
 
   constructor(options: { parent?: SqlScope }) {
     this.parent = options.parent;
@@ -52,14 +52,15 @@ export class SqlScope {
     return this.nameToResultSet.get(name.toLowerCase()) ?? this.parent?.resolveResultSetForReference(name);
   }
 
-  registerCommonTableExpression(name: string, subquery: PreparedSubquery) {
+  registerCommonTableExpression(name: string, subquery: CommonTableExpression) {
     this.commonTableExpressions.set(name.toLowerCase(), subquery);
   }
 
   resolveCommonTableExpression(name: string): PreparedSubquery | null {
     const inThisScope = this.commonTableExpressions.get(name.toLowerCase());
     if (inThisScope) {
-      return inThisScope;
+      inThisScope.used = true;
+      return inThisScope.subquery;
     }
 
     return this.parent ? this.parent.resolveCommonTableExpression(name) : null;

--- a/packages/sync-rules/src/compiler/sqlite.ts
+++ b/packages/sync-rules/src/compiler/sqlite.ts
@@ -55,6 +55,11 @@ export interface PreparedSubquery {
   where: SqlExpression<ExpressionInput> | null;
 }
 
+export interface CommonTableExpression {
+  subquery: PreparedSubquery;
+  used: boolean;
+}
+
 export interface PostgresToSqliteOptions {
   readonly originalText: string;
   readonly scope: SqlScope;

--- a/packages/sync-rules/src/from_yaml.ts
+++ b/packages/sync-rules/src/from_yaml.ts
@@ -7,7 +7,7 @@ import {
   TimeValuePrecision
 } from './compatibility.js';
 import { ParsingErrorListener, SyncStreamsCompiler } from './compiler/compiler.js';
-import { PreparedSubquery } from './compiler/sqlite.js';
+import { CommonTableExpression } from './compiler/sqlite.js';
 import { SqlRuleError, SyncRulesErrors, YamlError } from './errors.js';
 import { SqlEventDescriptor } from './events/SqlEventDescriptor.js';
 import { validateSyncRulesSchema } from './json_schema.js';
@@ -35,6 +35,8 @@ export class SyncConfigFromYaml {
 
   // Names of bucket definitions and sync streams, to prevent duplicates.
   readonly #definitionNames = new Set<string>();
+
+  readonly #definedCtes: CommonTableExpressionWithName[] = [];
 
   constructor(
     private readonly options: SyncConfigFromYamlOptions,
@@ -87,6 +89,7 @@ export class SyncConfigFromYaml {
     let result: SyncConfig;
     if (compatibility.edition >= CompatibilityEdition.COMPILED_STREAMS) {
       result = this.#compileSyncPlan(bucketMap, streamMap, globalCtes, compatibility);
+      this.#warnOnUnusedCtes();
     } else {
       if (globalCtes != null) {
         // We don't support CTEs at all in this compiler implementation.
@@ -195,8 +198,8 @@ export class SyncConfigFromYaml {
 
     const compiler = new SyncStreamsCompiler(this.options);
 
-    const parseCommonTableExpressions = (from: YAMLMap | null): Map<string, PreparedSubquery> => {
-      const map = new Map();
+    const parseCommonTableExpressions = (from: YAMLMap | null): Map<string, CommonTableExpression> => {
+      const map = new Map<string, CommonTableExpression>();
       if (from != null) {
         for (const entry of from.items ?? []) {
           const { key: cteNameScalar, value: cteQuery } = entry as { key: Scalar<string>; value: Node };
@@ -219,7 +222,9 @@ export class SyncConfigFromYaml {
             const [sql, errorListener] = this.#scalarErrorListener(cteQuery);
             const parsed = compiler.commonTableExpression(sql, errorListener);
             if (parsed) {
-              map.set(cteName, parsed);
+              const cte = { subquery: parsed, used: false };
+              this.#definedCtes.push({ cte, name: cteNameScalar });
+              map.set(cteName, cte);
             }
           }
         }
@@ -288,6 +293,16 @@ export class SyncConfigFromYaml {
       engine: javaScriptExpressionEngine(compatibility),
       sourceText: this.yaml
     });
+  }
+
+  #warnOnUnusedCtes() {
+    for (const cte of this.#definedCtes) {
+      if (!cte.cte.used) {
+        const error = this.#yamlError(cte.name, `This common table expression isn't referenced.`);
+        error.type = 'warning';
+        this.#errors.push(error);
+      }
+    }
   }
 
   #legacyParseBucketDefinitionsAndStreams(
@@ -631,4 +646,10 @@ export interface SyncConfigFromYamlOptions {
    * 'public' for Postgres, default database for MongoDB/MySQL.
    */
   readonly defaultSchema: string;
+}
+
+interface CommonTableExpressionWithName {
+  // The key in a `with` map defining the CTE.
+  name: Scalar<string>;
+  cte: CommonTableExpression;
 }

--- a/packages/sync-rules/test/src/compiler/cte.test.ts
+++ b/packages/sync-rules/test/src/compiler/cte.test.ts
@@ -138,7 +138,8 @@ streams:
     });
 
     test('local ctes take precedence', () => {
-      compileToSyncPlanWithoutErrors(`
+      const [errors] = yamlToSyncPlan(
+        `
 config:
   edition: 3
 
@@ -151,7 +152,19 @@ streams:
       owned_orgs: SELECT id AS org_id FROM orgs WHERE owner = auth.user_id()
     # This would emit an error about a missing org_id column if the global definition was used.
     query: SELECT * FROM orgs WHERE id IN (SELECT org_id FROM owned_orgs)
-`);
+`,
+        { defaultSchema: 'ignored', includeErrorSpans: true }
+      );
+
+      expect(errors).toStrictEqual([
+        {
+          message: "This common table expression isn't referenced.",
+          source: 'owned_orgs',
+          isWarning: true,
+          // The first owned_orgs (global CTE).
+          startOffset: 31
+        }
+      ]);
     });
   });
 

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -62,6 +62,11 @@ streams:
         source: `with:
       foo: SELECT id FROM users
 `
+      },
+      {
+        message: "This common table expression isn't referenced.",
+        source: 'foo',
+        isWarning: true
       }
     ]);
   });

--- a/packages/sync-rules/test/src/compiler/utils.ts
+++ b/packages/sync-rules/test/src/compiler/utils.ts
@@ -15,6 +15,7 @@ interface TranslationError {
   message: string;
   source: string;
   isWarning?: boolean;
+  startOffset?: number;
 }
 
 export function compileSingleStreamAndSerialize(...sql: string[]): unknown {
@@ -76,7 +77,7 @@ function compileSingleStream(...sql: string[]): [TranslationError[], SyncPlan] {
 
 export function yamlToSyncPlan(
   source: string,
-  options: SyncRulesOptions = { defaultSchema: 'test_schema' }
+  options: SyncRulesOptions & { includeErrorSpans?: boolean } = { defaultSchema: 'test_schema' }
 ): [TranslationError[], SyncPlan] {
   const { config, errors } = SqlSyncRules.fromYaml(source, {
     throwOnError: false,
@@ -87,6 +88,10 @@ export function yamlToSyncPlan(
     const error: TranslationError = { message: e.message, source: source.substring(e.location.start, e.location.end) };
     if ('type' in e && e.type == 'warning') {
       error.isWarning = true;
+    }
+
+    if (options.includeErrorSpans) {
+      error.startOffset = e.location.start;
     }
 
     return error;


### PR DESCRIPTION
Unlike with bucket definitions, where adding a parameter query is enough to ensure it gets evaluated, an unreferenced common table expression for Sync Streams has absolutely no effect.

It looks like this behavior is at least somewhat unintuitive, since this definition showed up as an example for the "dangerous query" warning not working in an internal document:

```yaml
streams:
  migrated_to_streams:
       auto_subscribe: true
       with:
         # Missing "clients can send any value for this unauthenticated parameter" warning?
         list_array_param: SELECT value AS list FROM json_each(connection.parameters() ->> 'list_array')
       queries:
         - SELECT * FROM customers
         - SELECT * FROM catalog
        # No, because there is no parameter! Just an unused CTE
```

There really is no good reason to define a CTE and then not use it, and it can potentially be an issue (like a typo which then gets interpreted as a real table in the worst case). So, this adds a warning.