### PR TITLE
[Incremental Reprocessing] Sync plan equality checks

### DIFF
--- a/.changeset/empty-spiders-share.md
+++ b/.changeset/empty-spiders-share.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': minor
+---
+
+[Internal] Add comparison methods for serialized sync plans.

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -34,7 +34,10 @@ export * from './types/time.js';
 export * from './utils.js';
 
 export * from './compiler/compiler.js';
-export { Database, SQLite, Statement, nodeSqlite } from './sync_plan/engine/sqlite.js';
+export { HashMap, HashSet } from './compiler/equality.js';
+export { javaScriptExpressionEngine } from './sync_plan/engine/javascript.js';
+export { Database, SQLite, Statement, nodeSqlite, sqliteExpressionEngine } from './sync_plan/engine/sqlite.js';
 export { PrecompiledSyncConfig } from './sync_plan/evaluator/index.js';
 export * from './sync_plan/plan.js';
-export { deserializeSyncPlan, serializeSyncPlan } from './sync_plan/serialize.js';
+export * from './sync_plan/plan_equality_serialized.js';
+export * from './sync_plan/serialize.js';

--- a/packages/sync-rules/src/sync_plan/plan_equality_serialized.ts
+++ b/packages/sync-rules/src/sync_plan/plan_equality_serialized.ts
@@ -1,0 +1,47 @@
+import { Equality } from '../compiler/equality.js';
+import {
+  SerializedBucketDataSource,
+  SerializedDataSource,
+  SerializedParameterIndexLookupCreator
+} from './serialize.js';
+
+export interface SerializedBucketDataSourceWithDataSources {
+  bucket: SerializedBucketDataSource;
+  dataSources: readonly SerializedDataSource[];
+}
+
+export const serializedStreamDataSourceEquality = jsonEquality<SerializedDataSource>();
+
+export const serializedStreamParameterIndexLookupCreatorEquality =
+  jsonEquality<SerializedParameterIndexLookupCreator>();
+
+export const serializedStreamBucketDataSourceEquality: Equality<SerializedBucketDataSourceWithDataSources> = {
+  hash(hasher, value) {
+    hasher.addString(JSON.stringify(bucketIdentity(value)));
+  },
+  equals(a, b) {
+    return a === b || JSON.stringify(bucketIdentity(a)) == JSON.stringify(bucketIdentity(b));
+  }
+};
+
+function bucketIdentity(value: SerializedBucketDataSourceWithDataSources) {
+  const { bucket, dataSources } = value;
+
+  return {
+    hash: bucket.hash,
+    uniqueName: bucket.uniqueName,
+    // Sort so that the order of sources does not affect equality, as long as the same data sources are included.
+    sources: bucket.sources.map((index) => JSON.stringify(dataSources[index])).sort()
+  };
+}
+
+function jsonEquality<T>(): Equality<T> {
+  return {
+    hash(hasher, value) {
+      hasher.addString(JSON.stringify(value));
+    },
+    equals(a, b) {
+      return a === b || JSON.stringify(a) == JSON.stringify(b);
+    }
+  };
+}

--- a/packages/sync-rules/src/sync_plan/plan_equality_serialized.ts
+++ b/packages/sync-rules/src/sync_plan/plan_equality_serialized.ts
@@ -10,11 +10,26 @@ export interface SerializedBucketDataSourceWithDataSources {
   dataSources: readonly SerializedDataSource[];
 }
 
-export const serializedStreamDataSourceEquality = jsonEquality<SerializedDataSource>();
-
+/**
+ * Equality for SerializedParameterIndexLookupCreator.
+ *
+ * This compares the JSON form directly. These are self-contained and use a stable serialization form, so it's
+ * safe to compare this way.
+ *
+ * These are only considered equal if the lookupName remains the same, so may be affected by changing order of queries.
+ */
 export const serializedStreamParameterIndexLookupCreatorEquality =
   jsonEquality<SerializedParameterIndexLookupCreator>();
 
