### PR TITLE
Normalize host strings before IP validation

### DIFF
--- a/.changeset/fix-host-normalization.md
+++ b/.changeset/fix-host-normalization.md
@@ -1,0 +1,5 @@
+---
+'@powersync/lib-services-framework': patch
+---
+
+Normalize host strings in `validateIpHostname` before IP validation. Adds `hostWithoutPort`, which strips port suffixes and unwraps bracketed IPv6 literals, so values produced by `URL.hostname` and the `uri.hosts` entries returned by `mongodb-connection-string-url` are recognized as IPs.

--- a/.changeset/fix-host-normalization.md
+++ b/.changeset/fix-host-normalization.md
@@ -1,5 +1,7 @@
 ---
 '@powersync/lib-services-framework': patch
+'@powersync/lib-service-mongodb': patch
+'@powersync/service-core': patch
 ---
 
-Normalize host strings in `validateIpHostname` before IP validation. Adds `hostWithoutPort`, which strips port suffixes and unwraps bracketed IPv6 literals, so values produced by `URL.hostname` and the `uri.hosts` entries returned by `mongodb-connection-string-url` are recognized as IPs.
+Normalize socket addresses to bare hostnames before IP-range validation, so direct-IP literals with any port form are recognized as IPs.

--- a/libs/lib-mongodb/src/types/types.ts
+++ b/libs/lib-mongodb/src/types/types.ts
@@ -1,5 +1,6 @@
 import {
   ErrorCode,
+  hostnameFromSocketAddress,
   LookupOptions,
   makeMultiHostnameLookupFunction,
   ServiceError
@@ -145,7 +146,8 @@ export function normalizeMongoConfig(options: BaseMongoConfigDecoded): Normalize
   const lookupOptions: LookupOptions = {
     reject_ip_ranges: options.reject_ip_ranges ?? []
   };
-  const lookup = makeMultiHostnameLookupFunction(uri.hosts, lookupOptions);
+  const hostnames = uri.hosts.map(hostnameFromSocketAddress);
+  const lookup = makeMultiHostnameLookupFunction(hostnames, lookupOptions);
 
   // Parse connection parameters from URL query string
   const connectionParams = parseMongoConnectionParams(uri.searchParams);

--- a/libs/lib-mongodb/test/src/config.test.ts
+++ b/libs/lib-mongodb/test/src/config.test.ts
@@ -163,6 +163,21 @@ describe('config', () => {
     expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
   });
 
+  test('Should reject an IP host with an empty explicit port', async () => {
+    let err: ServiceError | undefined;
+    try {
+      normalizeMongoConfig({
+        type: 'mongodb',
+        uri: 'mongodb://127.0.0.1:/powersync_test',
+        reject_ip_ranges: ['127.0.0.1/0']
+      });
+    } catch (e) {
+      err = e as ServiceError;
+    }
+
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
   test('Should reject IP hosts with explicit ports in a replica-set host list', async () => {
     let err: ServiceError | undefined;
     try {
@@ -184,6 +199,21 @@ describe('config', () => {
       normalizeMongoConfig({
         type: 'mongodb',
         uri: 'mongodb://[::1]:27017/powersync_test',
+        reject_ip_ranges: ['::1/128']
+      });
+    } catch (e) {
+      err = e as ServiceError;
+    }
+
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('Should reject a bracketed IPv6 host with an empty explicit port', async () => {
+    let err: ServiceError | undefined;
+    try {
+      normalizeMongoConfig({
+        type: 'mongodb',
+        uri: 'mongodb://[::1]:/powersync_test',
         reject_ip_ranges: ['::1/128']
       });
     } catch (e) {

--- a/libs/lib-mongodb/test/src/config.test.ts
+++ b/libs/lib-mongodb/test/src/config.test.ts
@@ -148,6 +148,51 @@ describe('config', () => {
     expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
   });
 
+  test('Should reject an IP host with an explicit port', async () => {
+    let err: ServiceError | undefined;
+    try {
+      normalizeMongoConfig({
+        type: 'mongodb',
+        uri: 'mongodb://127.0.0.1:27017/powersync_test',
+        reject_ip_ranges: ['127.0.0.1/0']
+      });
+    } catch (e) {
+      err = e as ServiceError;
+    }
+
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('Should reject IP hosts with explicit ports in a replica-set host list', async () => {
+    let err: ServiceError | undefined;
+    try {
+      normalizeMongoConfig({
+        type: 'mongodb',
+        uri: 'mongodb://10.0.0.1:27017,127.0.0.1:27018/powersync_test?replicaSet=rs0',
+        reject_ip_ranges: ['127.0.0.1/0']
+      });
+    } catch (e) {
+      err = e as ServiceError;
+    }
+
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('Should reject a bracketed IPv6 host with an explicit port', async () => {
+    let err: ServiceError | undefined;
+    try {
+      normalizeMongoConfig({
+        type: 'mongodb',
+        uri: 'mongodb://[::1]:27017/powersync_test',
+        reject_ip_ranges: ['::1/128']
+      });
+    } catch (e) {
+      err = e as ServiceError;
+    }
+
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
   test('Should make a lookup function for multiple hosts', async () => {
     const lookup = normalizeMongoConfig({
       type: 'mongodb',

--- a/libs/lib-postgres/src/types/types.ts
+++ b/libs/lib-postgres/src/types/types.ts
@@ -80,6 +80,7 @@ export function normalizeConnectionConfig(options: BasePostgresConnectionConfigD
     uri = urijs.parse('postgresql:///');
   }
 
+  // urijs returns a normalized hostname; URL / mongodb-connection-string-url do not — see hostnameFromSocketAddress.
   const hostname = options.hostname ?? uri.host ?? '';
   const port = validatePort(options.port ?? uri.port ?? 5432);
 

--- a/libs/lib-services/src/ip/lookup.ts
+++ b/libs/lib-services/src/ip/lookup.ts
@@ -14,13 +14,15 @@ export interface LookupOptions {
  *
  * If one of the hostnames is an IP, this synchronously validates it.
  *
+ * Each entry must be a normalized hostname (no port, no IPv6 brackets); pass
+ * socket-address inputs through {@link hostnameFromSocketAddress} first.
+ *
  * @returns a function to use as the `lookup` option in `net.connect`.
  */
 export function makeMultiHostnameLookupFunction(
   hostnames: string[],
   lookupOptions: LookupOptions
 ): net.LookupFunction | undefined {
-  // If any of the hostnames are IPs, validate them synchronously
   for (let host of hostnames) {
     validateIpHostname(host, lookupOptions);
   }
@@ -32,6 +34,9 @@ export function makeMultiHostnameLookupFunction(
  * Generate a custom DNS lookup function, that rejects specific IP ranges.
  *
  * If hostname is an IP, this synchronously validates it.
+ *
+ * `hostname` must be normalized (no port, no IPv6 brackets); pass socket-address
+ * inputs through {@link hostnameFromSocketAddress} first.
  *
  * @returns a function to use as the `lookup` option in `net.connect`.
  */
@@ -73,24 +78,20 @@ export function makeLookupFunction(lookupOptions: LookupOptions): net.LookupFunc
 }
 
 /**
- * Validate IPs synchronously.
+ * Validate IPs synchronously. If the hostname is not an IP, this does nothing.
  *
- * If the hostname is not an ip, this does nothing.
- *
- * @param hostname IP or DNS name
- * @param options
+ * `hostname` must be normalized (no port, no IPv6 brackets); pass socket-address
+ * inputs through {@link hostnameFromSocketAddress} first, otherwise `[::1]` or
+ * `host:port` will fail `ip.isValid` and silently fall through to the DNS path.
  */
 export function validateIpHostname(hostname: string, options: LookupOptions): void {
   const { reject_ip_ranges: reject_ranges } = options;
-  // `URL.hostname` exposes IPv6 literals wrapped in brackets (e.g. `[::1]`);
-  // normalize so the IP check recognizes them.
-  const ipaddr = hostWithoutPort(hostname);
-  if (!ip.isValid(ipaddr)) {
+  if (!ip.isValid(hostname)) {
     // Treat as a DNS name.
     return;
   }
 
-  const parsed = ip.parse(ipaddr);
+  const parsed = ip.parse(hostname);
   const rejectLocal = reject_ranges.includes('local');
   const rejectSubnets = reject_ranges.filter((range) => range != 'local');
 
@@ -102,7 +103,7 @@ export function validateIpHostname(hostname: string, options: LookupOptions): vo
 
   if (ip.subnetMatch(parsed, reject) == 'blocked') {
     // Ranges explicitly blocked, e.g. private IPv6 ranges
-    throw new ServiceError(ErrorCode.PSYNC_S2203, `IPs in this range are not supported: ${ipaddr}`);
+    throw new ServiceError(ErrorCode.PSYNC_S2203, `IPs in this range are not supported: ${hostname}`);
   }
 
   if (!rejectLocal) {
@@ -117,33 +118,22 @@ export function validateIpHostname(hostname: string, options: LookupOptions): vo
     return;
   } else {
     // Do not connect to any reserved IPs, including loopback and private ranges
-    throw new ServiceError(ErrorCode.PSYNC_S2203, `IPs in this range are not supported: ${ipaddr}`);
+    throw new ServiceError(ErrorCode.PSYNC_S2203, `IPs in this range are not supported: ${hostname}`);
   }
 }
 
 /**
- * Return the bare hostname from a `host[:port]`-style authority string.
- *
- * Accepts `hostname`, `hostname:port`, `[::1]`, `[::1]:port`, and bare IPv6 literals like `::1`.
+ * Normalize a socket address (`host[:port]`, with IPv6 hosts optionally bracketed)
+ * to a bare hostname. Used for `URL.host`/`URL.hostname` and
+ * `mongodb-connection-string-url`'s `uri.hosts` entries. Non-IP input is returned
+ * unchanged (downstream falls through to the DNS path).
  */
-export function hostWithoutPort(host: string): string {
-  if (host.startsWith('[')) {
-    const end = host.indexOf(']');
-    if (end > 0) {
-      return host.substring(1, end);
-    }
-    return host;
+export function hostnameFromSocketAddress(socketAddress: string): string {
+  const parsed = net.SocketAddress.parse(socketAddress);
+  if (parsed != null) {
+    return parsed.address;
   }
-  const firstColon = host.indexOf(':');
-  const lastColon = host.lastIndexOf(':');
-  if (firstColon !== lastColon) {
-    // Multiple colons => bare IPv6 literal; no port suffix possible.
-    return host;
-  }
-  if (firstColon > 0 && /^\d+$/.test(host.substring(firstColon + 1))) {
-    return host.substring(0, firstColon);
-  }
-  return host;
+  return socketAddress;
 }
 
 /**

--- a/libs/lib-services/src/ip/lookup.ts
+++ b/libs/lib-services/src/ip/lookup.ts
@@ -82,12 +82,13 @@ export function makeLookupFunction(lookupOptions: LookupOptions): net.LookupFunc
  */
 export function validateIpHostname(hostname: string, options: LookupOptions): void {
   const { reject_ip_ranges: reject_ranges } = options;
-  if (!ip.isValid(hostname)) {
+  // `URL.hostname` exposes IPv6 literals wrapped in brackets (e.g. `[::1]`);
+  // normalize so the IP check recognizes them.
+  const ipaddr = hostWithoutPort(hostname);
+  if (!ip.isValid(ipaddr)) {
     // Treat as a DNS name.
     return;
   }
-
-  const ipaddr = hostname;
 
   const parsed = ip.parse(ipaddr);
   const rejectLocal = reject_ranges.includes('local');
@@ -118,6 +119,31 @@ export function validateIpHostname(hostname: string, options: LookupOptions): vo
     // Do not connect to any reserved IPs, including loopback and private ranges
     throw new ServiceError(ErrorCode.PSYNC_S2203, `IPs in this range are not supported: ${ipaddr}`);
   }
+}
+
+/**
+ * Return the bare hostname from a `host[:port]`-style authority string.
+ *
+ * Accepts `hostname`, `hostname:port`, `[::1]`, `[::1]:port`, and bare IPv6 literals like `::1`.
+ */
+export function hostWithoutPort(host: string): string {
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']');
+    if (end > 0) {
+      return host.substring(1, end);
+    }
+    return host;
+  }
+  const firstColon = host.indexOf(':');
+  const lastColon = host.lastIndexOf(':');
+  if (firstColon !== lastColon) {
+    // Multiple colons => bare IPv6 literal; no port suffix possible.
+    return host;
+  }
+  if (firstColon > 0 && /^\d+$/.test(host.substring(firstColon + 1))) {
+    return host.substring(0, firstColon);
+  }
+  return host;
 }
 
 /**

--- a/libs/lib-services/test/src/lookup.test.ts
+++ b/libs/lib-services/test/src/lookup.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { ErrorCode, ServiceError } from '../../src/errors/errors-index.js';
-import { hostWithoutPort, validateIpHostname } from '../../src/ip/lookup.js';
+import { hostnameFromSocketAddress, validateIpHostname } from '../../src/ip/lookup.js';
 
 function captureValidationError(hostname: string, options: { reject_ip_ranges: string[]; reject_ipv6?: boolean }) {
   let err: ServiceError | undefined;
@@ -19,59 +19,73 @@ describe('validateIpHostname', () => {
     expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
   });
 
-  test('rejects an IPv4 literal with an explicit port', () => {
-    const err = captureValidationError('127.0.0.1:8080', { reject_ip_ranges: ['local'] });
+  test('rejects a bare IPv6 literal in a blocked range', () => {
+    const err = captureValidationError('::1', { reject_ip_ranges: ['local'] });
     expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('rejects a bare IPv6 literal against an explicit CIDR', () => {
+    const err = captureValidationError('::1', { reject_ip_ranges: ['::1/128'] });
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('rejects a bare IPv6 literal when reject_ipv6 is set', () => {
+    const err = captureValidationError('::1', { reject_ip_ranges: [], reject_ipv6: true });
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2202);
   });
 
   test('treats unknown hostnames as DNS names', () => {
     expect(captureValidationError('example.com', { reject_ip_ranges: ['local'] })).toBeUndefined();
   });
 
-  test('rejects a bracketed IPv6 loopback literal as used by URL.hostname', () => {
-    const err = captureValidationError('[::1]', { reject_ip_ranges: ['local'] });
-    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
-  });
-
-  test('rejects a bracketed IPv6 literal against an explicit CIDR', () => {
-    const err = captureValidationError('[::1]', { reject_ip_ranges: ['::1/128'] });
-    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
-  });
-
-  test('rejects a bracketed IPv6 literal when reject_ipv6 is set', () => {
-    const err = captureValidationError('[::1]', { reject_ip_ranges: [], reject_ipv6: true });
-    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2202);
+  test('treats a port-suffixed input as a DNS name (precondition: caller normalizes first)', () => {
+    expect(captureValidationError('127.0.0.1:5432', { reject_ip_ranges: ['local'] })).toBeUndefined();
   });
 });
 
-describe('hostWithoutPort', () => {
-  test('returns a bare hostname unchanged', () => {
-    expect(hostWithoutPort('example.com')).toEqual('example.com');
+describe('hostnameFromSocketAddress', () => {
+  test('returns a bare IPv4 unchanged', () => {
+    expect(hostnameFromSocketAddress('127.0.0.1')).toEqual('127.0.0.1');
   });
 
-  test('strips a port suffix from a hostname', () => {
-    expect(hostWithoutPort('example.com:8080')).toEqual('example.com');
+  test('strips an explicit IPv4 port', () => {
+    expect(hostnameFromSocketAddress('127.0.0.1:27017')).toEqual('127.0.0.1');
   });
 
-  test('strips a port suffix from an IPv4 literal', () => {
-    expect(hostWithoutPort('127.0.0.1:27017')).toEqual('127.0.0.1');
+  test('strips an empty IPv4 port', () => {
+    expect(hostnameFromSocketAddress('127.0.0.1:')).toEqual('127.0.0.1');
+  });
+
+  test('strips a zero IPv4 port', () => {
+    expect(hostnameFromSocketAddress('127.0.0.1:0')).toEqual('127.0.0.1');
   });
 
   test('unwraps a bracketed IPv6 literal', () => {
-    expect(hostWithoutPort('[::1]')).toEqual('::1');
+    expect(hostnameFromSocketAddress('[::1]')).toEqual('::1');
   });
 
   test('unwraps a bracketed IPv6 literal with a port', () => {
-    expect(hostWithoutPort('[::1]:27017')).toEqual('::1');
+    expect(hostnameFromSocketAddress('[::1]:27017')).toEqual('::1');
   });
 
-  test('leaves a bare IPv6 literal unchanged', () => {
-    // IPv6 with a port is always bracketed; bare multi-colon input has no port to strip.
-    expect(hostWithoutPort('::1')).toEqual('::1');
-    expect(hostWithoutPort('2001:db8::1')).toEqual('2001:db8::1');
+  test('unwraps a bracketed IPv6 literal with an empty port', () => {
+    expect(hostnameFromSocketAddress('[::1]:')).toEqual('::1');
   });
 
-  test('leaves trailing non-numeric segments alone', () => {
-    expect(hostWithoutPort('example.com:not-a-port')).toEqual('example.com:not-a-port');
+  test('returns a bare IPv6 literal unchanged', () => {
+    expect(hostnameFromSocketAddress('::1')).toEqual('::1');
+    expect(hostnameFromSocketAddress('2001:db8::1')).toEqual('2001:db8::1');
+  });
+
+  test('returns DNS names unchanged', () => {
+    expect(hostnameFromSocketAddress('example.com')).toEqual('example.com');
+  });
+
+  test('returns DNS-with-port unchanged (not an IP socket address)', () => {
+    expect(hostnameFromSocketAddress('example.com:8080')).toEqual('example.com:8080');
+  });
+
+  test('returns IPv4 with a non-numeric port unchanged', () => {
+    expect(hostnameFromSocketAddress('127.0.0.1:abc')).toEqual('127.0.0.1:abc');
   });
 });

--- a/libs/lib-services/test/src/lookup.test.ts
+++ b/libs/lib-services/test/src/lookup.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+
+import { ErrorCode, ServiceError } from '../../src/errors/errors-index.js';
+import { hostWithoutPort, validateIpHostname } from '../../src/ip/lookup.js';
+
+function captureValidationError(hostname: string, options: { reject_ip_ranges: string[]; reject_ipv6?: boolean }) {
+  let err: ServiceError | undefined;
+  try {
+    validateIpHostname(hostname, options);
+  } catch (e) {
+    err = e as ServiceError;
+  }
+  return err;
+}
+
+describe('validateIpHostname', () => {
+  test('rejects an IPv4 literal in a blocked range', () => {
+    const err = captureValidationError('127.0.0.1', { reject_ip_ranges: ['local'] });
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('rejects an IPv4 literal with an explicit port', () => {
+    const err = captureValidationError('127.0.0.1:8080', { reject_ip_ranges: ['local'] });
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('treats unknown hostnames as DNS names', () => {
+    expect(captureValidationError('example.com', { reject_ip_ranges: ['local'] })).toBeUndefined();
+  });
+
+  test('rejects a bracketed IPv6 loopback literal as used by URL.hostname', () => {
+    const err = captureValidationError('[::1]', { reject_ip_ranges: ['local'] });
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('rejects a bracketed IPv6 literal against an explicit CIDR', () => {
+    const err = captureValidationError('[::1]', { reject_ip_ranges: ['::1/128'] });
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2203);
+  });
+
+  test('rejects a bracketed IPv6 literal when reject_ipv6 is set', () => {
+    const err = captureValidationError('[::1]', { reject_ip_ranges: [], reject_ipv6: true });
+    expect(err?.toJSON().code).toEqual(ErrorCode.PSYNC_S2202);
+  });
+});
+
+describe('hostWithoutPort', () => {
+  test('returns a bare hostname unchanged', () => {
+    expect(hostWithoutPort('example.com')).toEqual('example.com');
+  });
+
+  test('strips a port suffix from a hostname', () => {
+    expect(hostWithoutPort('example.com:8080')).toEqual('example.com');
+  });
+
+  test('strips a port suffix from an IPv4 literal', () => {
+    expect(hostWithoutPort('127.0.0.1:27017')).toEqual('127.0.0.1');
+  });
+
+  test('unwraps a bracketed IPv6 literal', () => {
+    expect(hostWithoutPort('[::1]')).toEqual('::1');
+  });
+
+  test('unwraps a bracketed IPv6 literal with a port', () => {
+    expect(hostWithoutPort('[::1]:27017')).toEqual('::1');
+  });
+
+  test('leaves a bare IPv6 literal unchanged', () => {
+    // IPv6 with a port is always bracketed; bare multi-colon input has no port to strip.
+    expect(hostWithoutPort('::1')).toEqual('::1');
+    expect(hostWithoutPort('2001:db8::1')).toEqual('2001:db8::1');
+  });
+
+  test('leaves trailing non-numeric segments alone', () => {
+    expect(hostWithoutPort('example.com:not-a-port')).toEqual('example.com:not-a-port');
+  });
+});

--- a/packages/service-core/src/auth/RemoteJWKSCollector.ts
+++ b/packages/service-core/src/auth/RemoteJWKSCollector.ts
@@ -5,6 +5,7 @@ import fetch from 'node-fetch';
 import {
   AuthorizationError,
   ErrorCode,
+  hostnameFromSocketAddress,
   LookupOptions,
   makeHostnameLookupFunction,
   ServiceAssertionError,
@@ -140,7 +141,8 @@ export class RemoteJWKSCollector implements KeyCollector {
    */
   resolveAgent(): http.Agent | https.Agent {
     const lookupOptions = this.options?.lookupOptions ?? { reject_ip_ranges: [] };
-    const lookup = makeHostnameLookupFunction(this.url.hostname, lookupOptions);
+    const hostname = hostnameFromSocketAddress(this.url.hostname);
+    const lookup = makeHostnameLookupFunction(hostname, lookupOptions);
 
     const options: http.AgentOptions = {
       lookup

--- a/packages/service-core/test/src/auth.test.ts
+++ b/packages/service-core/test/src/auth.test.ts
@@ -484,6 +484,17 @@ describe('JWT Auth', () => {
           }
         })
     ).toThrowError('IPs in this range are not supported');
+
+    // `URL.hostname` exposes IPv6 literals wrapped in brackets; ensure they are
+    // handled like other direct-IP cases.
+    expect(
+      () =>
+        new RemoteJWKSCollector('https://[::1]/.well-known/jwks.json', {
+          lookupOptions: {
+            reject_ip_ranges: ['local']
+          }
+        })
+    ).toThrowError('IPs in this range are not supported');
   });
 
   test('http not blocking local IPs', async () => {


### PR DESCRIPTION
Normalizes the host string inside `validateIpHostname` so that direct-IP literals coming from URL parsers are recognized as IPs (instead of falling through to the DNS path).

Two upstream parsers produce host strings that didn't match the previous `ip.isValid(hostname)` check:
- `URL.hostname` wraps IPv6 literals in brackets `new URL('https://[::1]/').hostname === '[::1]'`.
- `mongodb-connection-string-url` returns `uri.hosts` entries as `host:port`, `[::1]`, or `[::1]:port`.

Adds a small `hostWithoutPort` helper that strips a `:port` suffix and unwraps bracketed IPv6, called from `validateIpHostname` before `ip.isValid`.

### AI Usage
Tests and codebase exploration done with Claude. Verified issues and fix correctness.