### PR TITLE
Resolve !env tags in test-client

### DIFF
--- a/.changeset/test-client-env-tag.md
+++ b/.changeset/test-client-env-tag.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+'test-client': patch
+---
+
+Resolve `!env` tags when the test client parses `powersync.yaml`, and add an optional `--env <path>` flag to load a `.env` file first.

--- a/packages/service-core/src/util/util-index.ts
+++ b/packages/service-core/src/util/util-index.ts
@@ -17,6 +17,7 @@ export * from './config/collectors/config-collector.js';
 export * from './config/collectors/impl/base64-config-collector.js';
 export * from './config/collectors/impl/fallback-config-collector.js';
 export * from './config/collectors/impl/filesystem-config-collector.js';
+export * from './config/collectors/impl/yaml-env.js';
 
 export * from './config/sync-rules/impl/base64-sync-rules-collector.js';
 export * from './config/sync-rules/impl/filesystem-sync-rules-collector.js';

--- a/test-client/README.md
+++ b/test-client/README.md
@@ -54,6 +54,12 @@ Used to generate a JWT token based on your current PowerSync YAML config.
 node dist/bin.js generate-token --config path/to/powersync.yaml --sub test-user
 ```
 
+If your config uses `!env PS_*` tags, pass `--env` to load a `.env` file before parsing (or export the variables in your shell). This flag is also supported by `fetch-operations` and `concurrent-connections`.
+
+```sh
+node dist/bin.js generate-token --config path/to/powersync.yaml --env path/to/.env --sub test-user
+```
+
 ### concurrent-connections
 
 Use this command to simulate concurrent connections to a PowerSync instance. This can be used for performance benchmarking

--- a/test-client/src/auth.ts
+++ b/test-client/src/auth.ts
@@ -1,3 +1,4 @@
+import { YamlEnvTag } from '@powersync/service-core';
 import * as jose from 'jose';
 import * as fs from 'node:fs/promises';
 import * as yaml from 'yaml';
@@ -31,7 +32,7 @@ export async function getCredentials(options: CredentialsOptions): Promise<Crede
     }
   } else if (options.config != null) {
     const file = await fs.readFile(options.config, 'utf-8');
-    const parsed = await yaml.parse(file);
+    const parsed = await yaml.parse(file, { customTags: [YamlEnvTag] });
     const keys = (parsed.client_auth?.jwks?.keys ?? []).filter((key: any) => key.alg == 'HS256');
     if (keys.length == 0) {
       throw new Error('No HS256 key found in the config');

--- a/test-client/src/bin.ts
+++ b/test-client/src/bin.ts
@@ -4,14 +4,22 @@ import { getCredentials } from './auth.js';
 import { getCheckpointData } from './client.js';
 import { concurrentConnections } from './load-testing/load-test.js';
 
+function loadEnvFile(path?: string) {
+  if (path != null) {
+    process.loadEnvFile(path);
+  }
+}
+
 program
   .command('fetch-operations')
   .option('-t, --token [token]', 'JWT to use for authentication')
   .option('-e, --endpoint [endpoint]', 'endpoint URI')
   .option('-c, --config [config]', 'path to powersync.yaml, to auto-generate a token from a HS256 key')
   .option('-u, --sub [sub]', 'sub field for auto-generated token')
+  .option('--env [env]', 'path to a .env file to load before resolving !env tags in the config')
   .option('--raw', 'output operations as received, without normalizing')
   .action(async (options) => {
+    loadEnvFile(options.env);
     const credentials = await getCredentials(options);
     const data = await getCheckpointData({ ...credentials, raw: options.raw });
     console.log(JSON.stringify(data, null, 2));
@@ -23,7 +31,9 @@ program
   .option('-c, --config [config]', 'path to powersync.yaml')
   .option('-u, --sub [sub]', 'payload sub')
   .option('-e, --endpoint [endpoint]', 'additional payload aud')
+  .option('--env [env]', 'path to a .env file to load before resolving !env tags in the config')
   .action(async (options) => {
+    loadEnvFile(options.env);
     const credentials = await getCredentials(options);
     const decoded = await jose.decodeJwt(credentials.token);
 
@@ -41,8 +51,10 @@ program
   .option('-n, --num-clients [num-clients]', 'number of clients to connect')
   .option('-m, --mode [mode]', 'http or websocket')
   .option('-p, --print [print]', 'print a field from the data being downloaded')
+  .option('--env [env]', 'path to a .env file to load before resolving !env tags in the config')
   .option('--once', 'stop after the first checkpoint')
   .action(async (options) => {
+    loadEnvFile(options.env);
     const credentials = await getCredentials(options);
 
     await concurrentConnections(


### PR DESCRIPTION
This addresses #321 

The `test-client` can now resolve `!env` tags in `powersync.yaml` configuration files by using the service’s existing `YamlEnvTag` custom tag.

Environment variables are read from exported shell variables by default, or they can be loaded explicitly from a file using the new `--env` flag.