### PR TITLE
Fix edge case with emtpy bucket results

### DIFF
--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -54,14 +54,14 @@ function* walkDocumentOps(
 }
 
 function extractRowsFromDocument(
-  doc: bson.Document,
+  doc: BucketDataDocumentV3,
   context: { replicationStreamId: number; definitionId: string },
   bucketMap: Map<string, InternalOpId>,
   endOpId: InternalOpId,
   remainingLimit: number
 ): { rows: BucketDataDoc[]; remainingLimit: number; limitReached: boolean } {
   const rows: BucketDataDoc[] = [];
-  for (const row of loadBucketDataDocument(context, doc as BucketDataDocumentV3)) {
+  for (const row of loadBucketDataDocument(context, doc)) {
     const bucket = row.bucketKey.bucket;
     const bucketStart = bucketMap.get(bucket);
     if (bucketStart == null) {
@@ -473,14 +473,24 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       let chunkSizeBytes = 0;
       let sharedRemainingLimit = limit;
       let limitReached = false;
+      // Buckets whose matched document contributed no rows after filtering.
+      const completeEmptyBuckets = new Set<string>();
 
       for (const raw of rawData) {
-        const doc = bson.deserialize(raw, storage.BSON_DESERIALIZE_INTERNAL_OPTIONS);
+        const doc = bson.deserialize(raw, storage.BSON_DESERIALIZE_INTERNAL_OPTIONS) as BucketDataDocumentV3;
         const {
           rows,
           remainingLimit,
           limitReached: docLimitReached
         } = extractRowsFromDocument(doc, context, bucketMap, end, sharedRemainingLimit);
+        if (rows.length == 0) {
+          // The document straddles the requested (start, end] window: it matched the
+          // query, but none of its ops are in range. Since its _id.o (max op) must be
+          // > end (any op <= end would have been > start, and thus in range), and
+          // document ranges per bucket are disjoint, no later document for this bucket
+          // can match either. The bucket is complete through the checkpoint.
+          completeEmptyBuckets.add(doc._id.b);
+        }
         data.push(...rows);
         documentOpCounts.push(rows.length);
         documentSizes.push(raw.byteLength);
@@ -494,7 +504,36 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
 
       const batchHasMore = hasMore || limitReached;
 
+      // Empty chunks are not forwarded to clients, but report progress to the caller:
+      // the bucket's position advances to the checkpoint, so it is not re-requested.
+      // If the batch produced no data at all, the last empty chunk also carries the
+      // has_more signal, so the caller re-requests the remaining buckets instead of
+      // treating an all-filtered batch as the end of the stream.
+      const emptyBuckets = Array.from(completeEmptyBuckets);
+      for (const [index, bucket] of emptyBuckets.entries()) {
+        const startOpId = bucketMap.get(bucket);
+        if (startOpId == null) {
+          throw new ServiceAssertionError(`data for unexpected bucket: ${bucket}`);
+        }
+        const isLastChunkOfBatch = data.length == 0 && index == emptyBuckets.length - 1;
+        yield {
+          chunkData: {
+            bucket,
+            after: internalToExternalOpId(startOpId),
+            has_more: isLastChunkOfBatch && batchHasMore,
+            data: [],
+            next_after: internalToExternalOpId(end)
+          },
+          targetOp: null
+        };
+      }
+
       if (data.length == 0) {
+        if (batchHasMore) {
+          // The remaining documents are read in the next round, after the caller has
+          // advanced the positions of the empty buckets above.
+          return;
+        }
         continue;
       }
 

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -1061,6 +1061,101 @@ describe('sync - mongodb', () => {
           const ops = await getFilteredOps(50, 55);
           expect(ops).toEqual([]);
         });
+
+        test('all-filtered first batch still returns data behind the batch boundary', async () => {
+          // Documents straddling the requested (start, end] window are matched by the
+          // query, but contribute no rows after filtering. If an entire server batch
+          // (~101 documents) consists of such straddlers, the remaining documents in
+          // the cursor must still be reachable. Storage reports the straddler buckets
+          // as complete via empty chunks, and the caller re-requests the rest.
+          await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
+          const syncRules = await factory.updateSyncRules(
+            updateSyncRulesFromYaml(
+              `
+          bucket_definitions:
+            by_user:
+              parameters: select request.user_id() as user_id
+              data: [select * from test where owner_id = bucket.user_id]
+          `,
+              { storageVersion }
+            )
+          );
+          const bucketStorage = factory.getInstance(syncRules) as MongoSyncBucketStorage;
+          const db = bucketStorage.db as VersionedPowerSyncMongoV3;
+
+          const start = 5n;
+          const end = 50n;
+
+          // 150 buckets sorted before the data bucket, each with a single document
+          // containing ops at 1 and 100: matched (_id.o=100 > start, min_op=1 <= end),
+          // but no op in (5, 50].
+          const straddlerNames = Array.from({ length: 150 }, (_, i) => `b${`${i}`.padStart(3, '0')}`);
+          const requests = [...straddlerNames, 'zzz'].map((id) =>
+            bucketRequest(syncRules.syncConfigContent[0], `by_user["${id}"]`, start)
+          );
+          const definitionId = bucketStorage.mapping.bucketSourceId(requests[0].source);
+          const collection = db.bucketData(syncRules.replicationStreamId, definitionId);
+          const sourceTable = new bson.ObjectId();
+
+          function makeOps(bucket: string, opIds: bigint[]): BucketDataDoc[] {
+            const bucketKey: BucketKey = {
+              replicationStreamId: syncRules.replicationStreamId,
+              definitionId,
+              bucket
+            };
+            return opIds.map((opId) => ({
+              bucketKey,
+              o: opId,
+              op: 'PUT' as const,
+              source_table: sourceTable,
+              source_key: test_utils.rid(`row-${opId}`),
+              table: 'test',
+              row_id: `row-${opId}`,
+              checksum: BigInt(opId) * 10n,
+              data: `{"id":"row-${opId}"}`
+            }));
+          }
+
+          const straddlerDocs = requests
+            .slice(0, -1)
+            .map((request) => serializeBucketData(request.bucket, makeOps(request.bucket, [1n, 100n])));
+          const dataBucket = requests[requests.length - 1].bucket;
+          const dataDoc = serializeBucketData(dataBucket, makeOps(dataBucket, [10n]));
+          await collection.insertMany([...straddlerDocs, dataDoc]);
+
+          // Emulate the caller loop in sync.ts / BucketChecksumState: advance bucket
+          // positions from each chunk, drop completed buckets, and re-request while
+          // any chunk reported has_more.
+          const positions = new Map(requests.map((request) => [request.bucket, request.start]));
+          const pending = new Set(positions.keys());
+          const receivedOps: bigint[] = [];
+          let rounds = 0;
+
+          while (rounds < 10) {
+            rounds++;
+            const roundRequests = requests
+              .filter((request) => pending.has(request.bucket))
+              .map((request) => ({ ...request, start: positions.get(request.bucket)! }));
+            const batch = await test_utils.fromAsync(bucketStorage.getBucketDataBatch(end, roundRequests));
+            let anyHasMore = false;
+            for (const { chunkData } of batch) {
+              positions.set(chunkData.bucket, BigInt(chunkData.next_after));
+              if (chunkData.has_more) {
+                anyHasMore = true;
+              } else {
+                pending.delete(chunkData.bucket);
+              }
+              receivedOps.push(...chunkData.data.map((entry) => BigInt(entry.op_id)));
+            }
+            if (!anyHasMore) {
+              break;
+            }
+          }
+
+          // The op behind the all-straddler first batch must be returned.
+          expect(receivedOps).toEqual([10n]);
+          expect(rounds).toBeLessThan(10);
+        });
       });
     });
   }

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -367,6 +367,11 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
         checkpointInvalidated = true;
       }
       if (r.data.length == 0) {
+        // An empty chunk is not sent to the client, but may still report progress:
+        // storage can emit an empty chunk for a bucket that has no operations in the
+        // requested range, and its position must advance so the bucket is not
+        // re-requested indefinitely.
+        checkpointLine.updateBucketPosition({ bucket: r.bucket, nextAfter: BigInt(r.next_after), hasMore: r.has_more });
         continue;
       }
       logger.debug(`Sending data for ${r.bucket}`);


