### PR TITLE
Fix Sync Streams iif arity validation

### DIFF
--- a/.changeset/fix-sync-streams-iif-arity.md
+++ b/.changeset/fix-sync-streams-iif-arity.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Validate `iif()` calls with the same three-argument arity used by the sync stream evaluator.

--- a/packages/sync-rules/src/sync_plan/expression.ts
+++ b/packages/sync-rules/src/sync_plan/expression.ts
@@ -143,7 +143,7 @@ export const supportedFunctions: Record<string, ArgumentCount> = {
   hex: 1,
   ifnull: { min: 2 },
   //if: { min: 2 },
-  iif: { min: 2 },
+  iif: 3,
   instr: 2,
   length: 1,
   // TODO: Establish defaults for case sensitivity, changing escape characters, ICU support.

--- a/packages/sync-rules/test/src/compiler/sqlite.test.ts
+++ b/packages/sync-rules/test/src/compiler/sqlite.test.ts
@@ -85,6 +85,22 @@ describe('sqlite conversion', () => {
         ]);
       });
 
+      test('iif requires exactly three args', () => {
+        expect(translate('iif(1, 2)')[1]).toStrictEqual([
+          {
+            message: 'Expected at least 3 arguments',
+            source: 'iif(1, 2)'
+          }
+        ]);
+
+        expect(translate('iif(1, 2, 3, 4)')[1]).toStrictEqual([
+          {
+            message: 'Expected at most 3 arguments',
+            source: 'iif(1, 2, 3, 4)'
+          }
+        ]);
+      });
+
       test.skip('must be even', () => {
         expect(translate("json_object('foo')")[1]).toStrictEqual([
           {


### PR DESCRIPTION
## Summary
- validate Sync Streams `iif()` calls with the same three-argument arity used by the evaluator
- add compiler regressions for two-arg and four-arg `iif()` calls
- add a patch changeset for `@powersync/service-sync-rules`

## Why
`iif` is implemented and documented as `iif(x, y, z)`, but the compiler previously accepted any call with at least two arguments. That allowed invalid sync definitions such as `iif(1, 2)` or `iif(1, 2, 3, 4)` through validation even though the runtime implementation only consumes three arguments.

## Verification
- `corepack pnpm --filter @powersync/service-sync-rules exec vitest run test/src/compiler/sqlite.test.ts`
- `corepack pnpm --filter @powersync/service-sync-rules build:tsc`