### PR TITLE
fix(sync-rules): substring() should index by code points to match SQLite

### DIFF
--- a/.changeset/sync-rules-substr-code-points.md
+++ b/.changeset/sync-rules-substr-code-points.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Make `substring()` index by Unicode code points (matching SQLite) rather than UTF-16 code units. Previously, slicing through a non-BMP code point (emoji, CJK Extension, ancient scripts) returned a broken unpaired surrogate or split the character in half — server output silently disagreed with SQLite client output.

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -101,18 +101,29 @@ const substring: DocumentedSqlFunction = {
       // Different from undefined in this case, to match SQLite behavior
       return null;
     }
+    // SQLite's substr() indexes by *characters* (Unicode code points), not
+    // UTF-16 code units. JavaScript's `String.prototype.substring` and
+    // `String.prototype.length` count code units, so any non-BMP code point
+    // (emoji like 😀, CJK Extension B-G, ancient scripts) is counted as 2 -
+    // and slicing in the middle of a surrogate pair returns a broken
+    // unpaired surrogate. Walk the string once into a code-point array and
+    // slice that instead, to match SQLite. Same silent-failure class as the
+    // length() / upper() / lower() fixes (#664 / #663) and the merged
+    // #644-#647.
+    const codePoints = [...text];
+    const totalLen = codePoints.length;
     const castLength = cast(length ?? null, 'integer') as bigint | null;
     let realLength: number;
     if (castLength == null) {
       // undefined (not specified)
-      realLength = text.length + 1; // +1 to account for the start = 0 special case
+      realLength = totalLen + 1; // +1 to account for the start = 0 special case
     } else {
       realLength = Number(castLength);
     }
 
     let realStart = 0;
     if (startIndex < 0n) {
-      realStart = Math.max(0, text.length + Number(startIndex));
+      realStart = Math.max(0, totalLen + Number(startIndex));
     } else if (startIndex == 0n) {
       // Weird special case
       realStart = 0;
@@ -124,10 +135,10 @@ const substring: DocumentedSqlFunction = {
     if (realLength < 0) {
       // Negative length means we return that many characters _before_
       // the start index.
-      return text.substring(realStart + realLength, realStart);
+      return codePoints.slice(realStart + realLength, realStart).join('');
     }
 
-    return text.substring(realStart, realStart + realLength);
+    return codePoints.slice(realStart, realStart + realLength).join('');
   },
   parameters: [
     { name: 'value', type: ExpressionType.TEXT, optional: false },
@@ -137,7 +148,7 @@ const substring: DocumentedSqlFunction = {
   getReturnType(args) {
     return ExpressionType.TEXT;
   },
-  detail: 'Compute a substring',
+  detail: 'Compute a substring (indexes by Unicode code points to match SQLite)',
   documentation: 'The start index starts at 1. If no length is specified, the remainder of the string is returned.'
 };
 

--- a/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
@@ -4,6 +4,34 @@ import { requestParameters, TestSourceTable } from '../../util.js';
 import { syncTest } from './utils.js';
 
 describe('operators match SQLite', () => {
+  syncTest('substring() indexes by code points, not UTF-16 code units (matches SQLite)', ({ sync }) => {
+    // SQLite's substr() indexes by characters (code points). JavaScript's
+    // String.prototype.substring and .length count UTF-16 code units, so
+    // for a non-BMP code point (emoji 😀, CJK Extension B+, ancient scripts)
+    // - which is one code point but two code units - slicing in the middle
+    // of the surrogate pair returns a broken unpaired surrogate. Same
+    // silent-failure class as #644-#647 / #565 / upper/lower / length().
+    const streams = sync.prepareSyncStreams(`
+config:
+  edition: 3
+
+streams:
+  a:
+    query: 'SELECT id, substring(name, 1, 2) AS first_two FROM tbl'
+`);
+
+    const table = new TestSourceTable('tbl');
+    function firstTwo(name: SqliteValue) {
+      const [row] = streams.evaluateRow({ sourceTable: table, record: { id: 'ignored', name } });
+      return row.data['first_two'];
+    }
+
+    expect(firstTwo('hello')).toStrictEqual('he'); // ASCII (control)
+    expect(firstTwo('a😀bc')).toStrictEqual('a😀'); // was 'a\uD83D' (unpaired surrogate)
+    expect(firstTwo('😀😀😀')).toStrictEqual('😀😀'); // two whole emoji
+    expect(firstTwo('𐀀ab')).toStrictEqual('𐀀a'); // U+10000 Linear B
+  });
+
   syncTest('division by zero', ({ sync }) => {
     // Regression test for https://github.com/powersync-ja/powersync-service/pull/646.
     const streams = sync.prepareSyncStreams(`


### PR DESCRIPTION
Same silent-data-loss class as the merged #644 / #645 / #646 / #647 and the open #565 PR #662, #663 (ASCII upper/lower), and #664 (length code points).

### The bug

`substring()` used `String.prototype.substring` and `String.prototype.length`, which count **UTF-16 code units**. SQLite's `substr()` indexes by **characters** (Unicode code points).

For any string containing a non-BMP code point — `😀`, CJK Extension B–G, ancient scripts — the two views disagree:

| Call | Server (JS) | SQLite client | Match? |
|---|---|---|---|
| `substring('hello', 1, 2)` | `'he'` | `'he'` | ✅ |
| `substring('a😀bc', 1, 2)` | `'a\uD83D'` (unpaired surrogate!) | `'a😀'` | ❌ broken |
| `substring('😀😀😀', 1, 2)` | `'😀'` (only first emoji's pair) | `'😀😀'` | ❌ |
| `substring('𐀀ab', 1, 2)` | `'𐀀'` (just the surrogate pair of one emoji) | `'𐀀a'` | ❌ |

The two-code-unit case happens to coincide for a single non-BMP code point, but the general case is broken — the JS path produces either an unpaired-surrogate string or splits characters across boundary indices.

### Fix

One change: walk the string into a code-point array (`const codePoints = [...text]`) once, and slice/length-check on that array instead of on the original string. All index arithmetic now operates on code points; `join('')` produces well-formed output.

### Tests

New `syncTest('substring() indexes by code points, not UTF-16 code units (matches SQLite)')` in `sqlite_semantics.test.ts`:

- `'hello'` → `'he'` (ASCII control)
- `'a😀bc'` → `'a😀'` (was `'a\uD83D'`)
- `'😀😀😀'` → `'😀😀'` (was a single emoji's surrogate pair)
- `'𐀀ab'` (U+10000 Linear B) → `'𐀀a'` (was just `𐀀` surrogate pair)

`sync_rules.test.ts`: 40/40 still green.