### PR DESCRIPTION
## Summary

There's an edge case with V3 multi-op in the V3 multi-op document read path, when all operations are filtered out in memory:`getBucketDataBatch()` stops reading and emitted neither data nor a `has_more` signal, so buckets behind
the batch boundary were silently treated as fully synced. Clients would be missing operations and fail checksum validation.

The fix makes storage report such buckets as complete via empty chunks, and makes the sync stream advance bucket positions for empty chunks. The existing caller loop (`BucketChecksumState` / `sync.ts`) then re-requests the remaining buckets and reaches the data.

## The bug (written by Claude)

With chunked multi-op documents, the read query can only filter on document-level metadata (`min_op` and `_id.o`); it cannot see individual operations. A document can therefore match the query while none of its operations are in the requested window.

Concrete example. Op ids come from one global sequence, so a bucket's ops are sparse. Suppose bucket A has ops 10, 20 and 100 stored in a single document:

```
document: min_op = 10, _id.o = 100, ops = [10, 20, 100]
```

A client synced through op 20 requests `(start = 20, end = 50]`:

- Query: `_id.o > 20` ✓ (100), `min_op <= 50` ✓ (10) → document fetched.
- Post-filter: 10 and 20 are `<= start`, 100 is `> end` → **zero rows**.

That result is correct for bucket A — it has no data in the window. The problem was the handling: if every document in the first server batch (~101 documents) was such a "straddler" (one per bucket; plausible when a request covers 100+ buckets mid-reconnect with writes racing past the checkpoint), the code hit `if (data.length == 0) continue;` and abandoned the cursor. Documents behind the batch boundary — containing real data for other buckets — were never read, and no `has_more` was emitted for them.

