### PR TITLE
Fix sync rules overlap evaluator

### DIFF
--- a/.changeset/fix-sync-rules-overlap-evaluator.md
+++ b/.changeset/fix-sync-rules-overlap-evaluator.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix the `&&` (overlap) operator on JSON arrays so it correctly tests intersection. Also compares array elements with SQLite affinity so `&&` handles bigint/number mixes consistently.

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -662,10 +662,11 @@ export function evaluateOperator(op: string, a: SqliteValue, b: SqliteValue): Sq
       }
 
       const aParsed = checkJsonArray(a, '&& is only supported on JSON arrays');
-      const bParsed = checkJsonArray(a, '&& is only supported on JSON arrays');
+      const bParsed = checkJsonArray(b, '&& is only supported on JSON arrays');
 
-      for (const elementInA in aParsed) {
-        if (bParsed.includes(elementInA)) {
+      // Use compare() for SQLite affinity since Array.includes strict equality mismatches bigint vs number.
+      for (const elementInA of aParsed) {
+        if (bParsed.some((v) => compare(v, elementInA) === 0)) {
           return sqliteBool(true);
         }
       }

--- a/packages/sync-rules/test/src/sql_operators.test.ts
+++ b/packages/sync-rules/test/src/sql_operators.test.ts
@@ -129,4 +129,31 @@ describe('SQL operators', () => {
     expect(evaluateOperator('-', 3n, '2.0')).toStrictEqual(1.0);
     expect(evaluateOperator('-', '3', '2.0')).toStrictEqual(1.0);
   });
+
+  test('&&', () => {
+    // null short-circuit
+    expect(evaluateOperator('&&', null, '["foo"]')).toStrictEqual(null);
+    expect(evaluateOperator('&&', '["foo"]', null)).toStrictEqual(null);
+
+    // disjoint arrays
+    expect(evaluateOperator('&&', '["bar"]', '["foo"]')).toStrictEqual(0n);
+    expect(evaluateOperator('&&', '[]', '["foo"]')).toStrictEqual(0n);
+    expect(evaluateOperator('&&', '["foo"]', '[]')).toStrictEqual(0n);
+
+    // overlapping arrays
+    expect(evaluateOperator('&&', '["foo"]', '["foo"]')).toStrictEqual(1n);
+    expect(evaluateOperator('&&', '["bar","foo"]', '["foo"]')).toStrictEqual(1n);
+    expect(evaluateOperator('&&', '["foo"]', '["bar","foo"]')).toStrictEqual(1n);
+
+    // regression: index-like string on the left must not satisfy any right-hand array.
+    // The previous implementation iterated indexes of the left array, so "0" would
+    // overlap any non-empty right-hand array.
+    expect(evaluateOperator('&&', '["0"]', '["foo"]')).toStrictEqual(0n);
+    expect(evaluateOperator('&&', '["0","1"]', '["foo","bar"]')).toStrictEqual(0n);
+    expect(evaluateOperator('&&', '["0"]', '["0"]')).toStrictEqual(1n);
+
+    // numeric affinity: bigint on one side, number on the other should still match.
+    expect(evaluateOperator('&&', '[1]', '[1]')).toStrictEqual(1n);
+    expect(evaluateOperator('&&', '[1,2,3]', '[4,3]')).toStrictEqual(1n);
+  });
 });

--- a/packages/sync-rules/test/src/streams.test.ts
+++ b/packages/sync-rules/test/src/streams.test.ts
@@ -524,10 +524,8 @@ describe('streams', () => {
     });
 
     test('token array against literal (request filter)', async () => {
-      // Regression for the parameter-only && path: the left-hand array must only
+      // Regression test for the parameter-only && path: the left-hand array must only
       // satisfy the filter when it intersects the literal right-hand array.
-      // Previously, a left-hand array containing an index-like string such as "0"
-      // overlapped any right-hand array because the evaluator iterated indexes.
       const desc = parseStream(`SELECT * FROM comments WHERE auth.parameters() -> 'tags' && '["foo"]'`);
 
       expect(await queryBucketIds(desc, { tokenPayload: { sub: 'u1', tags: ['foo'] } })).toStrictEqual([

--- a/packages/sync-rules/test/src/streams.test.ts
+++ b/packages/sync-rules/test/src/streams.test.ts
@@ -528,9 +528,7 @@ describe('streams', () => {
       // satisfy the filter when it intersects the literal right-hand array.
       // Previously, a left-hand array containing an index-like string such as "0"
       // overlapped any right-hand array because the evaluator iterated indexes.
-      const desc = parseStream(
-        `SELECT * FROM comments WHERE auth.parameters() -> 'tags' && '["foo"]'`
-      );
+      const desc = parseStream(`SELECT * FROM comments WHERE auth.parameters() -> 'tags' && '["foo"]'`);
 
       expect(await queryBucketIds(desc, { tokenPayload: { sub: 'u1', tags: ['foo'] } })).toStrictEqual([
         '1#stream|0[]'

--- a/packages/sync-rules/test/src/streams.test.ts
+++ b/packages/sync-rules/test/src/streams.test.ts
@@ -522,6 +522,27 @@ describe('streams', () => {
         })
       ).toStrictEqual(['1#stream|0["issue_id"]']);
     });
+
+    test('token array against literal (request filter)', async () => {
+      // Regression for the parameter-only && path: the left-hand array must only
+      // satisfy the filter when it intersects the literal right-hand array.
+      // Previously, a left-hand array containing an index-like string such as "0"
+      // overlapped any right-hand array because the evaluator iterated indexes.
+      const desc = parseStream(
+        `SELECT * FROM comments WHERE auth.parameters() -> 'tags' && '["foo"]'`
+      );
+
+      expect(await queryBucketIds(desc, { tokenPayload: { sub: 'u1', tags: ['foo'] } })).toStrictEqual([
+        '1#stream|0[]'
+      ]);
+      expect(await queryBucketIds(desc, { tokenPayload: { sub: 'u1', tags: ['bar', 'foo'] } })).toStrictEqual([
+        '1#stream|0[]'
+      ]);
+      expect(await queryBucketIds(desc, { tokenPayload: { sub: 'u1', tags: ['bar'] } })).toStrictEqual([]);
+      expect(await queryBucketIds(desc, { tokenPayload: { sub: 'u1', tags: [] } })).toStrictEqual([]);
+      // Index-like string must not satisfy the filter.
+      expect(await queryBucketIds(desc, { tokenPayload: { sub: 'u1', tags: ['0'] } })).toStrictEqual([]);
+    });
   });
 
   describe('errors', () => {


### PR DESCRIPTION
### Problem

The `&&` evaluator parsed both operands from the left-hand side and iterated with `for...in`, so it checked array indexes instead of elements. Non-overlapping arrays could evaluate true (notably when the left contained "0") and overlapping arrays could evaluate false.

### Fix

Parse the right operand from `b`, iterate with `for...of`, and compare elements with `compare()` for SQLite affinity (matching `IN`).

### AI Usage

Claude used for generating tests. Verified with manual testing.