### PR TITLE
[Internal] Fixes for parameterValueEquality

### DIFF
--- a/packages/sync-rules/src/compiler/equality.ts
+++ b/packages/sync-rules/src/compiler/equality.ts
@@ -89,7 +89,7 @@ export class StableHasher {
             break;
           case 'number':
             const normalized = value || 0; // Ensure 0 and -0 have the same hash code.
-            buf.setFloat64(0, value, true);
+            buf.setFloat64(0, normalized, true);
             hasher.addHash(buf.getUint32(0, true));
             hasher.addHash(buf.getUint32(4, true));
             break;
@@ -98,6 +98,7 @@ export class StableHasher {
             buf.setBigInt64(0, value, true);
             hasher.addHash(buf.getUint32(0, true));
             hasher.addHash(buf.getUint32(4, true));
+            break;
           case 'boolean':
             hasher.addHash(value ? 0 : 1);
             break;

--- a/packages/sync-rules/test/src/compiler/equality.test.ts
+++ b/packages/sync-rules/test/src/compiler/equality.test.ts
@@ -30,6 +30,22 @@ describe('equality', () => {
   });
 });
 
+describe('parameterValueEquality', () => {
+  test('strings', () => {
+    expectEqual(StableHasher.parameterValueEquality, 'foo', 'foo');
+    expectNotEqual(StableHasher.parameterValueEquality, 'foo', 'bar');
+  });
+
+  test('numbers', () => {
+    expectEqual(StableHasher.parameterValueEquality, 42, 42);
+    expectNotEqual(StableHasher.parameterValueEquality, 1, 2);
+    expectEqual(StableHasher.parameterValueEquality, -0, 0);
+
+    expectEqual(StableHasher.parameterValueEquality, 42n, 42n);
+    expectNotEqual(StableHasher.parameterValueEquality, 10, 10n);
+  });
+});
+
 test('map', () => {
   const map = new HashMap(listEquality(stringEquality));
 

--- a/packages/sync-rules/test/src/compiler/equality.test.ts
+++ b/packages/sync-rules/test/src/compiler/equality.test.ts
@@ -39,6 +39,9 @@ describe('parameterValueEquality', () => {
   test('numbers', () => {
     expectEqual(StableHasher.parameterValueEquality, 42, 42);
     expectNotEqual(StableHasher.parameterValueEquality, 1, 2);
+    expectNotEqual(StableHasher.parameterValueEquality, 10, NaN);
+    expectNotEqual(StableHasher.parameterValueEquality, 0, NaN, true);
+    expectNotEqual(StableHasher.parameterValueEquality, NaN, NaN, true);
     expectEqual(StableHasher.parameterValueEquality, -0, 0);
 
     expectEqual(StableHasher.parameterValueEquality, 42n, 42n);
@@ -71,12 +74,14 @@ function expectEqual<T>(equality: Equality<T>, a: T, b: T) {
   expect(StableHasher.hashWith(equality, a)).toEqual(StableHasher.hashWith(equality, b));
 }
 
-function expectNotEqual<T>(equality: Equality<T>, a: T, b: T) {
+function expectNotEqual<T>(equality: Equality<T>, a: T, b: T, allowCollision = false) {
   expect(equality.equals(a, b)).toBeFalsy();
 
   // This is technically incorrect, distinct objects are allowed to have the same hash code.
   // In practice, it's almost guaranteed to hold.
-  expect(StableHasher.hashWith(equality, a)).not.toEqual(StableHasher.hashWith(equality, b));
+  if (!allowCollision) {
+    expect(StableHasher.hashWith(equality, a)).not.toEqual(StableHasher.hashWith(equality, b));
+  }
 }
 
 const stringEquality: Equality<string> = {


### PR DESCRIPTION
Fixes minor issues in #633, picked up by Codex when scanning other changes.

As far as I can see, this did not cause any visible issues:
1. `hasher.addHash` effectively performs the same normalization internally, producing the same hash value for 0 and -0.
2. The missing `break` for the bigint case caused an extra value added to the hash, but did not break anything.