## The fix

Two small changes that reuse the existing caller retry loop instead of adding a second read loop inside storage:

### 1. `MongoSyncBucketStorageV3.getBucketDataBatchImpl`

When a matched document contributes zero rows, its bucket is provably complete through the checkpoint: any op `<= end` in that document would also be `> start` (the query guarantees `_id.o > start`), and since per-bucket document ranges are disjoint, no later document for that bucket can match either.

Storage now yields an **empty chunk** for each such bucket (`data: [], next_after = checkpoint, has_more: false`), so the caller can retire it. If the batch produced no data at all, the last empty chunk carries `has_more: true` (mirroring the existing last-chunk convention), so the caller re-requests the remaining buckets instead of treating the stream as complete. Progress is guaranteed: each round retires every straddler bucket in the batch, so the next request no longer matches their documents.

### 2. `sync.ts` — `bucketDataBatch`

`updateBucketPosition()` is now called for empty chunks before they are skipped. Previously empty chunks were dropped _before_ the position update, which would have re-requested the same buckets with the same positions indefinitely. Empty chunks are still never sent to clients — the protocol output is unchanged.

This also fixes a pre-existing inefficiency in the mixed case (some buckets straddle, others have data): straddler buckets previously never advanced their positions, so every subsequent round re-fetched their straddling documents.

## Semantics note

This slightly extends the implicit `SyncBucketDataChunk` contract: an empty chunk is a progress marker ("this bucket has no operations in the requested range; advance to `next_after`"). Other storage implementations never emit empty chunks and are unaffected.

## AI Usage

Used Claude Fable 5 to find the bug. Manually suggested the fix, and had Claude implement it.