### PR TITLE
Fail early if too many parameters are requested at once

### DIFF
--- a/.changeset/public-bikes-tan.md
+++ b/.changeset/public-bikes-tan.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': minor
+---
+
+Fail early if too many parameters are requested at once.

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -616,9 +616,28 @@ export class BucketParameterState {
       // that. We should replace queriers for Sync Streams with an explicit graph structure based on sync plans instead
       // of adding these checks to the imperative querier interface.
       const lookupLog: storage.ParameterQueryInvocationLog[] = [];
+      const state = this;
 
       dynamicBuckets = await querier.queryDynamicBucketDescriptions({
         async getParameterSets(lookups, definition) {
+          if (lookups.length > parameterLimit) {
+            // Typically, this method is called with a single lookup and we want to constrain the maximum amount of
+            // outputs. For Sync Streams, it's possible to chain parameter lookups, which means that a large output
+            // result set of an earlier call might be used here. Since it's somewhat expensive to serialize lookups and
+            // to send them to bucket storage implementations, we also want to avoid large requests here.
+            // Using the original parameter limit option for that is a very generous limit, reasonable queries would be
+            // much smaller. The only way for these large lookups to work at all is for most lookups to return no rows,
+            // which would be an unusual query anyway.
+
+            const msg = `Attempted to fetch ${lookups.length} lookups at once, a maximum of ${parameterLimit} lookups are allowed.`;
+            state.logger.error(msg, {
+              user_id: state.syncParams.userId,
+              checkpoint: checkpoint.base.checkpoint,
+              cause: definition
+            });
+            throw new ServiceError(ErrorCode.PSYNC_S2305, msg);
+          }
+
           for (const lookup of lookups) {
             recordedLookups.add(lookup.serializedRepresentation);
           }

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -616,22 +616,15 @@ export class BucketParameterState {
       // that. We should replace queriers for Sync Streams with an explicit graph structure based on sync plans instead
       // of adding these checks to the imperative querier interface.
       const lookupLog: storage.ParameterQueryInvocationLog[] = [];
-      const state = this;
 
       dynamicBuckets = await querier.queryDynamicBucketDescriptions({
-        async getParameterSets(lookups, definition) {
+        getParameterSets: async (lookups, definition) => {
           if (lookups.length > parameterLimit) {
-            // Typically, this method is called with a single lookup and we want to constrain the maximum amount of
-            // outputs. For Sync Streams, it's possible to chain parameter lookups, which means that a large output
-            // result set of an earlier call might be used here. Since it's somewhat expensive to serialize lookups and
-            // to send them to bucket storage implementations, we also want to avoid large requests here.
-            // Using the original parameter limit option for that is a very generous limit, reasonable queries would be
-            // much smaller. The only way for these large lookups to work at all is for most lookups to return no rows,
-            // which would be an unusual query anyway.
-
+            // Sync Streams can chain parameter lookups, so a large output from an earlier call may become the input
+            // here. We reuse the output limit as a generous upper bound; legitimate queries are much smaller.
             const msg = `Attempted to fetch ${lookups.length} lookups at once, a maximum of ${parameterLimit} lookups are allowed.`;
-            state.logger.error(msg, {
-              user_id: state.syncParams.userId,
+            this.logger.error(msg, {
+              user_id: this.syncParams.userId,
               checkpoint: checkpoint.base.checkpoint,
               cause: definition
             });

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -1005,6 +1005,71 @@ streams:
       ]);
     });
 
+    test('throws error when too many lookups are requested at once', async () => {
+      const syncRules = SqlSyncRules.fromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  a:
+    auto_subscribe: true
+    query: SELECT * FROM a WHERE x IN (SELECT x FROM b WHERE y IN auth.parameter('p'))
+`,
+        { defaultSchema: 'public' }
+      ).config.hydrate({
+        hydrationState: versionedHydrationState(1)
+      });
+
+      const storage = new MockBucketChecksumStateStorage();
+
+      const errorData: any[] = [];
+      const mockLogger = {
+        info: () => {},
+        error: (_message: string, data: any) => {
+          errorData.push(data);
+        },
+        warn: () => {},
+        debug: () => {}
+      };
+
+      const smallContext = new SyncContext({
+        maxBuckets: 100,
+        maxParameterQueryResults: 10,
+        maxDataFetchConcurrency: 10
+      });
+
+      const state = new BucketChecksumState({
+        syncContext: smallContext,
+        tokenPayload: new JwtPayload({
+          sub: 'u1',
+          p: Array.from({ length: 100 }, (_, i) => i)
+        }),
+        syncRequest,
+        syncRules,
+        bucketStorage: storage,
+        logger: mockLogger as any
+      });
+
+      await expect(
+        state.buildNextCheckpointLine({
+          base: storage.makeCheckpoint(1n, () => {
+            throw new Error('should not get called');
+          }),
+          writeCheckpoint: null,
+          update: CHECKPOINT_INVALIDATE_ALL
+        })
+      ).rejects.toThrow('Attempted to fetch 100 lookups at once, a maximum of 10 lookups are allowed');
+
+      expect(errorData).toStrictEqual([
+        {
+          user_id: 'u1',
+          checkpoint: 1n,
+          cause: 'Stream a evaluating parameter on b'
+        }
+      ]);
+    });
+
     test('throws error with breakdown when bucket limit is exceeded', async () => {
       // These streams are designed to return buckets without consuming too many parameters (as exceeding that limit is
       // a different error).


### PR DESCRIPTION
This follows a comment [from here](https://github.com/powersync-ja/powersync-service/pull/630#pullrequestreview-4264991729): 

>For example, MongoDB has a [limit of 1000 stages](https://www.mongodb.com/docs/manual/core/aggregation-pipeline-limits/#number-of-stages-restrictions) in a pipeline. It's not clear how that applies to `$unionWith` - whether that applies to the number of top-level stages, or the total number of nested stages. Either way, we'll need to test and potentially split into separate operations if the number of lookups grow too big.

While `$unionWith` is currently only used in the V3 implementation, bucket storage implementations are not really optimized for parameter queries with a large amount of concurrent lookups. With bucket definitions, we used to pass at most one lookup in a `getParameterSets` and this is completely fine. With Sync Streams however, there is no strict upper bound because lookups can be nested (so an array in a parameter might expand into a large amount of lookups we'd request in a single call).

As a very generous limit, this uses the amount of lookup _results_ as an upper bound of allowed lookup _requests_. This should be a fairly safe choice, only very sparse lookups where most queries return no value would have worked for this before. In the future, we can likely reduce the limit further after benchmarking what storage implemenations can reasonably handle.

## AI usage disclaimer

I used Claude to review this manual change, it insisted on rewriting a comment.