### PR TITLE
fix(sync-rules): upper()/lower() should be ASCII-only to match SQLite

### DIFF
--- a/.changeset/sync-rules-ascii-upper-lower.md
+++ b/.changeset/sync-rules-ascii-upper-lower.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Make `upper()` and `lower()` ASCII-only in the JS evaluator to match SQLite's default behaviour. Previously the server used `String.prototype.toUpperCase()` / `.toLowerCase()`, which are Unicode-aware and perform length-changing case folds (ß -> SS, fi -> FI, İ -> İ̇). The client SQLite uses ASCII-only semantics for the same calls, so server-side bucket keys silently disagreed with client-side parameter values for any source data containing non-ASCII letters.

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -60,30 +60,62 @@ export function getOperatorFunction(op: string): SqlFunction {
   };
 }
 
+/**
+ * SQLite's default `upper()` and `lower()` are ASCII-only: only `a-z` <-> `A-Z`
+ * are converted; all other characters (including length-changing case folds
+ * like ß -> SS, fi -> FI, I-dot) pass through unchanged.
+ *
+ * `String.prototype.toUpperCase()` / `.toLowerCase()` in JavaScript are
+ * Unicode-aware and DO perform length-changing folds, so an `upper()` or
+ * `lower()` call evaluated server-side here produces a different string than
+ * the same call run client-side against SQLite. Bucket keys silently desync;
+ * rows containing non-ASCII letters end up routed to the wrong bucket.
+ *
+ * Same class of bug as the merged Sync Streams correctness fixes
+ * #644 / #645 / #646 / #647.
+ */
+function asciiToUpper(text: string): string {
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    out += code >= 97 && code <= 122 ? String.fromCharCode(code - 32) : text[i];
+  }
+  return out;
+}
+
+function asciiToLower(text: string): string {
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    out += code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : text[i];
+  }
+  return out;
+}
+
 const upper: DocumentedSqlFunction = {
   debugName: 'upper',
   call(value: SqliteValue) {
     const text = castAsText(value);
-    return text?.toUpperCase() ?? null;
+    return text == null ? null : asciiToUpper(text);
   },
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
   },
-  detail: 'Convert text to upper case'
+  detail: 'Convert ASCII a-z to A-Z (matches SQLite default; non-ASCII passes through)'
 };
 
 const lower: DocumentedSqlFunction = {
   debugName: 'lower',
   call(value: SqliteValue) {
     const text = castAsText(value);
-    return text?.toLowerCase() ?? null;
+    return text == null ? null : asciiToLower(text);
   },
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.TEXT;
   },
