### PR TITLE
Support SQLite as a scalar expression engine

### DIFF
--- a/.changeset/pretty-ravens-ring.md
+++ b/.changeset/pretty-ravens-ring.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-core': minor
+'@powersync/service-sync-rules': minor
+'@powersync/service-module-mongodb-storage': patch
+---
+
+Add the experimental `unstable_sqlite_expression_engine` sync config option to evaluate Sync Streams with SQLite.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoPersistedSyncRules.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoPersistedSyncRules.ts
@@ -1,3 +1,5 @@
+import * as sqlite from 'node:sqlite';
+
 import { ServiceAssertionError } from '@powersync/lib-services-framework';
 import { storage } from '@powersync/service-core';
 import {
@@ -7,6 +9,7 @@ import {
   DEFAULT_HYDRATION_STATE,
   HydratedSyncConfig,
   HydrationState,
+  nodeSqlite,
   ParameterIndexLookupCreator,
   ParameterLookupScope,
   SyncConfigWithErrors,
@@ -41,7 +44,10 @@ export class MongoPersistedSyncRules implements storage.PersistedSyncRules {
   }
 
   hydratedSyncConfig(): HydratedSyncConfig {
-    return this.syncConfigWithErrors.config.hydrate({ hydrationState: this.hydrationState });
+    return this.syncConfigWithErrors.config.hydrate({
+      hydrationState: this.hydrationState,
+      sqlite: nodeSqlite(sqlite)
+    });
   }
 }
 

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -1,7 +1,8 @@
 import { deserializeParameterLookup, JwtPayload, storage, updateSyncRulesFromYaml } from '@powersync/service-core';
 import { bucketRequest, register, test_utils } from '@powersync/service-core-tests';
-import { DEFAULT_HYDRATION_STATE, RequestParameters, SqlSyncRules } from '@powersync/service-sync-rules';
+import { DEFAULT_HYDRATION_STATE, nodeSqlite, RequestParameters, SqlSyncRules } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
+import * as sqlite from 'node:sqlite';
 import { describe, expect, test } from 'vitest';
 import { MongoBucketStorage } from '../../src/storage/MongoBucketStorage.js';
 import { MongoSyncBucketStorage } from '../../src/storage/implementation/createMongoSyncBucketStorage.js';
@@ -55,7 +56,7 @@ function objectIdGenerator(id: string) {
 function hydratedRulesFor(yaml: string) {
   const parsed = SqlSyncRules.fromYaml(yaml, test_utils.PARSE_OPTIONS);
   expect(parsed.errors).toEqual([]);
-  return parsed.config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+  return parsed.config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE, sqlite: nodeSqlite(sqlite) });
 }
 
 function registerSyncStorageTests(storageConfig: storage.TestStorageConfig, storageVersion: number) {

--- a/packages/service-core-tests/src/tests/util.ts
+++ b/packages/service-core-tests/src/tests/util.ts
@@ -4,7 +4,6 @@ import {
   ParameterLookupDefinitionId,
   ParameterLookupScope,
   SourceTableRef,
-  SqliteRow,
   TablePattern
 } from '@powersync/service-sync-rules';
 import { bucketRequest } from '../test-utils/general-utils.js';
@@ -36,8 +35,12 @@ const EMPTY_LOOKUP_SOURCE: ParameterIndexLookupCreator = {
   getSourceTables(): Set<TablePattern> {
     return new Set();
   },
-  evaluateParameterRow(_sourceTable: SourceTableRef, _row: SqliteRow) {
-    return [];
+  createEvaluator(input) {
+    return {
+      evaluateParameterRow(sourceTable, row) {
+        return [];
+      }
+    };
   },
   tableSyncsParameters(_table: SourceTableRef): boolean {
     return false;

--- a/packages/service-core/src/routes/endpoints/admin.ts
+++ b/packages/service-core/src/routes/endpoints/admin.ts
@@ -1,5 +1,7 @@
+import * as sqlite from 'node:sqlite';
+
 import { ErrorCode, errors, router, schema } from '@powersync/lib-services-framework';
-import { SourceSchema, SqlSyncRules, StaticSchema } from '@powersync/service-sync-rules';
+import { nodeSqlite, SourceSchema, SqlSyncRules, StaticSchema } from '@powersync/service-sync-rules';
 import { internal_routes } from '@powersync/service-types';
 
 import { DEFAULT_HYDRATION_STATE } from '@powersync/service-sync-rules';
@@ -182,7 +184,10 @@ class FakeSyncRulesContentForValidation extends storage.PersistedSyncRulesConten
       }),
       hydrationState: DEFAULT_HYDRATION_STATE,
       hydratedSyncConfig() {
-        return this.syncConfigWithErrors.config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+        return this.syncConfigWithErrors.config.hydrate({
+          hydrationState: DEFAULT_HYDRATION_STATE,
+          sqlite: nodeSqlite(sqlite)
+        });
       }
     };
   }

--- a/packages/service-core/src/storage/PersistedSyncRulesContent.ts
+++ b/packages/service-core/src/storage/PersistedSyncRulesContent.ts
@@ -7,7 +7,7 @@ import {
   ErrorLocation,
   HydratedSyncConfig,
   HydrationState,
-  javaScriptExpressionEngine,
+  nodeSqlite,
   PrecompiledSyncConfig,
   SqlEventDescriptor,
   SqlSyncRules,
@@ -15,6 +15,7 @@ import {
   versionedHydrationState,
   YamlError
 } from '@powersync/service-sync-rules';
+import * as sqlite from 'node:sqlite';
 import { SerializedSyncPlan, UpdateSyncRulesOptions } from './BucketStorageFactory.js';
 import { ReplicationLock } from './ReplicationLock.js';
 import { STORAGE_VERSION_CONFIG, StorageVersionConfig } from './StorageVersionConfig.js';
@@ -101,7 +102,6 @@ export abstract class PersistedSyncRulesContent implements PersistedSyncRulesCon
 
       const precompiled = new PrecompiledSyncConfig(plan, compatibility, eventDefinitions, {
         defaultSchema: options.defaultSchema,
-        engine: javaScriptExpressionEngine(compatibility),
         sourceText: this.sync_rules_content
       });
 
@@ -144,7 +144,7 @@ export abstract class PersistedSyncRulesContent implements PersistedSyncRulesCon
       syncConfigWithErrors: config,
       hydrationState,
       hydratedSyncConfig: () => {
-        return config.config.hydrate({ hydrationState });
+        return config.config.hydrate({ hydrationState, sqlite: nodeSqlite(sqlite) });
       }
     };
   }

--- a/packages/service-core/test/src/routes/stream.test.ts
+++ b/packages/service-core/test/src/routes/stream.test.ts
@@ -1,6 +1,12 @@
 import { BasicRouterRequest, Context, JwtPayload, SyncRulesBucketStorage } from '@/index.js';
-import { RouterResponse, ServiceError, logger } from '@powersync/lib-services-framework';
-import { DEFAULT_HYDRATION_STATE, SqlSyncRules } from '@powersync/service-sync-rules';
+import { logger, RouterResponse, ServiceError } from '@powersync/lib-services-framework';
+import {
+  DEFAULT_HYDRATION_STATE,
+  HydrateSyncConfigParams,
+  nodeSqlite,
+  SqlSyncRules
+} from '@powersync/service-sync-rules';
+import * as sqlite from 'node:sqlite';
 import { Readable, Writable } from 'stream';
 import { pipeline } from 'stream/promises';
 import { describe, expect, it } from 'vitest';
