### PR TITLE
Fix NOT IN json type mismatch

### DIFF
--- a/.changeset/humble-hairs-brake.md
+++ b/.changeset/humble-hairs-brake.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix IN / NOT IN against a scalar JSON array so it applies SQLite type for booleans and integers above 2^53

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -652,7 +652,8 @@ export function evaluateOperator(op: string, a: SqliteValue, b: SqliteValue): Sq
         return null;
       }
       const bParsed = checkJsonArray(b, 'IN is only supported on JSON arrays');
-      return sqliteBool(bParsed.includes(a));
+      // Use compare() for SQLite affinity since Array.includes strict equality mismatches bigint vs number.
+      return sqliteBool(bParsed.some((v) => compare(v, a) === 0));
     }
     case '&&': {
       // a && b evaluates to true iff they're both arrays and have a non-empty intersection.
@@ -675,17 +676,18 @@ export function evaluateOperator(op: string, a: SqliteValue, b: SqliteValue): Sq
   }
 }
 
-export function checkJsonArray(value: SqliteValue, errorMessage: string): any[] {
+export function checkJsonArray(value: SqliteValue, errorMessage: string): SqliteValue[] {
   if (typeof value != 'string') {
     throw new Error(errorMessage);
   }
 
-  const parsed = JSON.parse(value);
+  // JSONBig preserves precision for integers above 2^53
+  const parsed = JSONBig.parse(value);
   if (!Array.isArray(parsed)) {
     throw new Error(value);
   }
 
-  return parsed;
+  return parsed.map((v: any) => jsonValueToSqlite(true, v));
 }
 
 export function getOperatorReturnType(op: string, left: ExpressionType, right: ExpressionType) {

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -676,7 +676,7 @@ export function evaluateOperator(op: string, a: SqliteValue, b: SqliteValue): Sq
   }
 }
 
-export function checkJsonArray(value: SqliteValue, errorMessage: string): SqliteValue[] {
+export function checkJsonArray(value: SqliteValue, errorMessage: string): any[] {
   if (typeof value != 'string') {
     throw new Error(errorMessage);
   }

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -1,6 +1,6 @@
 import { JSONBig } from '@powersync/service-jsonbig';
 import { SQLITE_FALSE, SQLITE_TRUE, sqliteBool, sqliteNot } from './sql_support.js';
-import { SqliteInputValue, SqliteValue } from './types.js';
+import { SqliteInputValue, SqliteJsonValue, SqliteValue } from './types.js';
 import { jsonValueToSqlite } from './utils.js';
 // Declares @syncpoint/wkx module
 // This allows for consumers of this lib to resolve types correctly
@@ -676,7 +676,7 @@ export function evaluateOperator(op: string, a: SqliteValue, b: SqliteValue): Sq
   }
 }
 
-export function checkJsonArray(value: SqliteValue, errorMessage: string): any[] {
+export function checkJsonArray(value: SqliteValue, errorMessage: string): SqliteJsonValue[] {
   if (typeof value != 'string') {
     throw new Error(errorMessage);
   }

--- a/packages/sync-rules/test/src/sync_plan/evaluator/not_in_type_affinity.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/not_in_type_affinity.test.ts
@@ -16,12 +16,8 @@ streams:
     query: SELECT * FROM docs WHERE flag NOT IN '[true]'
 `);
 
-    expect(
-      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', flag: 1n } })
-    ).toHaveLength(0);
-    expect(
-      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', flag: 0n } })
-    ).toHaveLength(1);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', flag: 1n } })).toHaveLength(0);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', flag: 0n } })).toHaveLength(1);
   });
 
   syncTest('boolean column IN [true] admits only the matching row', ({ sync }) => {
@@ -35,12 +31,8 @@ streams:
     query: SELECT * FROM docs WHERE flag IN '[true]'
 `);
 
-    expect(
-      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', flag: 1n } })
-    ).toHaveLength(1);
-    expect(
-      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', flag: 0n } })
-    ).toHaveLength(0);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', flag: 1n } })).toHaveLength(1);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', flag: 0n } })).toHaveLength(0);
   });
 
   syncTest('large bigint column NOT IN keeps precision via JSONBig parse', ({ sync }) => {
@@ -55,12 +47,8 @@ streams:
     query: SELECT * FROM docs WHERE big NOT IN '[9999999999999999]'
 `);
 
-    expect(
-      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', big: 9999999999999999n } })
-    ).toHaveLength(0);
-    expect(
-      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', big: 1n } })
-    ).toHaveLength(1);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', big: 9999999999999999n } })).toHaveLength(0);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', big: 1n } })).toHaveLength(1);
   });
 
   syncTest('integer column NOT IN [1] excludes 1n and admits 2n', ({ sync }) => {
@@ -89,11 +77,7 @@ streams:
     query: SELECT * FROM docs WHERE state NOT IN '["foo"]'
 `);
 
-    expect(
-      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', state: 'foo' } })
-    ).toHaveLength(0);
-    expect(
-      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', state: 'bar' } })
-    ).toHaveLength(1);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', state: 'foo' } })).toHaveLength(0);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', state: 'bar' } })).toHaveLength(1);
   });
 });

