### PR TITLE
[MongoDB] Fix batch logs

### DIFF
--- a/.changeset/clean-things-float.md
+++ b/.changeset/clean-things-float.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
+---
+
+Fix duration logs for "Processing batch"

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -830,8 +830,8 @@ export class ChangeStream {
           }
 
           batchSpan.end();
-          const durations = outerSpan.end();
-          const duration = batchSpan.endAt - batchSpan.startAt;
+          const durationsMicroseconds = outerSpan.end();
+          const duration = batchSpan.durationMillis;
 
           this.logger.info(
             `Processed batch of ${events.length} changes / ${eventBatch.byteSize} bytes in ${duration}ms`,
@@ -839,7 +839,7 @@ export class ChangeStream {
               count: events.length,
               bytes: eventBatch.byteSize,
               duration,
-              t: durations
+              t: durationsMicroseconds
             }
           );
           outerSpan = tracer.span('batch');

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -515,7 +515,9 @@ export class ChangeStream {
     const bytesReplicatedMetric = this.metrics.getCounter(ReplicationMetric.DATA_REPLICATED_BYTES);
     const chunksReplicatedMetric = this.metrics.getCounter(ReplicationMetric.CHUNKS_REPLICATED);
 
-    const tracer = new PerformanceTracer('MongoDB streaming replication');
+    const tracer = new PerformanceTracer<
+      'storage' | 'evaluate' | 'batch' | 'source_checkpoint' | 'changestream' | 'processing'
+    >('MongoDB streaming replication');
     await this.storage.startBatch(
       {
         logger: this.logger,

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -715,6 +715,7 @@ export class ChangeStream {
                 const hasBufferedChanges = eventIndex < events.length - 1;
                 if (waitForCheckpointLsn != null || hasBufferedChanges) {
                   if (waitForCheckpointLsn == null) {
+                    using _ = tracer.span('source_checkpoint');
                     waitForCheckpointLsn = await createCheckpoint(this.client, this.defaultDb, this.checkpointStreamId);
                   }
                   continue;
@@ -754,6 +755,7 @@ export class ChangeStream {
               changeDocument.operationType == 'delete'
             ) {
               if (waitForCheckpointLsn == null) {
+                using _ = tracer.span('source_checkpoint');
                 waitForCheckpointLsn = await createCheckpoint(this.client, this.defaultDb, this.checkpointStreamId);
               }
 

--- a/packages/service-core/src/tracing/PerformanceTracer.ts
+++ b/packages/service-core/src/tracing/PerformanceTracer.ts
@@ -2,12 +2,31 @@ import { traceWriter } from './TraceWriter.js';
 
 export interface Span extends Disposable {
   name: string;
+  /**
+   * Start time in microseconds since an arbitrary epoch.
+   */
   startAt: number;
+  /**
+   * End time in microseconds since an arbitrary epoch.
+   */
   endAt: number;
+  /**
+   * Time spent not in nested spans.
+   */
   selfDuration: number;
+
   nestedSince: number | undefined;
   subtrackFromSelf: number;
+
+  /**
+   * Durations spent in nested spans, in microseconds.
+   */
   nestedDurations: Record<string, number>;
+
+  /**
+   *
+   */
+  durationMillis: number;
 
   /**
    * End the span - same as [Symbol.dispose]().
@@ -114,6 +133,10 @@ export class PerformanceTracer<K extends string> {
           parent.nestedSince = undefined;
         }
         return this.nestedDurations;
+      },
+
+      get durationMillis() {
+        return Math.ceil((this.endAt - this.startAt) / 1000);
       },
       [Symbol.dispose]() {
         this.end();

--- a/packages/service-core/src/tracing/PerformanceTracer.ts
+++ b/packages/service-core/src/tracing/PerformanceTracer.ts
@@ -24,7 +24,7 @@ export interface Span extends Disposable {
   nestedDurations: Record<string, number>;
 
   /**
-   *
+   * Total duration of this span in milliseconds, rounded up. Only valid after the span has ended.
    */
   durationMillis: number;
 
@@ -33,7 +33,7 @@ export interface Span extends Disposable {
    *
    * Safe to call multiple times. Any nested spans will automatically end as well.
    *
-   * Returns an aggregate record of category -> "selfDuration".
+   * Returns an aggregate record of category -> "selfDuration", in microseconds.
    */
   end(): Record<string, number>;
 }


### PR DESCRIPTION
#616 added more detailed per-batch logs for MongoDB replication.

However, there is a unit issue. Example:

```js
  "duration": 63867734,
  "message": "[powersync_1_ff18] Processed batch of 1 changes / 25229 bytes in 63867734ms",
  "t": { "changestream": 9677292, "evaluate": 609, "processing": 63841971, "storage": 25154 },
  "timestamp": "2026-06-03T08:36:22.546Z"
```

The durations above are all in microseconds. For the JSON values it can be good to have that precision, but the "in 63867734ms" is wrong.

This fixes it to correctly calculate the milliseconds duration.

In addition, this now separately reports the time take to create the `_powersync_checkpoints` write in the source database, instead of falling under the generic "processing" as above.

## AI usage

No AI was used to create the code. Used Codex to sanity-check the changes.