### PR TITLE
Fix Sync Streams division by zero semantics

### DIFF
--- a/.changeset/quiet-lemons-divide.md
+++ b/.changeset/quiet-lemons-divide.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix Sync Streams division by zero semantics

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -744,6 +744,10 @@ function doMath(op: string, a: SqliteValue, b: SqliteValue) {
   let na = cast(a, 'numeric') as number | bigint;
   let nb = cast(b, 'numeric') as number | bigint;
 
+  if (op == '/' && nb == 0) {
+    return null;
+  }
+
   if (typeof na == 'bigint' && typeof nb != 'bigint') {
     // bigint, real
     na = Number(na);

--- a/packages/sync-rules/test/src/sql_operators.test.ts
+++ b/packages/sync-rules/test/src/sql_operators.test.ts
@@ -110,6 +110,14 @@ describe('SQL operators', () => {
     expect(evaluateOperator('/', 5n, '2.0')).toStrictEqual(2.5);
   });
 
+  test('division by zero follows SQLite null semantics', () => {
+    expect(evaluateOperator('/', 5n, 0n)).toStrictEqual(null);
+    expect(evaluateOperator('/', 5n, 0)).toStrictEqual(null);
+    expect(evaluateOperator('/', 5, 0)).toStrictEqual(null);
+    expect(evaluateOperator('/', -5n, '0')).toStrictEqual(null);
+    expect(evaluateOperator('/', 0n, 0n)).toStrictEqual(null);
+  });
+
   test('*', () => {
     expect(evaluateOperator('*', 3n, null)).toStrictEqual(null);
     expect(evaluateOperator('*', 3n, 2)).toStrictEqual(6);


### PR DESCRIPTION
## Summary

This fixes a Sync Streams JavaScript evaluator divergence from SQLite around division by zero.

SQLite returns `NULL` for divide-by-zero expressions:

- `5 / 0`
- `5 / 0.0`
- `5 / '0'`
- `0 / 0`

The current JavaScript evaluator can instead return `Infinity` for real division by zero or throw for bigint division by zero. In filter expressions this can create evaluator errors or non-SQLite truthiness instead of SQLite's `NULL` result.

## Changes

- Return `null` from the shared math operator implementation when the division RHS casts to zero.
- Add regression coverage for bigint, number, string-cast, negative, and zero-over-zero cases.
- Add a patch changeset for `@powersync/service-sync-rules`.

## Verification

```text
sqlite3 :memory: "select typeof(5/0), 5/0, typeof(5/0.0), 5/0.0, typeof(5/'0'), 5/'0';"
# null||null||null|

corepack pnpm --dir packages/sync-rules exec vitest test/src/sql_operators.test.ts --run
# 15 passed

corepack pnpm --dir packages/sync-rules exec vitest test/src/sql_functions.test.ts --run --testTimeout=10000
# 25 passed

corepack pnpm --dir packages/sync-rules run build:tsc
# passed

git diff --check
# passed
```
