### PR TITLE
fix(sync-rules): surface JOIN clauses in Sync Streams as a loud error (#565)

### DIFF
--- a/.changeset/sync-rules-join-aliased-warning.md
+++ b/.changeset/sync-rules-join-aliased-warning.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Surface joining onto an aliased primary table as a non-fatal warning in the Sync Streams compiler. The stream
+compiles successfully, but filter expressions that reference the joined table cannot be resolved through the
+alias and the stream may silently sync zero rows. Drop the alias on the primary table, or quote it
+(`FROM user_data AS "users", ...`) to acknowledge the constraint and suppress the warning. Addresses #565.

--- a/.changeset/sync-rules-join-aliased-warning.md
+++ b/.changeset/sync-rules-join-aliased-warning.md
@@ -2,7 +2,6 @@
 '@powersync/service-sync-rules': patch
 ---
 
-Surface joining onto an aliased primary table as a non-fatal warning in the Sync Streams compiler. The stream
-compiles successfully, but filter expressions that reference the joined table cannot be resolved through the
-alias and the stream may silently sync zero rows. Drop the alias on the primary table, or quote it
-(`FROM user_data AS "users", ...`) to acknowledge the constraint and suppress the warning. Addresses #565.
+Emit a warning for Sync Streams with joins where the primary table has an alias. Adding an alias syncs the table under the changed name, which may be unintentional for joins if aliases are only added to simplify filters.
+
+Closes #565.

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -254,7 +254,6 @@ export class StreamQueryParser {
       return false;
     }
 
-    this.diagnoseAliasedPrimaryWithJoin(node.from);
     node.from?.forEach((f) => this.processFrom(f));
     if (node.where) {
       this.addAndTermToWhereClause(node.where);
@@ -262,6 +261,9 @@ export class StreamQueryParser {
 
     if (!options.forSubquery && node.columns) {
       this.processResultColumns(node, node.columns);
+      // Run after processResultColumns so the primary table (determined by the selected columns, not the
+      // order of the FROM clause) is known. See #565.
+      this.diagnoseAliasedPrimaryWithJoin(node.from);
     }
 
     this.warnUnsupported(node.groupBy, 'GROUP BY');
@@ -359,54 +361,62 @@ export class StreamQueryParser {
   }
 
   /**
-   * Diagnose silent-row-loss from joining onto an aliased primary table when one or more join targets are
-   * unaliased. See #565: a query like
+   * Warn when a Sync Stream joins multiple tables, the primary table (the one the stream selects from) carries
+   * an alias, and at least one joined source is referenced by its bare (unaliased) name. See #565: a query like
    *
    *   SELECT cm.* FROM chat_messages cm
    *     INNER JOIN chat_conversations ON cm.conversation_id = chat_conversations.id
    *     WHERE chat_conversations.user_id = auth.user_id()
    *
-   * parses, but filter compilation cannot route the `chat_conversations.user_id` reference back to the
-   * joined table when the primary table wears an alias and the joined table is referenced by its bare name.
-   * Downstream the stream may silently degenerate and sync zero rows.
+   * compiles successfully, but the alias renames the synced table: rows sync under `cm` rather than
+   * `chat_messages`. When joining, an alias is frequently introduced only to make the join's `ON` clause
+   * easier to write, in which case the rename is unintentional and clients querying `chat_messages` will
+   * unexpectedly see zero rows.
    *
-   * The check intentionally suppresses the warning when *every* join target is also aliased — that is the
-   * idiom for queries where the author has already disambiguated scopes (e.g. `FROM users AS u JOIN orgs
-   * AS uom ON ...`) and the silent-row-loss footgun does not apply.
+   * The primary table is determined by the selected columns (tracked in {@link primaryResultSet} by
+   * {@link processResultColumns}), not by the order of the `FROM` clause, so this must run afterwards.
    *
-   * Escape hatch: if the primary alias is double-quoted in source SQL (e.g. `FROM user_data AS "users"`) we
-   * treat that as a deliberate signal that the author has accepted the constraint and suppress the warning.
+   * The warning is suppressed when every joined source is itself aliased (e.g. `json_each(...) AS tags`):
+   * there the author has clearly opted into explicit naming and the rename is unlikely to surprise. It is also
+   * suppressed when the alias is double-quoted in the source SQL (e.g. `FROM user_data AS "users"`), which we
+   * treat as a deliberate rename.
    */
   private diagnoseAliasedPrimaryWithJoin(fromList: From[] | nil) {
+    // Only relevant when joining (more than one source in the FROM clause).
     if (!fromList || fromList.length < 2) {
       return;
     }
-    const primary = fromList[0];
-    if (primary.type != 'table' || !primary.name.alias) {
+    const primary = this.primaryResultSet;
+    if (primary == null || primary.source.explicitName == null) {
       return;
     }
-    if (this.aliasIsQuoted(primary.name)) {
+    // An explicitly quoted alias signals the rename is intentional.
+    if (this.aliasIsQuoted(primary.source.origin)) {
       return;
     }
-    const hasUnaliasedJoin = fromList.slice(1).some((entry) => {
+    // Only warn when a joined source is referenced by its bare name; if every join target is aliased the author
+    // has opted into explicit naming and the primary's alias is unlikely to be a surprise.
+    const hasUnaliasedJoinTarget = fromList.some((entry) => {
       if (entry.type == 'table') {
-        return !entry.name.alias;
+        // Skip the primary table itself (identified by node identity, since it need not be the first entry).
+        return entry.name !== primary.source.origin && !entry.name.alias;
       }
       if (entry.type == 'call' || entry.type == 'statement') {
         return !entry.alias;
       }
       return false;
     });
-    if (!hasUnaliasedJoin) {
+    if (!hasUnaliasedJoinTarget) {
       return;
     }
+    const alias = primary.source.explicitName;
+    const tableName = primary.tablePattern.name;
     this.errors.report(
-      'Joining onto an aliased primary table is not currently supported and may silently sync zero rows: ' +
-        'filter expressions that reference the joined table cannot be resolved through the alias. ' +
-        'Drop the alias on the primary table, or quote it (`AS "' +
-        primary.name.alias +
-        '"`) to silence this warning if the join is intentional.',
-      primary.name,
+      `The primary table is synced under its alias '${alias}' instead of '${tableName}'. ` +
+        `When joining, an alias is often added only to make the ON clause easier to write; if that is the case ` +
+        `here, the rename is likely unintentional and clients querying '${tableName}' will see zero rows. ` +
+        `Drop the alias on the primary table, or quote it (\`AS "${alias}"\`) to keep the rename and silence this warning.`,
+      primary.source.origin,
       { isWarning: true }
     );
   }

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -254,6 +254,7 @@ export class StreamQueryParser {
       return false;
     }
 
+    this.diagnoseAliasedPrimaryWithJoin(node.from);
     node.from?.forEach((f) => this.processFrom(f));
     if (node.where) {
       this.addAndTermToWhereClause(node.where);
@@ -355,6 +356,70 @@ export class StreamQueryParser {
         this.addAndTermToWhereClause(join.on);
       }
     }
+  }
+
+  /**
+   * Diagnose silent-row-loss from joining onto an aliased primary table when one or more join targets are
+   * unaliased. See #565: a query like
+   *
+   *   SELECT cm.* FROM chat_messages cm
+   *     INNER JOIN chat_conversations ON cm.conversation_id = chat_conversations.id
+   *     WHERE chat_conversations.user_id = auth.user_id()
+   *
+   * parses, but filter compilation cannot route the `chat_conversations.user_id` reference back to the
+   * joined table when the primary table wears an alias and the joined table is referenced by its bare name.
+   * Downstream the stream may silently degenerate and sync zero rows.
+   *
+   * The check intentionally suppresses the warning when *every* join target is also aliased — that is the
+   * idiom for queries where the author has already disambiguated scopes (e.g. `FROM users AS u JOIN orgs
+   * AS uom ON ...`) and the silent-row-loss footgun does not apply.
+   *
+   * Escape hatch: if the primary alias is double-quoted in source SQL (e.g. `FROM user_data AS "users"`) we
+   * treat that as a deliberate signal that the author has accepted the constraint and suppress the warning.
+   */
+  private diagnoseAliasedPrimaryWithJoin(fromList: From[] | nil) {
+    if (!fromList || fromList.length < 2) {
+      return;
+    }
+    const primary = fromList[0];
+    if (primary.type != 'table' || !primary.name.alias) {
+      return;
+    }
+    if (this.aliasIsQuoted(primary.name)) {
+      return;
+    }
+    const hasUnaliasedJoin = fromList.slice(1).some((entry) => {
+      if (entry.type == 'table') {
+        return !entry.name.alias;
+      }
+      if (entry.type == 'call' || entry.type == 'statement') {
+        return !entry.alias;
+      }
+      return false;
+    });
+    if (!hasUnaliasedJoin) {
+      return;
+    }
+    this.errors.report(
+      'Joining onto an aliased primary table is not currently supported and may silently sync zero rows: ' +
+        'filter expressions that reference the joined table cannot be resolved through the alias. ' +
+        'Drop the alias on the primary table, or quote it (`AS "' +
+        primary.name.alias +
+        '"`) to silence this warning if the join is intentional.',
+      primary.name,
+      { isWarning: true }
+    );
+  }
+
+  private aliasIsQuoted(name: PGNode): boolean {
+    const loc = name._location;
+    if (!loc) {
+      return false;
+    }
+    // The alias appears at the tail of the from-table fragment. A quoted alias is the only way for a literal
+    // double-quote to show up here, so the substring test is sufficient and intentionally cheap.
+    const text = this.originalText.substring(loc.start, loc.end);
+    return text.includes('"');
   }
 
   private resolveTableValued(call: ExprCall, source: SyntacticResultSetSource): TableValuedResultSet {

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -358,8 +358,8 @@ export class StreamQueryParser {
   }
 
   /**
-   * Warn when a Sync Stream joins multiple tables, the primary table (the one the stream selects from) carries
-   * an alias, and at least one joined source is referenced by its bare (unaliased) name. See #565: a query like
+   * Warn when a Sync Stream joins multiple tables and the primary table (the one the stream selects from) carries
+   * an alias. See #565: a query like
    *
    *   SELECT cm.* FROM chat_messages cm
    *     INNER JOIN chat_conversations ON cm.conversation_id = chat_conversations.id
@@ -369,9 +369,6 @@ export class StreamQueryParser {
    * `chat_messages`. When joining, an alias is frequently introduced only to make the join's `ON` clause
    * easier to write, in which case the rename is unintentional and clients querying `chat_messages` will
    * unexpectedly see zero rows.
-   *
-   * The primary table is determined by the selected columns, not by the order of the `FROM` clause, so this
-   * runs after a non-null primary result set has been established.
    *
    * The warning is suppressed when the alias is double-quoted in the source SQL (e.g. `FROM user_data AS "users"`),
    * which we treat as a deliberate rename.

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -162,11 +162,11 @@ export class StreamQueryParser {
       if (this.primaryResultSet == null) {
         return null;
       }
+      // The statement must be a select statement, as processAst would have returned false otherwise.
+      const select = stmt as SelectFromStatement;
+      this.diagnoseAliasedPrimaryWithJoin(select.from, this.primaryResultSet);
 
-      const where = this.compileFilterClause(
-        // The statement must be a select statement, as processAst would have returned false otherwise.
-        stmt as SelectFromStatement
-      );
+      const where = this.compileFilterClause(select);
       const joined: SourceResultSet[] = [];
       for (const source of this.resultSets.values()) {
         if (source != this.primaryResultSet) {
@@ -261,9 +261,6 @@ export class StreamQueryParser {
 
     if (!options.forSubquery && node.columns) {
       this.processResultColumns(node, node.columns);
-      // Run after processResultColumns so the primary table (determined by the selected columns, not the
-      // order of the FROM clause) is known. See #565.
-      this.diagnoseAliasedPrimaryWithJoin(node.from);
     }
 
     this.warnUnsupported(node.groupBy, 'GROUP BY');
@@ -373,49 +370,31 @@ export class StreamQueryParser {
    * easier to write, in which case the rename is unintentional and clients querying `chat_messages` will
    * unexpectedly see zero rows.
    *
-   * The primary table is determined by the selected columns (tracked in {@link primaryResultSet} by
-   * {@link processResultColumns}), not by the order of the `FROM` clause, so this must run afterwards.
+   * The primary table is determined by the selected columns, not by the order of the `FROM` clause, so this
+   * runs after a non-null primary result set has been established.
    *
-   * The warning is suppressed when every joined source is itself aliased (e.g. `json_each(...) AS tags`):
-   * there the author has clearly opted into explicit naming and the rename is unlikely to surprise. It is also
-   * suppressed when the alias is double-quoted in the source SQL (e.g. `FROM user_data AS "users"`), which we
-   * treat as a deliberate rename.
+   * The warning is suppressed when the alias is double-quoted in the source SQL (e.g. `FROM user_data AS "users"`),
+   * which we treat as a deliberate rename.
    */
-  private diagnoseAliasedPrimaryWithJoin(fromList: From[] | nil) {
+  private diagnoseAliasedPrimaryWithJoin(fromList: From[] | nil, primary: PhysicalSourceResultSet) {
     // Only relevant when joining (more than one source in the FROM clause).
     if (!fromList || fromList.length < 2) {
       return;
     }
-    const primary = this.primaryResultSet;
-    if (primary == null || primary.source.explicitName == null) {
+    if (primary.source.explicitName == null) {
       return;
     }
     // An explicitly quoted alias signals the rename is intentional.
     if (this.aliasIsQuoted(primary.source.origin)) {
       return;
     }
-    // Only warn when a joined source is referenced by its bare name; if every join target is aliased the author
-    // has opted into explicit naming and the primary's alias is unlikely to be a surprise.
-    const hasUnaliasedJoinTarget = fromList.some((entry) => {
-      if (entry.type == 'table') {
-        // Skip the primary table itself (identified by node identity, since it need not be the first entry).
-        return entry.name !== primary.source.origin && !entry.name.alias;
-      }
-      if (entry.type == 'call' || entry.type == 'statement') {
-        return !entry.alias;
-      }
-      return false;
-    });
-    if (!hasUnaliasedJoinTarget) {
-      return;
-    }
     const alias = primary.source.explicitName;
     const tableName = primary.tablePattern.name;
     this.errors.report(
-      `The primary table is synced under its alias '${alias}' instead of '${tableName}'. ` +
+      `The source row is synced under its alias '${alias}' instead of '${tableName}'. ` +
         `When joining, an alias is often added only to make the ON clause easier to write; if that is the case ` +
         `here, the rename is likely unintentional and clients querying '${tableName}' will see zero rows. ` +
-        `Drop the alias on the primary table, or quote it (\`AS "${alias}"\`) to keep the rename and silence this warning.`,
+        `Drop the alias on the source table, or quote it (\`AS "${alias}"\`) to keep the rename and silence this warning.`,
       primary.source.origin,
       { isWarning: true }
     );

--- a/packages/sync-rules/test/src/compiler/advanced.test.ts
+++ b/packages/sync-rules/test/src/compiler/advanced.test.ts
@@ -26,7 +26,7 @@ describe('new sync stream features', () => {
       expect(
         compileSingleStreamAndSerialize(`
           SELECT u.*
-            FROM users u
+            FROM users AS "u"
             JOIN group_memberships gm1 ON u.id = gm1.user_id
             JOIN group_memberships gm2 ON gm1.group_id = gm2.group_id
             WHERE gm2.user_id = auth.user_id();
@@ -38,7 +38,7 @@ describe('new sync stream features', () => {
       expect(
         compileSingleStreamAndSerialize(`
           SELECT m.* 
-            FROM message m
+            FROM message AS "m"
             JOIN roles srm
               ON m.organization_id = srm.organization_id 
               WHERE srm.account_id=auth.user_id() 
@@ -74,7 +74,7 @@ describe('new sync stream features', () => {
 SELECT
     u.*
 FROM
-    public.users AS u
+    public.users AS "u"
 JOIN
     public.user_organization_map AS uom_colleagues ON u.id = uom_colleagues.user_id
 WHERE
@@ -96,7 +96,7 @@ FROM
 JOIN
     public.user_organization_map AS uom2 ON uom1.organization_id = uom2.organization_id
 JOIN
-    public.users AS u ON uom2.user_id = u.id
+    public.users AS "u" ON uom2.user_id = u.id
 WHERE
     uom1.user_id = auth.user_id()
         `;
@@ -112,7 +112,7 @@ SELECT
 FROM
     public.users AS u
 JOIN
-    public.addresses AS a ON u.address_id = a.id
+    public.addresses AS "a" ON u.address_id = a.id
 WHERE
     u.id IN (
         SELECT
@@ -137,7 +137,7 @@ WHERE
       // This would already be supported with old sync streams by using a subquery
       const stream = `
 SELECT t.*
-FROM ticket t
+FROM ticket AS "t"
     JOIN ticket_detail_item item ON item.ticket_id = t.id
     WHERE item.user_id = auth.user_id();
         `;
@@ -167,7 +167,7 @@ join assignment a
   on a.id = uas.assignment_id
 join assignment_checkpoint ac
   on ac.assignment_id = a.id
-join checkpoint c
+join checkpoint AS "c"
   on c.id = ac.checkpoint_id
 where uas.user_id = auth.user_id()
   and a.active = true;`;

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -12,6 +12,19 @@ function expectSingleErrorSource(yaml: string, source: string) {
   expect(sources[0]).toEqual(source);
 }
 
+function aliasedPrimaryJoinWarning(alias: string, source: string) {
+  return {
+    isWarning: true,
+    message:
+      'Joining onto an aliased primary table is not currently supported and may silently sync zero rows: ' +
+      'filter expressions that reference the joined table cannot be resolved through the alias. ' +
+      'Drop the alias on the primary table, or quote it (`AS "' +
+      alias +
+      '"`) to silence this warning if the join is intentional.',
+    source
+  };
+}
+
 describe('compilation errors', () => {
   test('parsing error in query', () => {
     const [errors] = yamlToSyncPlan(`
@@ -117,6 +130,7 @@ streams:
 
   test('join with using', () => {
     expect(compilationErrorsForSingleStream('SELECT u.* FROM users u INNER JOIN orgs USING (org_id)')).toStrictEqual([
+      aliasedPrimaryJoinWarning('u', 'users'),
       {
         message: 'USING is not supported',
         source: 'SELECT u.* FROM users u INNER JOIN orgs USING (org_id)'
@@ -139,6 +153,7 @@ streams:
         'SELECT u.*, orgs.* FROM users u INNER JOIN orgs ON u.id = auth.user_id() AND u.org = orgs.id'
       )
     ).toStrictEqual([
+      aliasedPrimaryJoinWarning('u', 'users'),
       {
         message: "Sync streams can only select from a single table, and this one already selects from 'users'.",
         source: 'orgs.*'
@@ -152,6 +167,7 @@ streams:
         "SELECT u.* FROM users u INNER JOIN orgs WHERE u.name || orgs.name = subscription.parameter('a')"
       )
     ).toStrictEqual([
+      aliasedPrimaryJoinWarning('u', 'users'),
       {
         message:
           "This expression already references 'users', so it can't also reference data from this row unless the two are compared with an equals operator.",
@@ -164,6 +180,7 @@ streams:
     expect(
       compilationErrorsForSingleStream('SELECT u.* FROM users u INNER JOIN orgs ON u.org = orgs.id WHERE is_public')
     ).toStrictEqual([
+      aliasedPrimaryJoinWarning('u', 'users'),
       {
         message: 'Invalid unqualified reference since multiple tables are in scope',
         source: 'is_public'
@@ -262,6 +279,34 @@ streams:
     expect(compilationErrorsForSingleStream('select i.* from issues i FULL JOIN users u')).toStrictEqual([
       { message: 'FULL JOIN is not supported', source: 'select i.* from issues i FULL JOIN users u' }
     ]);
+  });
+
+  test('aliased primary table with join (silent-row-loss diagnostic for #565)', () => {
+    // The silent-row-loss case: an aliased primary table joined onto another table where the WHERE clause
+    // references the joined table by name. Filter compilation can't route the reference back through the
+    // alias and the stream may silently sync zero rows. Surface a non-fatal warning pointing at the workaround.
+    expect(
+      compilationErrorsForSingleStream(
+        'SELECT cm.* FROM chat_messages cm ' +
+          'INNER JOIN chat_conversations ON cm.conversation_id = chat_conversations.id ' +
+          'WHERE chat_conversations.user_id = auth.user_id()'
+      )
+    ).toStrictEqual([aliasedPrimaryJoinWarning('cm', 'chat_messages')]);
+  });
+
+  test('aliased primary table with join: quoted alias is an escape hatch', () => {
+    // Quoting the alias signals deliberate intent and suppresses the warning. The maintainer-suggested
+    // form is `FROM user_data AS "users", $joins`.
+    expect(
+      compilationErrorsForSingleStream(
+        'SELECT users.* FROM user_data AS "users", chat_msg WHERE users.id = chat_msg.user_id'
+      )
+    ).toStrictEqual([]);
+  });
+
+  test('aliased primary table without join: no warning', () => {
+    // A bare aliased primary with no join is the canonical safe form.
+    expect(compilationErrorsForSingleStream('SELECT u.* FROM users u WHERE u.id = auth.user_id()')).toStrictEqual([]);
   });
 
   test('subquery star', () => {

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -12,16 +12,15 @@ function expectSingleErrorSource(yaml: string, source: string) {
   expect(sources[0]).toEqual(source);
 }
 
-function aliasedPrimaryJoinWarning(alias: string, source: string) {
+function aliasedPrimaryJoinWarning(alias: string, tableName: string) {
   return {
     isWarning: true,
     message:
-      'Joining onto an aliased primary table is not currently supported and may silently sync zero rows: ' +
-      'filter expressions that reference the joined table cannot be resolved through the alias. ' +
-      'Drop the alias on the primary table, or quote it (`AS "' +
-      alias +
-      '"`) to silence this warning if the join is intentional.',
-    source
+      `The primary table is synced under its alias '${alias}' instead of '${tableName}'. ` +
+      `When joining, an alias is often added only to make the ON clause easier to write; if that is the case ` +
+      `here, the rename is likely unintentional and clients querying '${tableName}' will see zero rows. ` +
+      `Drop the alias on the primary table, or quote it (\`AS "${alias}"\`) to keep the rename and silence this warning.`,
+    source: tableName
   };
 }
 
@@ -130,11 +129,11 @@ streams:
 
   test('join with using', () => {
     expect(compilationErrorsForSingleStream('SELECT u.* FROM users u INNER JOIN orgs USING (org_id)')).toStrictEqual([
-      aliasedPrimaryJoinWarning('u', 'users'),
       {
         message: 'USING is not supported',
         source: 'SELECT u.* FROM users u INNER JOIN orgs USING (org_id)'
-      }
+      },
+      aliasedPrimaryJoinWarning('u', 'users')
     ]);
   });
 
@@ -153,11 +152,11 @@ streams:
         'SELECT u.*, orgs.* FROM users u INNER JOIN orgs ON u.id = auth.user_id() AND u.org = orgs.id'
       )
     ).toStrictEqual([
-      aliasedPrimaryJoinWarning('u', 'users'),
       {
         message: "Sync streams can only select from a single table, and this one already selects from 'users'.",
         source: 'orgs.*'
-      }
+      },
+      aliasedPrimaryJoinWarning('u', 'users')
     ]);
   });
 
@@ -180,11 +179,11 @@ streams:
     expect(
       compilationErrorsForSingleStream('SELECT u.* FROM users u INNER JOIN orgs ON u.org = orgs.id WHERE is_public')
     ).toStrictEqual([
-      aliasedPrimaryJoinWarning('u', 'users'),
       {
         message: 'Invalid unqualified reference since multiple tables are in scope',
         source: 'is_public'
-      }
+      },
+      aliasedPrimaryJoinWarning('u', 'users')
     ]);
   });
 
@@ -281,10 +280,10 @@ streams:
     ]);
   });
 
-  test('aliased primary table with join (silent-row-loss diagnostic for #565)', () => {
-    // The silent-row-loss case: an aliased primary table joined onto another table where the WHERE clause
-    // references the joined table by name. Filter compilation can't route the reference back through the
-    // alias and the stream may silently sync zero rows. Surface a non-fatal warning pointing at the workaround.
+  test('aliased primary table with join: warns the table syncs under its alias (#565)', () => {
+    // An aliased primary table joined onto another table syncs under the alias (`cm`) rather than the real
+    // table name (`chat_messages`). When the alias was added only to simplify the join's ON clause, that
+    // rename is unintentional and clients querying `chat_messages` see zero rows. Surface a non-fatal warning.
     expect(
       compilationErrorsForSingleStream(
         'SELECT cm.* FROM chat_messages cm ' +

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -16,10 +16,10 @@ function aliasedPrimaryJoinWarning(alias: string, tableName: string) {
   return {
     isWarning: true,
     message:
-      `The primary table is synced under its alias '${alias}' instead of '${tableName}'. ` +
+      `The source row is synced under its alias '${alias}' instead of '${tableName}'. ` +
       `When joining, an alias is often added only to make the ON clause easier to write; if that is the case ` +
       `here, the rename is likely unintentional and clients querying '${tableName}' will see zero rows. ` +
-      `Drop the alias on the primary table, or quote it (\`AS "${alias}"\`) to keep the rename and silence this warning.`,
+      `Drop the alias on the source table, or quote it (\`AS "${alias}"\`) to keep the rename and silence this warning.`,
     source: tableName
   };
 }
@@ -276,7 +276,8 @@ streams:
 
   test('full join', () => {
     expect(compilationErrorsForSingleStream('select i.* from issues i FULL JOIN users u')).toStrictEqual([
-      { message: 'FULL JOIN is not supported', source: 'select i.* from issues i FULL JOIN users u' }
+      { message: 'FULL JOIN is not supported', source: 'select i.* from issues i FULL JOIN users u' },
+      aliasedPrimaryJoinWarning('i', 'issues')
     ]);
   });
 
@@ -301,6 +302,14 @@ streams:
         'SELECT users.* FROM user_data AS "users", chat_msg WHERE users.id = chat_msg.user_id'
       )
     ).toStrictEqual([]);
+  });
+
+  test('aliased primary table with join: still warns when joined tables are aliased', () => {
+    expect(
+      compilationErrorsForSingleStream(
+        'SELECT u.* FROM users u INNER JOIN orgs o ON u.org_id = o.id WHERE o.owner_id = auth.user_id()'
+      )
+    ).toStrictEqual([aliasedPrimaryJoinWarning('u', 'users')]);
   });
 
   test('aliased primary table without join: no warning', () => {

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -518,7 +518,7 @@ streams:
   stream:
       auto_subscribe: true
       query: |
-        SELECT c.* FROM comments c
+        SELECT c.* FROM comments AS "c"
           INNER JOIN issues i ON c.issue = i.id
           INNER JOIN users owner ON owner.name = i.owned_by
         WHERE owner.id = auth.user_id()

--- a/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/table_valued.test.ts
@@ -21,7 +21,7 @@ config:
 streams:
   stream:
       accept_potentially_dangerous_queries: true
-      query: SELECT s.id AS id FROM stores s INNER JOIN json_each(s.tags) as tags WHERE tags.value = subscription.parameter('tag')
+      query: SELECT s.id AS id FROM stores AS "s" INNER JOIN json_each(s.tags) as tags WHERE tags.value = subscription.parameter('tag')
 `);
 
     const sourceTable = new TestSourceTable('stores');


### PR DESCRIPTION
Addresses #565.

## What this PR changes

This PR emits a non-fatal Sync Streams compiler warning when a stream joins multiple sources and the primary table selected by the stream has an unquoted alias.

That matters because an alias on the primary table changes the name the rows sync under. For example:

```sql
SELECT cm.*
FROM chat_messages cm
INNER JOIN chat_conversations
  ON cm.conversation_id = chat_conversations.id
WHERE chat_conversations.user_id = auth.user_id()
```

can compile, but rows sync under `cm` rather than `chat_messages`. If the alias was only added to simplify the join expression, clients querying `chat_messages` can unexpectedly see zero rows.

The warning explains that behavior and tells users to either:

- drop the alias on the source table when the rename was unintentional, or
- quote the alias, for example `AS "cm"`, when they intentionally want rows to sync under the alias name.

## Where the detection lives

The diagnostic runs in the new compiler after result columns have been processed, so the primary table is determined from the selected source row rather than from `FROM` clause order.

It warns when:

- the stream has more than one source in `FROM`, and
- the primary source row has an alias, and
- that alias was not explicitly double-quoted in the source SQL.

It is intentionally suppressed for quoted aliases such as `FROM user_data AS "users"`, which serve as an escape hatch for deliberate table renames.

## Tests

Regression coverage in `packages/sync-rules/test/src/compiler/errors.test.ts` covers:

- aliased primary table with a join warns that rows sync under the alias;
- quoted alias suppresses the warning;
- aliased joined tables do not suppress the warning when the primary table is still aliased;
- aliased primary table without a join does not warn;
- existing unsupported join diagnostics still include the new warning where appropriate.

Also touched intentional-alias fixtures in evaluator/table-valued tests so deliberate aliasing uses the quoted-alias escape hatch.

Local validation from the latest pushed head:

- `pnpm --dir packages/sync-rules build`
- `pnpm --dir packages/sync-rules test`
- Prettier check on touched files

## Why this style of fix

This follows the same Sync Streams correctness pattern as the earlier sprint fixes: surface surprising SQLite/Sync Streams semantic traps before users silently get wrong rows. It does not add broader JOIN support; it makes the existing alias behavior explicit and actionable for the #565 case.
