### PR TITLE
Fix Sync Streams json_each object and scalar evaluation

### DIFF
--- a/.changeset/fresh-rivers-each.md
+++ b/.changeset/fresh-rivers-each.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix Sync Streams json_each object and scalar evaluation.

--- a/packages/sync-rules/src/TableValuedFunctions.ts
+++ b/packages/sync-rules/src/TableValuedFunctions.ts
@@ -1,5 +1,5 @@
 import { CompatibilityContext, CompatibilityOption } from './compatibility.js';
-import { SqliteJsonValue, SqliteRow, SqliteValue } from './types.js';
+import { SqliteRow, SqliteValue } from './types.js';
 import { jsonValueToSqlite } from './utils.js';
 
 export interface TableValuedFunction {
@@ -22,25 +22,32 @@ function jsonEachImplementation(fixedJsonBehavior: boolean): TableValuedFunction
       } else if (typeof valueString !== 'string') {
         throw new Error(`Expected json_each to be called with a string, got ${valueString}`);
       }
-      let values: SqliteJsonValue[] = [];
+      let value: unknown;
       try {
         // FIXME: This should use JsonBig to parse integers as bigints.
-        values = JSON.parse(valueString);
+        value = JSON.parse(valueString);
       } catch (e) {
         throw new Error('Expected JSON string');
       }
-      if (!Array.isArray(values)) {
-        throw new Error(`Expected an array, got ${valueString}`);
+
+      if (Array.isArray(value)) {
+        return value.map((v, key) => ({
+          key,
+          value: jsonValueToSqlite(fixedJsonBehavior, v)
+        }));
       }
 
-      return values.map((v) => {
-        return {
+      if (typeof value == 'object' && value != null) {
+        return Object.entries(value).map(([key, v]) => ({
+          key,
           value: jsonValueToSqlite(fixedJsonBehavior, v)
-        };
-      });
+        }));
+      }
+
+      return [{ key: null, value: jsonValueToSqlite(fixedJsonBehavior, value) }];
     },
-    detail: 'Each element of a JSON array',
-    documentation: 'Returns each element of a JSON array as a separate row.'
+    detail: 'Each element of a JSON value',
+    documentation: 'Returns each element of a JSON array or object as a separate row.'
   };
 }
 

--- a/packages/sync-rules/src/TableValuedFunctions.ts
+++ b/packages/sync-rules/src/TableValuedFunctions.ts
@@ -32,7 +32,7 @@ function jsonEachImplementation(fixedJsonBehavior: boolean): TableValuedFunction
 
       if (Array.isArray(value)) {
         return value.map((v, key) => ({
-          key,
+          key: BigInt(key),
           value: jsonValueToSqlite(fixedJsonBehavior, v)
         }));
       }

--- a/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
@@ -234,6 +234,28 @@ function defineEngineTests(
     ]);
   });
 
+  test('SELECT key, value FROM json_each(?) for objects and scalars', () => {
+    const fn: TableValuedFunction = {
+      name: 'json_each',
+      inputs: [{ type: 'data', source: 1 }]
+    };
+
+    const stmt = prepare({
+      outputs: [
+        { type: 'data', source: { function: fn, column: 'key' } },
+        { type: 'data', source: { function: fn, column: 'value' } }
+      ],
+      tableValuedFunctions: [fn]
+    });
+
+    expect(stmt.evaluate([JSON.stringify({ a: 1, b: true, c: null })])).toStrictEqual([
+      ['a', isJavaScript ? 1 : 1n],
+      ['b', 1n],
+      ['c', isJavaScript ? 'null' : null]
+    ]);
+    expect(stmt.evaluate(['42'])).toStrictEqual([[null, isJavaScript ? 42 : 42n]]);
+  });
+
   test('filters and multiple sources', () => {
     // SELECT a.value, b.value FROM json_each(?1) a, json_each(?2) b where length(a.value || b.value) > 5
     const a: TableValuedFunction = {

--- a/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
@@ -248,6 +248,10 @@ function defineEngineTests(
       tableValuedFunctions: [fn]
     });
 
+    expect(stmt.evaluate([JSON.stringify([1, 'two'])])).toStrictEqual([
+      [0n, isJavaScript ? 1 : 1n],
+      [1n, 'two']
+    ]);
     expect(stmt.evaluate([JSON.stringify({ a: 1, b: true, c: null })])).toStrictEqual([
       ['a', isJavaScript ? 1 : 1n],
       ['b', 1n],


### PR DESCRIPTION
This fixes a Sync Streams JavaScript evaluator divergence from SQLite around `json_each()`.

SQLite's `json_each()` emits rows for JSON arrays, JSON objects, and scalar JSON values:

```sql
SELECT key, value FROM json_each('{"a":1,"b":true}');
SELECT key, value FROM json_each('42');
```

The current JavaScript table-valued-function evaluator only accepts arrays, throws for objects, and cannot expose the `key` column. That means valid Sync Streams rules using object-shaped request/JWT/connection JSON can fail or diverge when evaluated by the JavaScript engine.

This PR:

- Keeps existing array behavior.
- Adds SQLite-compatible rows for JSON objects using object keys.
- Adds SQLite-compatible scalar handling with `key = null`.
- Exposes both `key` and `value` columns from the JavaScript evaluator.
- Adds focused engine coverage for object and scalar `json_each()` evaluation.
- Adds a patch changeset for `@powersync/service-sync-rules`.

Verification:

```bash
corepack pnpm --filter @powersync/service-sync-rules exec vitest --run test/src/sync_plan/engine/engine.test.ts -t "javascript.*json_each"
corepack pnpm --filter @powersync/service-sync-rules run build:tsc
git diff --check
```

Note: the local `node:sqlite` side of this engine test still hits the same local Node binding issue seen on earlier Sync Streams PR verification (`column index out of range` while binding table-valued JSON inputs), so I scoped the runnable local test command to the JavaScript evaluator path this patch changes.
