### PR TITLE
Add custom error handler for content-encoding honouring

### DIFF
--- a/.changeset/fix-error-handler-content-encoding.md
+++ b/.changeset/fix-error-handler-content-encoding.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Add a custom Fastify error handler so uncaught errors honour the negotiated `Content-Encoding` (gzip/zstd) instead of returning a header that doesn't match the body.

--- a/packages/service-core/src/routes/configure-fastify.ts
+++ b/packages/service-core/src/routes/configure-fastify.ts
@@ -1,6 +1,10 @@
 import type fastify from 'fastify';
 
-import { registerFastifyNotFoundHandler, registerFastifyRoutes } from './route-register.js';
+import {
+  registerFastifyErrorHandler,
+  registerFastifyNotFoundHandler,
+  registerFastifyRoutes
+} from './route-register.js';
 
 import * as system from '../system/system-index.js';
 
@@ -65,6 +69,9 @@ export function configureFastifyServer(server: fastify.FastifyInstance, options:
       logger: options.logger
     };
   };
+
+  // Set on the outer server so both child scopes inherit.
+  registerFastifyErrorHandler(server);
 
   /**
    * Fastify creates an encapsulated context for each `.register` call.

--- a/packages/service-core/src/routes/route-register.ts
+++ b/packages/service-core/src/routes/route-register.ts
@@ -2,7 +2,7 @@ import type fastify from 'fastify';
 import * as zlib from 'node:zlib';
 import * as uuid from 'uuid';
 
-import { errors, HTTPMethod, logger, RouteNotFound, router, ServiceError } from '@powersync/lib-services-framework';
+import { errors, HTTPMethod, logger, RouteNotFound, router } from '@powersync/lib-services-framework';
 import { FastifyReply } from 'fastify';
 import { Context, ContextProvider, RequestEndpoint, RequestEndpointHandlerPayload } from './router.js';
 
@@ -106,48 +106,84 @@ export function registerFastifyNotFoundHandler(app: fastify.FastifyInstance) {
   });
 }
 
-/**
- * Registers a custom error handler so uncaught errors surface with the same schema as other service errors,
- * and the synthesised body honours any negotiated `Content-Encoding`.
- */
+/** Registers a custom error handler that emits service-error JSON honouring any negotiated `Content-Encoding`. */
 export function registerFastifyErrorHandler(app: fastify.FastifyInstance) {
-  app.setErrorHandler(async (error, _request, reply) => {
-    const serviceError = errors.asServiceError(error);
-    logger.error(`Request failed`, serviceError);
+  app.setErrorHandler<Error>(async (error, _request, reply) => {
+    if (reply.raw.headersSent) {
+      // Headers already flushed - reply.code/header would throw ERR_HTTP_HEADERS_SENT.
+      reply.raw.destroy(error);
+      return;
+    }
 
-    const response = serviceErrorToResponse(serviceError);
-    const json = JSON.stringify(response.data);
+    const { status, data } = fastifyErrorToResponse(error);
+    if (status >= 500) {
+      logger.error('Request failed', error);
+    } else {
+      logger.warn(`Request failed: ${error.message}`, {
+        status,
+        code: data.error.code
+      });
+    }
 
-    // Fastify's default error handler clears `content-type` and `content-length` from `kReplyHeaders`
-    // but leaves `content-encoding` intact, so we honour or strip it ourselves.
+    const json = JSON.stringify(data);
+
+    // Fastify's default handler leaves `content-encoding` intact when it rewrites the body.
     const encoding = reply.getHeader('content-encoding');
     let body: string | Buffer = json;
     if (encoding === 'gzip') {
-      body = zlib.gzipSync(Buffer.from(json));
+      body = zlib.gzipSync(json);
     } else if (encoding === 'zstd') {
-      body = zlib.zstdCompressSync(Buffer.from(json));
+      body = zlib.zstdCompressSync(json);
     } else {
       reply.removeHeader('content-encoding');
     }
 
     reply
-      .code(response.status)
+      .code(status)
       .header('content-type', 'application/json; charset=utf-8')
       .header('content-length', Buffer.byteLength(body))
       .send(body);
   });
 }
 
-function serviceErrorToResponse(error: ServiceError): router.RouterResponse {
+type ErrorResponseData = { error: errors.ErrorData };
+
+function serviceErrorToResponse(serviceError: errors.ServiceError): router.RouterResponse<ErrorResponseData> {
   return new router.RouterResponse({
-    status: error.errorData.status || 500,
+    status: serviceError.errorData.status || 500,
     headers: {
       'Content-Type': 'application/json'
     },
     data: {
-      error: error.errorData
+      error: serviceError.errorData
     }
   });
+}
+
+function fastifyErrorToResponse(error: any): router.RouterResponse<ErrorResponseData> {
+  // Preserve 4xx status from Fastify built-ins (validation, invalid JSON body, etc.) instead of collapsing to 500.
+  if (
+    typeof error?.statusCode === 'number' &&
+    error.statusCode >= 400 &&
+    error.statusCode < 500 &&
+    typeof error.code === 'string'
+  ) {
+    return new router.RouterResponse({
+      status: error.statusCode,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      data: {
+        error: {
+          name: error.name,
+          code: error.code,
+          status: error.statusCode,
+          description: error.message
+        }
+      }
+    });
+  }
+  return serviceErrorToResponse(errors.asServiceError(error));
 }
 
 async function respond(reply: FastifyReply, response: router.RouterResponse) {

--- a/packages/service-core/src/routes/route-register.ts
+++ b/packages/service-core/src/routes/route-register.ts
@@ -1,4 +1,5 @@
 import type fastify from 'fastify';
+import * as zlib from 'node:zlib';
 import * as uuid from 'uuid';
 
 import { errors, HTTPMethod, logger, RouteNotFound, router, ServiceError } from '@powersync/lib-services-framework';
@@ -102,6 +103,38 @@ export function registerFastifyRoutes(
 export function registerFastifyNotFoundHandler(app: fastify.FastifyInstance) {
   app.setNotFoundHandler(async (request, reply) => {
     await respond(reply, serviceErrorToResponse(new RouteNotFound(request.originalUrl, request.method)));
+  });
+}
+
+/**
+ * Registers a custom error handler so uncaught errors surface with the same schema as other service errors,
+ * and the synthesised body honours any negotiated `Content-Encoding`.
+ */
+export function registerFastifyErrorHandler(app: fastify.FastifyInstance) {
+  app.setErrorHandler(async (error, _request, reply) => {
+    const serviceError = errors.asServiceError(error);
+    logger.error(`Request failed`, serviceError);
+
+    const response = serviceErrorToResponse(serviceError);
+    const json = JSON.stringify(response.data);
+
+    // Fastify's default error handler clears `content-type` and `content-length` from `kReplyHeaders`
+    // but leaves `content-encoding` intact, so we honour or strip it ourselves.
+    const encoding = reply.getHeader('content-encoding');
+    let body: string | Buffer = json;
+    if (encoding === 'gzip') {
+      body = zlib.gzipSync(Buffer.from(json));
+    } else if (encoding === 'zstd') {
+      body = zlib.zstdCompressSync(Buffer.from(json));
+    } else {
+      reply.removeHeader('content-encoding');
+    }
+
+    reply
+      .code(response.status)
+      .header('content-type', 'application/json; charset=utf-8')
+      .header('content-length', Buffer.byteLength(body))
+      .send(body);
   });
 }
 

--- a/packages/service-core/test/src/routes/error-handler.integration.test.ts
+++ b/packages/service-core/test/src/routes/error-handler.integration.test.ts
@@ -1,0 +1,275 @@
+import { errors } from '@powersync/lib-services-framework';
+import Fastify, { FastifyInstance } from 'fastify';
+import { Readable } from 'node:stream';
+import * as zlib from 'node:zlib';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { registerFastifyErrorHandler } from '../../../src/routes/route-register.js';
+
+describe('Fastify error handler', () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    app = Fastify();
+    registerFastifyErrorHandler(app);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('errors thrown in route before sending a response', () => {
+    it('returns a JSON error body with no content-encoding when none was set', async () => {
+      app.get('/boom', async () => {
+        throw new errors.ServiceError({
+          status: 503,
+          code: 'PSYNC_S2003' as any,
+          description: 'Service unavailable'
+        });
+      });
+      await app.ready();
+
+      const response = await app.inject({ method: 'GET', url: '/boom' });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+      expect(response.headers['content-encoding']).toBeUndefined();
+      expect(JSON.parse(response.payload)).toMatchObject({
+        error: { code: 'PSYNC_S2003', status: 503 }
+      });
+    });
+
+    it('gzip-encodes the error body when content-encoding=gzip was set before the throw', async () => {
+      app.get('/boom', async (_request, reply) => {
+        reply.header('content-encoding', 'gzip');
+        throw new Error('kaboom');
+      });
+      await app.ready();
+
+      const response = await app.inject({ method: 'GET', url: '/boom' });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers['content-encoding']).toBe('gzip');
+      const decoded = zlib.gunzipSync(response.rawPayload).toString('utf8');
+      expect(JSON.parse(decoded).error.code).toBe('PSYNC_S2001');
+    });
+
+    it('zstd-encodes the error body when content-encoding=zstd was set before the throw', async () => {
+      app.get('/boom', async (_request, reply) => {
+        reply.header('content-encoding', 'zstd');
+        throw new Error('kaboom');
+      });
+      await app.ready();
+
+      const response = await app.inject({ method: 'GET', url: '/boom' });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers['content-encoding']).toBe('zstd');
+      const decoded = zlib.zstdDecompressSync(response.rawPayload).toString('utf8');
+      expect(JSON.parse(decoded).error.code).toBe('PSYNC_S2001');
+    });
+  });
+
+  describe('errors after responding with a stream, before any data is sent', () => {
+    it('still returns a JSON error response with no encoding', async () => {
+      app.get('/stream', async (_request, reply) => {
+        const stream = new Readable({
+          read() {
+            process.nextTick(() => this.destroy(new Error('pre-data failure')));
+          }
+        });
+        reply.header('content-type', 'application/x-ndjson');
+        return reply.send(stream);
+      });
+      await app.ready();
+
+      const response = await app.inject({ method: 'GET', url: '/stream' });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers['content-encoding']).toBeUndefined();
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+      expect(JSON.parse(response.payload).error.code).toBe('PSYNC_S2001');
+    });
+
+    it('still returns a gzip-encoded JSON error response when encoding was set first', async () => {
+      app.get('/stream', async (_request, reply) => {
+        reply.header('content-encoding', 'gzip');
+        reply.header('content-type', 'application/x-ndjson');
+        const stream = new Readable({
+          read() {
+            process.nextTick(() => this.destroy(new Error('pre-data failure')));
+          }
+        });
+        return reply.send(stream);
+      });
+      await app.ready();
+
+      const response = await app.inject({ method: 'GET', url: '/stream' });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers['content-encoding']).toBe('gzip');
+      const decoded = zlib.gunzipSync(response.rawPayload).toString('utf8');
+      expect(JSON.parse(decoded).error.code).toBe('PSYNC_S2001');
+    });
+  });
+
+  describe('errors after a stream has sent data', () => {
+    it('lets fastify tear the response down without raising an uncaught exception', async () => {
+      app.get('/stream', async (_request, reply) => {
+        let chunks = 0;
+        const stream = new Readable({
+          read() {
+            if (chunks++ === 0) {
+              this.push('first chunk\n');
+            } else {
+              this.destroy(new Error('mid-stream failure'));
+            }
+          }
+        });
+        reply.header('content-type', 'application/x-ndjson');
+        return reply.send(stream);
+      });
+      await app.ready();
+
+      const uncaught: Error[] = [];
+      const onUncaught = (err: Error) => uncaught.push(err);
+      const onUnhandled = (err: any) => uncaught.push(err);
+      process.on('uncaughtException', onUncaught);
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        await expect(app.inject({ method: 'GET', url: '/stream' })).rejects.toThrow(/destroyed/);
+        await new Promise((resolve) => setImmediate(resolve));
+      } finally {
+        process.off('uncaughtException', onUncaught);
+        process.off('unhandledRejection', onUnhandled);
+      }
+
+      expect(uncaught).toEqual([]);
+    });
+  });
+
+  describe('handler inheritance into child scopes', () => {
+    it('handles errors thrown in routes registered inside a child scope', async () => {
+      await app.register(async (child) => {
+        child.get('/boom', async () => {
+          throw new Error('child scope failure');
+        });
+      });
+      await app.ready();
+
+      const response = await app.inject({ method: 'GET', url: '/boom' });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+      const body = JSON.parse(response.payload);
+      expect(body.error?.code).toBe('PSYNC_S2001');
+    });
+  });
+
+  describe('built-in Fastify errors', () => {
+    it('preserves the 400 status code for an invalid JSON body', async () => {
+      app.post('/echo', async (request) => ({ received: request.body }));
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/echo',
+        headers: { 'content-type': 'application/json' },
+        payload: '{ not json'
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.error.status).toBe(400);
+      expect(body.error.code).toBe('FST_ERR_CTP_INVALID_JSON_BODY');
+    });
+
+    it('preserves the 400 status code for an empty JSON body', async () => {
+      app.post('/echo', async (request) => ({ received: request.body }));
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/echo',
+        headers: { 'content-type': 'application/json' },
+        payload: ''
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.error.status).toBe(400);
+      expect(body.error.code).toBe('FST_ERR_CTP_EMPTY_JSON_BODY');
+    });
+
+    it('preserves the 400 status code for a schema validation failure', async () => {
+      app.post(
+        '/schema',
+        {
+          schema: {
+            body: {
+              type: 'object',
+              required: ['name'],
+              properties: { name: { type: 'string' } }
+            }
+          }
+        },
+        async () => ({ ok: true })
+      );
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/schema',
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({})
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.payload);
+      expect(body.error.status).toBe(400);
+      expect(body.error.code).toBe('FST_ERR_VALIDATION');
+    });
+
+    it('preserves the 413 status code when the body exceeds the limit', async () => {
+      const tinyApp = Fastify({ bodyLimit: 16 });
+      registerFastifyErrorHandler(tinyApp);
+      tinyApp.post('/echo', async (request) => ({ received: request.body }));
+      await tinyApp.ready();
+
+      try {
+        const response = await tinyApp.inject({
+          method: 'POST',
+          url: '/echo',
+          headers: { 'content-type': 'application/json' },
+          payload: JSON.stringify({ data: 'x'.repeat(64) })
+        });
+
+        expect(response.statusCode).toBe(413);
+        const body = JSON.parse(response.payload);
+        expect(body.error.status).toBe(413);
+        expect(body.error.code).toBe('FST_ERR_CTP_BODY_TOO_LARGE');
+      } finally {
+        await tinyApp.close();
+      }
+    });
+
+    it('preserves the 415 status code for an unsupported media type', async () => {
+      app.post('/json-only', async (request) => ({ received: request.body }));
+      // Drop the default text/plain parser so non-JSON content types are rejected.
+      app.removeContentTypeParser('text/plain');
+      await app.ready();
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/json-only',
+        headers: { 'content-type': 'text/plain' },
+        payload: 'hello'
+      });
+
+      expect(response.statusCode).toBe(415);
+      const body = JSON.parse(response.payload);
+      expect(body.error.status).toBe(415);
+      expect(body.error.code).toBe('FST_ERR_CTP_INVALID_MEDIA_TYPE');
+    });
+  });
+});


### PR DESCRIPTION
This fixes an issue where service error response bodies were sent as uncompressed JSON while the `content-encoding` header was set.

This caused issues on the SDK's which used HTTP clients. They honoured the `content-encoding` header and read the JSON body as if it were compressed data - which lead to errors surfacing as `content-encoding` body mismatches or malformed compression bodies, instead of the underlying service error.

To fix this mismatch we recompresses the error bodies when `content-encoding` is detected on the error path.