@@ -10,6 +16,11 @@ import { DEFAULT_PARAM_LOGGING_FORMAT_OPTIONS, limitParamsForLogging } from '../
 import { mockServiceContext } from './mocks.js';
 
 describe('Stream Route', () => {
+  const defaultHydrationOptions: HydrateSyncConfigParams = {
+    hydrationState: DEFAULT_HYDRATION_STATE,
+    sqlite: nodeSqlite(sqlite)
+  };
+
   describe('compressed stream', () => {
     it('handles missing sync rules', async () => {
       const context: Context = {
@@ -45,7 +56,7 @@ describe('Stream Route', () => {
 
       const storage = {
         getParsedSyncRules() {
-          return new SqlSyncRules('bucket_definitions: {}').hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+          return new SqlSyncRules('bucket_definitions: {}').hydrate(defaultHydrationOptions);
         },
         watchCheckpointChanges: async function* (options) {
           throw new Error('Simulated storage error');
@@ -83,7 +94,7 @@ describe('Stream Route', () => {
     it('logs the application metadata', async () => {
       const storage = {
         getParsedSyncRules() {
-          return new SqlSyncRules('bucket_definitions: {}').hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+          return new SqlSyncRules('bucket_definitions: {}').hydrate(defaultHydrationOptions);
         },
         watchCheckpointChanges: async function* (options) {
           throw new Error('Simulated storage error');

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -15,17 +15,18 @@ import {
 } from '@/index.js';
 import { JSONBig } from '@powersync/service-jsonbig';
 import {
+  nodeSqlite,
   ParameterIndexLookupCreator,
   ParameterLookupDefinitionId,
   ParameterLookupRows,
   ParameterLookupScope,
   ScopedParameterLookup,
   SourceTableRef,
-  SqliteRow,
   SqlSyncRules,
   TablePattern,
   versionedHydrationState
 } from '@powersync/service-sync-rules';
+import * as sqlite from 'node:sqlite';
 import { beforeEach, describe, expect, test } from 'vitest';
 
 describe('BucketChecksumState', () => {
@@ -39,8 +40,12 @@ describe('BucketChecksumState', () => {
     getSourceTables(): Set<TablePattern> {
       return new Set();
     },
-    evaluateParameterRow(_sourceTable: SourceTableRef, _row: SqliteRow) {
-      return [];
+    createEvaluator() {
+      return {
+        evaluateParameterRow() {
+          return [];
+        }
+      };
     },
     tableSyncsParameters(_table: SourceTableRef): boolean {
       return false;
@@ -60,7 +65,7 @@ bucket_definitions:
     data: []
     `,
     { defaultSchema: 'public' }
-  ).config.hydrate({ hydrationState: versionedHydrationState(1) });
+  ).config.hydrate({ hydrationState: versionedHydrationState(1), sqlite: nodeSqlite(sqlite) });
 
   // global[1] and global[2]
   const SYNC_RULES_GLOBAL_TWO = SqlSyncRules.fromYaml(
@@ -73,7 +78,7 @@ bucket_definitions:
     data: []
     `,
     { defaultSchema: 'public' }
-  ).config.hydrate({ hydrationState: versionedHydrationState(2) });
+  ).config.hydrate({ hydrationState: versionedHydrationState(2), sqlite: nodeSqlite(sqlite) });
 
   // by_project[n]
   const SYNC_RULES_DYNAMIC = SqlSyncRules.fromYaml(
@@ -84,7 +89,7 @@ bucket_definitions:
     data: []
     `,
     { defaultSchema: 'public' }
-  ).config.hydrate({ hydrationState: versionedHydrationState(3) });
+  ).config.hydrate({ hydrationState: versionedHydrationState(3), sqlite: nodeSqlite(sqlite) });
 
   const syncContext = new SyncContext({
     maxBuckets: 100,
@@ -655,7 +660,7 @@ config:
 
       const rules = SqlSyncRules.fromYaml(source, {
         defaultSchema: 'public'
-      }).config.hydrate({ hydrationState: versionedHydrationState(1) });
+      }).config.hydrate({ hydrationState: versionedHydrationState(1), sqlite: nodeSqlite(sqlite) });
 
       return new BucketChecksumState({
         syncContext,
@@ -921,7 +926,8 @@ streams:
 `,
         { defaultSchema: 'public' }
       ).config.hydrate({
-        hydrationState: versionedHydrationState(1)
+        hydrationState: versionedHydrationState(1),
+        sqlite: nodeSqlite(sqlite)
       });
 
       const storage = new MockBucketChecksumStateStorage();
@@ -1018,7 +1024,8 @@ streams:
 `,
         { defaultSchema: 'public' }
       ).config.hydrate({
-        hydrationState: versionedHydrationState(1)
+        hydrationState: versionedHydrationState(1),
+        sqlite: nodeSqlite(sqlite)
       });
 
       const storage = new MockBucketChecksumStateStorage();
@@ -1090,7 +1097,7 @@ streams:
     query: SELECT id FROM comments WHERE p IN auth.parameter('c')
     `,
         { defaultSchema: 'public' }
-      ).config.hydrate({ hydrationState: versionedHydrationState(4) });
+      ).config.hydrate({ hydrationState: versionedHydrationState(4), sqlite: nodeSqlite(sqlite) });
 
       const storage = new MockBucketChecksumStateStorage();
 
@@ -1165,7 +1172,8 @@ streams:
       }
 
       const SYNC_RULES_MANY = SqlSyncRules.fromYaml(yamlDefinitions, { defaultSchema: 'public' }).config.hydrate({
-        hydrationState: versionedHydrationState(5)
+        hydrationState: versionedHydrationState(5),
+        sqlite: nodeSqlite(sqlite)
       });
 
       const storage = new MockBucketChecksumStateStorage();

--- a/packages/sync-rules/src/BucketSource.ts
+++ b/packages/sync-rules/src/BucketSource.ts
@@ -5,9 +5,11 @@ import {
   UnscopedParameterLookup
 } from './BucketParameterQuerier.js';
 import { ColumnDefinition } from './ExpressionType.js';
-import { DEFAULT_HYDRATION_STATE, HydrationState, ParameterLookupDefinitionId } from './HydrationState.js';
+import { HydrationState, ParameterLookupDefinitionId } from './HydrationState.js';
 import { SourceTableRef } from './SourceTableRef.js';
 import { GetQuerierOptions } from './SqlSyncRules.js';
+import { ScalarExpressionEngine } from './sync_plan/engine/scalar_expression_engine.js';
+import { SQLite } from './sync_plan/engine/sqlite.js';
 import { TablePattern } from './TablePattern.js';
 import {
   EvaluatedParameters,
@@ -25,6 +27,17 @@ import { withBucketSource } from './utils.js';
 
 export interface CreateSourceParams {
   hydrationState: HydrationState;
+}
+
+export interface HydrateSyncConfigParams extends CreateSourceParams {
+  /**
+   * The SQLite engine to use to evaluate scalar expressions in Sync Streams.
+   */
+  sqlite: SQLite | null;
+}
+
+export interface HydrationInput extends CreateSourceParams {
+  scalarExpressions: ScalarExpressionEngine;
 }
 
 /**
@@ -58,7 +71,7 @@ export interface BucketSource {
 
   debugRepresentation(): any;
 
-  hydrate(params: CreateSourceParams): HydratedBucketSource;
+  hydrate(params: HydrationInput): HydratedBucketSource;
 }
 
 /**
@@ -104,11 +117,7 @@ export interface BucketDataSource {
   getSourceTables(): Set<TablePattern>;
   tableSyncsData(table: SourceTableRef): boolean;
 
-  /**
-   * Given a row as it appears in a table that affects sync data, return buckets, logical table names and transformed
-   * data for rows to add to buckets.
-   */
-  evaluateRow(options: EvaluateRowOptions): UnscopedEvaluationResult[];
+  createEvaluator(input: HydrationInput): BucketDataEvaluator;
 
   /**
    * Given a static schema, infer all logical tables and associated columns that appear in buckets defined by this
@@ -119,6 +128,14 @@ export interface BucketDataSource {
   resolveResultSets(schema: SourceSchema, tables: Record<string, Record<string, ColumnDefinition>>): void;
 
   debugWriteOutputTables(result: Record<string, { query: string }[]>): void;
+}
+
+export interface BucketDataEvaluator {
+  /**
+   * Given a row as it appears in a table that affects sync data, return buckets, logical table names and transformed
+   * data for rows to add to buckets.
+   */
+  evaluateRow(options: EvaluateRowOptions): UnscopedEvaluationResult[];
 }
 
 /**
@@ -137,6 +154,13 @@ export interface ParameterIndexLookupCreator {
 
   getSourceTables(): Set<TablePattern>;
 
+  /** Whether the table possibly affects the buckets resolved by this source. */
+  tableSyncsParameters(table: SourceTableRef): boolean;
+
+  createEvaluator(input: HydrationInput): ParameterIndexLookupEvaluator;
+}
+
+export interface ParameterIndexLookupEvaluator {
   /**
    * Given a row in a source table that affects sync parameters, returns a structure to index which buckets rows should
    * be associated with.
@@ -145,14 +169,6 @@ export interface ParameterIndexLookupCreator {
    * system to find buckets.
    */
   evaluateParameterRow(sourceTable: SourceTableRef, row: SqliteRow): UnscopedEvaluatedParametersResult[];
-
-  /** Whether the table possibly affects the buckets resolved by this source. */
-  tableSyncsParameters(table: SourceTableRef): boolean;
-}
-
-export interface DebugMergedSource extends HydratedBucketSource {
-  evaluateRow: ScopedEvaluateRow;
-  evaluateParameterRow: ScopedEvaluateParameterRow;
 }
 
 export enum BucketSourceType {
@@ -162,10 +178,11 @@ export enum BucketSourceType {
 
 export type ResultSetDescription = { name: string; columns: ColumnDefinition[] };
 
-export function hydrateEvaluateRow(hydrationState: HydrationState, source: BucketDataSource): ScopedEvaluateRow {
-  const scope = hydrationState.getBucketSourceScope(source);
+function hydrateEvaluateRow(input: HydrationInput, source: BucketDataSource): ScopedEvaluateRow {
+  const evaluator = source.createEvaluator(input);
+  const scope = input.hydrationState.getBucketSourceScope(source);
   return (options: EvaluateRowOptions): EvaluationResult[] => {
-    return source.evaluateRow(options).map((result) => {
+    return evaluator.evaluateRow(options).map((result) => {
       if (isEvaluationError(result)) {
         return result;
       }
@@ -183,13 +200,14 @@ export function hydrateEvaluateRow(hydrationState: HydrationState, source: Bucke
   };
 }
 
-export function hydrateEvaluateParameterRow(
-  hydrationState: HydrationState,
+function hydrateEvaluateParameterRow(
+  input: HydrationInput,
   source: ParameterIndexLookupCreator
 ): ScopedEvaluateParameterRow {
-  const scope = hydrationState.getParameterIndexLookupScope(source);
+  const evaluator = source.createEvaluator(input);
+  const scope = input.hydrationState.getParameterIndexLookupScope(source);
   return (sourceTable: SourceTableRef, row: SqliteRow): EvaluatedParametersResult[] => {
-    return source.evaluateParameterRow(sourceTable, row).map((result) => {
+    return evaluator.evaluateParameterRow(sourceTable, row).map((result) => {
       if (isEvaluationError(result)) {
         return result;
       }
@@ -202,10 +220,10 @@ export function hydrateEvaluateParameterRow(
 }
 
 export function mergeDataSources(
-  hydrationState: HydrationState,
+  input: HydrationInput,
   sources: BucketDataSource[]
 ): { evaluateRow: ScopedEvaluateRow } {
-  const withScope = sources.map((source) => hydrateEvaluateRow(hydrationState, source));
+  const withScope = sources.map((source) => hydrateEvaluateRow(input, source));
   return {
     evaluateRow(options: EvaluateRowOptions): EvaluationResult[] {
       return withScope.flatMap((source) => source(options));
@@ -214,34 +232,13 @@ export function mergeDataSources(
 }
 
 export function mergeParameterIndexLookupCreators(
-  hydrationState: HydrationState,
+  input: HydrationInput,
   sources: ParameterIndexLookupCreator[]
 ): { evaluateParameterRow: ScopedEvaluateParameterRow } {
-  const withScope = sources.map((source) => hydrateEvaluateParameterRow(hydrationState, source));
+  const withScope = sources.map((source) => hydrateEvaluateParameterRow(input, source));
   return {
     evaluateParameterRow(sourceTable: SourceTableRef, row: SqliteRow): EvaluatedParametersResult[] {
       return withScope.flatMap((source) => source(sourceTable, row));
     }
-  };
-}
-
-/**
- * For production purposes, we typically need to operate on the different sources separately. However, for debugging,
- * it is useful to have a single merged source that can evaluate everything.
- */
-export function debugHydratedMergedSource(bucketSource: BucketSource, params?: CreateSourceParams): DebugMergedSource {
-  const hydrationState = params?.hydrationState ?? DEFAULT_HYDRATION_STATE;
-  const resolvedParams = { hydrationState };
-  const dataSource = mergeDataSources(hydrationState, bucketSource.dataSources);
-  const parameterLookupSource = mergeParameterIndexLookupCreators(
-    hydrationState,
-    bucketSource.parameterIndexLookupCreators
-  );
-  const hydratedBucketSource = bucketSource.hydrate(resolvedParams);
-  return {
-    definition: bucketSource,
-    evaluateParameterRow: parameterLookupSource.evaluateParameterRow.bind(parameterLookupSource),
-    evaluateRow: dataSource.evaluateRow.bind(dataSource),
-    pushBucketParameterQueriers: hydratedBucketSource.pushBucketParameterQueriers.bind(hydratedBucketSource)
   };
 }

--- a/packages/sync-rules/src/HydratedSyncConfig.ts
+++ b/packages/sync-rules/src/HydratedSyncConfig.ts
@@ -1,4 +1,4 @@
-import { BucketDataSource, CreateSourceParams, HydratedBucketSource } from './BucketSource.js';
+import { BucketDataSource, HydratedBucketSource } from './BucketSource.js';
 import {
   BucketParameterQuerier,
   BucketSource,
@@ -8,7 +8,8 @@ import {
   EvaluationError,
   GetBucketParameterQuerierResult,
   GetQuerierOptions,
-  HydrationState,
+  HydrateSyncConfigParams,
+  HydrationInput,
   isEvaluatedParameters,
   isEvaluatedRow,
   isEvaluationError,
@@ -27,6 +28,7 @@ import {
   TablePattern
 } from './index.js';
 import { SourceTableRef, sourceTableRefKey } from './SourceTableRef.js';
+import { createScalarExpressionEngine } from './sync_plan/engine/factory.js';
 import { EvaluatedParametersResult, EvaluateRowOptions, EvaluationResult, SqliteRow } from './types.js';
 import { applyRowContext, uniqueBy } from './utils.js';
 
@@ -78,18 +80,17 @@ export class HydratedSyncConfig {
 
   private readonly innerEvaluateRow: ScopedEvaluateRow;
   private readonly innerEvaluateParameterRow: ScopedEvaluateParameterRow;
-  private readonly hydrationState: HydrationState;
+  private readonly hydrationInput: HydrationInput;
   private readonly matchingSourcesCache = new Map<string, MatchingSources>();
+
   private mergedEvaluatorCache = new WeakMap<BucketDataSource[], { evaluateRow: ScopedEvaluateRow }>();
   private mergedParameterIndexCreatorCache = new WeakMap<
     ParameterIndexLookupCreator[],
     { evaluateParameterRow: ScopedEvaluateParameterRow }
   >();
 
-  constructor(params: { definitions: SyncConfig[]; createParams: CreateSourceParams }) {
+  constructor(params: { definitions: SyncConfig[]; createParams: HydrateSyncConfigParams }) {
     const hydrationState = params.createParams.hydrationState;
-    this.hydrationState = hydrationState;
-
     const definitions = params.definitions;
     if (definitions.length == 0) {
       throw new Error('HydratedSyncRules requires at least one SyncConfig definition');
@@ -97,6 +98,10 @@ export class HydratedSyncConfig {
 
     this.sourceDefinitions = [...definitions];
     this.compatibility = assertSharedCompatibility(this.sourceDefinitions);
+    this.hydrationInput = {
+      hydrationState,
+      scalarExpressions: createScalarExpressionEngine(this.compatibility, params.createParams.sqlite)
+    };
 
     this.bucketDataSources = uniqueBy(
       definitions.flatMap((definition) => definition.bucketDataSources),
@@ -107,9 +112,9 @@ export class HydratedSyncConfig {
       (source) => parameterLookupScopeKey(hydrationState.getParameterIndexLookupScope(source))
     );
 
-    this.innerEvaluateRow = mergeDataSources(hydrationState, this.bucketDataSources).evaluateRow;
+    this.innerEvaluateRow = mergeDataSources(this.hydrationInput, this.bucketDataSources).evaluateRow;
     this.innerEvaluateParameterRow = mergeParameterIndexLookupCreators(
-      hydrationState,
+      this.hydrationInput,
       this.bucketParameterLookupSources
     ).evaluateParameterRow;
 
@@ -117,7 +122,7 @@ export class HydratedSyncConfig {
 
     if (definitions.length == 1) {
       this.#bucketSourceDefinitions = definitions[0].bucketSources;
-      this.bucketSources = this.#bucketSourceDefinitions.map((source) => source.hydrate(params.createParams));
+      this.bucketSources = this.#bucketSourceDefinitions.map((source) => source.hydrate(this.hydrationInput));
     } else {
       // We do not support merging bucket sources across multiple definitions - these are always used with one
       // SyncConfig at a time.
@@ -197,7 +202,7 @@ export class HydratedSyncConfig {
       // It is not a strict requirement to use stable arrays, but it can help for performance.
       let merged = this.mergedEvaluatorCache.get(options.bucketDataSources);
       if (merged == null) {
-        merged = mergeDataSources(this.hydrationState, options.bucketDataSources);
+        merged = mergeDataSources(this.hydrationInput, options.bucketDataSources);
         this.mergedEvaluatorCache.set(options.bucketDataSources, merged);
       }
       rawResults = merged.evaluateRow(options);
@@ -236,7 +241,7 @@ export class HydratedSyncConfig {
       // It is not a strict requirement to use stable arrays, but it can help for performance.
       let merged = this.mergedParameterIndexCreatorCache.get(options.parameterLookupSources);
       if (merged == null) {
-        merged = mergeParameterIndexLookupCreators(this.hydrationState, options.parameterLookupSources);
+        merged = mergeParameterIndexLookupCreators(this.hydrationInput, options.parameterLookupSources);
         this.mergedParameterIndexCreatorCache.set(options.parameterLookupSources, merged);
       }
       rawResults = merged.evaluateParameterRow(table, row);

--- a/packages/sync-rules/src/SqlBucketDescriptor.ts
+++ b/packages/sync-rules/src/SqlBucketDescriptor.ts
@@ -1,5 +1,6 @@
 import { PendingQueriers } from './BucketParameterQuerier.js';
 import {
+  BucketDataEvaluator,
   BucketDataSource,
   BucketSource,
   BucketSourceType,
@@ -164,7 +165,7 @@ export class SqlBucketDescriptor implements BucketSource {
   }
 }
 
-export class BucketDefinitionDataSource implements BucketDataSource {
+export class BucketDefinitionDataSource implements BucketDataSource, BucketDataEvaluator {
   constructor(private descriptor: SqlBucketDescriptor) {}
 
   /**
@@ -176,6 +177,10 @@ export class BucketDefinitionDataSource implements BucketDataSource {
 
   public get uniqueName(): string {
     return this.descriptor.name;
+  }
+
+  createEvaluator(): BucketDataEvaluator {
+    return this;
   }
 
   evaluateRow(options: EvaluateRowOptions) {

--- a/packages/sync-rules/src/SqlParameterQuery.ts
+++ b/packages/sync-rules/src/SqlParameterQuery.ts
@@ -18,6 +18,7 @@ import {
   BucketDataSource,
   BucketParameterQuerierSource,
   GetQuerierOptions,
+  ParameterIndexLookupEvaluator,
   resolvedBucket,
   ScopedParameterLookup,
   UnscopedEvaluatedParameters,
@@ -76,7 +77,7 @@ export interface SqlParameterQueryOptions {
  *  SELECT id as user_id FROM users WHERE users.user_id = token_parameters.user_id
  *  SELECT id as user_id, token_parameters.is_admin as is_admin FROM users WHERE users.user_id = token_parameters.user_id
  */
-export class SqlParameterQuery implements ParameterIndexLookupCreator {
+export class SqlParameterQuery implements ParameterIndexLookupCreator, ParameterIndexLookupEvaluator {
   static fromSql(
     descriptorName: string,
     sql: string,
@@ -361,6 +362,10 @@ export class SqlParameterQuery implements ParameterIndexLookupCreator {
         result.queriers.push(q);
       }
     };
+  }
+
+  createEvaluator(): ParameterIndexLookupEvaluator {
+    return this;
   }
 
   /**

--- a/packages/sync-rules/src/SyncConfig.ts
+++ b/packages/sync-rules/src/SyncConfig.ts
@@ -1,4 +1,9 @@
-import { BucketDataSource, BucketSource, CreateSourceParams, ParameterIndexLookupCreator } from './BucketSource.js';
+import {
+  BucketDataSource,
+  BucketSource,
+  HydrateSyncConfigParams,
+  ParameterIndexLookupCreator
+} from './BucketSource.js';
 import { CompatibilityContext } from './compatibility.js';
 import { YamlError } from './errors.js';
 import { SqlEventDescriptor } from './events/SqlEventDescriptor.js';
@@ -42,7 +47,7 @@ export abstract class SyncConfig {
    *
    * @param params.hydrationState Transforms bucket ids based on persisted state.
    */
-  hydrate(params: CreateSourceParams): HydratedSyncConfig {
+  hydrate(params: HydrateSyncConfigParams): HydratedSyncConfig {
     return new HydratedSyncConfig({
       definitions: [this],
       createParams: params

--- a/packages/sync-rules/src/compatibility.ts
+++ b/packages/sync-rules/src/compatibility.ts
@@ -62,7 +62,7 @@ export class CompatibilityOption {
 
   static sqliteExpressionEngine = new CompatibilityOption(
     'unstable_sqlite_expression_engine',
-    'Experimental options to evaluate functions and operators in Sync Streams with SQLite instead of a JavaScript implementation.',
+    'Experimental option to evaluate functions and operators in Sync Streams with SQLite instead of a JavaScript implementation.',
     null
   );
 

--- a/packages/sync-rules/src/compatibility.ts
+++ b/packages/sync-rules/src/compatibility.ts
@@ -33,7 +33,7 @@ export class CompatibilityOption {
   private constructor(
     readonly name: string,
     readonly description: string,
-    readonly fixedIn: CompatibilityEdition
+    readonly fixedIn: CompatibilityEdition | null
   ) {}
 
   static timestampsIso8601 = new CompatibilityOption(
@@ -60,11 +60,18 @@ export class CompatibilityOption {
     CompatibilityEdition.SYNC_STREAMS
   );
 
+  static sqliteExpressionEngine = new CompatibilityOption(
+    'unstable_sqlite_expression_engine',
+    'Experimental options to evaluate functions and operators in Sync Streams with SQLite instead of a JavaScript implementation.',
+    null
+  );
+
   static byName: Record<string, CompatibilityOption> = Object.freeze({
     timestamps_iso8601: this.timestampsIso8601,
     versioned_bucket_ids: this.versionedBucketIds,
     fixed_json_extract: this.fixedJsonExtract,
-    custom_postgres_types: this.customTypes
+    custom_postgres_types: this.customTypes,
+    unstable_sqlite_expression_engine: this.sqliteExpressionEngine
   });
 }
 
@@ -103,7 +110,7 @@ export class CompatibilityContext {
   }
 
   isEnabled(option: CompatibilityOption) {
-    return this.overrides.get(option) ?? option.fixedIn <= this.edition;
+    return this.overrides.get(option) ?? (option.fixedIn != null && option.fixedIn <= this.edition);
   }
 
   equals(other: CompatibilityContext): boolean {

--- a/packages/sync-rules/src/from_yaml.ts
+++ b/packages/sync-rules/src/from_yaml.ts
@@ -15,7 +15,6 @@ import { QueryParseResult, SqlBucketDescriptor } from './SqlBucketDescriptor.js'
 import { SqlSyncRules } from './SqlSyncRules.js';
 import { validateStorageVersion } from './StorageVersion.js';
 import { syncStreamFromSql } from './streams/from_sql.js';
-import { javaScriptExpressionEngine } from './sync_plan/engine/javascript.js';
 import { PrecompiledSyncConfig } from './sync_plan/evaluator/index.js';
 import { SyncConfig, SyncConfigWithErrors } from './SyncConfig.js';
 import { TablePattern } from './TablePattern.js';
@@ -77,6 +76,19 @@ export class SyncConfigFromYaml {
       const declaredOptions = parsed.get('config') as YAMLMap;
       compatibility = this.#parseCompatibilityOptions(declaredOptions);
       storageVersion = this.#validateStorageVersion(declaredOptions);
+
+      if (compatibility.isEnabled(CompatibilityOption.sqliteExpressionEngine)) {
+        // Evaluating expressions with SQLite requires edition: 3, older systems always use JavaScript.
+        if (compatibility.edition < CompatibilityEdition.SYNC_STREAMS) {
+          this.#errors.push(
+            this.#yamlError(declaredOptions, 'Enabling unstable_sqlite_expression_engine requires edition: 3')
+          );
+        } else if (!compatibility.isEnabled(CompatibilityOption.fixedJsonExtract)) {
+          this.#errors.push(
+            this.#yamlError(declaredOptions, 'Enabling unstable_sqlite_expression_engine requires fixed_json_extract')
+          );
+        }
+      }
     } else {
       compatibility = CompatibilityContext.FULL_BACKWARDS_COMPATIBILITY;
     }
@@ -290,7 +302,6 @@ export class SyncConfigFromYaml {
     // We pass an empty array for eventDefinitions here because those will get parsed in #parseEventDefinitions.
     return new PrecompiledSyncConfig(compiler.output.toSyncPlan(), compatibility, [], {
       defaultSchema: this.options.defaultSchema,
-      engine: javaScriptExpressionEngine(compatibility),
       sourceText: this.yaml
     });
   }

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -34,8 +34,7 @@ export * from './types/time.js';
 export * from './utils.js';
 
 export * from './compiler/compiler.js';
-export { javaScriptExpressionEngine } from './sync_plan/engine/javascript.js';
-export { nodeSqliteExpressionEngine } from './sync_plan/engine/sqlite.js';
+export { Database, SQLite, Statement, nodeSqlite } from './sync_plan/engine/sqlite.js';
 export { PrecompiledSyncConfig } from './sync_plan/evaluator/index.js';
 export * from './sync_plan/plan.js';
 export { deserializeSyncPlan, serializeSyncPlan } from './sync_plan/serialize.js';

--- a/packages/sync-rules/src/streams/filter.ts
+++ b/packages/sync-rules/src/streams/filter.ts
@@ -15,7 +15,7 @@ import {
 import { isJsonValue, normalizeParameterValue } from '../utils.js';
 
 import { NodeLocation } from 'pgsql-ast-parser';
-import { ParameterIndexLookupCreator } from '../BucketSource.js';
+import { ParameterIndexLookupCreator, ParameterIndexLookupEvaluator } from '../BucketSource.js';
 import { HydrationState, ParameterLookupDefinitionId } from '../HydrationState.js';
 import { SourceTableRef } from '../SourceTableRef.js';
 import { SubqueryEvaluator } from './parameter.js';
@@ -530,7 +530,7 @@ export class EvaluateSimpleCondition extends FilterOperator {
   }
 }
 
-export class SubqueryParameterLookupSource implements ParameterIndexLookupCreator {
+export class SubqueryParameterLookupSource implements ParameterIndexLookupCreator, ParameterIndexLookupEvaluator {
   constructor(
     private parameterTable: TablePattern,
     private column: RowValueClause,
@@ -550,6 +550,10 @@ export class SubqueryParameterLookupSource implements ParameterIndexLookupCreato
     let result = new Set<TablePattern>();
     result.add(this.parameterTable);
     return result;
+  }
+
+  createEvaluator(): ParameterIndexLookupEvaluator {
+    return this;
   }
 
   /**

--- a/packages/sync-rules/src/streams/stream.ts
+++ b/packages/sync-rules/src/streams/stream.ts
@@ -1,6 +1,7 @@
 import { BaseSqlDataQuery } from '../BaseSqlDataQuery.js';
 import { BucketPriority, DEFAULT_BUCKET_PRIORITY } from '../BucketDescription.js';
 import {
+  BucketDataEvaluator,
   BucketDataSource,
   BucketParameterQuerierSource,
   BucketSource,
@@ -78,7 +79,7 @@ export class SyncStream implements BucketSource {
   }
 }
 
-export class SyncStreamDataSource implements BucketDataSource {
+export class SyncStreamDataSource implements BucketDataSource, BucketDataEvaluator {
   constructor(
     private stream: SyncStream,
     private data: BaseSqlDataQuery,
@@ -115,6 +116,10 @@ export class SyncStreamDataSource implements BucketDataSource {
     };
 
     result[this.data.table!.sqlName].push(r);
+  }
+
+  createEvaluator(): BucketDataEvaluator {
+    return this;
   }
 
   evaluateRow(options: EvaluateRowOptions): UnscopedEvaluationResult[] {

--- a/packages/sync-rules/src/sync_plan/engine/factory.ts
+++ b/packages/sync-rules/src/sync_plan/engine/factory.ts
@@ -1,0 +1,19 @@
+import { CompatibilityContext, CompatibilityOption } from '../../compatibility.js';
+import { javaScriptExpressionEngine } from './javascript.js';
+import { ScalarExpressionEngine } from './scalar_expression_engine.js';
+import { SQLite, sqliteExpressionEngine } from './sqlite.js';
+
+export function createScalarExpressionEngine(
+  compatibility: CompatibilityContext,
+  sqlite: SQLite | null
+): ScalarExpressionEngine {
+  if (compatibility.isEnabled(CompatibilityOption.sqliteExpressionEngine)) {
+    if (sqlite == null) {
+      throw new Error(`sqlite_expression_engine is unsupported on this target.`);
+    }
+
+    return sqliteExpressionEngine(sqlite, compatibility);
+  }
+
+  return javaScriptExpressionEngine(compatibility);
+}

--- a/packages/sync-rules/src/sync_plan/engine/javascript.ts
+++ b/packages/sync-rules/src/sync_plan/engine/javascript.ts
@@ -57,7 +57,6 @@ export function javaScriptExpressionEngine(compatibility: CompatibilityContext):
   });
 
   return {
-    close() {},
     prepareEvaluator({ outputs = [], filters = [], tableValuedFunctions = [] }): ScalarExpressionEvaluator {
       function compileScalar(expr: SqlExpression<number | TableValuedFunctionOutput>) {
         return compiler.compile(expr);

--- a/packages/sync-rules/src/sync_plan/engine/scalar_expression_engine.ts
+++ b/packages/sync-rules/src/sync_plan/engine/scalar_expression_engine.ts
@@ -39,11 +39,6 @@ export interface TableValuedFunctionOutput {
 
 export interface ScalarExpressionEngine {
   prepareEvaluator(statement: ScalarStatement): ScalarExpressionEvaluator;
-
-  /**
-   * Disposes all evaluators and closes this engine.
-   */
-  close(): void;
 }
 
 export interface ScalarExpressionEvaluator {

--- a/packages/sync-rules/src/sync_plan/engine/scalar_expression_engine.ts
+++ b/packages/sync-rules/src/sync_plan/engine/scalar_expression_engine.ts
@@ -60,7 +60,7 @@ export function scalarStatementToSql({ filters = [], outputs = [], tableValuedFu
   } else {
     outputs.forEach((expr, i) => {
       if (i != 0) toSqlite.comma();
-      visitExpr(toSqlite, expr, null);
+      visitExpr(toSqlite, expr, 0);
     });
   }
 
@@ -73,7 +73,7 @@ export function scalarStatementToSql({ filters = [], outputs = [], tableValuedFu
         toSqlite.comma();
       }
 
-      visitExpr(toSqlite, { type: 'function', function: fn.name, parameters: fn.inputs }, null);
+      visitExpr(toSqlite, { type: 'function', function: fn.name, parameters: fn.inputs }, 0);
       toSqlite.addLexeme('AS');
       toSqlite.identifier(name);
 

--- a/packages/sync-rules/src/sync_plan/engine/sqlite.ts
+++ b/packages/sync-rules/src/sync_plan/engine/sqlite.ts
@@ -1,28 +1,73 @@
-import { CompatibilityContext, CompatibilityOption } from '../../compatibility.js';
+import { CompatibilityContext } from '../../compatibility.js';
 import { evaluateOperator, generateSqlFunctions } from '../../index.js';
 import { SqliteValue } from '../../types.js';
 import { ScalarExpressionEngine, ScalarExpressionEvaluator, scalarStatementToSql } from './scalar_expression_engine.js';
 
 /**
- * Creates a {@link ScalarExpressionEngine} backed by an in-memory SQLite database using `node:sqlite` APIs.
+ * Simple cross-platform SQLite interface.
  *
- * @param module The imported `node:sqlite` module (passed as a parameter to ensure this package keeps working in
- * browsers).
+ * Use {@link nodeSqlite} for an implementation based on `node:sqlite`.
+ */
+export interface SQLite {
+  openInMemory(): Database;
+}
+
+export interface Database {
+  registerFunction(name: string, options: { variadic: boolean }, func: (...args: SqliteValue[]) => SqliteValue): void;
+  prepare(sql: string): Statement;
+}
+
+export interface Statement {
+  run(inputs: SqliteValue[]): SqliteValue[][];
+}
+
+/**
+ * A {@link SQLite} implementation based on builtin `node:sqlite` support.
+ */
+export function nodeSqlite(module: typeof import('node:sqlite')): SQLite {
+  return {
+    openInMemory() {
+      // We don't close this database instance, which is acceptable. It's an in-memory database, so we don't care about
+      // closing file descriptors at a specific point in time. Node makes the destructor run when V8 deallocates the JS
+      // object (the DatabaseSync::DatabaseSync() constructor calls MakeWeak(), and DatabaseSync::~DatabaseSync calls
+      // sqlite3_close_v2, see node_sqlite.cc).
+      const db = new module.DatabaseSync(':memory:', { readOnly: true, readBigInts: true, returnArrays: true } as any);
+
+      return {
+        registerFunction(name, options, func) {
+          db.function(name, { useBigIntArguments: true, varargs: options.variadic, deterministic: true }, func);
+        },
+        prepare(sql) {
+          // Note: Like databases, node will finalize the underlying statement once it's no longer referenced from JS.
+          const stmt = db.prepare(sql);
+          return {
+            run(inputs) {
+              // Types are wrong, all() will return a SqliteValue[][] because returnArrays is enabled.
+              return stmt.all(...inputs) as unknown as SqliteValue[][];
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
+/**
+ * Creates a {@link ScalarExpressionEngine} backed by an in-memory SQLite database.
+ *
+ * @param sqlite The {@link SQLite} implementation to use.
  *
  * @experimental This engine is not drop-in compatible with the JS operator implementations. So we can only use this
- * engine when a new compatibility option is enabled. Currently, it is only used in tests.
+ * engine when a new compatibility option is enabled.
  */
-export function nodeSqliteExpressionEngine(
-  module: typeof import('node:sqlite'),
-  compatibility: CompatibilityContext
-): ScalarExpressionEngine {
-  const db = new module.DatabaseSync(':memory:', { readOnly: true, readBigInts: true, returnArrays: true } as any);
+export function sqliteExpressionEngine(sqlite: SQLite, compatibility: CompatibilityContext): ScalarExpressionEngine {
+  const db = sqlite.openInMemory();
   const functions = generateSqlFunctions(compatibility);
 
   function registerPowerSyncFunction(name: string) {
     const impl = functions.named[name]!;
 
-    db.function(name, { useBigIntArguments: true, varargs: true, deterministic: true }, (...args) => {
+    db.registerFunction(name, { variadic: true }, (...args) => {
       return impl.call(...args);
     });
   }
@@ -36,33 +81,17 @@ export function nodeSqliteExpressionEngine(
   registerPowerSyncFunction('st_x');
   registerPowerSyncFunction('st_y');
 
-  db.function('ps_json_contains', { useBigIntArguments: true, deterministic: true }, (a, b) =>
-    evaluateOperator('IN', a, b)
-  );
-
-  if (!compatibility.isEnabled(CompatibilityOption.fixedJsonExtract)) {
-    // For backwards compatibility, use the old JSON operators which parse the path argument differently.
-    db.function('->', { useBigIntArguments: true, varargs: true, deterministic: true }, (...args) => {
-      return functions.operatorJsonExtractJson.call(...args);
-    });
-
-    db.function('->>', { useBigIntArguments: true, varargs: true, deterministic: true }, (...args) => {
-      return functions.operatorJsonExtractSql.call(...args);
-    });
-  }
+  db.registerFunction('ps_json_contains', { variadic: false }, (a, b) => evaluateOperator('IN', a, b));
 
   return {
     prepareEvaluator(input): ScalarExpressionEvaluator {
+      // Note: Like databases, node will finalize the underlying statement once it's no longer referenced from JS.
       const stmt = db.prepare(scalarStatementToSql(input));
       return {
         evaluate(inputs) {
-          // Types are wrong, all() will return a SqliteValue[][] because returnArrays is enabled.
-          return stmt.all(...inputs) as unknown as SqliteValue[][];
+          return stmt.run(inputs);
         }
       };
-    },
-    close() {
-      db.close();
     }
   };
 }

--- a/packages/sync-rules/src/sync_plan/evaluator/bucket_data_source.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/bucket_data_source.ts
@@ -1,4 +1,4 @@
-import { BucketDataSource } from '../../BucketSource.js';
+import { BucketDataEvaluator, BucketDataSource, HydrationInput } from '../../BucketSource.js';
 import { idFromData } from '../../cast.js';
 import { ColumnDefinition } from '../../ExpressionType.js';
 import { SourceTableRef } from '../../SourceTableRef.js';
@@ -12,7 +12,8 @@ import {
 } from '../../types.js';
 import { filterJsonRow, isJsonValue, isValidParameterValue, JSONBucketNameSerialize } from '../../utils.js';
 import {
-  ScalarExpressionEvaluator,
+  ScalarExpressionEngine,
+  ScalarStatement,
   scalarStatementToSql,
   TableValuedFunctionOutput
 } from '../engine/scalar_expression_engine.js';
@@ -25,7 +26,7 @@ import { TableProcessorToSqlHelper } from './table_processor_to_sql.js';
 
 export class PreparedStreamBucketDataSource implements BucketDataSource {
   private readonly sourceTables = new Set<TablePattern>();
-  private readonly sources: PreparedStreamDataSource[] = [];
+  private readonly pendingSources: PendingStreamDataSource[] = [];
   private readonly defaultSchema: string;
 
   constructor(
@@ -35,10 +36,10 @@ export class PreparedStreamBucketDataSource implements BucketDataSource {
     this.defaultSchema = context.defaultSchema;
 
     for (const data of source.sources) {
-      const prepared = new PreparedStreamDataSource(data, context);
+      const pending = new PendingStreamDataSource(data, context.defaultSchema);
 
-      this.sources.push(prepared);
-      this.sourceTables.add(prepared.tablePattern);
+      this.pendingSources.push(pending);
+      this.sourceTables.add(pending.tablePattern);
     }
   }
 
@@ -58,25 +59,32 @@ export class PreparedStreamBucketDataSource implements BucketDataSource {
     return this.sourceTables;
   }
 
-  private *sourcesForTable(table: SourceTableRef) {
-    for (const source of this.sources) {
-      if (source.tablePattern.matches(table)) {
-        yield source;
-      }
-    }
-  }
-
   tableSyncsData(table: SourceTableRef): boolean {
-    return !this.sourcesForTable(table).next().done;
-  }
-
-  evaluateRow(options: EvaluateRowOptions): UnscopedEvaluationResult[] {
-    const results: UnscopedEvaluationResult[] = [];
-    for (const source of this.sourcesForTable(options.sourceTable)) {
-      source.evaluateRow(options, results);
+    for (const source of this.sourceTables) {
+      if (source.matches(table)) return true;
     }
 
-    return results;
+    return false;
+  }
+
+  createEvaluator(context: HydrationInput): BucketDataEvaluator {
+    const sources = this.pendingSources.map((s) => ({
+      pattern: s.tablePattern,
+      evaluate: s.instantiate(context.scalarExpressions)
+    }));
+
+    return {
+      evaluateRow(options: EvaluateRowOptions): UnscopedEvaluationResult[] {
+        const results: UnscopedEvaluationResult[] = [];
+        for (const { pattern, evaluate } of sources) {
+          if (pattern.matches(options.sourceTable)) {
+            evaluate(options, results);
+          }
+        }
+
+        return results;
+      }
+    };
   }
 
   resolveResultSets(schema: SourceSchema, tables: Record<string, Record<string, ColumnDefinition>>): void {
@@ -87,7 +95,7 @@ export class PreparedStreamBucketDataSource implements BucketDataSource {
   }
 
   debugWriteOutputTables(result: Record<string, { query: string }[]>): void {
-    for (const source of this.sources) {
+    for (const source of this.pendingSources) {
       const table = source.fixedOutputTableName;
       if (table != null) {
         const queries = (result[table] ??= []);
@@ -97,17 +105,16 @@ export class PreparedStreamBucketDataSource implements BucketDataSource {
   }
 }
 
-class PreparedStreamDataSource {
+class PendingStreamDataSource {
   readonly tablePattern: TablePattern;
   private readonly outputs: ('star' | { index: number; alias: string })[] = [];
   private readonly numberOfOutputExpressions: number;
   private readonly numberOfParameters: number;
-  private readonly evaluator: ScalarExpressionEvaluator;
   private readonly evaluatorInputs: plan.ColumnSqlParameterValue[];
+  private readonly statement: ScalarStatement;
   readonly fixedOutputTableName?: string;
-  readonly debugSql: string;
 
-  constructor(evaluator: plan.StreamDataSource, { engine, defaultSchema }: StreamEvaluationContext) {
+  constructor(evaluator: plan.StreamDataSource, defaultSchema: string) {
     const translationHelper = new TableProcessorToSqlHelper(evaluator);
     const outputExpressions: SqlExpression<number | TableValuedFunctionOutput>[] = [];
 
@@ -127,54 +134,60 @@ class PreparedStreamDataSource {
     }
     this.numberOfParameters = evaluator.parameters.length;
 
-    const evaluatorOptions = {
+    this.statement = {
       outputs: outputExpressions,
       filters: translationHelper.filterExpressions,
       tableValuedFunctions: translationHelper.tableValuedFunctions
     };
-    this.debugSql = scalarStatementToSql(evaluatorOptions);
-    this.evaluator = engine.prepareEvaluator(evaluatorOptions);
     this.fixedOutputTableName = evaluator.outputTableName;
     this.tablePattern = evaluator.sourceTable.toTablePattern(defaultSchema);
     this.evaluatorInputs = translationHelper.mapper.instantiation;
   }
 
-  evaluateRow(options: EvaluateRowOptions, results: UnscopedEvaluationResult[]) {
-    try {
-      const inputInstantiation = this.evaluatorInputs.map((input) => options.record[input.column]);
-      row: for (const source of this.evaluator.evaluate(inputInstantiation)) {
-        const record: SqliteJsonRow = {};
-        for (const output of this.outputs) {
-          if (output === 'star') {
-            Object.assign(record, filterJsonRow(options.record));
-          } else {
-            const value = source[output.index];
-            if (isJsonValue(value)) {
-              record[output.alias] = value;
+  get debugSql(): string {
+    return scalarStatementToSql(this.statement);
+  }
+
+  instantiate(engine: ScalarExpressionEngine) {
+    const evaluator = engine.prepareEvaluator(this.statement);
+
+    return (options: EvaluateRowOptions, results: UnscopedEvaluationResult[]) => {
+      try {
+        const inputInstantiation = this.evaluatorInputs.map((input) => options.record[input.column]);
+        row: for (const source of evaluator.evaluate(inputInstantiation)) {
+          const record: SqliteJsonRow = {};
+          for (const output of this.outputs) {
+            if (output === 'star') {
+              Object.assign(record, filterJsonRow(options.record));
+            } else {
+              const value = source[output.index];
+              if (isJsonValue(value)) {
+                record[output.alias] = value;
+              }
             }
           }
-        }
-        const id = idFromData(record);
-        // source is [...outputs, ...partitionValues]
-        const partitionValues = source.splice(this.numberOfOutputExpressions, this.numberOfParameters);
+          const id = idFromData(record);
+          // source is [...outputs, ...partitionValues]
+          const partitionValues = source.splice(this.numberOfOutputExpressions, this.numberOfParameters);
 
-        for (const bucketParameter of partitionValues) {
-          if (!isValidParameterValue(bucketParameter)) {
-            continue row;
+          for (const bucketParameter of partitionValues) {
+            if (!isValidParameterValue(bucketParameter)) {
+              continue row;
+            }
           }
+
+          results.push({
+            id,
+            data: record,
+            table: this.fixedOutputTableName ?? options.sourceTable.name,
+            serializedBucketParameters: JSONBucketNameSerialize.stringify(partitionValues)
+          } satisfies UnscopedEvaluatedRow);
         }
 
-        results.push({
-          id,
-          data: record,
-          table: this.fixedOutputTableName ?? options.sourceTable.name,
-          serializedBucketParameters: JSONBucketNameSerialize.stringify(partitionValues)
-        } satisfies UnscopedEvaluatedRow);
+        return results;
+      } catch (e) {
+        return results.push({ error: e.message });
       }
-
-      return results;
-    } catch (e) {
-      return results.push({ error: e.message });
-    }
+    };
   }
 }

--- a/packages/sync-rules/src/sync_plan/evaluator/bucket_source.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/bucket_source.ts
@@ -6,6 +6,7 @@ import {
   BucketSourceType,
   CreateSourceParams,
   HydratedBucketSource,
+  HydrationInput,
   ParameterIndexLookupCreator
 } from '../../BucketSource.js';
 import { RequestedStream } from '../../SqlSyncRules.js';
@@ -53,8 +54,10 @@ export class StreamBucketSource implements BucketSource {
     return `stream ${this.stream.stream.name}`;
   }
 
-  hydrate(params: CreateSourceParams): HydratedBucketSource {
-    const queriers = this.stream.queriers.map((q) => new PreparedQuerier(this.stream.stream, q, this.input));
+  hydrate(params: HydrationInput): HydratedBucketSource {
+    const queriers = this.stream.queriers.map(
+      (q) => new PreparedQuerier(this.stream.stream, q, this.input, params.scalarExpressions)
+    );
 
     return {
       definition: this,
@@ -99,16 +102,18 @@ class PreparedQuerier {
   constructor(
     readonly stream: plan.StreamOptions,
     querier: plan.StreamQuerier,
-    options: StreamInput
+    options: StreamInput,
+    engine: ScalarExpressionEngine
   ) {
     this.dataSource = options.preparedBuckets.get(querier.bucket)!;
-    this.matchesParameters = PreparedQuerier.prepareFilters(options.engine, querier.requestFilters);
+    this.matchesParameters = PreparedQuerier.prepareFilters(engine, querier.requestFilters);
 
     this.lookupStages = RequestParameterEvaluators.prepare(
       stream,
       querier.lookupStages,
       querier.sourceInstantiation,
-      options
+      options,
+      engine
     );
   }
 

--- a/packages/sync-rules/src/sync_plan/evaluator/index.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/index.ts
@@ -1,7 +1,6 @@
 import { SyncConfig } from '../../SyncConfig.js';
 import { CompatibilityContext } from '../../compatibility.js';
 import { SqlEventDescriptor } from '../../index.js';
-import { ScalarExpressionEngine } from '../engine/scalar_expression_engine.js';
 import * as plan from '../plan.js';
 import { PreparedStreamBucketDataSource } from './bucket_data_source.js';
 import { StreamBucketSource, StreamInput } from './bucket_source.js';
@@ -9,8 +8,6 @@ import { PreparedParameterIndexLookupCreator } from './parameter_index_lookup_cr
 
 export interface StreamEvaluationContext {
   defaultSchema: string;
-  engine: ScalarExpressionEngine;
-
   /**
    * Source contents that were used to compile the sync plan.
    *

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -6,6 +6,7 @@ import { RequestParameters, SqliteParameterValue, SqliteValue } from '../../type
 import { isValidParameterValue } from '../../utils.js';
 import {
   mapExternalDataToInstantiation,
+  ScalarExpressionEngine,
   TableValuedFunction,
   TableValuedFunctionOutput
 } from '../engine/scalar_expression_engine.js';
@@ -149,12 +150,14 @@ export class RequestParameterEvaluators {
    * @param values The {@link plan.StreamQuerier.sourceInstantiation} of the querier to compile.
    * @param input Access to bucket and parameter sources generated for buckets and parameter lookups referenced by the
    * querier.
+   * @param engine The scalar SQL engine used to evaluate operators and functions on request data.
    */
   static prepare(
     stream: plan.StreamOptions,
     lookupStages: plan.ExpandingLookup[][],
     values: plan.ParameterValue[],
-    input: StreamInput
+    input: StreamInput,
+    engine: ScalarExpressionEngine
   ) {
     const mappedStages: PreparedExpandingLookup[][] = [];
     const lookupToStage = new Map<plan.ExpandingLookup, { stage: number; index: number }>();
@@ -163,7 +166,7 @@ export class RequestParameterEvaluators {
       if (value.type == 'request') {
         // Prepare an expression evaluating the expression derived from request data.
         const mapper = mapExternalDataToInstantiation<plan.RequestSqlParameterValue>();
-        const prepared = input.engine.prepareEvaluator({ filters: [], outputs: [mapper.transform(value.expr)] });
+        const prepared = engine.prepareEvaluator({ filters: [], outputs: [mapper.transform(value.expr)] });
         const instantiation = mapper.instantiation;
 
         return {
@@ -213,7 +216,7 @@ export class RequestParameterEvaluators {
             })
           );
 
-          const prepared = input.engine.prepareEvaluator({
+          const prepared = engine.prepareEvaluator({
             tableValuedFunctions: [fn],
             outputs: lookup.outputs.map((e) => visitExpr(mapOutputs, e, null)),
             filters: lookup.filters.map((e) => visitExpr(mapOutputs, e, null))

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_index_lookup_creator.ts
@@ -1,10 +1,10 @@
 import { UnscopedParameterLookup } from '../../BucketParameterQuerier.js';
-import { ParameterIndexLookupCreator } from '../../BucketSource.js';
+import { HydrationInput, ParameterIndexLookupCreator, ParameterIndexLookupEvaluator } from '../../BucketSource.js';
 import { ParameterLookupDefinitionId } from '../../HydrationState.js';
 import { SourceTableRef } from '../../SourceTableRef.js';
 import { TablePattern } from '../../TablePattern.js';
 import { SqliteJsonValue, SqliteParameterValue, SqliteRow, UnscopedEvaluatedParametersResult } from '../../types.js';
-import { ScalarExpressionEvaluator } from '../engine/scalar_expression_engine.js';
+import { ScalarStatement } from '../engine/scalar_expression_engine.js';
 import * as plan from '../plan.js';
 import { StreamEvaluationContext } from './index.js';
 import { isValidParameterValueRow } from './parameter_evaluator.js';
@@ -12,13 +12,13 @@ import { TableProcessorToSqlHelper } from './table_processor_to_sql.js';
 
 export class PreparedParameterIndexLookupCreator implements ParameterIndexLookupCreator {
   readonly sourceId: ParameterLookupDefinitionId;
-  private readonly evaluator: ScalarExpressionEvaluator;
   readonly sourceTable: TablePattern;
   private readonly evaluatorInputs: plan.ColumnSqlParameterValue[];
+  private readonly statement: ScalarStatement;
   private readonly numberOfOutputs: number;
   private readonly numberOfParameters: number;
 
-  constructor(source: plan.StreamParameterIndexLookupCreator, { engine, defaultSchema }: StreamEvaluationContext) {
+  constructor(source: plan.StreamParameterIndexLookupCreator, { defaultSchema }: StreamEvaluationContext) {
     this.sourceId = {
       ...source.defaultLookupScope
     };
@@ -31,11 +31,11 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
     }
     this.numberOfParameters = source.parameters.length;
 
-    this.evaluator = engine.prepareEvaluator({
+    this.statement = {
       outputs: expressions,
       filters: translationHelper.filterExpressions,
       tableValuedFunctions: translationHelper.tableValuedFunctions
-    });
+    };
     this.sourceTable = source.sourceTable.toTablePattern(defaultSchema);
     this.evaluatorInputs = translationHelper.mapper.instantiation;
   }
@@ -46,74 +46,80 @@ export class PreparedParameterIndexLookupCreator implements ParameterIndexLookup
     return set;
   }
 
-  evaluateParameterRow(sourceTable: SourceTableRef, row: SqliteRow): UnscopedEvaluatedParametersResult[] {
-    const results: UnscopedEvaluatedParametersResult[] = [];
-    if (!this.sourceTable.matches(sourceTable)) {
-      return results;
-    }
+  createEvaluator({ scalarExpressions }: HydrationInput): ParameterIndexLookupEvaluator {
+    const evaluator = scalarExpressions.prepareEvaluator(this.statement);
 
-    interface PendingLookup {
-      partitionValues: SqliteParameterValue[];
-      bucketParameters: Record<string, SqliteJsonValue>[];
-    }
+    return {
+      evaluateParameterRow: (sourceTable: SourceTableRef, row: SqliteRow): UnscopedEvaluatedParametersResult[] => {
+        const results: UnscopedEvaluatedParametersResult[] = [];
+        if (!this.sourceTable.matches(sourceTable)) {
+          return results;
+        }
 
-    function parametersEqual(a: SqliteParameterValue[], b: SqliteParameterValue[]) {
-      if (a.length != b.length) return false;
+        interface PendingLookup {
+          partitionValues: SqliteParameterValue[];
+          bucketParameters: Record<string, SqliteJsonValue>[];
+        }
 
-      return a.every((val, idx) => val === b[idx]);
-    }
+        function parametersEqual(a: SqliteParameterValue[], b: SqliteParameterValue[]) {
+          if (a.length != b.length) return false;
 
-    try {
-      const inputInstantiation = this.evaluatorInputs.map((input) => row[input.column]);
+          return a.every((val, idx) => val === b[idx]);
+        }
 
-      // In almost all cases, lookups generate at most one output with exactly one bucket parameter. This is the case
-      // for all lookups without a table-valued function, e.g. `SELECT foo.* FROM foo, bar ON foo.x = bar.x AND
-      // bar.y = auth.user_id()` which generates a lookup from `bar.y` to `bar.x`. However, it's also possible for:
-      //
-      //  - a single row with one partition value to generate multiple outputs, which would yield a lookup with multiple
-      //    entries in bucketParameters.
-      //  - a single row to generate multiple partition values, which would yield multiple lookup entries.
-      //  - a combination of those two, if multiple table-valued functions are used in the parameter result set.
-      const lookups: PendingLookup[] = [];
+        try {
+          const inputInstantiation = this.evaluatorInputs.map((input) => row[input.column]);
 
-      function resolveLookup(entries: SqliteParameterValue[]) {
-        // The lookups array could be a hash map, but since we don't expect rows to generate many lookups, a hash map
-        // would likely be more expensive than this linear search.
-        for (const existing of lookups) {
-          if (parametersEqual(existing.partitionValues, entries)) {
-            return existing;
+          // In almost all cases, lookups generate at most one output with exactly one bucket parameter. This is the case
+          // for all lookups without a table-valued function, e.g. `SELECT foo.* FROM foo, bar ON foo.x = bar.x AND
+          // bar.y = auth.user_id()` which generates a lookup from `bar.y` to `bar.x`. However, it's also possible for:
+          //
+          //  - a single row with one partition value to generate multiple outputs, which would yield a lookup with multiple
+          //    entries in bucketParameters.
+          //  - a single row to generate multiple partition values, which would yield multiple lookup entries.
+          //  - a combination of those two, if multiple table-valued functions are used in the parameter result set.
+          const lookups: PendingLookup[] = [];
+
+          function resolveLookup(entries: SqliteParameterValue[]) {
+            // The lookups array could be a hash map, but since we don't expect rows to generate many lookups, a hash map
+            // would likely be more expensive than this linear search.
+            for (const existing of lookups) {
+              if (parametersEqual(existing.partitionValues, entries)) {
+                return existing;
+              }
+            }
+
+            const created: PendingLookup = { partitionValues: entries, bucketParameters: [] };
+            lookups.push(created);
+            return created;
           }
+
+          for (const outputRow of evaluator.evaluate(inputInstantiation)) {
+            if (!isValidParameterValueRow(outputRow)) {
+              continue;
+            }
+
+            const outputs: Record<string, SqliteJsonValue> = {};
+            for (let i = 0; i < this.numberOfOutputs; i++) {
+              outputs[i.toString()] = outputRow[i];
+            }
+
+            // source is [...outputs, ...partitionValues]
+            const partitionValues = outputRow.splice(this.numberOfOutputs, this.numberOfParameters);
+            const pendingLookup = resolveLookup(partitionValues);
+            pendingLookup.bucketParameters.push(outputs);
+          }
+
+          for (const { partitionValues, bucketParameters } of lookups) {
+            results.push({ lookup: UnscopedParameterLookup.normalized(partitionValues), bucketParameters });
+          }
+        } catch (e) {
+          results.push({ error: e.message });
         }
 
-        const created: PendingLookup = { partitionValues: entries, bucketParameters: [] };
-        lookups.push(created);
-        return created;
+        return results;
       }
-
-      for (const outputRow of this.evaluator.evaluate(inputInstantiation)) {
-        if (!isValidParameterValueRow(outputRow)) {
-          continue;
-        }
-
-        const outputs: Record<string, SqliteJsonValue> = {};
-        for (let i = 0; i < this.numberOfOutputs; i++) {
-          outputs[i.toString()] = outputRow[i];
-        }
-
-        // source is [...outputs, ...partitionValues]
-        const partitionValues = outputRow.splice(this.numberOfOutputs, this.numberOfParameters);
-        const pendingLookup = resolveLookup(partitionValues);
-        pendingLookup.bucketParameters.push(outputs);
-      }
-
-      for (const { partitionValues, bucketParameters } of lookups) {
-        results.push({ lookup: UnscopedParameterLookup.normalized(partitionValues), bucketParameters });
-      }
-    } catch (e) {
-      results.push({ error: e.message });
-    }
-
-    return results;
+    };
   }
 
   tableSyncsParameters(table: SourceTableRef): boolean {

--- a/packages/sync-rules/src/sync_plan/expression_to_sql.ts
+++ b/packages/sync-rules/src/sync_plan/expression_to_sql.ts
@@ -71,7 +71,7 @@ export class ExpressionToSqlite<Data> implements ExpressionVisitor<Data, void, P
   }
 
   private maybeParenthesis(outerPrecedence: Precedence | 0, innerPrecedence: Precedence, inner: () => void) {
-    if (outerPrecedence > innerPrecedence) {
+    if (outerPrecedence >= innerPrecedence) {
       this.parenthesis(inner);
     } else {
       inner();

--- a/packages/sync-rules/test/src/compatibility.test.ts
+++ b/packages/sync-rules/test/src/compatibility.test.ts
@@ -1,15 +1,19 @@
+import * as sqlite from 'node:sqlite';
+
 import { describe, expect, test } from 'vitest';
 import {
   CompatibilityContext,
   CompatibilityOption,
   DateTimeValue,
+  HydrateSyncConfigParams,
+  nodeSqlite,
   SerializedCompatibilityContext,
   SqlSyncRules,
   TimeValuePrecision,
   toSyncRulesValue
 } from '../../src/index.js';
 
-import { DEFAULT_HYDRATION_STATE, versionedHydrationState } from '../../src/HydrationState.js';
+import { DEFAULT_HYDRATION_STATE, HydrationState, versionedHydrationState } from '../../src/HydrationState.js';
 import { ASSETS, normalizeQuerierOptions, PARSE_OPTIONS } from './util.js';
 
 describe('compatibility options', () => {
@@ -28,7 +32,7 @@ bucket_definitions:
       - SELECT id, description FROM assets
     `,
         PARSE_OPTIONS
-      ).config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+      ).config.hydrate(generateHydrationParams());
 
       expect(
         rules.evaluateRow({
@@ -55,7 +59,7 @@ config:
   timestamps_iso8601: true
     `,
         PARSE_OPTIONS
-      ).config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+      ).config.hydrate(generateHydrationParams());
 
       expect(
         rules.evaluateRow({
@@ -82,7 +86,7 @@ config:
   edition: 2
     `,
         PARSE_OPTIONS
-      ).config.hydrate({ hydrationState: versionedHydrationState(1) });
+      ).config.hydrate(generateHydrationParams(versionedHydrationState(1)));
 
       expect(
         rules.evaluateRow({
@@ -120,7 +124,7 @@ config:
   versioned_bucket_ids: false
     `,
         PARSE_OPTIONS
-      ).config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+      ).config.hydrate(generateHydrationParams());
 
       expect(rules.compatibility.isEnabled(CompatibilityOption.timestampsIso8601)).toStrictEqual(false);
       // This does not have a direct effect on the hydration here anymore - we now do that one level higher.
@@ -160,7 +164,7 @@ config:
   edition: 2
     `,
       PARSE_OPTIONS
-    ).config.hydrate({ hydrationState: versionedHydrationState(1) });
+    ).config.hydrate(generateHydrationParams(versionedHydrationState(1)));
 
     expect(
       rules.evaluateRow({
@@ -190,7 +194,7 @@ bucket_definitions:
       - SELECT id, description ->> 'foo.bar' AS "desc" FROM assets
     `,
         PARSE_OPTIONS
-      ).config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+      ).config.hydrate(generateHydrationParams());
 
       expect(
         rules.evaluateRow({
@@ -214,7 +218,7 @@ config:
   fixed_json_extract: true
     `,
         PARSE_OPTIONS
-      ).config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+      ).config.hydrate(generateHydrationParams());
 
       expect(
         rules.evaluateRow({
@@ -269,9 +273,7 @@ config:
         `;
       }
 
-      const rules = SqlSyncRules.fromYaml(syncRules, PARSE_OPTIONS).config.hydrate({
-        hydrationState: DEFAULT_HYDRATION_STATE
-      });
+      const rules = SqlSyncRules.fromYaml(syncRules, PARSE_OPTIONS).config.hydrate(generateHydrationParams());
       expect(
         rules.evaluateRow({
           sourceTable: ASSETS,
@@ -448,3 +450,7 @@ config:
     });
   });
 });
+
+function generateHydrationParams(hydrationState: HydrationState = DEFAULT_HYDRATION_STATE): HydrateSyncConfigParams {
+  return { hydrationState, sqlite: nodeSqlite(sqlite) };
+}

--- a/packages/sync-rules/test/src/hydrated_sync_rules.test.ts
+++ b/packages/sync-rules/test/src/hydrated_sync_rules.test.ts
@@ -1,10 +1,20 @@
+import * as sqlite from 'node:sqlite';
 import { describe, expect, test } from 'vitest';
 import { DEFAULT_HYDRATION_STATE } from '../../src/HydrationState.js';
-import { HydratedSyncConfig, ScopedParameterLookup, SqlSyncRules } from '../../src/index.js';
+import {
+  HydratedSyncConfig,
+  HydrateSyncConfigParams,
+  nodeSqlite,
+  ScopedParameterLookup,
+  SqlSyncRules
+} from '../../src/index.js';
 import { ASSETS, lookupScope, PARSE_OPTIONS, USERS } from './util.js';
 
 describe('hydrated sync rules', () => {
-  const hydrationParams = { hydrationState: DEFAULT_HYDRATION_STATE };
+  const hydrationParams: HydrateSyncConfigParams = {
+    hydrationState: DEFAULT_HYDRATION_STATE,
+    sqlite: nodeSqlite(sqlite)
+  };
 
   test('can evaluate rows across multiple sync configs', () => {
     const { config: first } = SqlSyncRules.fromYaml(

--- a/packages/sync-rules/test/src/parameter_queries.test.ts
+++ b/packages/sync-rules/test/src/parameter_queries.test.ts
@@ -20,7 +20,8 @@ import {
   findQuerierLookups,
   lookupScope,
   PARSE_OPTIONS,
-  requestParameters
+  requestParameters,
+  testHydrationInput
 } from './util.js';
 
 describe('parameter queries', () => {
@@ -913,7 +914,7 @@ describe('parameter queries', () => {
     });
 
     test('for lookups', function () {
-      const merged = mergeParameterIndexLookupCreators(hydrationState, [query]);
+      const merged = mergeParameterIndexLookupCreators(testHydrationInput({ hydrationState }), [query]);
       const result = merged.evaluateParameterRow(TABLE_GROUPS, {
         id: 'group1',
         user_ids: JSON.stringify(['test-user', 'other-user'])

--- a/packages/sync-rules/test/src/streams.test.ts
+++ b/packages/sync-rules/test/src/streams.test.ts
@@ -7,7 +7,6 @@ import {
   CompatibilityContext,
   CompatibilityEdition,
   CreateSourceParams,
-  debugHydratedMergedSource,
   DEFAULT_TAG,
   EvaluationResult,
   GetBucketParameterQuerierResult,
@@ -24,7 +23,15 @@ import {
   syncStreamFromSql,
   UnscopedParameterLookup
 } from '../../src/index.js';
-import { lookupScope, normalizeQuerierOptions, PARSE_OPTIONS, requestParameters, TestSourceTable } from './util.js';
+import {
+  debugHydratedMergedSource,
+  lookupScope,
+  normalizeQuerierOptions,
+  PARSE_OPTIONS,
+  requestParameters,
+  testHydrationInput,
+  TestSourceTable
+} from './util.js';
 
 describe('streams', () => {
   const STREAM_0: ParameterLookupScope = lookupScope('stream', '0');
@@ -44,7 +51,9 @@ describe('streams', () => {
 
     expect(desc.variants).toHaveLength(1);
     expect(evaluateBucketIds(desc, COMMENTS, { id: 'foo' })).toStrictEqual(['1#stream|0[]']);
-    expect(desc.dataSources[0].evaluateRow({ sourceTable: USERS, record: { id: 'foo' } })).toHaveLength(0);
+
+    const source = debugHydratedMergedSource(desc, hydrationParams);
+    expect(source.evaluateRow({ sourceTable: USERS, record: { id: 'foo' } })).toHaveLength(0);
   });
 
   test('row condition', () => {
@@ -308,7 +317,11 @@ describe('streams', () => {
       const lookup = desc.parameterIndexLookupCreators[0];
 
       expect(lookup.tableSyncsParameters(ISSUES)).toBe(true);
-      expect(lookup.evaluateParameterRow(ISSUES, { id: 'issue_id', owner_id: 'user1', name: 'name' })).toStrictEqual([
+      expect(
+        lookup
+          .createEvaluator(testHydrationInput())
+          .evaluateParameterRow(ISSUES, { id: 'issue_id', owner_id: 'user1', name: 'name' })
+      ).toStrictEqual([
         {
           lookup: UnscopedParameterLookup.normalized(['user1']),
           bucketParameters: [
@@ -337,11 +350,12 @@ describe('streams', () => {
     test('parameter value in subquery', async () => {
       const desc = parseStream('SELECT * FROM issues WHERE auth.user_id() IN (SELECT id FROM users WHERE is_admin)');
       const lookup = desc.parameterIndexLookupCreators[0];
+      const lookupEvaluator = lookup.createEvaluator(testHydrationInput());
 
       expect(lookup.tableSyncsParameters(ISSUES)).toBe(false);
       expect(lookup.tableSyncsParameters(USERS)).toBe(true);
 
-      expect(lookup.evaluateParameterRow(USERS, { id: 'u', is_admin: 1n })).toStrictEqual([
+      expect(lookupEvaluator.evaluateParameterRow(USERS, { id: 'u', is_admin: 1n })).toStrictEqual([
         {
           lookup: UnscopedParameterLookup.normalized(['u']),
           bucketParameters: [
@@ -351,7 +365,7 @@ describe('streams', () => {
           ]
         }
       ]);
-      expect(lookup.evaluateParameterRow(USERS, { id: 'u', is_admin: 0n })).toStrictEqual([]);
+      expect(lookupEvaluator.evaluateParameterRow(USERS, { id: 'u', is_admin: 0n })).toStrictEqual([]);
 
       // Should return bucket id for admin users
       expect(
@@ -496,7 +510,9 @@ describe('streams', () => {
       const lookup = desc.parameterIndexLookupCreators[0];
 
       expect(lookup.tableSyncsParameters(FRIENDS)).toBe(true);
-      expect(lookup.evaluateParameterRow(FRIENDS, { user_a: 'a', user_b: 'b' })).toStrictEqual([
+      expect(
+        lookup.createEvaluator(testHydrationInput()).evaluateParameterRow(FRIENDS, { user_a: 'a', user_b: 'b' })
+      ).toStrictEqual([
         {
           lookup: UnscopedParameterLookup.normalized(['b']),
           bucketParameters: [
@@ -669,7 +685,7 @@ describe('streams', () => {
       );
 
       expect(
-        desc.parameterIndexLookupCreators[0].evaluateParameterRow(ISSUES, {
+        desc.parameterIndexLookupCreators[0].createEvaluator(testHydrationInput()).evaluateParameterRow(ISSUES, {
           id: 'issue_id',
           owner_id: 'user1',
           name: 'name'
@@ -801,7 +817,11 @@ describe('streams', () => {
       expect(stream.parameterIndexLookupCreators[0].tableSyncsParameters(accountMember)).toBeTruthy();
 
       // Ensure lookup steps work.
-      expect(stream.parameterIndexLookupCreators[0].evaluateParameterRow(accountMember, row)).toStrictEqual([
+      expect(
+        stream.parameterIndexLookupCreators[0]
+          .createEvaluator(testHydrationInput())
+          .evaluateParameterRow(accountMember, row)
+      ).toStrictEqual([
         {
           lookup: UnscopedParameterLookup.normalized(['id']),
           bucketParameters: [
@@ -882,11 +902,13 @@ WHERE
       expect(evaluateBucketIds(desc, scene, { _id: 'scene', project: 'foo' })).toStrictEqual(['1#stream|0["foo"]']);
 
       expect(
-        desc.parameterIndexLookupCreators[0].evaluateParameterRow(projectInvitation, {
-          project: 'foo',
-          appliedTo: '[1,2]',
-          status: 'CLAIMED'
-        })
+        desc.parameterIndexLookupCreators[0]
+          .createEvaluator(testHydrationInput())
+          .evaluateParameterRow(projectInvitation, {
+            project: 'foo',
+            appliedTo: '[1,2]',
+            status: 'CLAIMED'
+          })
       ).toStrictEqual([
         {
           lookup: UnscopedParameterLookup.normalized([1n, 'foo']),
@@ -971,8 +993,10 @@ WHERE
         '1#stream|0["user"]'
       ]);
 
+      const lookupEvaluator = desc.parameterIndexLookupCreators[0].createEvaluator(testHydrationInput());
+
       expect(
-        desc.parameterIndexLookupCreators[0].evaluateParameterRow(teamMembers, {
+        lookupEvaluator.evaluateParameterRow(teamMembers, {
           user_id: 'user',
           team_id: 'team',
           role: 'owner'
@@ -988,14 +1012,14 @@ WHERE
         }
       ]);
       expect(
-        desc.parameterIndexLookupCreators[0].evaluateParameterRow(teamMembers, {
+        lookupEvaluator.evaluateParameterRow(teamMembers, {
           user_id: 'user',
           team_id: 'team',
           role: 'another'
         })
       ).toStrictEqual([]);
       expect(
-        desc.parameterIndexLookupCreators[0].evaluateParameterRow(teamMembers, {
+        lookupEvaluator.evaluateParameterRow(teamMembers, {
           user_id: 'user',
           team_id: 'team',
           role: 'owner',

--- a/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
@@ -1,14 +1,15 @@
 import * as sqlite from 'node:sqlite';
 
-import { describe, expect, onTestFinished, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import {
   CompatibilityContext,
   CompatibilityEdition,
   generateSqlFunctions,
-  javaScriptExpressionEngine,
-  nodeSqliteExpressionEngine,
   SqliteValue
 } from '../../../../src/index.js';
+import { javaScriptExpressionEngine } from '../../../../src/sync_plan/engine/javascript.js';
+import { nodeSqlite, sqliteExpressionEngine } from '../../../../src/sync_plan/engine/sqlite.js';
+
 import {
   ScalarExpressionEngine,
   ScalarStatement,
@@ -17,7 +18,7 @@ import {
 import { BinaryOperator, supportedFunctions } from '../../../../src/sync_plan/expression.js';
 
 describe('sqlite', () => {
-  defineEngineTests(false, (c) => nodeSqliteExpressionEngine(sqlite, c));
+  defineEngineTests(false, (c) => sqliteExpressionEngine(nodeSqlite(sqlite), c));
 });
 
 describe('javascript', () => {
@@ -39,7 +40,6 @@ function defineEngineTests(
 
   function prepare(stmt: ScalarStatement) {
     const engine = createEngine(compatibility);
-    onTestFinished(() => engine.close());
     return engine.prepareEvaluator(stmt);
   }
 
@@ -304,11 +304,13 @@ function defineEngineTests(
 
   test('legacy and fixed JSON behavior', () => {
     const jsonObject = JSON.stringify({ foo: { bar: ['baz'] }, 'foo.bar': ['another'] });
-    compatibility = CompatibilityContext.FULL_BACKWARDS_COMPATIBILITY;
 
-    // Legacy JSON behavior, support paths without $. prefix
-    expectFunction('->', [jsonObject, 'foo.bar'], '["baz"]');
-    expectFunction('->>', [jsonObject, 'foo.bar.0'], 'baz');
+    // Legacy JSON behavior (not supported by SQLite), support paths without $. prefix
+    if (isJavaScript) {
+      compatibility = CompatibilityContext.FULL_BACKWARDS_COMPATIBILITY;
+      expectFunction('->', [jsonObject, 'foo.bar'], '["baz"]');
+      expectFunction('->>', [jsonObject, 'foo.bar.0'], 'baz');
+    }
 
     // New JSON behavior, require $. syntax.
     compatibility = new CompatibilityContext({ edition: CompatibilityEdition.SYNC_STREAMS });

--- a/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/engine/engine.test.ts
@@ -302,6 +302,26 @@ function defineEngineTests(
     expectFunction('instr', [new Uint8Array([0xde, 0xad]), null], null);
   });
 
+  test('preserves right-nested binary expression precedence', () => {
+    const stmt = prepare({
+      outputs: [
+        {
+          type: 'binary',
+          left: { type: 'data', source: 1 },
+          operator: '-',
+          right: {
+            type: 'binary',
+            left: { type: 'data', source: 2 },
+            operator: '-',
+            right: { type: 'data', source: 3 }
+          }
+        }
+      ]
+    });
+
+    expect(stmt.evaluate([10n, 3n, 1n])).toStrictEqual([[8n]]);
+  });
+
   test('legacy and fixed JSON behavior', () => {
     const jsonObject = JSON.stringify({ foo: { bar: ['baz'] }, 'foo.bar': ['another'] });
 

--- a/packages/sync-rules/test/src/sync_plan/engine/scalarStatementToSql.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/engine/scalarStatementToSql.test.ts
@@ -93,4 +93,24 @@ describe('scalarStatementToSql', () => {
       })
     ).toStrictEqual(`SELECT "tbl_0"."value" FROM "json_each"(?1) AS "tbl_0" WHERE "foo"("tbl_0"."key")`);
   });
+
+  test('preserves right-nested binary expression precedence', () => {
+    const stmt = scalarStatementToSql({
+      outputs: [
+        {
+          type: 'binary',
+          left: { type: 'data', source: 1 },
+          operator: '-',
+          right: {
+            type: 'binary',
+            left: { type: 'data', source: 2 },
+            operator: '-',
+            right: { type: 'data', source: 3 }
+          }
+        }
+      ]
+    });
+
+    expect(stmt).toStrictEqual('SELECT ?1 - (?2 - ?3)');
+  });
 });

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -1223,6 +1223,25 @@ streams:
   expect(dynamicBuckets.map((b) => b.bucket)).toStrictEqual(['stream|0["issue"]']);
 });
 
+syncTest('throws when using SQLite without providing it', ({ sync }) => {
+  const desc = sync.prepareWithoutHydration(`
+config:
+  edition: 3
+  unstable_sqlite_expression_engine: true
+
+streams:
+  stream:
+      auto_subscribe: true
+      query: SELECT comments.* FROM comments, issues
+        WHERE issues.id = comments.issue
+        AND issues.owner = auth.user_id()
+`);
+
+  expect(() => desc.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE, sqlite: null })).toThrow(
+    'sqlite_expression_engine is unsupported on this target.'
+  );
+});
+
 function evaluateBucketIds(source: HydratedSyncConfig, sourceTable: SourceTableRef, record: SqliteRow) {
   return source.evaluateRow({ sourceTable, record }).map((r) => r.bucket);
 }

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -1,7 +1,9 @@
+import * as sqlite from 'node:sqlite';
 import { describe, expect } from 'vitest';
 import {
   DEFAULT_HYDRATION_STATE,
   HydratedSyncConfig,
+  nodeSqlite,
   ParameterLookupRows,
   PrecompiledSyncConfig,
   ScopedParameterLookup,
@@ -612,7 +614,7 @@ streams:
   stream:
       query: SELECT a.* FROM a, b, c WHERE a.id1 = b.id1 AND a.c1 = c.c1 AND b.c1 = c.c1 AND b.c2 = c.c2 AND c.u = auth.user_id()
 `) as PrecompiledSyncConfig;
-    const desc = compiled.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE });
+    const desc = compiled.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE, sqlite: nodeSqlite(sqlite) });
 
     const { querier, errors } = desc.getBucketParameterQuerier({
       globalParameters: requestParameters({ sub: 'user1' }),
@@ -1168,6 +1170,57 @@ streams:
       ]);
     });
   });
+});
+
+syncTest('SQLite smoke test', async ({ sync }) => {
+  const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+  unstable_sqlite_expression_engine: true
+
+streams:
+  stream:
+      auto_subscribe: true
+      query: SELECT comments.* FROM comments, issues
+        WHERE issues.id = comments.issue
+        AND issues.owner = auth.user_id()
+`);
+
+  expect(desc.evaluateParameterRow(ISSUES, { id: 'issue', owner: 'user' })).toStrictEqual([
+    {
+      lookup: ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['user']),
+      bucketParameters: [
+        {
+          '0': 'issue'
+        }
+      ]
+    }
+  ]);
+  expect(desc.evaluateRow({ sourceTable: COMMENTS, record: { id: 'c', issue: 'issue', text: 'foo' } })).toStrictEqual([
+    {
+      bucket: 'stream|0["issue"]',
+      id: 'c',
+      data: { id: 'c', issue: 'issue', text: 'foo' },
+      table: 'comments'
+    }
+  ]);
+
+  const { querier, errors } = desc.getBucketParameterQuerier({
+    globalParameters: requestParameters({ sub: 'user' }),
+    hasDefaultStreams: true,
+    streams: {}
+  });
+  expect(errors).toHaveLength(0);
+  expect(querier.staticBuckets).toHaveLength(0);
+
+  const dynamicBuckets = await querier.queryDynamicBucketDescriptions({
+    async getParameterSets(lookups) {
+      expect(lookups).toStrictEqual([ScopedParameterLookup.direct(lookupScope('lookup', '0'), ['user'])]);
+
+      return [{ lookup: lookups[0], rows: [{ '0': 'issue' }] }];
+    }
+  });
+  expect(dynamicBuckets.map((b) => b.bucket)).toStrictEqual(['stream|0["issue"]']);
 });
 
 function evaluateBucketIds(source: HydratedSyncConfig, sourceTable: SourceTableRef, record: SqliteRow) {

--- a/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
@@ -9,7 +9,7 @@ import {
   TableProcessorTableValuedFunction
 } from '../../../../src/index.js';
 import { PreparedStreamBucketDataSource } from '../../../../src/sync_plan/evaluator/bucket_data_source.js';
-import { lookupScope, requestParameters, TestSourceTable } from '../../util.js';
+import { lookupScope, requestParameters, testHydrationInput, TestSourceTable } from '../../util.js';
 import { syncTest } from './utils.js';
 
 describe('table-valued functions', () => {
@@ -136,9 +136,8 @@ streams:
 
     const evaluator = new PreparedStreamBucketDataSource(plan.buckets[0], {
       defaultSchema: 'test_schema',
-      engine: sync.engine,
       sourceText: ''
-    });
+    }).createEvaluator(testHydrationInput());
     const products = new TestSourceTable('products');
 
     expect(

--- a/packages/sync-rules/test/src/sync_plan/evaluator/utils.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/utils.ts
@@ -1,42 +1,37 @@
+import * as sqlite from 'node:sqlite';
+
 import { test } from 'vitest';
 import {
   CompatibilityContext,
-  CompatibilityEdition,
-  CreateSourceParams,
   DEFAULT_HYDRATION_STATE,
   HydratedSyncConfig,
-  javaScriptExpressionEngine,
+  HydrateSyncConfigParams,
+  nodeSqlite,
   PrecompiledSyncConfig,
   SyncConfig
 } from '../../../../src/index.js';
-import { ScalarExpressionEngine } from '../../../../src/sync_plan/engine/scalar_expression_engine.js';
 import { compileToSyncPlanWithoutErrors } from '../../compiler/utils.js';
 
 interface SyncTest {
-  engine: ScalarExpressionEngine;
   prepareWithoutHydration(yaml: string): SyncConfig;
-  prepareSyncStreams(yaml: string): HydratedSyncConfig;
+  prepareSyncStreams(yaml: string, params?: HydrateSyncConfigParams): HydratedSyncConfig;
 }
 
 export const syncTest = test.extend<{ sync: SyncTest }>({
   sync: async ({}, use) => {
-    const engine = javaScriptExpressionEngine(new CompatibilityContext({ edition: CompatibilityEdition.SYNC_STREAMS }));
-
     await use({
-      engine,
       prepareWithoutHydration: (inputs) => {
         const plan = compileToSyncPlanWithoutErrors(inputs);
         return new PrecompiledSyncConfig(plan, new CompatibilityContext({ edition: 3 }), [], {
-          engine,
           sourceText: '',
           defaultSchema: 'test_schema'
         });
       },
-      prepareSyncStreams(inputs, params?: CreateSourceParams) {
-        return this.prepareWithoutHydration(inputs).hydrate(params ?? { hydrationState: DEFAULT_HYDRATION_STATE });
+      prepareSyncStreams(inputs, params?: HydrateSyncConfigParams) {
+        return this.prepareWithoutHydration(inputs).hydrate(
+          params ?? { hydrationState: DEFAULT_HYDRATION_STATE, sqlite: nodeSqlite(sqlite) }
+        );
       }
     });
-
-    engine.close();
   }
 });

--- a/packages/sync-rules/test/src/sync_plan/evaluator/utils.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/utils.ts
@@ -1,16 +1,14 @@
 import * as sqlite from 'node:sqlite';
 
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 import {
-  CompatibilityContext,
   DEFAULT_HYDRATION_STATE,
   HydratedSyncConfig,
   HydrateSyncConfigParams,
   nodeSqlite,
-  PrecompiledSyncConfig,
+  SqlSyncRules,
   SyncConfig
 } from '../../../../src/index.js';
-import { compileToSyncPlanWithoutErrors } from '../../compiler/utils.js';
 
 interface SyncTest {
   prepareWithoutHydration(yaml: string): SyncConfig;
@@ -21,11 +19,10 @@ export const syncTest = test.extend<{ sync: SyncTest }>({
   sync: async ({}, use) => {
     await use({
       prepareWithoutHydration: (inputs) => {
-        const plan = compileToSyncPlanWithoutErrors(inputs);
-        return new PrecompiledSyncConfig(plan, new CompatibilityContext({ edition: 3 }), [], {
-          sourceText: '',
-          defaultSchema: 'test_schema'
-        });
+        const { config, errors } = SqlSyncRules.fromYaml(inputs, { defaultSchema: 'test_schema', throwOnError: false });
+        expect(errors).toHaveLength(0);
+
+        return config;
       },
       prepareSyncStreams(inputs, params?: HydrateSyncConfigParams) {
         return this.prepareWithoutHydration(inputs).hydrate(

--- a/packages/sync-rules/test/src/sync_plan/schema_inference.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/schema_inference.test.ts
@@ -5,7 +5,6 @@ import {
   DEFAULT_TAG,
   deserializeSyncPlan,
   ExpressionType,
-  javaScriptExpressionEngine,
   PrecompiledSyncConfig,
   SourceTableDefinition,
   sqlTypeName,
@@ -41,8 +40,6 @@ describe('schema inference', () => {
     const serializedPlan = compileSingleStreamAndSerialize(...queries);
     const plan = deserializeSyncPlan(serializedPlan);
     const rules = new PrecompiledSyncConfig(plan, new CompatibilityContext({ edition: 3 }), [], {
-      // Engine isn't actually used here, but required to load sync plan
-      engine: javaScriptExpressionEngine(CompatibilityContext.FULL_BACKWARDS_COMPATIBILITY),
       sourceText: '',
       defaultSchema: 'test_schema'
     });

--- a/packages/sync-rules/test/src/sync_rules.test.ts
+++ b/packages/sync-rules/test/src/sync_rules.test.ts
@@ -1,5 +1,13 @@
+import * as sqlite from 'node:sqlite';
+
 import { describe, expect, test } from 'vitest';
-import { BucketPriority, CreateSourceParams, ScopedParameterLookup, SqlSyncRules } from '../../src/index.js';
+import {
+  BucketPriority,
+  HydrateSyncConfigParams,
+  nodeSqlite,
+  ScopedParameterLookup,
+  SqlSyncRules
+} from '../../src/index.js';
 
 import {
   BucketDataScope,
@@ -22,7 +30,10 @@ import {
 } from './util.js';
 
 describe('sync rules', () => {
-  const hydrationParams: CreateSourceParams = { hydrationState: DEFAULT_HYDRATION_STATE };
+  const hydrationParams: HydrateSyncConfigParams = {
+    hydrationState: DEFAULT_HYDRATION_STATE,
+    sqlite: nodeSqlite(sqlite)
+  };
 
   test('parse empty sync rules', () => {
     const { config: rules } = SqlSyncRules.fromYaml('bucket_definitions: {}', PARSE_OPTIONS);
@@ -232,7 +243,7 @@ bucket_definitions:
         };
       }
     };
-    const hydrated = rules.hydrate({ hydrationState });
+    const hydrated = rules.hydrate({ hydrationState, sqlite: nodeSqlite(sqlite) });
     const { querier, errors } = hydrated.getBucketParameterQuerier(
       normalizeQuerierOptions({ sub: 'user1' }, { device_id: 'device1' })
     );
@@ -1222,5 +1233,33 @@ streams: []`,
     expect(rules.storageVersion).toBeUndefined();
     expect(errors[0].message).toContain('Storage version 1 is not supported');
     expect(errors[0].type).toBe('fatal');
+  });
+
+  test(`can't use sqlite_expression_engine in old config edition`, () => {
+    const { config: rules, errors } = SqlSyncRules.fromYaml(
+      `
+config:
+  unstable_sqlite_expression_engine: true
+
+bucket_definitions:`,
+      { ...PARSE_OPTIONS, throwOnError: false }
+    );
+
+    expect(errors[0].message).toContain('Enabling unstable_sqlite_expression_engine requires edition: 3');
+  });
+
+  test(`can't use sqlite_expression_engine without json compatibility`, () => {
+    const { config: rules, errors } = SqlSyncRules.fromYaml(
+      `
+config:
+  edition: 3
+  unstable_sqlite_expression_engine: true
+  fixed_json_extract: false
+
+streams:`,
+      { ...PARSE_OPTIONS, throwOnError: false }
+    );
+
+    expect(errors[0].message).toContain('Enabling unstable_sqlite_expression_engine requires fixed_json_extract');
   });
 });

--- a/packages/sync-rules/test/src/util.ts
+++ b/packages/sync-rules/test/src/util.ts
@@ -1,24 +1,39 @@
+import * as sqlite from 'node:sqlite';
+
 import { expect } from 'vitest';
 import {
   BaseJwtPayload,
   BucketDataScope,
   BucketDataSource,
   BucketParameterQuerier,
+  BucketSource,
   ColumnDefinition,
   CompatibilityContext,
+  CompatibilityEdition,
+  CreateSourceParams,
+  DEFAULT_HYDRATION_STATE,
   DEFAULT_TAG,
   GetQuerierOptions,
+  HydratedBucketSource,
+  HydrationInput,
+  HydrationState,
+  mergeDataSources,
+  mergeParameterIndexLookupCreators,
+  nodeSqlite,
   ParameterIndexLookupCreator,
   ParameterLookupDefinitionId,
   ParameterLookupScope,
   RequestedStream,
   RequestParameters,
+  ScopedEvaluateParameterRow,
+  ScopedEvaluateRow,
   ScopedParameterLookup,
   SourceSchema,
   SourceTableRef,
   StaticSchema,
   TablePattern
 } from '../../src/index.js';
+import { createScalarExpressionEngine } from '../../src/sync_plan/engine/factory.js';
 
 export class TestSourceTable implements SourceTableRef {
   readonly connectionTag = DEFAULT_TAG;
@@ -98,7 +113,7 @@ export const EMPTY_DATA_SOURCE: BucketDataSource = {
   getSourceTables: function (): Set<TablePattern> {
     return new Set();
   },
-  evaluateRow(options) {
+  createEvaluator() {
     throw new Error('Function not implemented.');
   },
   tableSyncsData: function (table: SourceTableRef): boolean {
@@ -122,8 +137,12 @@ export const EMPTY_PARAMETER_LOOKUP_SOURCE: ParameterIndexLookupCreator = {
   getSourceTables(): Set<TablePattern> {
     return new Set();
   },
-  evaluateParameterRow() {
-    return [];
+  createEvaluator() {
+    return {
+      evaluateParameterRow() {
+        return [];
+      }
+    };
   },
   tableSyncsParameters() {
     return false;
@@ -154,4 +173,44 @@ export async function findQuerierLookups(querier: BucketParameterQuerier): Promi
   });
 
   return recordedLookups!;
+}
+
+export interface DebugMergedSource extends HydratedBucketSource {
+  evaluateRow: ScopedEvaluateRow;
+  evaluateParameterRow: ScopedEvaluateParameterRow;
+}
+
+/**
+ * For production purposes, we typically need to operate on the different sources separately. However, for debugging,
+ * it is useful to have a single merged source that can evaluate everything.
+ */
+export function debugHydratedMergedSource(bucketSource: BucketSource, params?: CreateSourceParams): DebugMergedSource {
+  const hydrationState = params?.hydrationState ?? DEFAULT_HYDRATION_STATE;
+  const input = testHydrationInput({ hydrationState });
+  const dataSource = mergeDataSources(input, bucketSource.dataSources);
+  const parameterLookupSource = mergeParameterIndexLookupCreators(input, bucketSource.parameterIndexLookupCreators);
+  const hydratedBucketSource = bucketSource.hydrate(input);
+  return {
+    definition: bucketSource,
+    evaluateParameterRow: parameterLookupSource.evaluateParameterRow.bind(parameterLookupSource),
+    evaluateRow: dataSource.evaluateRow.bind(dataSource),
+    pushBucketParameterQueriers: hydratedBucketSource.pushBucketParameterQueriers.bind(hydratedBucketSource)
+  };
+}
+
+export function testHydrationInput(
+  options: {
+    compatibility?: CompatibilityContext;
+    hydrationState?: HydrationState;
+  } = {}
+): HydrationInput {
+  const {
+    compatibility = new CompatibilityContext({ edition: CompatibilityEdition.COMPILED_STREAMS }),
+    hydrationState = DEFAULT_HYDRATION_STATE
+  } = options;
+
+  return {
+    scalarExpressions: createScalarExpressionEngine(compatibility, nodeSqlite(sqlite)),
+    hydrationState
+  };
 }


### PR DESCRIPTION
Apart from a few PowerSync-specific additions, the SQL dialect implemented in Sync Streams is supposed to be SQLite. Currently, we implement operators and functions in JavaScript, and the idea is that we're supposed to match semantics from SQLite. Recently, @sravan27 found a few cases where we're not quite getting this right:

1. `json_each` should work on objects and scalar values, we only support arrays (https://github.com/powersync-ja/powersync-service/pull/647).
2. SQLite returns `NULL` for a division by zero, our implementation throws or returns Infinity (https://github.com/powersync-ja/powersync-service/pull/646).
3. We don't handle `+` / `-` prefixes on numbers when casting from text (https://github.com/powersync-ja/powersync-service/pull/645).
4. There are a few cases where we don't handle `NULL` values correctly (https://github.com/powersync-ja/powersync-service/pull/643).
5. Noteworthy mention: `iif` was broken in the compiler but only there (https://github.com/powersync-ja/powersync-service/pull/644). This PR would not have fixed that one.

Fixing these is possible, but a breaking change in most cases (requiring a compatibility option). And even with options, we can't know how many remaining differences there are (those would require additional options).

As a solution, this adds the `unstable_sqlite_expression_engine` compatibility option. When enabled, functions and operators are evaluated by a scalar `SELECT` statement (without a `FROM` clause) on an in-memory SQLite database. This means we'll get the exact behavior from SQLite going forward.

This also includes a small refactoring on internal sync config representations to not require an SQL engine upfront. Instead, we:

1. First parse YAML (or restore a serialized) plan into an in-memory structure, this should not require access to a SQLite database.
6. To then evaluate rows, parameters or queriers, we hydrate the config. This step requires a SQL engine now.

## Known issues

`node:sqlite` is not yet stable, so we can't build stable options with it. SQLite is also known to change how it evaluates expressions from time to time (the text -> float conversion update in 3.52 is a good example for this).

I think this is good enough to ship it as an experimental option. To stabilize it, we should perhaps look into adopting a WebAssembly build of SQLite. That would give us a fixed SQLite version and allows us to install a custom VFS without time support (so we wouldn't have to override builtin date and time functions).

## Product visibility

We'll have to update the docs page on available options to mention this.