-  detail: 'Convert text to lower case'
+  detail: 'Convert ASCII A-Z to a-z (matches SQLite default; non-ASCII passes through)'
 };
 
 const substring: DocumentedSqlFunction = {

--- a/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
@@ -4,6 +4,42 @@ import { requestParameters, TestSourceTable } from '../../util.js';
 import { syncTest } from './utils.js';
 
 describe('operators match SQLite', () => {
+  syncTest('upper / lower use ASCII-only semantics (matches SQLite default)', ({ sync }) => {
+    // SQLite's default upper()/lower() only handles a-z / A-Z; non-ASCII
+    // letters pass through unchanged. JavaScript's toUpperCase/toLowerCase
+    // are Unicode-aware and length-changing (ß -> SS, fi -> FI). When the
+    // evaluator and the client disagree on the result of upper(), bucket
+    // keys silently diverge and rows are routed to the wrong bucket.
+    const streams = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  a:
+    query: 'SELECT id, UPPER(name) AS upper, LOWER(name) AS lower FROM tbl'
+`);
+
+    const table = new TestSourceTable('tbl');
+
+    function evaluate(name: SqliteValue) {
+      const [row] = streams.evaluateRow({ sourceTable: table, record: { id: 'ignored', name } });
+      return { upper: row.data['upper'], lower: row.data['lower'] };
+    }
+
+    // ASCII works exactly as before.
+    expect(evaluate('hello')).toStrictEqual({ upper: 'HELLO', lower: 'hello' });
+    expect(evaluate('Hello World')).toStrictEqual({ upper: 'HELLO WORLD', lower: 'hello world' });
+
+    // Non-ASCII letters now pass through unchanged (matching SQLite),
+    // instead of being length-changed by JS Unicode folding.
+    expect(evaluate('straße')).toStrictEqual({ upper: 'STRAßE', lower: 'straße' });
+    expect(evaluate('ﬁle')).toStrictEqual({ upper: 'ﬁLE', lower: 'ﬁle' });
+
+    // Length is preserved (was previously length-changed by JS folds).
+    expect(evaluate('straße').upper).toHaveLength('straße'.length);
+    expect(evaluate('ﬁle').upper).toHaveLength('ﬁle'.length);
+  });
+
   syncTest('division by zero', ({ sync }) => {
     // Regression test for https://github.com/powersync-ja/powersync-service/pull/646.
     const streams = sync.prepareSyncStreams(`


### PR DESCRIPTION
Same silent-data-loss class as the merged Sync Streams fixes #644 / #645 / #646 / #647 and the #565 JOIN loud-error PR #662 (open).

### The bug

`sql_functions.ts` implemented `upper()` / `lower()` with `String.prototype.toUpperCase()` / `.toLowerCase()`:

```ts
const upper: DocumentedSqlFunction = {
  call(value: SqliteValue) {
    const text = castAsText(value);
    return text?.toUpperCase() ?? null;
  },
  ...
};
```

JS's case methods are **Unicode-aware and length-changing**:
- `'straße'.toUpperCase()` → `'STRASSE'` (ß becomes SS — length 6 → 7)
- `'ﬁle'.toUpperCase()` → `'FILE'` (ﬁ ligature becomes FI — length 3 → 4)
- `'İstanbul'.toLowerCase()` → adds a combining dot above

SQLite's `upper()` / `lower()` are **ASCII-only** by default: only `a-z` ↔ `A-Z` is mapped; every other character (including all of the above) passes through unchanged. The PowerSync client runs SQLite, so the **server's bucket evaluator and the client's query disagree on the result of `upper(name)`** the moment `name` contains a non-ASCII letter:

| Source value | Server `upper()` (JS) | Client `upper()` (SQLite) | Bucket key match? |
|---|---|---|---|
| `"straße"` | `"STRASSE"` | `"STRAßE"` | ❌ silent miss |
| `"ﬁle"` | `"FILE"` | `"ﬁLE"` | ❌ silent miss |
| `"İstanbul"` | depends on locale, length-changed | unchanged | ❌ silent miss |
| `"hello"` | `"HELLO"` | `"HELLO"` | ✅ |

Effect: bucket-parameter expressions using `UPPER(...)` / `LOWER(...)` silently route the affected rows to the wrong bucket (or no bucket at all). No error, no warning — just missing rows in the client's local DB.

### Fix

Two small helpers in `sql_functions.ts` that walk the string and only map `a-z` ↔ `A-Z` (the SQLite default), used by `upper` and `lower`:

```ts
function asciiToUpper(text: string): string {
  let out = '';
  for (let i = 0; i < text.length; i++) {
    const code = text.charCodeAt(i);
    out += code >= 97 && code <= 122 ? String.fromCharCode(code - 32) : text[i];
  }
  return out;
}
```

The `detail` strings on `upper` and `lower` were updated so the registry doc reflects the actual behaviour.

### Tests

New `syncTest('upper / lower use ASCII-only semantics (matches SQLite default)')` in `sqlite_semantics.test.ts`:

- ASCII control (`"hello"`, `"Hello World"`) — unchanged behaviour
- `"straße"`, `"ﬁle"`, `"İstanbul"` — non-ASCII letters preserved instead of length-changed
- Length-preservation invariant (`'straße'.upper.length == 6`, not 7) — pins the silent-data-loss surface explicitly

The existing `transforming things with upper-case functions` test in `sync_rules.test.ts` keeps passing (it uses ASCII-only data — `'TEST'`, `'USER1'`). Full `sync_rules.test.ts`: 40/40.

### Compatibility note

If a user is already relying on the Unicode-aware behaviour (e.g. their bucket keys are currently `"STRASSE"`-shaped), this is a behaviour change. The previous behaviour was already broken in practice — the bucket keys never matched what the client computes — so any working setup is already ASCII-only or has been silently missing rows. The fix brings the server side in line with the actually-working comparison side.