--- a/packages/sync-rules/test/src/sync_plan/evaluator/not_in_type_affinity.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/not_in_type_affinity.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect } from 'vitest';
+import { TestSourceTable } from '../../util.js';
+import { syncTest } from './utils.js';
+
+describe('NOT IN scalar JSON array — type affinity', () => {
+  const DOCS = new TestSourceTable('docs');
+
+  syncTest('boolean column NOT IN [true] excludes the matching row', ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+    auto_subscribe: true
+    query: SELECT * FROM docs WHERE flag NOT IN '[true]'
+`);
+
+    expect(
+      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', flag: 1n } })
+    ).toHaveLength(0);
+    expect(
+      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', flag: 0n } })
+    ).toHaveLength(1);
+  });
+
+  syncTest('boolean column IN [true] admits only the matching row', ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+    auto_subscribe: true
+    query: SELECT * FROM docs WHERE flag IN '[true]'
+`);
+
+    expect(
+      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', flag: 1n } })
+    ).toHaveLength(1);
+    expect(
+      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', flag: 0n } })
+    ).toHaveLength(0);
+  });
+
+  syncTest('large bigint column NOT IN keeps precision via JSONBig parse', ({ sync }) => {
+    // 9999999999999999 exceeds Number.MAX_SAFE_INTEGER; JSON.parse would round it.
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+    auto_subscribe: true
+    query: SELECT * FROM docs WHERE big NOT IN '[9999999999999999]'
+`);
+
+    expect(
+      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', big: 9999999999999999n } })
+    ).toHaveLength(0);
+    expect(
+      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', big: 1n } })
+    ).toHaveLength(1);
+  });
+
+  syncTest('integer column NOT IN [1] excludes 1n and admits 2n', ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+    auto_subscribe: true
+    query: SELECT * FROM docs WHERE n NOT IN '[1]'
+`);
+
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', n: 1n } })).toHaveLength(0);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', n: 2n } })).toHaveLength(1);
+  });
+
+  syncTest('string variant still works (regression guard)', ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+    auto_subscribe: true
+    query: SELECT * FROM docs WHERE state NOT IN '["foo"]'
+`);
+
+    expect(
+      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', state: 'foo' } })
+    ).toHaveLength(0);
+    expect(
+      desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', state: 'bar' } })
+    ).toHaveLength(1);
+  });
+});

--- a/packages/sync-rules/test/src/sync_plan/evaluator/not_in_type_affinity.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/not_in_type_affinity.test.ts
@@ -66,6 +66,22 @@ streams:
     expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', n: 2n } })).toHaveLength(1);
   });
 
+  // TODO: unskip once json_each in TableValuedFunctions.ts uses JSONBig (behind a CompatibilityOption).
+  syncTest.skip('large bigint column IN keeps precision', ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  stream:
+    auto_subscribe: true
+    query: SELECT * FROM docs WHERE big IN '[9999999999999999]'
+`);
+
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'a', big: 9999999999999999n } })).toHaveLength(1);
+    expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'b', big: 1n } })).toHaveLength(0);
+  });
+
   syncTest('string variant still works (regression guard)', ({ sync }) => {
     const desc = sync.prepareSyncStreams(`
 config:


### PR DESCRIPTION
This pull request addresses issues with evaluating `IN` and `NOT IN` operators against scalar JSON arrays in SQLite, ensuring proper type affinity for booleans and large integers. The changes improve how values are compared, especially for booleans and integers larger than 2^53, and adds tests to prevent regressions.

### AI Usage
A large portion of the tests were written using Claude, but the results were manually verified.