+/**
+ * SerializedBucketDataSource is not safe to compare _directly_, since it contains index references to SerializedDataSource
+ * in the serialized sync plan. However, each SerializedDataSource is self-contained and safe to compare directly.
+ *
+ * So we compare the SerializedDataSource excluding `bucket.sources`, as well as the resolved SerializedDataSources (order independent).
+ * The caller is responsible for resolving the SerializedDataSources.
+ *
+ * These are only considered equal if uniqueName is the same, so may be affected by changing order of joins/subqueries.
+ */
 export const serializedStreamBucketDataSourceEquality: Equality<SerializedBucketDataSourceWithDataSources> = {
   hash(hasher, value) {
     hasher.addString(JSON.stringify(bucketIdentity(value)));

--- a/packages/sync-rules/src/sync_plan/serialize.ts
+++ b/packages/sync-rules/src/sync_plan/serialize.ts
@@ -332,7 +332,7 @@ export function deserializeSyncPlan(serialized: unknown): SyncPlan {
   };
 }
 
-interface SerializedSyncPlanV1 {
+export interface SerializedSyncPlanV1 {
   version: number;
   dataSources: SerializedDataSource[];
   buckets: SerializedBucketDataSource[];
@@ -340,32 +340,32 @@ interface SerializedSyncPlanV1 {
   streams: SerializedStream[];
 }
 
-interface SerializedBucketDataSource {
+export interface SerializedBucketDataSource {
   hash: number;
   uniqueName: string;
   sources: number[];
 }
 
-interface SerializedTablePattern {
+export interface SerializedTablePattern {
   connection: string | null;
   schema: string | null;
   table: string;
 }
 
-interface SerializedTableProcessorTableValuedFunctionOutput {
+export interface SerializedTableProcessorTableValuedFunctionOutput {
   function: number;
   outputName: string;
 }
 
-type SerializedTableProcessorData = ColumnSqlParameterValue | SerializedTableProcessorTableValuedFunctionOutput;
+export type SerializedTableProcessorData = ColumnSqlParameterValue | SerializedTableProcessorTableValuedFunctionOutput;
 
-interface SerializedPartitionKey {
+export interface SerializedPartitionKey {
   expr: SqlExpression<SerializedTableProcessorData>;
 }
 
-type SerializedColumnSource = 'star' | { expr: SqlExpression<SerializedTableProcessorData>; alias: string };
+export type SerializedColumnSource = 'star' | { expr: SqlExpression<SerializedTableProcessorData>; alias: string };
 
-interface SerializedDataSource {
+export interface SerializedDataSource {
   table: SerializedTablePattern;
   outputTableName?: string;
   hash: number;
@@ -375,7 +375,7 @@ interface SerializedDataSource {
   partitionBy: SerializedPartitionKey[];
 }
 
-interface SerializedParameterIndexLookupCreator {
+export interface SerializedParameterIndexLookupCreator {
   table: SerializedTablePattern;
   hash: number;
   lookupScope: ParameterLookupDefinitionId;
@@ -385,19 +385,19 @@ interface SerializedParameterIndexLookupCreator {
   partitionBy: SerializedPartitionKey[];
 }
 
-interface SerializedStream {
+export interface SerializedStream {
   stream: StreamOptions;
   queriers: SerializedStreamQuerier[];
 }
 
-interface SerializedStreamQuerier {
+export interface SerializedStreamQuerier {
   requestFilters: SqlExpression<RequestSqlParameterValue>[];
   lookupStages: SerializedExpandingLookup[][];
   bucket: number;
   sourceInstantiation: SerializedParameterValue[];
 }
 
-type SerializedExpandingLookup =
+export type SerializedExpandingLookup =
   | {
       type: 'parameter';
       lookup: number;
@@ -411,12 +411,12 @@ type SerializedExpandingLookup =
       filters: SqlExpression<ColumnSqlParameterValue>[];
     };
 
-interface LookupReference {
+export interface LookupReference {
   stageId: number;
   idInStage: number;
 }
 
-type SerializedParameterValue =
+export type SerializedParameterValue =
   | { type: 'request'; expr: SqlExpression<RequestSqlParameterValue> }
   | { type: 'lookup'; lookup: LookupReference; resultIndex: number }
   | { type: 'intersection'; values: SerializedParameterValue[] };

--- a/packages/sync-rules/test/src/sync_plan/evaluator/bucket_data_source_equality.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/bucket_data_source_equality.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import { Equality, StableHasher } from '../../../../src/compiler/equality.js';
+import { StableHasher } from '../../../../src/compiler/equality.js';
 import {
   BucketDataSource,
   SerializedBucketDataSourceWithDataSources,
@@ -28,9 +28,6 @@ streams:
   stream:
     query: SELECT id, owner_id FROM todos WHERE owner_id = auth.user_id()
 `;
-    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
-    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
-
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 
@@ -51,9 +48,6 @@ streams:
   stream:
     query: SELECT id, title FROM todos WHERE owner_id = auth.user_id()
 `;
-    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
-    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
-
     expectSerializedBucketSources(firstYaml, secondYaml, false);
   });
 
@@ -74,9 +68,6 @@ streams:
   stream:
     query: SELECT * FROM todos WHERE project_id = auth.user_id()
 `;
-    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
-    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
-
     expectSerializedBucketSources(firstYaml, secondYaml, false);
   });
 
@@ -129,9 +120,6 @@ streams:
         SELECT id FROM organizations WHERE owner_id = auth.user_id()
       )
 `;
-    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
-    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
-
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 
@@ -152,9 +140,6 @@ streams:
   stream:
     query: SELECT * FROM todos WHERE owner_id = auth.parameter('user_id')
 `;
-    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
-    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
-
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 
@@ -179,9 +164,6 @@ streams:
       - SELECT * FROM stores
       - SELECT * FROM products
 `;
-    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
-    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
-
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 
@@ -208,8 +190,6 @@ streams:
       FROM customers, json_each(customers.active_regions) AS region
       WHERE region.value < 'm'
 `;
-    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
-    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
 
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
@@ -234,8 +214,8 @@ function expectSerializedBucketSources(
 
   expect(serializedStreamBucketDataSourceEquality.equals(first, second)).toBe(equal);
   if (equal) {
-    expect(hashWith(serializedStreamBucketDataSourceEquality, first)).toEqual(
-      hashWith(serializedStreamBucketDataSourceEquality, second)
+    expect(StableHasher.hashWith(serializedStreamBucketDataSourceEquality, first)).toEqual(
+      StableHasher.hashWith(serializedStreamBucketDataSourceEquality, second)
     );
   }
 }
@@ -246,10 +226,4 @@ function firstSerializedBucketSource(yaml: string): SerializedBucketDataSourceWi
     bucket: plan.buckets[0],
     dataSources: plan.dataSources
   };
-}
-
-function hashWith<T>(equality: Equality<T>, value: T): number {
-  const hasher = new StableHasher();
-  equality.hash(hasher, value);
-  return hasher.buildHashCode();
 }

--- a/packages/sync-rules/test/src/sync_plan/evaluator/bucket_data_source_equality.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/bucket_data_source_equality.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { StableHasher } from '../../../../src/compiler/equality.js';
 import {
-  BucketDataSource,
   SerializedBucketDataSourceWithDataSources,
   serializedStreamBucketDataSourceEquality,
-  serializeSyncPlan,
-  SyncConfig
+  serializeSyncPlan
 } from '../../../../src/index.js';
 import { compileToSyncPlanWithoutErrors } from '../../compiler/utils.js';
 
@@ -87,8 +85,8 @@ streams:
   second_stream:
     query: SELECT id, owner_id FROM todos WHERE owner_id = auth.user_id()
 `;
-    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
-    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+    const first = firstSerializedBucketSource(firstYaml).bucket;
+    const second = firstSerializedBucketSource(secondYaml).bucket;
 
     expect(first.uniqueName).not.toEqual(second.uniqueName);
     expectSerializedBucketSources(firstYaml, secondYaml, false, true);
@@ -193,10 +191,6 @@ streams:
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 });
-
-function firstBucketSource(config: SyncConfig): BucketDataSource {
-  return config.bucketDataSources[0];
-}
 
 function expectSerializedBucketSources(
   firstYaml: string,

--- a/packages/sync-rules/test/src/sync_plan/evaluator/bucket_data_source_equality.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/bucket_data_source_equality.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect } from 'vitest';
+import { Equality, StableHasher } from '../../../../src/compiler/equality.js';
+import {
+  BucketDataSource,
+  SerializedBucketDataSourceWithDataSources,
+  serializedStreamBucketDataSourceEquality,
+  serializeSyncPlan,
+  SyncConfig
+} from '../../../../src/index.js';
+import { compileToSyncPlanWithoutErrors } from '../../compiler/utils.js';
+import { syncTest } from './utils.js';
+
+describe('prepared bucket data source equality', () => {
+  syncTest('matches equivalent prepared bucket sources from different plans', ({ sync }) => {
+    const firstYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: SELECT id, owner_id FROM todos WHERE owner_id = auth.user_id()
+`;
+    const secondYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: SELECT id, owner_id FROM todos WHERE owner_id = auth.user_id()
+`;
+    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
+    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+
+    expectSerializedBucketSources(firstYaml, secondYaml, true);
+  });
+
+  syncTest('does not match when output columns differ', ({ sync }) => {
+    const firstYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: SELECT id, owner_id FROM todos WHERE owner_id = auth.user_id()
+`;
+    const secondYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: SELECT id, title FROM todos WHERE owner_id = auth.user_id()
+`;
+    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
+    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+
+    expectSerializedBucketSources(firstYaml, secondYaml, false);
+  });
+
+  syncTest('does not match when partitioning differs', ({ sync }) => {
+    const firstYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: SELECT * FROM todos WHERE owner_id = auth.user_id()
+`;
+    const secondYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: SELECT * FROM todos WHERE project_id = auth.user_id()
+`;
+    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
+    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+
+    expectSerializedBucketSources(firstYaml, secondYaml, false);
+  });
+
+  syncTest('does not match equivalent bucket sources with different stream names', ({ sync }) => {
+    const firstYaml = `
+config:
+  edition: 3
+
+streams:
+  first_stream:
+    query: SELECT id, owner_id FROM todos WHERE owner_id = auth.user_id()
+`;
+    const secondYaml = `
+config:
+  edition: 3
+
+streams:
+  second_stream:
+    query: SELECT id, owner_id FROM todos WHERE owner_id = auth.user_id()
+`;
+    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
+    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+
+    expect(first.uniqueName).not.toEqual(second.uniqueName);
+    expectSerializedBucketSources(firstYaml, secondYaml, false, true);
+  });
+
+  syncTest('matches when subqueries differ but the data source does not', ({ sync }) => {
+    const firstYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: |
+      SELECT * FROM projects
+      WHERE org_id IN (
+        SELECT org_id FROM memberships WHERE user_id = auth.user_id()
+      )
+`;
+    const secondYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: |
+      SELECT * FROM projects
+      WHERE org_id IN (
+        SELECT id FROM organizations WHERE owner_id = auth.user_id()
+      )
+`;
+    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
+    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+
+    expectSerializedBucketSources(firstYaml, secondYaml, true);
+  });
+
+  syncTest('matches when only bucket input parameters differ', ({ sync }) => {
+    const firstYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: SELECT * FROM todos WHERE owner_id = auth.user_id()
+`;
+    const secondYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: SELECT * FROM todos WHERE owner_id = auth.parameter('user_id')
+`;
+    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
+    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+
+    expectSerializedBucketSources(firstYaml, secondYaml, true);
+  });
+
+  syncTest('matches buckets with the same data sources in a different order', ({ sync }) => {
+    const firstYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    queries:
+      - SELECT * FROM products
+      - SELECT * FROM stores
+`;
+    const secondYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    queries:
+      - SELECT * FROM stores
+      - SELECT * FROM products
+`;
+    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
+    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+
+    expectSerializedBucketSources(firstYaml, secondYaml, true);
+  });
+
+  syncTest('compares table-valued function output expressions by their bindings', ({ sync }) => {
+    const firstYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: |
+      SELECT customers.id as id
+      FROM customers, json_each(customers.active_regions) AS region
+      WHERE region.value < 'm'
+`;
+    const secondYaml = `
+config:
+  edition: 3
+
+streams:
+  stream:
+    query: |
+      SELECT customers.id as id
+      FROM customers, json_each(customers.active_regions) AS region
+      WHERE region.value < 'm'
+`;
+    const first = firstBucketSource(sync.prepareWithoutHydration(firstYaml));
+    const second = firstBucketSource(sync.prepareWithoutHydration(secondYaml));
+
+    expectSerializedBucketSources(firstYaml, secondYaml, true);
+  });
+});
+
+function firstBucketSource(config: SyncConfig): BucketDataSource {
+  return config.bucketDataSources[0];
+}
+
+function expectSerializedBucketSources(
+  firstYaml: string,
+  secondYaml: string,
+  equal: boolean,
+  expectDifferentUniqueNames = false
+) {
+  const first = firstSerializedBucketSource(firstYaml);
+  const second = firstSerializedBucketSource(secondYaml);
+
+  if (expectDifferentUniqueNames) {
+    expect(first.bucket.uniqueName).not.toEqual(second.bucket.uniqueName);
+  }
+
+  expect(serializedStreamBucketDataSourceEquality.equals(first, second)).toBe(equal);
+  if (equal) {
+    expect(hashWith(serializedStreamBucketDataSourceEquality, first)).toEqual(
+      hashWith(serializedStreamBucketDataSourceEquality, second)
+    );
+  }
+}
+
+function firstSerializedBucketSource(yaml: string): SerializedBucketDataSourceWithDataSources {
+  const plan = serializeSyncPlan(compileToSyncPlanWithoutErrors(yaml));
+  return {
+    bucket: plan.buckets[0],
+    dataSources: plan.dataSources
+  };
+}
+
+function hashWith<T>(equality: Equality<T>, value: T): number {
+  const hasher = new StableHasher();
+  equality.hash(hasher, value);
+  return hasher.buildHashCode();
+}

--- a/packages/sync-rules/test/src/sync_plan/evaluator/bucket_data_source_equality.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/bucket_data_source_equality.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { StableHasher } from '../../../../src/compiler/equality.js';
 import {
   BucketDataSource,
@@ -8,10 +8,9 @@ import {
   SyncConfig
 } from '../../../../src/index.js';
 import { compileToSyncPlanWithoutErrors } from '../../compiler/utils.js';
-import { syncTest } from './utils.js';
 
 describe('prepared bucket data source equality', () => {
-  syncTest('matches equivalent prepared bucket sources from different plans', ({ sync }) => {
+  it('matches equivalent prepared bucket sources from different plans', () => {
     const firstYaml = `
 config:
   edition: 3
@@ -31,7 +30,7 @@ streams:
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 
-  syncTest('does not match when output columns differ', ({ sync }) => {
+  it('does not match when output columns differ', () => {
     const firstYaml = `
 config:
   edition: 3
@@ -51,7 +50,7 @@ streams:
     expectSerializedBucketSources(firstYaml, secondYaml, false);
   });
 
-  syncTest('does not match when partitioning differs', ({ sync }) => {
+  it('does not match when partitioning differs', () => {
     const firstYaml = `
 config:
   edition: 3
@@ -71,7 +70,7 @@ streams:
     expectSerializedBucketSources(firstYaml, secondYaml, false);
   });
 
-  syncTest('does not match equivalent bucket sources with different stream names', ({ sync }) => {
+  it('does not match equivalent bucket sources with different stream names', () => {
     const firstYaml = `
 config:
   edition: 3
@@ -95,7 +94,7 @@ streams:
     expectSerializedBucketSources(firstYaml, secondYaml, false, true);
   });
 
-  syncTest('matches when subqueries differ but the data source does not', ({ sync }) => {
+  it('matches when subqueries differ but the data source does not', () => {
     const firstYaml = `
 config:
   edition: 3
@@ -123,7 +122,7 @@ streams:
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 
-  syncTest('matches when only bucket input parameters differ', ({ sync }) => {
+  it('matches when only bucket input parameters differ', () => {
     const firstYaml = `
 config:
   edition: 3
@@ -143,7 +142,7 @@ streams:
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 
-  syncTest('matches buckets with the same data sources in a different order', ({ sync }) => {
+  it('matches buckets with the same data sources in a different order', () => {
     const firstYaml = `
 config:
   edition: 3
@@ -167,7 +166,7 @@ streams:
     expectSerializedBucketSources(firstYaml, secondYaml, true);
   });
 
-  syncTest('compares table-valued function output expressions by their bindings', ({ sync }) => {
+  it('compares table-valued function output expressions by their bindings', () => {
     const firstYaml = `
 config:
   edition: 3


### PR DESCRIPTION
This implements equality checks for serialized sync plans. Specifically, this can compare:
1. `SerializedBucketDataSource` (requires some denormalization to lookup the `SerializedDataSource` definitions)
2. `SerializedParameterIndexLookupCreator`

This is to be used for incremental reprocessing, to preserve bucket data sources and parameter indexes if unchanged.

Since this operates on the serialized plans, only sync streams with `config.edition: 3` are supported.

Currently this requires `uniqueName` to be unchanged, to allow still using `uniqueName` in the bucket prefix. This means that:
1. A sync stream rename needs to reprocess the entire sync stream.
2. Changing order of queries in a sync stream _may_ require reprocessing:
    a. If the queries share the same `BucketDataSource` (same "bucket parameters"), order between them may change freely.
    b. If the same stream contains multiple `BucketDataSource`s (multiple queries with different "bucket parameters"), changing the order of those may trigger reprocessing.

For usage of these APIs, see #653. This PR is split out from that one to make it more manageable.

This also changes some interfaces to be public, so that we can access the types for serialized plans on the storage layer. The serialized format is considered stable now, so it should not introduce issues to make these public.

## Alternatives considered

1. Comparing parsed sync plans. This is feasible, but requires more logic. It also requires parsing sync plans just to compare them. See experimental implementation [here](https://github.com/powersync-ja/powersync-service/pull/653/changes/c7e8635af58897e3d54bd0d7a8820928e8f8b05b..9741d0924821640249a4aea35ef7d901eef93aa5)
2. Implementing an equality check directly on `PreparedStreamBucketDataSource` requires comparing `ScalarExpressionEvaluators` and other internals. We could use for example `ExpressionToSqlite.toSqlite` here, but overall this requires even more specific checks than the above. The one specific advantage this approach would have is that it could work for sync rules and legacy sync streams as well.
3. Using the existing equality checks the compiler uses for de-duplication. These currently only work when parsing directly from source, and would require significant restructuring to make these work with serialized plans, so not considered feasible.

## AI Usage

The implementation was mostly performed by Codex gpt-5.5. Manually evaluated the various approaches and tweaked the implementation.