### PR TITLE
Fix Sync Streams signed string casts

### DIFF
--- a/.changeset/fix-sync-streams-signed-cast.md
+++ b/.changeset/fix-sync-streams-signed-cast.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix SQLite-compatible casts from signed numeric strings in Sync Streams expressions.

--- a/packages/sync-rules/src/cast.ts
+++ b/packages/sync-rules/src/cast.ts
@@ -101,23 +101,25 @@ export function cast(value: SqliteValue, to: string) {
 }
 
 function parseNumeric(text: string): bigint | number {
-  const match = /^\s*(\d+)(\.\d*)?(e[+\-]?\d+)?/i.exec(text);
+  const match = /^\s*([+\-]?)(?:(\d+)(\.\d*)?|\.(\d+))(e[+\-]?\d+)?/i.exec(text);
   if (!match) {
     return 0n;
   }
 
-  if (match[2] != null || match[3] != null) {
+  if (match[3] != null || match[4] != null || match[5] != null) {
     const v = parseFloat(match[0]);
     return isNaN(v) ? 0n : v;
   } else {
-    return BigInt(match[1]);
+    const sign = match[1] == '-' ? '-' : '';
+    return BigInt(`${sign}${match[2]}`);
   }
 }
 
 function parseBigInt(text: string): bigint {
-  const match = /^\s*(\d+)/.exec(text);
+  const match = /^\s*([+\-]?)(\d+)/.exec(text);
   if (!match) {
     return 0n;
   }
-  return BigInt(match[1]);
+  const sign = match[1] == '-' ? '-' : '';
+  return BigInt(`${sign}${match[2]}`);
 }

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -230,6 +230,13 @@ describe('SQL functions', () => {
     expect(cast('1.2abc', 'real')).toEqual(1.2);
     expect(cast('1.2e60abc', 'numeric')).toEqual(1.2e60);
     expect(cast(' 1e60abc', 'numeric')).toEqual(1e60);
+    expect(cast('-12abc', 'integer')).toEqual(-12n);
+    expect(cast('+12abc', 'integer')).toEqual(12n);
+    expect(cast('-12.9abc', 'integer')).toEqual(-12n);
+    expect(cast('-12.5abc', 'numeric')).toEqual(-12.5);
+    expect(cast('-.5abc', 'numeric')).toEqual(-0.5);
+    expect(cast('+1.2e2abc', 'numeric')).toEqual(120);
+    expect(cast('-1.2e2abc', 'numeric')).toEqual(-120);
 
     // We differ from SQLite here
     expect(cast('abc', 'blob')).toEqual(Uint8Array.of(0x61, 0x62, 0x63));

--- a/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
@@ -109,6 +109,23 @@ function defineEngineTests(
     expect(stmt.evaluate([3])).toStrictEqual([[isJavaScript ? '3' : '3.0']]);
   });
 
+  test('signed string casts', () => {
+    const integerStmt = prepare({
+      outputs: [{ type: 'cast', operand: { type: 'data', source: 1 }, cast_as: 'integer' }]
+    });
+    const numericStmt = prepare({
+      outputs: [{ type: 'cast', operand: { type: 'data', source: 1 }, cast_as: 'numeric' }]
+    });
+
+    expect(integerStmt.evaluate(['-12abc'])).toStrictEqual([[-12n]]);
+    expect(integerStmt.evaluate(['+12abc'])).toStrictEqual([[12n]]);
+    expect(integerStmt.evaluate(['-12.9abc'])).toStrictEqual([[-12n]]);
+    expect(numericStmt.evaluate(['-12.5abc'])).toStrictEqual([[-12.5]]);
+    expect(numericStmt.evaluate(['-.5abc'])).toStrictEqual([[-0.5]]);
+    expect(numericStmt.evaluate(['+1.2e2abc'])).toStrictEqual([[isJavaScript ? 120 : 120n]]);
+    expect(numericStmt.evaluate(['-1.2e2abc'])).toStrictEqual([[isJavaScript ? -120 : -120n]]);
+  });
+
   test('unary not', () => {
     const stmt = prepare({ outputs: [{ type: 'unary', operator: 'not', operand: { type: 'data', source: 1 } }] });
 


### PR DESCRIPTION
## Summary

Fix Sync Streams expression evaluation for SQLite-style casts from signed numeric strings. The JavaScript evaluator previously parsed only unsigned numeric prefixes, so values like `CAST('-12' AS integer)` and `CAST('-.5' AS numeric)` evaluated as `0` instead of matching SQLite.

## Why this matters

Sync rules can cast request parameters or JSON/text values before filtering rows. A signed value in a parameter or source row could therefore select the wrong rows in the JavaScript evaluator compared with SQLite semantics.

## Changes

- Allow optional `+` / `-` prefixes when parsing integer casts from strings.
- Allow signed decimal and exponent forms for numeric casts, including `.5` / `-.5`.
- Add direct cast tests and scalar expression engine coverage.
- Add a changeset for `@powersync/service-sync-rules`.

## Verification

- `corepack pnpm --dir packages/sync-rules exec vitest test/src/sql_functions.test.ts --run`
- `corepack pnpm --dir packages/sync-rules exec vitest test/src/sync_plan/engine/engine.test.ts --run -t "javascript.*signed string casts|javascript"`
- `corepack pnpm --dir packages/sync-rules run build:tsc`

Note: running the full scalar engine test file against local Node v23.7.0 fails in the existing SQLite-engine tests because Node's experimental `node:sqlite` returns object rows instead of the array rows expected by the suite. The JavaScript evaluator path and pure cast tests pass locally.