### PR TITLE
[MongoDB] Fix checkpoint stalling

### DIFF
--- a/.changeset/short-laws-speak.md
+++ b/.changeset/short-laws-speak.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': patch
+---
+
+Fix edge case where checkpoints are stalled after an internal MongoDB command retry, leading to large reported replication lag.

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -713,11 +713,15 @@ export class ChangeStream {
                 // change stream events, collapse standalone checkpoints into the normal batch
                 // checkpoint flow to avoid commit churn under sustained load.
                 const hasBufferedChanges = eventIndex < events.length - 1;
-                if (waitForCheckpointLsn != null || hasBufferedChanges) {
-                  if (waitForCheckpointLsn == null) {
-                    waitForCheckpointLsn = await createCheckpoint(this.client, this.defaultDb, this.checkpointStreamId);
-                  }
+                if (hasBufferedChanges && waitForCheckpointLsn == null) {
+                  // Buffered changes - create a new batch checkpoint to rate limit commits
+                  waitForCheckpointLsn = await createCheckpoint(this.client, this.defaultDb, this.checkpointStreamId);
                   continue;
+                } else if (waitForCheckpointLsn != null) {
+                  // Skip this checkpoint - wait for the batch checkpoint.
+                  continue;
+                } else {
+                  // No buffered changes, and no batch checkpoint pending - commit immediately.
                 }
               } else if (!this.checkpointStreamId.equals(checkpointId)) {
                 continue;

--- a/modules/module-mongodb/src/replication/MongoRelation.ts
+++ b/modules/module-mongodb/src/replication/MongoRelation.ts
@@ -198,38 +198,33 @@ async function createCheckpointInner(
   db: mongo.Db,
   id: mongo.ObjectId | string
 ): Promise<string> {
-  const session = client.startSession();
-  try {
-    // We use an unique id per process, and clear documents on startup.
-    // This is so that we can filter events for our own process only, and ignore
-    // events from other processes.
+  // We use an unique id per process, and clear documents on startup.
+  // This is so that we can filter events for our own process only, and ignore
+  // events from other processes.
 
-    // We use a command instead of a regular update to avoid auto retries on writes.
-    // An auto retry on the write can trigger a weird edge case where the change stream event
-    // has the clusterTime of the first write, while the returned operation time is for the second no-op write.
-    // Instead, we do manual retries, which does not have the same write de-duplication logic.
-    // A sentinal-based approach would be better here, but that is a much bigger change.
+  // We use a command instead of a regular update to avoid auto retries on writes.
+  // An auto retry on the write can trigger a weird edge case where the change stream event
+  // has the clusterTime of the first write, while the returned operation time is for the second no-op write.
+  // Instead, we do manual retries, which does not have the same write de-duplication logic.
+  // A sentinal-based approach would be better here, but that is a much bigger change.
 
-    const response = await db.command({
-      findAndModify: '_powersync_checkpoints',
-      query: {
-        _id: id as any
-      },
-      new: true,
-      upsert: true,
-      update: {
-        $inc: { i: 1 }
-      }
-    });
-
-    const time = response.operationTime as mongo.Timestamp | undefined;
-    if (time == null) {
-      throw new ServiceError(ErrorCode.PSYNC_S1004, `clusterTime not available for checkpoint`);
+  const response = await db.command({
+    findAndModify: '_powersync_checkpoints',
+    query: {
+      _id: id as any
+    },
+    new: true,
+    upsert: true,
+    update: {
+      $inc: { i: 1 }
     }
-    return new MongoLSN({ timestamp: time }).comparable;
-  } finally {
-    await session.endSession();
+  });
+
+  const time = response.operationTime as mongo.Timestamp | undefined;
+  if (time == null) {
+    throw new ServiceError(ErrorCode.PSYNC_S1004, `clusterTime not available for checkpoint`);
   }
+  return new MongoLSN({ timestamp: time }).comparable;
 }
 
 const mongoTimeOptions: DateTimeSourceOptions = {

--- a/modules/module-mongodb/src/replication/MongoRelation.ts
+++ b/modules/module-mongodb/src/replication/MongoRelation.ts
@@ -13,9 +13,8 @@ import {
   TimeValuePrecision
 } from '@powersync/service-sync-rules';
 
-import { ErrorCode, ServiceError } from '@powersync/lib-services-framework';
+import { ErrorCode, logger, ServiceAssertionError, ServiceError } from '@powersync/lib-services-framework';
 import { MongoLSN } from '../common/MongoLSN.js';
-import { CHECKPOINTS_COLLECTION } from './replication-utils.js';
 
 export function getMongoRelation(
   source: mongo.ChangeStreamNameSpace,
@@ -179,26 +178,54 @@ export async function createCheckpoint(
   db: mongo.Db,
   id: mongo.ObjectId | string
 ): Promise<string> {
+  const TRIES = 2;
+  for (let i = 0; i < TRIES; i++) {
+    try {
+      return await createCheckpointInner(client, db, id);
+    } catch (e) {
+      if (i < TRIES - 1) {
+        logger.warn(`Failed to create checkpoint on attempt ${i + 1}`, e);
+      } else {
+        throw e;
+      }
+    }
+  }
+  throw new ServiceAssertionError(`Unreachable code`);
+}
+
+async function createCheckpointInner(
+  client: mongo.MongoClient,
+  db: mongo.Db,
+  id: mongo.ObjectId | string
+): Promise<string> {
   const session = client.startSession();
   try {
     // We use an unique id per process, and clear documents on startup.
     // This is so that we can filter events for our own process only, and ignore
     // events from other processes.
-    await db.collection(CHECKPOINTS_COLLECTION).findOneAndUpdate(
-      {
+
+    // We use a command instead of a regular update to avoid auto retries on writes.
+    // An auto retry on the write can trigger a weird edge case where the change stream event
+    // has the clusterTime of the first write, while the returned operation time is for the second no-op write.
+    // Instead, we do manual retries, which does not have the same write de-duplication logic.
+    // A sentinal-based approach would be better here, but that is a much bigger change.
+
+    const response = await db.command({
+      findAndModify: '_powersync_checkpoints',
+      query: {
         _id: id as any
       },
-      {
+      new: true,
+      upsert: true,
+      update: {
         $inc: { i: 1 }
-      },
-      {
-        upsert: true,
-        returnDocument: 'after',
-        session
       }
-    );
-    const time = session.operationTime!;
-    // TODO: Use the above when we support custom write checkpoints
+    });
+
+    const time = response.operationTime as mongo.Timestamp | undefined;
+    if (time == null) {
+      throw new ServiceError(ErrorCode.PSYNC_S1004, `clusterTime not available for checkpoint`);
+    }
     return new MongoLSN({ timestamp: time }).comparable;
   } finally {
     await session.endSession();

--- a/modules/module-mongodb/test/src/checkpoint_retry.test.ts
+++ b/modules/module-mongodb/test/src/checkpoint_retry.test.ts
@@ -4,123 +4,128 @@ import { mongo } from '@powersync/lib-service-mongodb';
 
 import { MongoLSN } from '@module/common/MongoLSN.js';
 import { createCheckpoint } from '@module/replication/MongoRelation.js';
-import { CHECKPOINTS_COLLECTION } from '@module/replication/replication-utils.js';
 import { clearTestDb, connectMongoData, requireFailCommand } from './util.js';
 
 describe('checkpoint retryable writes', () => {
-  for (let i = 0; i < 50; i++) {
-    test('can return a session operationTime newer than the checkpoint change event', { retry: 3 }, async (ctx) => {
-      // This test relies on very specific timing:
-      //
-      // 1. _powersync_checkpoints findAndModify command starts and is sent to the server
-      // 2. command is written to the server
-      // 3. _powersync_checkpoints findAndModify command fails with a retryable error (e.g. connection timeout)
-      // 4. command is retried
-      // 5. another write lands on the server, increasing the server's operationTime
-      // 6. command succeeds with a new operationTime, but without actually writing again (server de-duplicates based on transaction id)
-      //
-      // It is quite difficult to simulate this, even with failCommand. We currently rely on triggering a socket timeout for the first command,
-      // with another write happening right after that.
+  test('returns the persisted checkpoint clusterTime after a retryable write', { repeats: 1 }, async (ctx) => {
+    // This test relies on very specific timing:
+    //
+    // 1. _powersync_checkpoints findAndModify command starts and is sent to the server
+    // 2. command is written to the server
+    // 3. _powersync_checkpoints findAndModify command fails with a retryable error (e.g. connection timeout)
+    // 4. command is retried
+    // 5. another write lands on the server, increasing the server's operationTime
+    // 6. command succeeds with a new operationTime, but without actually writing again (server de-duplicates based on transaction id)
+    //
+    // It is quite difficult to simulate this, even with failCommand. We currently rely on triggering a socket timeout for the first command,
+    // with another write happening right after that.
 
-      const TIMEOUT = 100;
+    const TIMEOUT = 100;
+    const INSERT_COUNT = 5;
 
-      const { db, client } = await connectMongoData({
-        monitorCommands: true,
-        socketTimeoutMS: TIMEOUT,
-        maxPoolSize: 1
-      });
+    const { db, client } = await connectMongoData({
+      monitorCommands: true,
+      socketTimeoutMS: TIMEOUT,
+      maxPoolSize: 1
+    });
 
-      await using _client = { [Symbol.asyncDispose]: async () => await client.close() };
-      await client.connect();
-      await using failCommand = await requireFailCommand(client, ctx);
+    await using _client = { [Symbol.asyncDispose]: async () => await client.close() };
+    await client.connect();
+    await using failCommand = await requireFailCommand(client, ctx);
 
-      await clearTestDb(db);
-      await db.createCollection(CHECKPOINTS_COLLECTION);
+    await clearTestDb(db);
 
-      const checkpointId = new mongo.ObjectId();
-      const checkpoints = db.collection(CHECKPOINTS_COLLECTION);
-      const advanceClusterTime = db.collection('_advance_cluster_time');
+    const checkpointId = new mongo.ObjectId();
+    const advanceClusterTime = db.collection('_advance_cluster_time');
 
-      const changeStream = checkpoints.watch([], { maxAwaitTimeMS: TIMEOUT * 0.8 });
-      await using _changeStream = { [Symbol.asyncDispose]: async () => await changeStream.close() };
+    const changeStream = db.watch([], { maxAwaitTimeMS: TIMEOUT * 0.8 });
+    await using _changeStream = { [Symbol.asyncDispose]: async () => await changeStream.close() };
 
-      const checkpointEventPromise = waitForCheckpointEvent(changeStream, checkpointId).catch((e) => console.error(e));
-      const commandsStarted: mongo.CommandStartedEvent[] = [];
+    const checkpointEventPromise = waitForCheckpointEvent(changeStream, checkpointId, INSERT_COUNT).catch((e) =>
+      console.error(e)
+    );
 
+    const commandsStarted: mongo.CommandStartedEvent[] = [];
+
+    client.on('commandStarted', (event) => {
+      commandsStarted.push(event);
+    });
+
+    const DEBUG_COMMANDS = true;
+    if (DEBUG_COMMANDS) {
+      // For debugging: Log all commands
       client.on('commandStarted', (event) => {
-        commandsStarted.push(event);
+        console.log('commandStarted:', event);
       });
 
-      const DEBUG_COMMANDS = false;
-      if (DEBUG_COMMANDS) {
-        // For debugging: Log all commands
-        client.on('commandStarted', (event) => {
-          console.log('commandStarted:', event);
-        });
-
-        client.on('commandSucceeded', (event) => {
-          console.log('commandSucceeded:', event);
-        });
-
-        client.on('commandFailed', (event) => {
-          console.log('commandFailed:', event);
-        });
-      }
-
-      await failCommand.configure({
-        mode: { times: 1 },
-        data: {
-          failCommands: ['findAndModify'],
-          blockConnection: true,
-          blockTimeMS: TIMEOUT
-        }
+      client.on('commandSucceeded', (event) => {
+        console.log('commandSucceeded:', event);
       });
-      const returnedLsnPromise = createCheckpoint(client, db, checkpointId);
 
-      for (let i = 0; i < 10; i++) {
-        await advanceClusterTime.insertOne({ at: new Date() });
+      client.on('commandFailed', (event) => {
+        console.log('commandFailed:', event);
+      });
+    }
+
+    await failCommand.configure({
+      mode: { times: 1 },
+      data: {
+        failCommands: ['commitTransaction', 'findAndModify'],
+        blockConnection: true,
+        blockTimeMS: TIMEOUT
       }
+    });
+    const returnedLsnPromise = createCheckpoint(client, db, checkpointId);
 
-      const returnedLsn = await returnedLsnPromise;
-      const checkpointEvent = await checkpointEventPromise;
-      if (checkpointEvent == null) {
-        throw new Error('change stream failed');
-      }
+    for (let i = 0; i < INSERT_COUNT; i++) {
+      await advanceClusterTime.insertOne({ at: new Date() });
+    }
 
-      const eventLsn = new MongoLSN({
-        timestamp: checkpointEvent.clusterTime!,
-        resume_token: checkpointEvent._id
-      }).comparable;
+    const returnedLsn = await returnedLsnPromise;
+    const checkpointEvent = await checkpointEventPromise;
+    if (checkpointEvent == null) {
+      throw new Error('change stream failed');
+    }
 
-      const doc = await checkpoints.findOne({ _id: checkpointId });
-      expect(doc).toMatchObject({ i: 1 });
+    const eventLsn = new MongoLSN({
+      timestamp: checkpointEvent.clusterTime!,
+      resume_token: checkpointEvent._id
+    }).comparable;
 
+    if (DEBUG_COMMANDS) {
       const commands = commandsStarted
         .filter((c) => ['findAndModify', 'insert'].includes(c.commandName))
         .map((c) => c.commandName);
-      const first = commands.findIndex((c) => c == 'findAndModify');
-      const last = commands.findLastIndex((c) => c == 'findAndModify');
-      // If this expect fails, the test conditions were not met, rather than the behavior itself being wrong.
-      // We specifically need an insert between the two findAndModify commands, otherwise the test is not testing anything useful.
-      expect(last - first).toBeGreaterThan(1);
+      // In the failure case, we had findAndModify, insert, findAndModify, potentially with more inserts in between.
+      // With updated behavior, we only have a single findAndModify.
+      console.log('Command order:', commands);
+    }
 
-      expect(eventLsn >= returnedLsn).toBe(false);
-    });
-  }
+    expect(eventLsn >= returnedLsn).toBe(true);
+    expect(checkpointEvent.clusterTime).toEqual(MongoLSN.fromSerialized(returnedLsn).timestamp);
+  });
 });
 
 async function waitForCheckpointEvent(
   changeStream: mongo.ChangeStream,
-  checkpointId: mongo.ObjectId
-): Promise<mongo.ChangeStreamDocument> {
+  checkpointId: mongo.ObjectId,
+  insertCount: number
+): Promise<mongo.ChangeStreamDocument | null> {
+  let lastEvent: mongo.ChangeStreamDocument | null = null;
+  let seenInserts = 0;
   for await (const event of changeStream) {
     if (
       (event.operationType == 'insert' || event.operationType == 'update' || event.operationType == 'replace') &&
       checkpointId.equals(event.documentKey._id)
     ) {
-      return event;
+      lastEvent = event;
+    } else if (event.operationType == 'insert' && event.ns.coll === '_advance_cluster_time') {
+      seenInserts++;
+      if (seenInserts >= insertCount) {
+        // We finish when we hit the expected number of inserts, since the number of checkpoint events are unknown.
+        break;
+      }
     }
   }
-
-  throw new Error('Change stream closed before checkpoint event was received');
+  return lastEvent;
 }

--- a/modules/module-mongodb/test/src/checkpoint_retry.test.ts
+++ b/modules/module-mongodb/test/src/checkpoint_retry.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'vitest';
+
+import { mongo } from '@powersync/lib-service-mongodb';
+
+import { MongoLSN } from '@module/common/MongoLSN.js';
+import { createCheckpoint } from '@module/replication/MongoRelation.js';
+import { CHECKPOINTS_COLLECTION } from '@module/replication/replication-utils.js';
+import { clearTestDb, connectMongoData, requireFailCommand } from './util.js';
+
+describe('checkpoint retryable writes', () => {
+  for (let i = 0; i < 50; i++) {
+    test('can return a session operationTime newer than the checkpoint change event', { retry: 3 }, async (ctx) => {
+      // This test relies on very specific timing:
+      //
+      // 1. _powersync_checkpoints findAndModify command starts and is sent to the server
+      // 2. command is written to the server
+      // 3. _powersync_checkpoints findAndModify command fails with a retryable error (e.g. connection timeout)
+      // 4. command is retried
+      // 5. another write lands on the server, increasing the server's operationTime
+      // 6. command succeeds with a new operationTime, but without actually writing again (server de-duplicates based on transaction id)
+      //
+      // It is quite difficult to simulate this, even with failCommand. We currently rely on triggering a socket timeout for the first command,
+      // with another write happening right after that.
+
+      const TIMEOUT = 100;
+
+      const { db, client } = await connectMongoData({
+        monitorCommands: true,
+        socketTimeoutMS: TIMEOUT,
+        maxPoolSize: 1
+      });
+
+      await using _client = { [Symbol.asyncDispose]: async () => await client.close() };
+      await client.connect();
+      await using failCommand = await requireFailCommand(client, ctx);
+
+      await clearTestDb(db);
+      await db.createCollection(CHECKPOINTS_COLLECTION);
+
+      const checkpointId = new mongo.ObjectId();
+      const checkpoints = db.collection(CHECKPOINTS_COLLECTION);
+      const advanceClusterTime = db.collection('_advance_cluster_time');
+
+      const changeStream = checkpoints.watch([], { maxAwaitTimeMS: TIMEOUT * 0.8 });
+      await using _changeStream = { [Symbol.asyncDispose]: async () => await changeStream.close() };
+
+      const checkpointEventPromise = waitForCheckpointEvent(changeStream, checkpointId).catch((e) => console.error(e));
+      const commandsStarted: mongo.CommandStartedEvent[] = [];
+
+      client.on('commandStarted', (event) => {
+        commandsStarted.push(event);
+      });
+
+      const DEBUG_COMMANDS = false;
+      if (DEBUG_COMMANDS) {
+        // For debugging: Log all commands
+        client.on('commandStarted', (event) => {
+          console.log('commandStarted:', event);
+        });
+
+        client.on('commandSucceeded', (event) => {
+          console.log('commandSucceeded:', event);
+        });
+
+        client.on('commandFailed', (event) => {
+          console.log('commandFailed:', event);
+        });
+      }
+
+      await failCommand.configure({
+        mode: { times: 1 },
+        data: {
+          failCommands: ['findAndModify'],
+          blockConnection: true,
+          blockTimeMS: TIMEOUT
+        }
+      });
+      const returnedLsnPromise = createCheckpoint(client, db, checkpointId);
+
+      for (let i = 0; i < 10; i++) {
+        await advanceClusterTime.insertOne({ at: new Date() });
+      }
+
+      const returnedLsn = await returnedLsnPromise;
+      const checkpointEvent = await checkpointEventPromise;
+      if (checkpointEvent == null) {
+        throw new Error('change stream failed');
+      }
+
+      const eventLsn = new MongoLSN({
+        timestamp: checkpointEvent.clusterTime!,
+        resume_token: checkpointEvent._id
+      }).comparable;
+
+      const doc = await checkpoints.findOne({ _id: checkpointId });
+      expect(doc).toMatchObject({ i: 1 });
+
+      const commands = commandsStarted
+        .filter((c) => ['findAndModify', 'insert'].includes(c.commandName))
+        .map((c) => c.commandName);
+      const first = commands.findIndex((c) => c == 'findAndModify');
+      const last = commands.findLastIndex((c) => c == 'findAndModify');
+      // If this expect fails, the test conditions were not met, rather than the behavior itself being wrong.
+      // We specifically need an insert between the two findAndModify commands, otherwise the test is not testing anything useful.
+      expect(last - first).toBeGreaterThan(1);
+
+      expect(eventLsn >= returnedLsn).toBe(false);
+    });
+  }
+});
+
+async function waitForCheckpointEvent(
+  changeStream: mongo.ChangeStream,
+  checkpointId: mongo.ObjectId
+): Promise<mongo.ChangeStreamDocument> {
+  for await (const event of changeStream) {
+    if (
+      (event.operationType == 'insert' || event.operationType == 'update' || event.operationType == 'replace') &&
+      checkpointId.equals(event.documentKey._id)
+    ) {
+      return event;
+    }
+  }
+
+  throw new Error('Change stream closed before checkpoint event was received');
+}

--- a/modules/module-mongodb/test/src/checkpoint_retry.test.ts
+++ b/modules/module-mongodb/test/src/checkpoint_retry.test.ts
@@ -51,7 +51,7 @@ describe('checkpoint retryable writes', () => {
       commandsStarted.push(event);
     });
 
-    const DEBUG_COMMANDS = true;
+    const DEBUG_COMMANDS = false;
     if (DEBUG_COMMANDS) {
       // For debugging: Log all commands
       client.on('commandStarted', (event) => {


### PR DESCRIPTION
This fixes an issue surfaced in #573 (v1.20.3). Even though the issue was not directly _caused_ by that PR, it removed a fallback path that would have bypassed the issue.

What happens:
1. In the replication process, `createCheckpoint()` is called.
2. A connection error causes the write to fail after the server received it.
3. The driver retries the command automatically.
4. The server sees the retry as a no-op since it already applied the original one, and does not apply it again.
5. The client session's operationTime still increases after the retry.
6. Now, the operationTime reports the time of the second operation, while the change stream event contains the clusterTime of the first operation.
7. This causes the `lsn >= waitForCheckpointLsn` condition to not be hit when the change stream event is received.
8. Since #573, nothing else creates an update that passes the filter. The replication process indefinitely waits for a change stream event that it never receives.
9. This causes the replication process to never create a new sync checkpoint.

## Issue symptoms

The issue shows up as replication lag building up, without an actual backlog of data to process. Specifically:

1. An initial slow batch with long `processing` time.
2. After that, replication lag builds up indefinitely.
3. No specific large data volumes that cause replication lag. For example, there may be many small batches, where the majority of time is just spent waiting for new changes.
4. A restart resolves the issue, without processing a backlog.

## The fix

A good long term fix would be to use a sentinel-based approach, rather than relying on MongoDB clusterTime behavior and potentially making bad assumptions around that - see #605. However, that's a big and risky change.

The fix here is to bypass the internal driver's retry mechanism for writes. By adding our own retry logic, the retry will actually produce a new write with a new change stream event, which avoids this issue.

## AI usage

Used Codex gpt-5.5 to debug the issue and assist in writing a test for reproducing it.

The fix here was implemented manually.
