### PR TITLE
Verify string behavior with SQLite tests

### DIFF
--- a/.changeset/cuddly-cobras-remain.md
+++ b/.changeset/cuddly-cobras-remain.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Make `lower()` and `upper()` Unicode aware even when `unstable_sqlite_expression_engine: true` is enabled.

--- a/packages/sync-rules/src/sync_plan/engine/sqlite.ts
+++ b/packages/sync-rules/src/sync_plan/engine/sqlite.ts
@@ -73,8 +73,8 @@ export function sqliteExpressionEngine(sqlite: SQLite, compatibility: Compatibil
   }
 
   // We want upper / lower to use a JS implementation to make them Unicode aware.
-  db.registerFunction('upper', { variadic: false }, (value) => String(value).toUpperCase());
-  db.registerFunction('lower', { variadic: false }, (value) => String(value).toLowerCase());
+  registerPowerSyncFunction('upper');
+  registerPowerSyncFunction('lower');
 
   // Needed to make them deterministic / prevent passing 'now'
   registerPowerSyncFunction('unixepoch');

--- a/packages/sync-rules/src/sync_plan/engine/sqlite.ts
+++ b/packages/sync-rules/src/sync_plan/engine/sqlite.ts
@@ -72,6 +72,10 @@ export function sqliteExpressionEngine(sqlite: SQLite, compatibility: Compatibil
     });
   }
 
+  // We want upper / lower to use a JS implementation to make them Unicode aware.
+  db.registerFunction('upper', { variadic: false }, (value) => String(value).toUpperCase());
+  db.registerFunction('lower', { variadic: false }, (value) => String(value).toLowerCase());
+
   // Needed to make them deterministic / prevent passing 'now'
   registerPowerSyncFunction('unixepoch');
   registerPowerSyncFunction('datetime');

--- a/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
@@ -145,5 +145,73 @@ streams:
       expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'false-row', nullable_flag: 0n } })).toHaveLength(1);
       expect(desc.evaluateRow({ sourceTable: DOCS, record: { id: 'true-row', nullable_flag: 1n } })).toHaveLength(0);
     });
+
+    syncTest('substring() indexes by code points', ({ sync }) => {
+      const streams = sync.prepareSyncStreams(`
+config:
+  edition: 3
+  unstable_sqlite_expression_engine: true
+
+streams:
+  a:
+    query: 'SELECT id, substring(name, 1, 2) AS first_two FROM docs'
+`);
+
+      function firstTwo(name: SqliteValue) {
+        const [row] = streams.evaluateRow({ sourceTable: DOCS, record: { id: 'ignored', name } });
+        return row.data['first_two'];
+      }
+
+      expect(firstTwo('hello')).toStrictEqual('he');
+      expect(firstTwo('a😀bc')).toStrictEqual('a😀');
+      expect(firstTwo('😀😀😀')).toStrictEqual('😀😀');
+      expect(firstTwo('𐀀ab')).toStrictEqual('𐀀a');
+    });
+
+    syncTest('length() counts Unicode code points, not UTF-16 code units', ({ sync }) => {
+      const streams = sync.prepareSyncStreams(`
+config:
+  edition: 3
+  unstable_sqlite_expression_engine: true
+
+streams:
+  a:
+    query: 'SELECT id, length(name) AS len FROM docs'
+`);
+
+      function len(name: SqliteValue): SqliteJsonValue {
+        const [row] = streams.evaluateRow({ sourceTable: DOCS, record: { id: 'ignored', name } });
+        return row.data['len'];
+      }
+
+      expect(len('hello')).toStrictEqual(5n);
+      expect(len('straße')).toStrictEqual(6n);
+      expect(len('😀')).toStrictEqual(1n);
+      expect(len('a😀b')).toStrictEqual(3n);
+      expect(len('𐀀')).toStrictEqual(1n);
+    });
+
+    syncTest('upper() / lower() are unicode-aware', ({ sync }) => {
+      const streams = sync.prepareSyncStreams(`
+config:
+  edition: 3
+  unstable_sqlite_expression_engine: true
+
+streams:
+  a:
+    query: 'SELECT id, UPPER(name) AS upper, LOWER(name) AS lower FROM docs'
+`);
+
+      function evaluate(name: SqliteValue) {
+        const [row] = streams.evaluateRow({ sourceTable: DOCS, record: { id: 'ignored', name } });
+        return { upper: row.data['upper'], lower: row.data['lower'] };
+      }
+
+      expect(evaluate('hello')).toStrictEqual({ upper: 'HELLO', lower: 'hello' });
+      expect(evaluate('Hello World')).toStrictEqual({ upper: 'HELLO WORLD', lower: 'hello world' });
+
+      expect(evaluate('Straße')).toStrictEqual({ upper: 'STRASSE', lower: 'straße' });
+      expect(evaluate('ﬁle')).toStrictEqual({ upper: 'FILE', lower: 'ﬁle' });
+    });
   });
 });

--- a/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/sqlite_semantics.test.ts
@@ -209,6 +209,7 @@ streams:
 
       expect(evaluate('hello')).toStrictEqual({ upper: 'HELLO', lower: 'hello' });
       expect(evaluate('Hello World')).toStrictEqual({ upper: 'HELLO WORLD', lower: 'hello world' });
+      expect(evaluate(null)).toStrictEqual({ upper: null, lower: null });
 
       expect(evaluate('Straße')).toStrictEqual({ upper: 'STRASSE', lower: 'straße' });
       expect(evaluate('ﬁle')).toStrictEqual({ upper: 'FILE', lower: 'ﬁle' });


### PR DESCRIPTION
@sravan27 found a few more issues where the JavaScript expression evaluator diverges from SQLite:

1. Our `substring()` and `length` functions operate on UTF-16 code units instead of Unicode code points.
2. In SQLite, `lower()` and `upper()` only transform ASCII chars by default.

For the first issue, this ports tests from the PRs (so we know `unstable_sqlite_expression_engine` fixes this). For the second issue, I think having a Unicode-aware implementation is better than the SQLite default. So, this patches `lower()` and `upper()` to use the JS implementation and copies a test.

Closes https://github.com/powersync-ja/powersync-service/pull/663.
Closes https://github.com/powersync-ja/powersync-service/pull/664.
Closes https://github.com/powersync-ja/powersync-service/pull/665.

@sravan27, if you find more behavior differences between SQLite and our JS implementation, please only add tests to verify the behavior with `unstable_sqlite_expression_engine: true`. We're not looking for more JavaScript issues here, and want to move towards stabilizing SQLite as an option instead.