### PR TITLE
fix: Convex hostname normalization

### DIFF
--- a/.changeset/fix-host-normalization.md
+++ b/.changeset/fix-host-normalization.md
@@ -1,6 +1,7 @@
 ---
 '@powersync/lib-services-framework': patch
 '@powersync/lib-service-mongodb': patch
+'@powersync/service-module-convex': patch
 '@powersync/service-core': patch
 ---
 

--- a/modules/module-convex/src/types/types.ts
+++ b/modules/module-convex/src/types/types.ts
@@ -1,4 +1,9 @@
-import { ErrorCode, makeHostnameLookupFunction, ServiceError } from '@powersync/lib-services-framework';
+import {
+  ErrorCode,
+  hostnameFromSocketAddress,
+  makeHostnameLookupFunction,
+  ServiceError
+} from '@powersync/lib-services-framework';
 import * as service_types from '@powersync/service-types';
 import { LookupFunction } from 'node:net';
 import * as t from 'ts-codec';
@@ -78,7 +83,10 @@ export function normalizeConnectionConfig(options: ConvexConnectionConfig): Norm
     );
   }
 
-  const lookup = makeHostnameLookupFunction(deploymentURL.hostname, {
+  // URL.hostname returns IPv6 literals wrapped in brackets, while
+  // makeHostnameLookupFunction expects a normalized hostname: no port and no IPv6 brackets.
+  const hostname = hostnameFromSocketAddress(deploymentURL.hostname);
+  const lookup = makeHostnameLookupFunction(hostname, {
     reject_ip_ranges: options.reject_ip_ranges ?? []
   });
 

--- a/modules/module-convex/test/src/types.test.ts
+++ b/modules/module-convex/test/src/types.test.ts
@@ -68,4 +68,26 @@ describe('Convex connection config', () => {
       })
     ).toThrow('request_timeout_ms must be a positive finite number');
   });
+
+  it('rejects a bracketed IPv6 deployment URL when local IPs are blocked', () => {
+    expect(() =>
+      normalizeConnectionConfig({
+        type: CONVEX_CONNECTION_TYPE,
+        deployment_url: 'http://[::1]:3210',
+        deploy_key: 'secret-key',
+        reject_ip_ranges: ['local']
+      })
+    ).toThrow('IPs in this range are not supported');
+  });
+
+  it('rejects a bracketed IPv6 deployment URL against an explicit CIDR', () => {
+    expect(() =>
+      normalizeConnectionConfig({
+        type: CONVEX_CONNECTION_TYPE,
+        deployment_url: 'http://[::1]:3210',
+        deploy_key: 'secret-key',
+        reject_ip_ranges: ['::1/128']
+      })
+    ).toThrow('IPs in this range are not supported');
+  });
 });


### PR DESCRIPTION
This ports hostname string normalization changes from https://github.com/powersync-ja/powersync-service/pull/642 for the new Convex module.

---
AI Disclosure, this was implemented with the help of Codex GPT-5.5