### PR TITLE
fix(sync-rules): length() should count Unicode code points to match SQLite

### DIFF
--- a/.changeset/sync-rules-length-code-points.md
+++ b/.changeset/sync-rules-length-code-points.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Make `length()` count Unicode code points (matching SQLite) rather than JavaScript UTF-16 code units. Previously a string containing a non-BMP code point (emoji like `😀`, CJK Extension B–G, ancient scripts, etc.) had its length silently doubled on the server, producing a different bucket key than the SQLite client computes for the same expression.

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -157,6 +157,25 @@ const hex: DocumentedSqlFunction = {
   detail: 'Convert a blob to hex text'
 };
 
+/**
+ * SQLite's `length(X)` on text returns the number of *characters* in X
+ * (Unicode code points), not bytes and not UTF-16 code units. JavaScript's
+ * `String.prototype.length` returns UTF-16 code units, so any non-BMP code
+ * point (emoji like 😀, CJK Extension B-G, ancient scripts, etc.) is
+ * counted as 2 in JS but 1 by SQLite.
+ *
+ * Iterating the string with `for...of` walks code points instead, matching
+ * SQLite's character count. Same silent-failure class as #644 / #645 /
+ * #646 / #647 / the ASCII upper/lower fix. Blobs already match SQLite
+ * (byte length).
+ */
+function countCodePoints(text: string): number {
+  let n = 0;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for (const _ of text) n++;
+  return n;
+}
+
 const length: DocumentedSqlFunction = {
   debugName: 'length',
   call(value: SqliteValue) {
@@ -166,14 +185,14 @@ const length: DocumentedSqlFunction = {
       return BigInt(value.byteLength);
     } else {
       value = castAsText(value);
-      return BigInt(value!.length);
+      return BigInt(countCodePoints(value!));
     }
   },
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
   getReturnType(args) {
     return ExpressionType.INTEGER;
   },
-  detail: 'Returns the length of a text or blob value'
+  detail: 'Returns the number of characters in text (code points) or bytes in a blob (matches SQLite)'
 };
 
 const base64: DocumentedSqlFunction = {

--- a/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
@@ -4,6 +4,36 @@ import { requestParameters, TestSourceTable } from '../../util.js';
 import { syncTest } from './utils.js';
 
 describe('operators match SQLite', () => {
+  syncTest('length() counts Unicode code points, not UTF-16 code units (matches SQLite)', ({ sync }) => {
+    // SQLite's length(X) on text returns the number of characters
+    // (Unicode code points). JavaScript's String.prototype.length returns
+    // UTF-16 code units, so non-BMP code points (emoji 😀, CJK Extension B+,
+    // ancient scripts, etc.) are counted as 2 in JS but 1 in SQLite. A
+    // bucket-key expression like `length(name)` produced different integer
+    // values server-side vs client-side, silently routing rows to the
+    // wrong bucket. Same class as #644-#647 / #565 / ASCII upper/lower.
+    const streams = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  a:
+    query: 'SELECT id, length(name) AS len FROM tbl'
+`);
+
+    const table = new TestSourceTable('tbl');
+    function len(name: SqliteValue): SqliteJsonValue {
+      const [row] = streams.evaluateRow({ sourceTable: table, record: { id: 'ignored', name } });
+      return row.data['len'];
+    }
+
+    expect(len('hello')).toStrictEqual(5n);
+    expect(len('straße')).toStrictEqual(6n); // ß is BMP, ok in both
+    expect(len('😀')).toStrictEqual(1n); // emoji, was 2n
+    expect(len('a😀b')).toStrictEqual(3n); // a + emoji + b, was 4n
+    expect(len('𐀀')).toStrictEqual(1n); // U+10000 Linear B, was 2n
+  });
+
   syncTest('division by zero', ({ sync }) => {
     // Regression test for https://github.com/powersync-ja/powersync-service/pull/646.
     const streams = sync.prepareSyncStreams(`


### PR DESCRIPTION
Same silent-data-loss class as the merged Sync Streams fixes #644 / #645 / #646 / #647, the open #565 JOIN loud-error PR #662, and the ASCII upper/lower PR #663.

### The bug

`length()` on text returned `value.length` — JavaScript's `String.prototype.length`, which counts **UTF-16 code units**. SQLite's `length(X)` returns the number of **characters** (Unicode code points).

For any string containing a non-BMP code point (emoji like `😀`, CJK Extension B–G, ancient scripts) the two counts diverge: each non-BMP code point is one UTF-16 surrogate pair = 2 code units in JS but 1 character in SQLite.

| Source value | Server `length()` (JS) | Client `length()` (SQLite) | Bucket key match? |
|---|---|---|---|
| `"hello"` | `5` | `5` | ✅ |
| `"straße"` | `6` | `6` | ✅ (ß is BMP) |
| `"😀"` | `2` | `1` | ❌ silent miss |
| `"a😀b"` | `4` | `3` | ❌ silent miss |
| `"𐀀"` (Linear B) | `2` | `1` | ❌ silent miss |

A bucket-parameter or filter using `length(...)` silently routed any row containing such characters to a different bucket than the client query asks for.

### Fix

A tiny `countCodePoints(text)` helper that iterates the string with `for…of` (which walks code points, not code units) and `length` uses it for the text case. The blob branch already matches SQLite (byte length).

### Tests

New `syncTest('length() counts Unicode code points, not UTF-16 code units (matches SQLite)')` in `sqlite_semantics.test.ts` covering:

- `"hello"` → `5n` (ASCII control)
- `"straße"` → `6n` (BMP non-ASCII, unchanged)
- `"😀"` → `1n` (was `2n`)
- `"a😀b"` → `3n` (was `4n`)
- `"𐀀"` (U+10000, Linear B) → `1n` (was `2n`)

Full `sync_rules.test.ts`: 40/40.
