### PR TITLE
[Incremental Reprocessing] Sync config cleanup

### DIFF
--- a/modules/module-mongodb-storage/src/storage/implementation/common/PersistedBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/common/PersistedBatch.ts
@@ -96,7 +96,7 @@ export abstract class PersistedBatch {
   }
 
   saveBucketData(options: SaveBucketDataOptions) {
-    const remaining_buckets = new Map<string, SaveBucketDataOptions['before_buckets'][number]>();
+    const remaining_buckets = new Map<string, SourceRecordBucketState>();
     for (let bucket of options.before_buckets) {
       const mapped: SourceRecordBucketState = {
         bucket: bucket.bucket,
@@ -104,6 +104,11 @@ export abstract class PersistedBatch {
         id: bucket.id,
         table: bucket.table
       };
+      if (options.table.bucketDataSourceIds != null && !options.table.bucketDataSourceIds.has(mapped.definitionId!)) {
+        // The bucket definition is not active anymore.
+        // We don't cleanup these references upfront, but do need to ignore them after the definition is removed.
+        continue;
+      }
       remaining_buckets.set(currentBucketKey(mapped), mapped);
     }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -100,6 +100,11 @@ export class MongoStoppedSyncConfigCleanup {
       result.parameterIndexCollectionsDropped = await this.dropParameterIndexCollections(unusedParameterIndexIds);
     }
 
+    // Event-only source tables carry empty membership arrays, so they are never selected by the
+    // membership filter above. Clean them up separately, regardless of whether any bucket or
+    // parameter ids became unused (a stopped config may have contributed only an event trigger).
+    await this.cleanupEventOnlySourceTables(liveConfigDocs, result);
+
     result.stoppedSyncConfigsRemoved = await this.pruneStoppedSyncConfigStates(stoppedStates);
 
     if (result.stoppedSyncConfigsRemoved > 0) {
@@ -173,46 +178,11 @@ export class MongoStoppedSyncConfigCleanup {
       .filter((sourceTable) => !deletableSourceTables.some((deletable) => deletable._id.equals(sourceTable._id)))
       .map((sourceTable) => sourceTable._id);
 
-    // Re-fetch rows before deleting, so we don't delete a source table that became live
-    // through another writer after the planning read above.
-    const deletableSourceTableIds = deletableSourceTables.map((table) => table._id);
-    const sourceTablesToDelete =
-      deletableSourceTableIds.length == 0
-        ? []
-        : await this.db
-            .sourceTables(this.replicationStreamId)
-            .find(
-              this.deletableSourceTableFilter(
-                deletableSourceTableIds,
-                unusedBucketDefinitionIds,
-                unusedParameterIndexIds
-              ),
-              {
-                projection: { _id: 1 }
-              }
-            )
-            .toArray();
-
-    // Drop sourceRecords collections before the related sourceTables entries, so that we
-    // can recover after interruptions.
-    for (const sourceTable of sourceTablesToDelete) {
-      this.throwIfAborted();
-      await this.dropCollection(this.db.sourceRecords(this.replicationStreamId, sourceTable._id));
-      result.sourceRecordCollectionsDropped += 1;
-    }
-
-    if (sourceTablesToDelete.length > 0) {
-      this.throwIfAborted();
-      const deleteResult = await this.db.sourceTables(this.replicationStreamId).deleteMany(
-        this.deletableSourceTableFilter(
-          sourceTablesToDelete.map((table) => table._id),
-          unusedBucketDefinitionIds,
-          unusedParameterIndexIds
-        ),
-        { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
-      );
-      result.sourceTablesDeleted += deleteResult.deletedCount;
-    }
+    await this.deleteSourceTables(
+      deletableSourceTables.map((table) => table._id),
+      (ids) => this.deletableSourceTableFilter(ids, unusedBucketDefinitionIds, unusedParameterIndexIds),
+      result
+    );
 
     if (retainedSourceTableIds.length > 0) {
       this.throwIfAborted();
@@ -224,6 +194,80 @@ export class MongoStoppedSyncConfigCleanup {
         { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
       );
       result.sourceTablesUpdated += updateResult.modifiedCount;
+    }
+  }
+
+  /**
+   * Clean up event-only source tables that no live sync config still triggers events for.
+   *
+   * Event-only source tables carry empty membership arrays (see source-table-utils:
+   * "Empty memberships indicate an event-only table"), so the membership filter never selects
+   * them. Without this, the source_tables row and its source_records collection leak when the
+   * config that contributed the event trigger is stopped.
+   */
+  private async cleanupEventOnlySourceTables(
+    liveConfigDocs: SyncConfigDefinition[],
+    result: storage.CleanupStoppedSyncConfigsResult
+  ) {
+    const candidateSourceTables = await this.db
+      .sourceTables(this.replicationStreamId)
+      .find(this.eventOnlySourceTableFilter(), {
+        projection: {
+          _id: 1,
+          bucket_data_source_ids: 1,
+          parameter_lookup_source_ids: 1,
+          schema_name: 1,
+          table_name: 1
+        }
+      })
+      .toArray();
+    if (candidateSourceTables.length == 0) {
+      return;
+    }
+
+    const liveSyncConfigs = this.parseSyncConfigs(liveConfigDocs);
+    const deletableSourceTableIds = candidateSourceTables
+      .filter((sourceTable) => !this.triggersLiveEvent(sourceTable, liveSyncConfigs))
+      .map((sourceTable) => sourceTable._id);
+
+    await this.deleteSourceTables(deletableSourceTableIds, (ids) => this.eventOnlyDeletableFilter(ids), result);
+  }
+
+  /**
+   * Drop the given source tables and their source_records collections.
+   *
+   * `refetchFilter` re-applies the deletability predicate against the latest persisted state, so
+   * a source table that became live through another writer after planning is not deleted. The
+   * sourceRecords collection is dropped before the related sourceTables row, so an interruption
+   * can be recovered on the next run.
+   */
+  private async deleteSourceTables(
+    deletableSourceTableIds: bson.ObjectId[],
+    refetchFilter: (ids: bson.ObjectId[]) => Record<string, unknown>,
+    result: storage.CleanupStoppedSyncConfigsResult
+  ) {
+    if (deletableSourceTableIds.length == 0) {
+      return;
+    }
+    const sourceTablesToDelete = await this.db
+      .sourceTables(this.replicationStreamId)
+      .find(refetchFilter(deletableSourceTableIds), { projection: { _id: 1 } })
+      .toArray();
+
+    for (const sourceTable of sourceTablesToDelete) {
+      this.throwIfAborted();
+      await this.dropCollection(this.db.sourceRecords(this.replicationStreamId, sourceTable._id));
+      result.sourceRecordCollectionsDropped += 1;
+    }
+
+    if (sourceTablesToDelete.length > 0) {
+      this.throwIfAborted();
+      const deleteResult = await this.db
+        .sourceTables(this.replicationStreamId)
+        .deleteMany(refetchFilter(sourceTablesToDelete.map((table) => table._id)), {
+          maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS
+        });
+      result.sourceTablesDeleted += deleteResult.deletedCount;
     }
   }
 
@@ -249,6 +293,20 @@ export class MongoStoppedSyncConfigCleanup {
       _id: { $in: ids },
       bucket_data_source_ids: { $not: { $elemMatch: { $nin: unusedBucketDefinitionIds } } },
       parameter_lookup_source_ids: { $not: { $elemMatch: { $nin: unusedParameterIndexIds } } }
+    };
+  }
+
+  private eventOnlySourceTableFilter(): Record<string, unknown> {
+    return {
+      bucket_data_source_ids: { $size: 0 },
+      parameter_lookup_source_ids: { $size: 0 }
+    };
+  }
+
+  private eventOnlyDeletableFilter(ids: bson.ObjectId[]): Record<string, unknown> {
+    return {
+      _id: { $in: ids },
+      ...this.eventOnlySourceTableFilter()
     };
   }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -133,47 +133,34 @@ export class MongoStoppedSyncConfigCleanup {
     if (unusedParameterIndexIds.length > 0) {
       update.parameter_lookup_source_ids = { $in: unusedParameterIndexIds };
     }
-    if (Object.keys(update).length == 0) {
-      return;
-    }
-
-    const filter = this.sourceTableMembershipFilter(unusedBucketDefinitionIds, unusedParameterIndexIds);
-    const sourceTables = await this.db
-      .sourceTables(this.replicationStreamId)
-      .find(filter, { projection: { _id: 1 } })
-      .toArray();
-    if (sourceTables.length == 0) {
-      return;
-    }
-    const sourceTableIds = sourceTables.map((table) => table._id);
-    const liveSyncConfigs = this.parseSyncConfigs(liveConfigDocs);
 
     // Keep obsolete membership ids as the durable cleanup marker until each source table is
     // either deleted or retained. If interrupted after dropping a source_records collection,
     // the next run can still rediscover the source table from these obsolete ids and retry.
-    const sourceTablesAfterCleanup = await this.db
+    const filter = this.sourceTableMembershipFilter(unusedBucketDefinitionIds, unusedParameterIndexIds);
+    const candidateSourceTables = await this.db
       .sourceTables(this.replicationStreamId)
-      .find(
-        {
-          _id: { $in: sourceTableIds }
-        },
-        {
-          projection: {
-            _id: 1,
-            bucket_data_source_ids: 1,
-            parameter_lookup_source_ids: 1,
-            schema_name: 1,
-            table_name: 1
-          }
+      .find(filter, {
+        projection: {
+          _id: 1,
+          bucket_data_source_ids: 1,
+          parameter_lookup_source_ids: 1,
+          schema_name: 1,
+          table_name: 1
         }
-      )
+      })
       .toArray();
-    const deletableSourceTables = sourceTablesAfterCleanup.filter(
+    if (candidateSourceTables.length == 0) {
+      return;
+    }
+    const liveSyncConfigs = this.parseSyncConfigs(liveConfigDocs);
+
+    const deletableSourceTables = candidateSourceTables.filter(
       (sourceTable) =>
         this.membershipsBecomeEmpty(sourceTable, unusedBucketDefinitionIds, unusedParameterIndexIds) &&
         !this.triggersLiveEvent(sourceTable, liveSyncConfigs)
     );
-    const retainedSourceTableIds = sourceTablesAfterCleanup
+    const retainedSourceTableIds = candidateSourceTables
       .filter((sourceTable) => !deletableSourceTables.some((deletable) => deletable._id.equals(sourceTable._id)))
       .map((sourceTable) => sourceTable._id);
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -1,9 +1,8 @@
 import * as lib_mongo from '@powersync/lib-service-mongodb';
 import { Logger, ReplicationAbortedError } from '@powersync/lib-services-framework';
-import { storage } from '@powersync/service-core';
+import { SingleSyncConfigBucketDefinitionMapping, storage } from '@powersync/service-core';
 import { BucketDefinitionId, ParameterIndexId, SyncConfig } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
-import { SingleSyncConfigBucketDefinitionMapping } from '../BucketDefinitionMapping.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
 import { ReplicationStreamDocumentV3, SourceTableDocumentV3, SyncConfigDefinition } from './models.js';
 
@@ -113,7 +112,9 @@ export class MongoStoppedSyncConfigCleanup {
   }
 
   private storageIdsFor(configs: Pick<SyncConfigDefinition, 'rule_mapping'>[]) {
-    const mappings = configs.map((config) => SingleSyncConfigBucketDefinitionMapping.fromSyncConfig(config));
+    const mappings = configs.map((config) =>
+      SingleSyncConfigBucketDefinitionMapping.fromPersistedMapping(config.rule_mapping)
+    );
     return {
       bucketDefinitionIds: [...new Set(mappings.flatMap((mapping) => mapping.allBucketDefinitionIds()))],
       parameterIndexIds: [...new Set(mappings.flatMap((mapping) => mapping.allParameterIndexIds()))]

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -3,8 +3,14 @@ import { Logger, ReplicationAbortedError } from '@powersync/lib-services-framewo
 import { SingleSyncConfigBucketDefinitionMapping, storage } from '@powersync/service-core';
 import { BucketDefinitionId, ParameterIndexId, SyncConfig } from '@powersync/service-sync-rules';
 import * as bson from 'bson';
+import { idPrefixFilter, retryOnMongoMaxTimeMSExpired } from '../../../utils/util.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
-import { ReplicationStreamDocumentV3, SourceTableDocumentV3, SyncConfigDefinition } from './models.js';
+import {
+  BucketStateDocumentV3,
+  ReplicationStreamDocumentV3,
+  SourceTableDocumentV3,
+  SyncConfigDefinition
+} from './models.js';
 
 type SyncConfigState = ReplicationStreamDocumentV3['sync_configs'][number];
 
@@ -18,6 +24,7 @@ const EMPTY_RESULT: storage.CleanupStoppedSyncConfigsResult = {
   stoppedSyncConfigsRemoved: 0,
   bucketDataCollectionsDropped: 0,
   parameterIndexCollectionsDropped: 0,
+  bucketStateDocumentsDeleted: 0,
   sourceRecordCollectionsDropped: 0,
   sourceTablesUpdated: 0,
   sourceTablesDeleted: 0
@@ -89,6 +96,7 @@ export class MongoStoppedSyncConfigCleanup {
         result
       );
       result.bucketDataCollectionsDropped = await this.dropBucketDataCollections(unusedBucketDefinitionIds);
+      result.bucketStateDocumentsDeleted = await this.deleteBucketStateDocuments(unusedBucketDefinitionIds);
       result.parameterIndexCollectionsDropped = await this.dropParameterIndexCollections(unusedParameterIndexIds);
     }
 
@@ -292,6 +300,45 @@ export class MongoStoppedSyncConfigCleanup {
       await this.dropCollection(this.db.bucketData(this.replicationStreamId, definitionId));
     }
     return definitionIds.length;
+  }
+
+  /**
+   * Delete bucket_state documents for the unused bucket definitions.
+   *
+   * The bucket_state collection is shared across all bucket definitions of the
+   * stream (keyed by `_id`, an ordered `{ d, b }` compound), so we delete the individual documents.
+   *
+   * There can be hundreds of millions of buckets, so we delete per definition using a range filter
+   * on `_id` (which uses the `_id` index) rather than a slow `_id.d` field scan, and retry on
+   * MaxTimeMSExpired so each call makes progress in batches.
+   */
+  private async deleteBucketStateDocuments(definitionIds: BucketDefinitionId[]): Promise<number> {
+    const collection = this.db.bucketState(this.replicationStreamId);
+    let deletedCount = 0;
+    for (const definitionId of definitionIds) {
+      this.throwIfAborted();
+      const result = await retryOnMongoMaxTimeMSExpired(
+        () =>
+          collection.deleteMany(
+            {
+              _id: idPrefixFilter<BucketStateDocumentV3['_id']>({ d: definitionId }, ['b'])
+            },
+            { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
+          ),
+        {
+          signal: this.signal,
+          abortMessage: 'Aborted stopped sync config cleanup',
+          retryDelayMs: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS / 5,
+          onRetry: () => {
+            this.logger.info(
+              `Cleared batch of bucket state in ${lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS}ms, continuing...`
+            );
+          }
+        }
+      );
+      deletedCount += result.deletedCount;
+    }
+    return deletedCount;
   }
 
   private async dropParameterIndexCollections(indexIds: ParameterIndexId[]): Promise<number> {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -148,51 +148,112 @@ export class MongoStoppedSyncConfigCleanup {
     const sourceTableIds = sourceTables.map((table) => table._id);
     const liveSyncConfigs = this.parseSyncConfigs(liveConfigDocs);
 
-    this.throwIfAborted();
-    const updateResult = await this.db.sourceTables(this.replicationStreamId).updateMany(
-      { _id: { $in: sourceTableIds } },
-      {
-        $pull: update
-      },
-      { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
-    );
-    result.sourceTablesUpdated += updateResult.modifiedCount;
-
-    // Membership ids do not represent event-only tables, so an empty-membership table may
-    // still be needed for custom write checkpoint events.
-    const unusedSourceTables = await this.db
+    // Keep obsolete membership ids as the durable cleanup marker until each source table is
+    // either deleted or retained. If interrupted after dropping a source_records collection,
+    // the next run can still rediscover the source table from these obsolete ids and retry.
+    const sourceTablesAfterCleanup = await this.db
       .sourceTables(this.replicationStreamId)
       .find(
         {
-          _id: { $in: sourceTableIds },
-          bucket_data_source_ids: { $size: 0 },
-          parameter_lookup_source_ids: { $size: 0 }
+          _id: { $in: sourceTableIds }
         },
-        { projection: { _id: 1 } }
+        {
+          projection: {
+            _id: 1,
+            bucket_data_source_ids: 1,
+            parameter_lookup_source_ids: 1,
+            schema_name: 1,
+            table_name: 1
+          }
+        }
       )
       .toArray();
-    const deletableSourceTables = unusedSourceTables.filter(
-      (sourceTable) => !this.triggersLiveEvent(sourceTable, liveSyncConfigs)
+    const deletableSourceTables = sourceTablesAfterCleanup.filter(
+      (sourceTable) =>
+        this.membershipsBecomeEmpty(sourceTable, unusedBucketDefinitionIds, unusedParameterIndexIds) &&
+        !this.triggersLiveEvent(sourceTable, liveSyncConfigs)
     );
+    const retainedSourceTableIds = sourceTablesAfterCleanup
+      .filter((sourceTable) => !deletableSourceTables.some((deletable) => deletable._id.equals(sourceTable._id)))
+      .map((sourceTable) => sourceTable._id);
+
+    // Re-fetch rows before deleting, so we don't delete a source table that became live
+    // through another writer after the planning read above.
+    const deletableSourceTableIds = deletableSourceTables.map((table) => table._id);
+    const sourceTablesToDelete =
+      deletableSourceTableIds.length == 0
+        ? []
+        : await this.db
+            .sourceTables(this.replicationStreamId)
+            .find(
+              this.deletableSourceTableFilter(
+                deletableSourceTableIds,
+                unusedBucketDefinitionIds,
+                unusedParameterIndexIds
+              ),
+              {
+                projection: { _id: 1 }
+              }
+            )
+            .toArray();
 
     // Drop sourceRecords collections before the related sourceTables entries, so that we
     // can recover after interruptions.
-    for (const sourceTable of deletableSourceTables) {
+    for (const sourceTable of sourceTablesToDelete) {
       this.throwIfAborted();
       await this.dropCollection(this.db.sourceRecords(this.replicationStreamId, sourceTable._id));
       result.sourceRecordCollectionsDropped += 1;
     }
 
-    if (deletableSourceTables.length > 0) {
+    if (sourceTablesToDelete.length > 0) {
       this.throwIfAborted();
       const deleteResult = await this.db.sourceTables(this.replicationStreamId).deleteMany(
-        {
-          _id: { $in: deletableSourceTables.map((table) => table._id) }
-        },
+        this.deletableSourceTableFilter(
+          sourceTablesToDelete.map((table) => table._id),
+          unusedBucketDefinitionIds,
+          unusedParameterIndexIds
+        ),
         { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
       );
       result.sourceTablesDeleted += deleteResult.deletedCount;
     }
+
+    if (retainedSourceTableIds.length > 0) {
+      this.throwIfAborted();
+      const updateResult = await this.db.sourceTables(this.replicationStreamId).updateMany(
+        { _id: { $in: retainedSourceTableIds } },
+        {
+          $pull: update
+        },
+        { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
+      );
+      result.sourceTablesUpdated += updateResult.modifiedCount;
+    }
+  }
+
+  private membershipsBecomeEmpty(
+    sourceTable: Pick<SourceTableDocumentV3, 'bucket_data_source_ids' | 'parameter_lookup_source_ids'>,
+    unusedBucketDefinitionIds: BucketDefinitionId[],
+    unusedParameterIndexIds: ParameterIndexId[]
+  ): boolean {
+    const unusedBucketDefinitionIdSet = new Set(unusedBucketDefinitionIds);
+    const unusedParameterIndexIdSet = new Set(unusedParameterIndexIds);
+    return (
+      sourceTable.bucket_data_source_ids.every((id) => unusedBucketDefinitionIdSet.has(id)) &&
+      sourceTable.parameter_lookup_source_ids.every((id) => unusedParameterIndexIdSet.has(id))
+    );
+  }
+
+  private deletableSourceTableFilter(
+    ids: bson.ObjectId[],
+    unusedBucketDefinitionIds: BucketDefinitionId[],
+    unusedParameterIndexIds: ParameterIndexId[]
+  ): Record<string, unknown> {
+    return {
+      _id: { $in: ids },
+      bucket_data_source_ids: { $not: { $elemMatch: { $nin: unusedBucketDefinitionIds } } },
+      parameter_lookup_source_ids: { $not: { $elemMatch: { $nin: unusedParameterIndexIds } } }
+    };
   }
 
   private parseSyncConfigs(configDocs: SyncConfigDefinition[]): SyncConfig[] {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -1,0 +1,308 @@
+import * as lib_mongo from '@powersync/lib-service-mongodb';
+import { Logger, ReplicationAbortedError } from '@powersync/lib-services-framework';
+import { storage } from '@powersync/service-core';
+import { BucketDefinitionId, ParameterIndexId, SyncConfig } from '@powersync/service-sync-rules';
+import * as bson from 'bson';
+import { SingleSyncConfigBucketDefinitionMapping } from '../BucketDefinitionMapping.js';
+import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
+import { ReplicationStreamDocumentV3, SourceTableDocumentV3, SyncConfigDefinition } from './models.js';
+
+type SyncConfigState = ReplicationStreamDocumentV3['sync_configs'][number];
+
+const LIVE_STATES = new Set<storage.SyncRuleState>([
+  storage.SyncRuleState.ACTIVE,
+  storage.SyncRuleState.PROCESSING,
+  storage.SyncRuleState.ERRORED
+]);
+
+const EMPTY_RESULT: storage.CleanupStoppedSyncConfigsResult = {
+  stoppedSyncConfigsRemoved: 0,
+  bucketDataCollectionsDropped: 0,
+  parameterIndexCollectionsDropped: 0,
+  sourceRecordCollectionsDropped: 0,
+  sourceTablesUpdated: 0,
+  sourceTablesDeleted: 0
+};
+
+export interface MongoStoppedSyncConfigCleanupOptions extends storage.CleanupStoppedSyncConfigsOptions {
+  replicationStreamId: number;
+  db: VersionedPowerSyncMongoV3;
+  logger: Logger;
+}
+
+export class MongoStoppedSyncConfigCleanup {
+  private readonly db: VersionedPowerSyncMongoV3;
+  private readonly replicationStreamId: number;
+  private readonly signal: AbortSignal | undefined;
+  private readonly logger: Logger;
+  private readonly defaultSchema: string;
+  private readonly sourceConnectionTag: string;
+
+  constructor(options: MongoStoppedSyncConfigCleanupOptions) {
+    this.db = options.db;
+    this.replicationStreamId = options.replicationStreamId;
+    this.signal = options.signal;
+    this.logger = options.logger;
+    this.defaultSchema = options.defaultSchema;
+    this.sourceConnectionTag = options.sourceConnectionTag;
+  }
+
+  async run(): Promise<storage.CleanupStoppedSyncConfigsResult> {
+    this.throwIfAborted();
+
+    const doc = await this.db.sync_rules.findOne<ReplicationStreamDocumentV3>(
+      { _id: this.replicationStreamId },
+      { projection: { sync_configs: 1 } }
+    );
+    if (doc == null || doc.sync_configs.length == 0) {
+      return { ...EMPTY_RESULT };
+    }
+
+    const stoppedStates = doc.sync_configs.filter((config) => config.state == storage.SyncRuleState.STOP);
+    if (stoppedStates.length == 0) {
+      return { ...EMPTY_RESULT };
+    }
+
+    const liveStates = doc.sync_configs.filter((config) => LIVE_STATES.has(config.state));
+    const configDocs = await this.loadSyncConfigDefinitions([...stoppedStates, ...liveStates]);
+    const stoppedIds = new Set(stoppedStates.map((state) => state._id.toHexString()));
+    const liveIds = new Set(liveStates.map((state) => state._id.toHexString()));
+    const stoppedConfigDocs = configDocs.filter((config) => stoppedIds.has(config._id.toHexString()));
+    const liveConfigDocs = configDocs.filter((config) => liveIds.has(config._id.toHexString()));
+
+    const stoppedStorageIds = this.storageIdsFor(stoppedConfigDocs);
+    const liveStorageIds = this.storageIdsFor(liveConfigDocs);
+    const unusedBucketDefinitionIds = difference(
+      stoppedStorageIds.bucketDefinitionIds,
+      liveStorageIds.bucketDefinitionIds
+    );
+    const unusedParameterIndexIds = difference(stoppedStorageIds.parameterIndexIds, liveStorageIds.parameterIndexIds);
+
+    const result: storage.CleanupStoppedSyncConfigsResult = {
+      ...EMPTY_RESULT
+    };
+
+    if (unusedBucketDefinitionIds.length > 0 || unusedParameterIndexIds.length > 0) {
+      await this.cleanupSourceTableMemberships(
+        unusedBucketDefinitionIds,
+        unusedParameterIndexIds,
+        liveConfigDocs,
+        result
+      );
+      result.bucketDataCollectionsDropped = await this.dropBucketDataCollections(unusedBucketDefinitionIds);
+      result.parameterIndexCollectionsDropped = await this.dropParameterIndexCollections(unusedParameterIndexIds);
+    }
+
+    result.stoppedSyncConfigsRemoved = await this.pruneStoppedSyncConfigStates(stoppedStates);
+
+    if (result.stoppedSyncConfigsRemoved > 0) {
+      this.logger.info(
+        `Cleaned up ${result.stoppedSyncConfigsRemoved} stopped sync config${result.stoppedSyncConfigsRemoved == 1 ? '' : 's'}`,
+        result
+      );
+    }
+    return result;
+  }
+
+  private async loadSyncConfigDefinitions(states: SyncConfigState[]): Promise<SyncConfigDefinition[]> {
+    const ids = [...new Map(states.map((state) => [state._id.toHexString(), state._id])).values()];
+    if (ids.length == 0) {
+      return [];
+    }
+    return this.db.syncConfigDefinitions.find({ _id: { $in: ids } }).toArray();
+  }
+
+  private storageIdsFor(configs: Pick<SyncConfigDefinition, 'rule_mapping'>[]) {
+    const mappings = configs.map((config) => SingleSyncConfigBucketDefinitionMapping.fromSyncConfig(config));
+    return {
+      bucketDefinitionIds: [...new Set(mappings.flatMap((mapping) => mapping.allBucketDefinitionIds()))],
+      parameterIndexIds: [...new Set(mappings.flatMap((mapping) => mapping.allParameterIndexIds()))]
+    };
+  }
+
+  private async cleanupSourceTableMemberships(
+    unusedBucketDefinitionIds: BucketDefinitionId[],
+    unusedParameterIndexIds: ParameterIndexId[],
+    liveConfigDocs: SyncConfigDefinition[],
+    result: storage.CleanupStoppedSyncConfigsResult
+  ) {
+    const update: Record<string, unknown> = {};
+    if (unusedBucketDefinitionIds.length > 0) {
+      update.bucket_data_source_ids = { $in: unusedBucketDefinitionIds };
+    }
+    if (unusedParameterIndexIds.length > 0) {
+      update.parameter_lookup_source_ids = { $in: unusedParameterIndexIds };
+    }
+    if (Object.keys(update).length == 0) {
+      return;
+    }
+
+    const filter = this.sourceTableMembershipFilter(unusedBucketDefinitionIds, unusedParameterIndexIds);
+    const sourceTables = await this.db
+      .sourceTables(this.replicationStreamId)
+      .find(filter, { projection: { _id: 1 } })
+      .toArray();
+    if (sourceTables.length == 0) {
+      return;
+    }
+    const sourceTableIds = sourceTables.map((table) => table._id);
+    const liveSyncConfigs = this.parseSyncConfigs(liveConfigDocs);
+
+    this.throwIfAborted();
+    const updateResult = await this.db.sourceTables(this.replicationStreamId).updateMany(
+      { _id: { $in: sourceTableIds } },
+      {
+        $pull: update
+      },
+      { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
+    );
+    result.sourceTablesUpdated += updateResult.modifiedCount;
+
+    // Membership ids do not represent event-only tables, so an empty-membership table may
+    // still be needed for custom write checkpoint events.
+    const unusedSourceTables = await this.db
+      .sourceTables(this.replicationStreamId)
+      .find(
+        {
+          _id: { $in: sourceTableIds },
+          bucket_data_source_ids: { $size: 0 },
+          parameter_lookup_source_ids: { $size: 0 }
+        },
+        { projection: { _id: 1 } }
+      )
+      .toArray();
+    const deletableSourceTables = unusedSourceTables.filter(
+      (sourceTable) => !this.triggersLiveEvent(sourceTable, liveSyncConfigs)
+    );
+
+    // Drop sourceRecords collections before the related sourceTables entries, so that we
+    // can recover after interruptions.
+    for (const sourceTable of deletableSourceTables) {
+      this.throwIfAborted();
+      await this.dropCollection(this.db.sourceRecords(this.replicationStreamId, sourceTable._id));
+      result.sourceRecordCollectionsDropped += 1;
+    }
+
+    if (deletableSourceTables.length > 0) {
+      this.throwIfAborted();
+      const deleteResult = await this.db.sourceTables(this.replicationStreamId).deleteMany(
+        {
+          _id: { $in: deletableSourceTables.map((table) => table._id) }
+        },
+        { maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }
+      );
+      result.sourceTablesDeleted += deleteResult.deletedCount;
+    }
+  }
+
+  private parseSyncConfigs(configDocs: SyncConfigDefinition[]): SyncConfig[] {
+    // This is ugly - we should not need to re-parse to achieve this.
+    // Revisit persistence for this later.
+    return configDocs.map((config) => {
+      return storage.parsePersistedSyncConfigContent({
+        content: config.content,
+        compiledPlan: config.serialized_plan ?? null,
+        storageVersion: config.storage_version,
+        parseOptions: {
+          defaultSchema: this.defaultSchema
+        }
+      }).config;
+    });
+  }
+
+  private triggersLiveEvent(sourceTable: SourceTableDocumentV3, liveSyncConfigs: SyncConfig[]): boolean {
+    return liveSyncConfigs.some((syncConfig) =>
+      syncConfig.tableTriggersEvent({
+        connectionTag: this.sourceConnectionTag,
+        schema: sourceTable.schema_name,
+        name: sourceTable.table_name
+      })
+    );
+  }
+
+  private sourceTableMembershipFilter(
+    bucketDefinitionIds: BucketDefinitionId[],
+    parameterIndexIds: ParameterIndexId[]
+  ): Partial<SourceTableDocumentV3> | Record<string, unknown> {
+    const clauses: Record<string, unknown>[] = [];
+    if (bucketDefinitionIds.length > 0) {
+      clauses.push({ bucket_data_source_ids: { $in: bucketDefinitionIds } });
+    }
+    if (parameterIndexIds.length > 0) {
+      clauses.push({ parameter_lookup_source_ids: { $in: parameterIndexIds } });
+    }
+    if (clauses.length == 0) {
+      return { _id: { $exists: false } };
+    }
+    return { $or: clauses };
+  }
+
+  private async dropBucketDataCollections(definitionIds: BucketDefinitionId[]): Promise<number> {
+    for (const definitionId of definitionIds) {
+      this.throwIfAborted();
+      await this.dropCollection(this.db.bucketData(this.replicationStreamId, definitionId));
+    }
+    return definitionIds.length;
+  }
+
+  private async dropParameterIndexCollections(indexIds: ParameterIndexId[]): Promise<number> {
+    for (const indexId of indexIds) {
+      this.throwIfAborted();
+      await this.dropCollection(this.db.parameterIndex(this.replicationStreamId, indexId));
+    }
+    return indexIds.length;
+  }
+
+  private async dropCollection<T extends lib_mongo.mongo.Document>(
+    collection: lib_mongo.mongo.Collection<T>
+  ): Promise<void> {
+    await collection.drop({ maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }).catch((error) => {
+      if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+        return;
+      }
+      throw error;
+    });
+  }
+
+  private async pruneStoppedSyncConfigStates(stoppedStates: SyncConfigState[]): Promise<number> {
+    this.throwIfAborted();
+    const stoppedIds = stoppedStates.map((state) => state._id);
+    const result = await this.db.sync_rules.updateOne(
+      {
+        _id: this.replicationStreamId,
+        sync_configs: {
+          $not: {
+            $elemMatch: {
+              _id: { $in: stoppedIds },
+              state: { $ne: storage.SyncRuleState.STOP }
+            }
+          }
+        }
+      },
+      {
+        $pull: {
+          sync_configs: {
+            _id: { $in: stoppedIds },
+            state: storage.SyncRuleState.STOP
+          }
+        }
+      } as bson.Document
+    );
+    if (result.modifiedCount == 0 && stoppedIds.length > 0) {
+      this.logger.warn(`Skipped pruning stopped sync configs`);
+      return 0;
+    }
+    return stoppedStates.length;
+  }
+
+  private throwIfAborted() {
+    if (this.signal?.aborted) {
+      throw new ReplicationAbortedError('Aborted stopped sync config cleanup', this.signal.reason);
+    }
+  }
+}
+
+function difference<T>(left: T[], right: T[]): T[] {
+  const rightSet = new Set(right);
+  return left.filter((value) => !rightSet.has(value));
+}

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -174,15 +174,33 @@ export class MongoStoppedSyncConfigCleanup {
         this.membershipsBecomeEmpty(sourceTable, unusedBucketDefinitionIds, unusedParameterIndexIds) &&
         !this.triggersLiveEvent(sourceTable, liveSyncConfigs)
     );
-    const retainedSourceTableIds = candidateSourceTables
-      .filter((sourceTable) => !deletableSourceTables.some((deletable) => deletable._id.equals(sourceTable._id)))
-      .map((sourceTable) => sourceTable._id);
+    const retainedSourceTables = candidateSourceTables.filter(
+      (sourceTable) => !deletableSourceTables.some((deletable) => deletable._id.equals(sourceTable._id))
+    );
+    const retainedSourceTableIds = retainedSourceTables.map((sourceTable) => sourceTable._id);
 
     await this.deleteSourceTables(
       deletableSourceTables.map((table) => table._id),
       (ids) => this.deletableSourceTableFilter(ids, unusedBucketDefinitionIds, unusedParameterIndexIds),
       result
     );
+
+    // A retained source table whose memberships become empty is kept alive only by a live event
+    // (otherwise it would be deletable). It becomes event-only, and event-only save() never reads
+    // or writes current_data, so its source_records collection is now dead weight. Drop it before
+    // the $pull below, so the obsolete membership ids remain as a recovery marker if interrupted.
+    // Existing source-table docs only ever shrink their memberships, so this table cannot resume
+    // data sync on the same doc and need current_data again.
+    const becomingEventOnlySourceTableIds = retainedSourceTables
+      .filter((sourceTable) =>
+        this.membershipsBecomeEmpty(sourceTable, unusedBucketDefinitionIds, unusedParameterIndexIds)
+      )
+      .map((sourceTable) => sourceTable._id);
+    for (const sourceTableId of becomingEventOnlySourceTableIds) {
+      this.throwIfAborted();
+      await this.dropCollection(this.db.sourceRecords(this.replicationStreamId, sourceTableId));
+      result.sourceRecordCollectionsDropped += 1;
+    }
 
     if (retainedSourceTableIds.length > 0) {
       this.throwIfAborted();

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -36,6 +36,7 @@ import {
 import { MongoBucketBatchV3 } from './MongoBucketBatchV3.js';
 import { MongoChecksumsV3 } from './MongoChecksumsV3.js';
 import { MongoCompactorV3 } from './MongoCompactorV3.js';
+import { MongoStoppedSyncConfigCleanup } from './MongoStoppedSyncConfigCleanup.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
 
 export interface MongoSyncBucketStorageContextV3 {
@@ -399,6 +400,19 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         }
         throw error;
       });
+  }
+
+  async cleanupStoppedSyncConfigs(
+    options: storage.CleanupStoppedSyncConfigsOptions
+  ): Promise<storage.CleanupStoppedSyncConfigsResult> {
+    return new MongoStoppedSyncConfigCleanup({
+      db: this.db,
+      replicationStreamId: this.replicationStreamId,
+      signal: options.signal,
+      logger: options.logger ?? this.logger,
+      defaultSchema: options.defaultSchema,
+      sourceConnectionTag: options.sourceConnectionTag
+    }).run();
   }
 
   protected getDataBucketChangesImpl(

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/PersistedBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/PersistedBatchV3.ts
@@ -11,6 +11,7 @@ import {
   SaveParameterDataOptions,
   UpsertCurrentDataOptions
 } from '../common/PersistedBatch.js';
+import { SourceRecordLookupState } from '../common/SourceRecordStore.js';
 import { serializeBucketData } from './bucket-format.js';
 import { chunkBucketData } from './chunking.js';
 import {
@@ -46,11 +47,16 @@ export class PersistedBatchV3 extends PersistedBatch {
 
   saveParameterData(data: SaveParameterDataOptions) {
     const { sourceTable, sourceKey, evaluated } = data;
-    const remaining_lookups = new Map<string, SaveParameterDataOptions['existing_lookups'][number]>();
+    const remaining_lookups = new Map<string, SourceRecordLookupState>();
 
     for (let lookup of data.existing_lookups) {
       if (lookup.indexId == null) {
         throw new ReplicationAssertionError('Expected lookup when incrementalReprocessing is enabled');
+      }
+      if (sourceTable.parameterLookupSourceIds != null && !sourceTable.parameterLookupSourceIds.has(lookup.indexId)) {
+        // The parameter index is not active anymore.
+        // We don't cleanup these references upfront, but do need to ignore them after the definition is removed.
+        continue;
       }
       remaining_lookups.set(`${lookup.indexId}.${lookup.lookup.toString('base64')}`, lookup);
     }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/source-table-utils.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/source-table-utils.ts
@@ -242,7 +242,8 @@ class SourceTableReconciliationPlanner {
       connectionTag,
       syncConfig,
       mapping,
-      matchingSourcesFor(desired, memberships)
+      matchingSourcesFor(desired, memberships),
+      memberships
     );
     table.storeCurrentData = storeCurrentData;
     return table;
@@ -307,7 +308,8 @@ export function createNewSourceTable(
     connectionTag,
     syncConfig,
     mapping,
-    matchingSourcesFor(desired, memberships)
+    matchingSourcesFor(desired, memberships),
+    memberships
   );
   table.storeCurrentData = storeCurrentData;
 
@@ -348,9 +350,16 @@ export function sourceTableFromDocument(
   connectionTag: string,
   syncConfig: HydratedSyncConfig,
   mapping: BucketDefinitionMapping,
-  memberships?: MatchingSources
+  memberships?: MatchingSources,
+  membershipIds?: SourceTableMembershipIds
 ): storage.SourceTable {
   const resolvedMemberships = memberships ?? sourceTableMembershipsFromDocument(doc, syncConfig, mapping);
+  const resolvedMembershipIds = membershipIds ?? {
+    bucketDataSourceIds: resolvedMemberships.bucketDataSources.map((source) => mapping.bucketSourceId(source)),
+    parameterLookupSourceIds: resolvedMemberships.parameterLookupSources.map((source) =>
+      mapping.parameterLookupId(source)
+    )
+  };
   const table = new storage.SourceTable({
     id: doc._id,
     ref: {
@@ -364,7 +373,9 @@ export function sourceTableFromDocument(
     ),
     snapshotComplete: doc.snapshot_done,
     bucketDataSources: resolvedMemberships.bucketDataSources,
-    parameterLookupSources: resolvedMemberships.parameterLookupSources
+    parameterLookupSources: resolvedMemberships.parameterLookupSources,
+    bucketDataSourceIds: new Set(resolvedMembershipIds.bucketDataSourceIds),
+    parameterLookupSourceIds: new Set(resolvedMembershipIds.parameterLookupSourceIds)
   });
   table.syncData = table.bucketDataSources.length > 0;
   table.syncParameters = table.parameterLookupSources.length > 0;

--- a/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
+++ b/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
@@ -157,6 +157,7 @@ streams:
       stoppedSyncConfigsRemoved: 1,
       bucketDataCollectionsDropped: 1,
       parameterIndexCollectionsDropped: 1,
+      bucketStateDocumentsDeleted: 1,
       sourceRecordCollectionsDropped: 2,
       sourceTablesUpdated: 0,
       sourceTablesDeleted: 2
@@ -255,6 +256,7 @@ streams:
       stoppedSyncConfigsRemoved: 1,
       bucketDataCollectionsDropped: 1,
       parameterIndexCollectionsDropped: 0,
+      bucketStateDocumentsDeleted: 1,
       sourceRecordCollectionsDropped: 0,
       sourceTablesUpdated: 1,
       sourceTablesDeleted: 0

--- a/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
+++ b/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
@@ -1,0 +1,262 @@
+import { MongoSyncBucketStorageV3 } from '@module/storage/implementation/v3/MongoSyncBucketStorageV3.js';
+import { storage, updateSyncRulesFromYaml } from '@powersync/service-core';
+import { test_utils } from '@powersync/service-core-tests';
+import * as bson from 'bson';
+import { describe, expect, test } from 'vitest';
+import { VersionedPowerSyncMongoV3 } from '../../src/storage/implementation/v3/VersionedPowerSyncMongoV3.js';
+import { ReplicationStreamDocumentV3 } from '../../src/storage/implementation/v3/models.js';
+import { INITIALIZED_MONGO_STORAGE_FACTORY } from './util.js';
+
+function sourceDescriptor(name: string, options: { objectId?: string } = {}): storage.SourceEntityDescriptor {
+  return {
+    connectionTag: storage.SourceTable.DEFAULT_TAG,
+    objectId: options.objectId ?? name,
+    schema: 'public',
+    name,
+    replicaIdColumns: [
+      {
+        name: 'id',
+        type: 'VARCHAR',
+        typeId: 25
+      }
+    ]
+  };
+}
+
+function objectIdGenerator(id: string) {
+  let used = false;
+  return () => {
+    if (used) {
+      throw new Error(`Can only generate a single id using ${id}`);
+    }
+    used = true;
+    return new bson.ObjectId(id);
+  };
+}
+
+async function collectionExists(db: VersionedPowerSyncMongoV3, name: string) {
+  return await db.db.listCollections({ name }, { nameOnly: true }).hasNext();
+}
+
+async function cleanupStoppedSyncConfigs(bucketStorage: MongoSyncBucketStorageV3) {
+  return bucketStorage.cleanupStoppedSyncConfigs({
+    defaultSchema: 'public',
+    sourceConnectionTag: storage.SourceTable.DEFAULT_TAG
+  });
+}
+
+describe('cleanupStoppedSyncConfigs - mongodb', () => {
+  test('cleans up unused stopped sync config storage', async () => {
+    await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
+
+    const first = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_project:
+    query: |
+      SELECT id, project FROM "Scene"
+      WHERE project IN (
+        SELECT project FROM "ProjectInvitation"
+        WHERE project = subscription.parameter('project')
+      )
+`,
+        { storageVersion: 3 }
+      )
+    );
+    const firstStorage = factory.getInstance(first) as MongoSyncBucketStorageV3;
+    const db = firstStorage.db as VersionedPowerSyncMongoV3;
+    await using firstWriter = await firstStorage.createWriter(test_utils.BATCH_OPTIONS);
+
+    const sceneTable = (
+      await firstWriter.resolveTables({
+        connection_id: 1,
+        source: sourceDescriptor('Scene', { objectId: 'scene-relation' }),
+        idGenerator: objectIdGenerator('6544e3899293153fa7b38350')
+      })
+    ).tables[0];
+    const invitationTable = (
+      await firstWriter.resolveTables({
+        connection_id: 1,
+        source: sourceDescriptor('ProjectInvitation', { objectId: 'project-invitation-relation' }),
+        idGenerator: objectIdGenerator('6544e3899293153fa7b38351')
+      })
+    ).tables[0];
+    await firstWriter.save({
+      sourceTable: sceneTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'scene-1',
+        project: 'project-1'
+      },
+      afterReplicaId: test_utils.rid('scene-1')
+    });
+    await firstWriter.save({
+      sourceTable: invitationTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'invitation-1',
+        project: 'project-1'
+      },
+      afterReplicaId: test_utils.rid('invitation-1')
+    });
+    await firstWriter.markAllSnapshotDone('1/1');
+    await firstWriter.commit('1/1');
+
+    const stoppedMapping = first.syncConfigContent[0].mapping;
+    const stoppedBucketDefinitionId = stoppedMapping.allBucketDefinitionIds()[0];
+    const stoppedParameterIndexId = stoppedMapping.allParameterIndexIds()[0];
+    expect(stoppedBucketDefinitionId).toBeDefined();
+    expect(stoppedParameterIndexId).toBeDefined();
+    const bucketDataCollection = db.bucketData(first.replicationStreamId, stoppedBucketDefinitionId!).collectionName;
+    const parameterIndexCollection = db.parameterIndex(
+      first.replicationStreamId,
+      stoppedParameterIndexId!
+    ).collectionName;
+    const sceneRecordsCollection = db.sourceRecords(
+      first.replicationStreamId,
+      sceneTable.id as bson.ObjectId
+    ).collectionName;
+    const invitationRecordsCollection = db.sourceRecords(
+      first.replicationStreamId,
+      invitationTable.id as bson.ObjectId
+    ).collectionName;
+    expect(await collectionExists(db, bucketDataCollection)).toBe(true);
+    expect(await collectionExists(db, parameterIndexCollection)).toBe(true);
+    expect(await collectionExists(db, sceneRecordsCollection)).toBe(true);
+    expect(await collectionExists(db, invitationRecordsCollection)).toBe(true);
+
+    const second = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_owner:
+    query: SELECT * FROM todos WHERE owner_id = subscription.parameter('owner_id')
+`,
+        { storageVersion: 3 }
+      )
+    );
+    expect(second.replicationStreamId).toBe(first.replicationStreamId);
+    const replicatingStreams = await factory.getReplicatingReplicationStreams();
+    const secondStorage = factory.getInstance(replicatingStreams[0]) as MongoSyncBucketStorageV3;
+    await using secondWriter = await secondStorage.createWriter(test_utils.BATCH_OPTIONS);
+    await secondWriter.markAllSnapshotDone('2/1');
+    await secondWriter.commit('2/1');
+
+    const result = await cleanupStoppedSyncConfigs(
+      (await factory.getActiveSyncConfig())!.storage as MongoSyncBucketStorageV3
+    );
+
+    expect(result).toEqual({
+      stoppedSyncConfigsRemoved: 1,
+      bucketDataCollectionsDropped: 1,
+      parameterIndexCollectionsDropped: 1,
+      sourceRecordCollectionsDropped: 2,
+      sourceTablesUpdated: 0,
+      sourceTablesDeleted: 2
+    });
+    expect(await collectionExists(db, bucketDataCollection)).toBe(false);
+    expect(await collectionExists(db, parameterIndexCollection)).toBe(false);
+    expect(await collectionExists(db, sceneRecordsCollection)).toBe(false);
+    expect(await collectionExists(db, invitationRecordsCollection)).toBe(false);
+    expect(
+      await db.sourceTables(first.replicationStreamId).countDocuments({ _id: sceneTable.id as bson.ObjectId })
+    ).toBe(0);
+    expect(
+      await db.sourceTables(first.replicationStreamId).countDocuments({ _id: invitationTable.id as bson.ObjectId })
+    ).toBe(0);
+
+    const streamDoc = (await db.sync_rules.findOne({ _id: first.replicationStreamId })) as ReplicationStreamDocumentV3;
+    expect(streamDoc.sync_configs.map((config) => config.state)).toEqual([storage.SyncRuleState.ACTIVE]);
+  });
+
+  test('keeps source table membership still used by a live sync config', async () => {
+    await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
+
+    const first = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_owner:
+    query: SELECT * FROM todos WHERE owner_id = subscription.parameter('owner_id')
+`,
+        { storageVersion: 3 }
+      )
+    );
+    const firstStorage = factory.getInstance(first) as MongoSyncBucketStorageV3;
+    const db = firstStorage.db as VersionedPowerSyncMongoV3;
+    await using firstWriter = await firstStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const resolved = await firstWriter.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('todos', { objectId: 'todos-relation' }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38352')
+    });
+    await firstWriter.markAllSnapshotDone('1/1');
+    await firstWriter.commit('1/1');
+
+    const sourceTableId = resolved.tables[0].id as bson.ObjectId;
+    const sourceRecordsCollection = db.sourceRecords(first.replicationStreamId, sourceTableId).collectionName;
+    const firstDefinitionId = first.syncConfigContent[0].mapping.allBucketDefinitionIds()[0];
+
+    const second = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_project:
+    query: SELECT * FROM todos WHERE project_id = subscription.parameter('project_id')
+`,
+        { storageVersion: 3 }
+      )
+    );
+    expect(second.replicationStreamId).toBe(first.replicationStreamId);
+    const secondDefinitionId = second.syncConfigContent[1].mapping.allBucketDefinitionIds()[0];
+    expect(secondDefinitionId).not.toBe(firstDefinitionId);
+
+    const replicatingStreams = await factory.getReplicatingReplicationStreams();
+    const secondStorage = factory.getInstance(replicatingStreams[0]) as MongoSyncBucketStorageV3;
+    await using secondWriter = await secondStorage.createWriter(test_utils.BATCH_OPTIONS);
+    await secondWriter.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('todos', { objectId: 'todos-relation' }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38353')
+    });
+    await secondWriter.markAllSnapshotDone('2/1');
+    await secondWriter.commit('2/1');
+    await db.sourceTables(first.replicationStreamId).updateOne(
+      { _id: sourceTableId },
+      {
+        $set: {
+          bucket_data_source_ids: [firstDefinitionId, secondDefinitionId]
+        }
+      }
+    );
+
+    const result = await cleanupStoppedSyncConfigs(
+      (await factory.getActiveSyncConfig())!.storage as MongoSyncBucketStorageV3
+    );
+
+    expect(result).toEqual({
+      stoppedSyncConfigsRemoved: 1,
+      bucketDataCollectionsDropped: 1,
+      parameterIndexCollectionsDropped: 0,
+      sourceRecordCollectionsDropped: 0,
+      sourceTablesUpdated: 1,
+      sourceTablesDeleted: 0
+    });
+    const sourceTable = await db.sourceTables(first.replicationStreamId).findOne({ _id: sourceTableId });
+    expect(sourceTable?.bucket_data_source_ids).toEqual([secondDefinitionId]);
+    expect(await collectionExists(db, sourceRecordsCollection)).toBe(true);
+  });
+});

--- a/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
+++ b/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
@@ -188,6 +188,8 @@ config:
 streams:
   by_owner:
     query: SELECT * FROM todos WHERE owner_id = subscription.parameter('owner_id')
+  by_project:
+    query: SELECT * FROM todos WHERE project_id = subscription.parameter('project_id')
 `,
         { storageVersion: 3 }
       )
@@ -200,12 +202,27 @@ streams:
       source: sourceDescriptor('todos', { objectId: 'todos-relation' }),
       idGenerator: objectIdGenerator('6544e3899293153fa7b38352')
     });
+    await firstWriter.save({
+      sourceTable: resolved.tables[0],
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'todo-1',
+        owner_id: 'user-1',
+        project_id: 'project-1'
+      },
+      afterReplicaId: test_utils.rid('todo-1')
+    });
     await firstWriter.markAllSnapshotDone('1/1');
     await firstWriter.commit('1/1');
 
     const sourceTableId = resolved.tables[0].id as bson.ObjectId;
     const sourceRecordsCollection = db.sourceRecords(first.replicationStreamId, sourceTableId).collectionName;
-    const firstDefinitionId = first.syncConfigContent[0].mapping.allBucketDefinitionIds()[0];
+    const [ownerDefinitionId, projectDefinitionId] = first.syncConfigContent[0].mapping.allBucketDefinitionIds();
+    const ownerBucketDataCollection = db.bucketData(first.replicationStreamId, ownerDefinitionId).collectionName;
+    expect(await collectionExists(db, ownerBucketDataCollection)).toBe(true);
+    expect(
+      (await db.sourceTables(first.replicationStreamId).findOne({ _id: sourceTableId }))?.bucket_data_source_ids
+    ).toEqual([ownerDefinitionId, projectDefinitionId]);
 
     const second = await factory.updateSyncRules(
       updateSyncRulesFromYaml(
@@ -222,26 +239,13 @@ streams:
     );
     expect(second.replicationStreamId).toBe(first.replicationStreamId);
     const secondDefinitionId = second.syncConfigContent[1].mapping.allBucketDefinitionIds()[0];
-    expect(secondDefinitionId).not.toBe(firstDefinitionId);
+    expect(secondDefinitionId).toBe(projectDefinitionId);
 
     const replicatingStreams = await factory.getReplicatingReplicationStreams();
     const secondStorage = factory.getInstance(replicatingStreams[0]) as MongoSyncBucketStorageV3;
     await using secondWriter = await secondStorage.createWriter(test_utils.BATCH_OPTIONS);
-    await secondWriter.resolveTables({
-      connection_id: 1,
-      source: sourceDescriptor('todos', { objectId: 'todos-relation' }),
-      idGenerator: objectIdGenerator('6544e3899293153fa7b38353')
-    });
     await secondWriter.markAllSnapshotDone('2/1');
     await secondWriter.commit('2/1');
-    await db.sourceTables(first.replicationStreamId).updateOne(
-      { _id: sourceTableId },
-      {
-        $set: {
-          bucket_data_source_ids: [firstDefinitionId, secondDefinitionId]
-        }
-      }
-    );
 
     const result = await cleanupStoppedSyncConfigs(
       (await factory.getActiveSyncConfig())!.storage as MongoSyncBucketStorageV3
@@ -257,6 +261,163 @@ streams:
     });
     const sourceTable = await db.sourceTables(first.replicationStreamId).findOne({ _id: sourceTableId });
     expect(sourceTable?.bucket_data_source_ids).toEqual([secondDefinitionId]);
+    expect(await collectionExists(db, ownerBucketDataCollection)).toBe(false);
     expect(await collectionExists(db, sourceRecordsCollection)).toBe(true);
+
+    const activeStorage = (await factory.getActiveSyncConfig())!.storage as MongoSyncBucketStorageV3;
+    await using activeWriter = await activeStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const activeTable = (
+      await activeWriter.resolveTables({
+        connection_id: 1,
+        source: sourceDescriptor('todos', { objectId: 'todos-relation' }),
+        idGenerator: objectIdGenerator('6544e3899293153fa7b38354')
+      })
+    ).tables[0];
+    await activeWriter.save({
+      sourceTable: activeTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      before: {
+        id: 'todo-1'
+      },
+      after: {
+        id: 'todo-1',
+        owner_id: 'user-1',
+        project_id: 'project-2'
+      },
+      beforeReplicaId: test_utils.rid('todo-1'),
+      afterReplicaId: test_utils.rid('todo-1')
+    });
+    await activeWriter.commit('3/1');
+
+    expect(await collectionExists(db, ownerBucketDataCollection)).toBe(false);
+    const sourceRecord = await db.sourceRecords(first.replicationStreamId, sourceTableId).findOne({
+      _id: test_utils.rid('todo-1') as any
+    });
+    expect(sourceRecord?.buckets.map((bucket) => bucket.def)).toEqual([secondDefinitionId]);
+  });
+
+  test('does not recreate dropped parameter indexes from stale source record lookups', async () => {
+    await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
+
+    const first = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_role:
+    query: |
+      SELECT * FROM todos
+      WHERE role_id IN (
+        SELECT role_id FROM memberships
+        WHERE role_id = subscription.parameter('role_id')
+      )
+  by_org:
+    query: |
+      SELECT * FROM todos
+      WHERE org_id IN (
+        SELECT org_id FROM memberships
+        WHERE org_id = subscription.parameter('org_id')
+      )
+`,
+        { storageVersion: 3 }
+      )
+    );
+    const firstStorage = factory.getInstance(first) as MongoSyncBucketStorageV3;
+    const db = firstStorage.db as VersionedPowerSyncMongoV3;
+    await using firstWriter = await firstStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const resolved = await firstWriter.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('memberships', { objectId: 'memberships-relation' }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38355')
+    });
+    await firstWriter.save({
+      sourceTable: resolved.tables[0],
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'membership-1',
+        org_id: 'org-1',
+        role_id: 'role-1'
+      },
+      afterReplicaId: test_utils.rid('membership-1')
+    });
+    await firstWriter.markAllSnapshotDone('1/1');
+    await firstWriter.commit('1/1');
+
+    const sourceTableId = resolved.tables[0].id as bson.ObjectId;
+    const sourceRecordsCollection = db.sourceRecords(first.replicationStreamId, sourceTableId).collectionName;
+    const [roleIndexId, orgIndexId] = first.syncConfigContent[0].mapping.allParameterIndexIds();
+    const orgParameterIndexCollection = db.parameterIndex(first.replicationStreamId, orgIndexId).collectionName;
+    expect(await collectionExists(db, orgParameterIndexCollection)).toBe(true);
+    expect(
+      (await db.sourceTables(first.replicationStreamId).findOne({ _id: sourceTableId }))?.parameter_lookup_source_ids
+    ).toEqual([roleIndexId, orgIndexId]);
+
+    const second = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_role:
+    query: |
+      SELECT * FROM todos
+      WHERE role_id IN (
+        SELECT role_id FROM memberships
+        WHERE role_id = subscription.parameter('role_id')
+      )
+`,
+        { storageVersion: 3 }
+      )
+    );
+    expect(second.replicationStreamId).toBe(first.replicationStreamId);
+    const secondIndexId = second.syncConfigContent[1].mapping.allParameterIndexIds()[0];
+    expect(secondIndexId).toBe(roleIndexId);
+
+    const replicatingStreams = await factory.getReplicatingReplicationStreams();
+    const secondStorage = factory.getInstance(replicatingStreams[0]) as MongoSyncBucketStorageV3;
+    await using secondWriter = await secondStorage.createWriter(test_utils.BATCH_OPTIONS);
+    await secondWriter.markAllSnapshotDone('2/1');
+    await secondWriter.commit('2/1');
+
+    const result = await cleanupStoppedSyncConfigs(
+      (await factory.getActiveSyncConfig())!.storage as MongoSyncBucketStorageV3
+    );
+    expect(result.parameterIndexCollectionsDropped).toBe(1);
+    expect(await collectionExists(db, orgParameterIndexCollection)).toBe(false);
+    expect(await collectionExists(db, sourceRecordsCollection)).toBe(true);
+
+    const activeStorage = (await factory.getActiveSyncConfig())!.storage as MongoSyncBucketStorageV3;
+    await using activeWriter = await activeStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const activeTable = (
+      await activeWriter.resolveTables({
+        connection_id: 1,
+        source: sourceDescriptor('memberships', { objectId: 'memberships-relation' }),
+        idGenerator: objectIdGenerator('6544e3899293153fa7b38357')
+      })
+    ).tables[0];
+    await activeWriter.save({
+      sourceTable: activeTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      before: {
+        id: 'membership-1'
+      },
+      after: {
+        id: 'membership-1',
+        org_id: 'org-1',
+        role_id: 'role-2'
+      },
+      beforeReplicaId: test_utils.rid('membership-1'),
+      afterReplicaId: test_utils.rid('membership-1')
+    });
+    await activeWriter.commit('3/1');
+
+    expect(await collectionExists(db, orgParameterIndexCollection)).toBe(false);
+    const sourceRecord = await db.sourceRecords(first.replicationStreamId, sourceTableId).findOne({
+      _id: test_utils.rid('membership-1') as any
+    });
+    expect(sourceRecord?.lookups.map((lookup) => lookup.i)).toEqual([secondIndexId]);
   });
 });

--- a/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
+++ b/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
@@ -298,6 +298,111 @@ streams:
     expect(sourceRecord?.buckets.map((bucket) => bucket.def)).toEqual([secondDefinitionId]);
   });
 
+  test('drops current_data when a table becomes event-only but is kept by a live event', async () => {
+    await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
+
+    // The first config syncs `todos` data and also fires events for it.
+    const first = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_owner:
+    query: SELECT * FROM todos WHERE owner_id = subscription.parameter('owner_id')
+
+event_definitions:
+  audit:
+    payloads:
+      - SELECT id, owner_id FROM todos
+`,
+        { storageVersion: 3 }
+      )
+    );
+    const firstStorage = factory.getInstance(first) as MongoSyncBucketStorageV3;
+    const db = firstStorage.db as VersionedPowerSyncMongoV3;
+    await using firstWriter = await firstStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const resolved = await firstWriter.resolveTables({
+      connection_id: 1,
+      source: sourceDescriptor('todos', { objectId: 'todos-relation' }),
+      idGenerator: objectIdGenerator('6544e3899293153fa7b38370')
+    });
+    await firstWriter.save({
+      sourceTable: resolved.tables[0],
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'todo-1',
+        owner_id: 'user-1'
+      },
+      afterReplicaId: test_utils.rid('todo-1')
+    });
+    await firstWriter.markAllSnapshotDone('1/1');
+    await firstWriter.commit('1/1');
+
+    const sourceTableId = resolved.tables[0].id as bson.ObjectId;
+    const sourceRecordsCollection = db.sourceRecords(first.replicationStreamId, sourceTableId).collectionName;
+    const ownerDefinitionId = first.syncConfigContent[0].mapping.allBucketDefinitionIds()[0];
+    expect(
+      (await db.sourceTables(first.replicationStreamId).findOne({ _id: sourceTableId }))?.bucket_data_source_ids
+    ).toEqual([ownerDefinitionId]);
+    // The prior snapshot is persisted in current_data.
+    expect(await collectionExists(db, sourceRecordsCollection)).toBe(true);
+
+    // The second (active) config drops the `todos` data stream but keeps the audit event, so the
+    // `todos` source table becomes event-only while staying alive for the live event.
+    const second = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_id:
+    query: SELECT * FROM other WHERE id = subscription.parameter('id')
+
+event_definitions:
+  audit:
+    payloads:
+      - SELECT id, owner_id FROM todos
+`,
+        { storageVersion: 3 }
+      )
+    );
+    expect(second.replicationStreamId).toBe(first.replicationStreamId);
+
+    const replicatingStreams = await factory.getReplicatingReplicationStreams();
+    const secondStorage = factory.getInstance(replicatingStreams[0]) as MongoSyncBucketStorageV3;
+    await using secondWriter = await secondStorage.createWriter(test_utils.BATCH_OPTIONS);
+    await secondWriter.markAllSnapshotDone('2/1');
+    await secondWriter.commit('2/1');
+
+    const result = await cleanupStoppedSyncConfigs(
+      (await factory.getActiveSyncConfig())!.storage as MongoSyncBucketStorageV3
+    );
+
+    expect(result).toEqual({
+      stoppedSyncConfigsRemoved: 1,
+      bucketDataCollectionsDropped: 1,
+      parameterIndexCollectionsDropped: 0,
+      bucketStateDocumentsDeleted: 1,
+      sourceRecordCollectionsDropped: 1,
+      sourceTablesUpdated: 1,
+      sourceTablesDeleted: 0
+    });
+
+    // The source table row survives (the live event still needs it), narrowed to empty
+    // memberships, but its now-unused current_data collection is dropped.
+    const sourceTable = await db.sourceTables(first.replicationStreamId).findOne({ _id: sourceTableId });
+    expect(sourceTable).not.toBeNull();
+    expect(sourceTable?.bucket_data_source_ids).toEqual([]);
+    expect(sourceTable?.parameter_lookup_source_ids).toEqual([]);
+    expect(await collectionExists(db, sourceRecordsCollection)).toBe(false);
+
+    const streamDoc = (await db.sync_rules.findOne({ _id: first.replicationStreamId })) as ReplicationStreamDocumentV3;
+    expect(streamDoc.sync_configs.map((config) => config.state)).toEqual([storage.SyncRuleState.ACTIVE]);
+  });
+
   test('cleans up event-only source tables no longer triggered by a live sync config', async () => {
     await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
 

--- a/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
+++ b/modules/module-mongodb-storage/test/src/cleanup-stopped-sync-configs.test.ts
@@ -298,6 +298,124 @@ streams:
     expect(sourceRecord?.buckets.map((bucket) => bucket.def)).toEqual([secondDefinitionId]);
   });
 
+  test('cleans up event-only source tables no longer triggered by a live sync config', async () => {
+    await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
+
+    // The first config syncs `todos` and additionally fires events for `audit_log`. The
+    // `audit_log` table is referenced only by the event trigger, so its source table carries
+    // empty membership arrays (an event-only table).
+    const first = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_owner:
+    query: SELECT * FROM todos WHERE owner_id = subscription.parameter('owner_id')
+
+event_definitions:
+  audit:
+    payloads:
+      - SELECT id FROM audit_log
+`,
+        { storageVersion: 3 }
+      )
+    );
+    const firstStorage = factory.getInstance(first) as MongoSyncBucketStorageV3;
+    const db = firstStorage.db as VersionedPowerSyncMongoV3;
+    await using firstWriter = await firstStorage.createWriter(test_utils.BATCH_OPTIONS);
+
+    const todosTable = (
+      await firstWriter.resolveTables({
+        connection_id: 1,
+        source: sourceDescriptor('todos', { objectId: 'todos-relation' }),
+        idGenerator: objectIdGenerator('6544e3899293153fa7b38360')
+      })
+    ).tables[0];
+    const auditTable = (
+      await firstWriter.resolveTables({
+        connection_id: 1,
+        source: sourceDescriptor('audit_log', { objectId: 'audit-log-relation' }),
+        idGenerator: objectIdGenerator('6544e3899293153fa7b38361')
+      })
+    ).tables[0];
+    await firstWriter.save({
+      sourceTable: todosTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'todo-1',
+        owner_id: 'user-1'
+      },
+      afterReplicaId: test_utils.rid('todo-1')
+    });
+    await firstWriter.save({
+      sourceTable: auditTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'audit-1'
+      },
+      afterReplicaId: test_utils.rid('audit-1')
+    });
+    await firstWriter.markAllSnapshotDone('1/1');
+    await firstWriter.commit('1/1');
+
+    const todosTableId = todosTable.id as bson.ObjectId;
+    const auditTableId = auditTable.id as bson.ObjectId;
+    // The event-only table is persisted with empty membership arrays, so the membership filter
+    // never selects it.
+    const auditSourceTable = await db.sourceTables(first.replicationStreamId).findOne({ _id: auditTableId });
+    expect(auditSourceTable?.bucket_data_source_ids).toEqual([]);
+    expect(auditSourceTable?.parameter_lookup_source_ids).toEqual([]);
+    const auditRecordsCollection = db.sourceRecords(first.replicationStreamId, auditTableId).collectionName;
+
+    // The second (active) config keeps the same `by_owner` stream but drops the audit event.
+    // The shared bucket definition stays in use, so no bucket/parameter ids become unused and
+    // the membership-cleanup block is skipped entirely.
+    const second = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(
+        `
+config:
+  edition: 3
+
+streams:
+  by_owner:
+    query: SELECT * FROM todos WHERE owner_id = subscription.parameter('owner_id')
+`,
+        { storageVersion: 3 }
+      )
+    );
+    expect(second.replicationStreamId).toBe(first.replicationStreamId);
+
+    const replicatingStreams = await factory.getReplicatingReplicationStreams();
+    const secondStorage = factory.getInstance(replicatingStreams[0]) as MongoSyncBucketStorageV3;
+    await using secondWriter = await secondStorage.createWriter(test_utils.BATCH_OPTIONS);
+    await secondWriter.markAllSnapshotDone('2/1');
+    await secondWriter.commit('2/1');
+
+    const result = await cleanupStoppedSyncConfigs(
+      (await factory.getActiveSyncConfig())!.storage as MongoSyncBucketStorageV3
+    );
+
+    expect(result).toEqual({
+      stoppedSyncConfigsRemoved: 1,
+      bucketDataCollectionsDropped: 0,
+      parameterIndexCollectionsDropped: 0,
+      bucketStateDocumentsDeleted: 0,
+      sourceRecordCollectionsDropped: 1,
+      sourceTablesUpdated: 0,
+      sourceTablesDeleted: 1
+    });
+    // The orphaned event-only table and its source records are removed...
+    expect(await db.sourceTables(first.replicationStreamId).countDocuments({ _id: auditTableId })).toBe(0);
+    expect(await collectionExists(db, auditRecordsCollection)).toBe(false);
+    // ...while the data table still used by the live config is retained.
+    expect(await db.sourceTables(first.replicationStreamId).countDocuments({ _id: todosTableId })).toBe(1);
+
+    const streamDoc = (await db.sync_rules.findOne({ _id: first.replicationStreamId })) as ReplicationStreamDocumentV3;
+    expect(streamDoc.sync_configs.map((config) => config.state)).toEqual([storage.SyncRuleState.ACTIVE]);
+  });
+
   test('does not recreate dropped parameter indexes from stale source record lookups', async () => {
     await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
 

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -371,6 +371,7 @@ export class ChangeStream {
   async replicate() {
     let streamPromise: Promise<void> | null = null;
     let loopPromise: Promise<void> | null = null;
+    let cleanupPromise: Promise<void> | null = null;
     try {
       // If anything errors here, the entire replication process is halted, and
       // all connections automatically closed, including this one.
@@ -388,6 +389,11 @@ export class ChangeStream {
       if (!this.snapshotter.supportsConcurrentSnapshots) {
         await Promise.race([this.snapshotter.waitForInitialSnapshot(), loopPromise]);
       }
+      // Unlike the other two, this resolves on completion, not an indefinite loop.
+      cleanupPromise = this.cleanupStoppedSyncConfigs().catch((e) => {
+        this.abortController.abort(e);
+        throw e;
+      });
       streamPromise = this.streamChanges()
         .then(() => {
           throw new ReplicationAssertionError(`Replication stream exited unexpectedly`);
@@ -397,7 +403,7 @@ export class ChangeStream {
           throw e;
         });
 
-      const results = await Promise.allSettled([loopPromise, streamPromise]);
+      const results = await Promise.allSettled([loopPromise, streamPromise, cleanupPromise]);
       throw replicationLoopError(results);
     } catch (e) {
       await this.storage.reportError(e);
@@ -425,6 +431,15 @@ export class ChangeStream {
       }
       await this.snapshotter.queueSnapshotTables(result.snapshotLsn);
     }
+  }
+
+  private async cleanupStoppedSyncConfigs() {
+    await this.storage.cleanupStoppedSyncConfigs?.({
+      signal: this.abortSignal,
+      logger: this.logger,
+      defaultSchema: this.defaultDb.databaseName,
+      sourceConnectionTag: this.connections.connectionTag
+    });
   }
 
   private async streamChanges() {

--- a/packages/service-core/src/storage/SourceTable.ts
+++ b/packages/service-core/src/storage/SourceTable.ts
@@ -1,6 +1,8 @@
 import {
   BucketDataSource,
+  BucketDefinitionId,
   DEFAULT_TAG,
+  ParameterIndexId,
   ParameterIndexLookupCreator,
   SourceTableRef
 } from '@powersync/service-sync-rules';
@@ -21,6 +23,8 @@ export interface SourceTableOptions {
   snapshotComplete: boolean;
   bucketDataSources: BucketDataSource[];
   parameterLookupSources: ParameterIndexLookupCreator[];
+  bucketDataSourceIds?: Set<BucketDefinitionId>;
+  parameterLookupSourceIds?: Set<ParameterIndexId>;
 }
 
 export interface TableSnapshotStatus {
@@ -124,6 +128,14 @@ export class SourceTable {
     return this.options.parameterLookupSources;
   }
 
+  get bucketDataSourceIds() {
+    return this.options.bucketDataSourceIds;
+  }
+
+  get parameterLookupSourceIds() {
+    return this.options.parameterLookupSourceIds;
+  }
+
   /**
    * Sanitized name of the entity in the format of "{schema}.{entity name}".
    * Suitable for safe use in Postgres queries.
@@ -147,7 +159,10 @@ export class SourceTable {
       replicaIdColumns: this.replicaIdColumns,
       snapshotComplete: this.snapshotComplete,
       bucketDataSources: this.bucketDataSources,
-      parameterLookupSources: this.parameterLookupSources
+      parameterLookupSources: this.parameterLookupSources,
+      bucketDataSourceIds: this.bucketDataSourceIds == null ? undefined : new Set(this.bucketDataSourceIds),
+      parameterLookupSourceIds:
+        this.parameterLookupSourceIds == null ? undefined : new Set(this.parameterLookupSourceIds)
     });
     copy.syncData = this.syncData;
     copy.syncParameters = this.syncParameters;

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -344,6 +344,8 @@ export interface CleanupStoppedSyncConfigsResult {
   stoppedSyncConfigsRemoved: number;
   bucketDataCollectionsDropped: number;
   parameterIndexCollectionsDropped: number;
+  /** Best-effort number, not accurate if the operation takes longer than the timeout. */
+  bucketStateDocumentsDeleted: number;
   sourceRecordCollectionsDropped: number;
   sourceTablesUpdated: number;
   sourceTablesDeleted: number;

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -152,7 +152,7 @@ export interface SyncRulesBucketStorage
    * Optional storage-provider cleanup for sync configs that have been stopped
    * inside this replication stream.
    */
-  cleanupStoppedSyncConfigs?(options?: CleanupStoppedSyncConfigsOptions): Promise<CleanupStoppedSyncConfigsResult>;
+  cleanupStoppedSyncConfigs?(options: CleanupStoppedSyncConfigsOptions): Promise<CleanupStoppedSyncConfigsResult>;
 }
 
 export interface SyncRulesBucketStorageListener {

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -147,6 +147,12 @@ export interface SyncRulesBucketStorage
    * Clear checksum cache. Primarily intended for tests.
    */
   clearChecksumCache(): void;
+
+  /**
+   * Optional storage-provider cleanup for sync configs that have been stopped
+   * inside this replication stream.
+   */
+  cleanupStoppedSyncConfigs?(options?: CleanupStoppedSyncConfigsOptions): Promise<CleanupStoppedSyncConfigsResult>;
 }
 
 export interface SyncRulesBucketStorageListener {
@@ -325,6 +331,22 @@ export interface PopulateChecksumCacheResults {
 
 export interface ClearStorageOptions {
   signal?: AbortSignal;
+}
+
+export interface CleanupStoppedSyncConfigsOptions {
+  signal?: AbortSignal;
+  logger?: Logger;
+  defaultSchema: string;
+  sourceConnectionTag: string;
+}
+
+export interface CleanupStoppedSyncConfigsResult {
+  stoppedSyncConfigsRemoved: number;
+  bucketDataCollectionsDropped: number;
+  parameterIndexCollectionsDropped: number;
+  sourceRecordCollectionsDropped: number;
+  sourceTablesUpdated: number;
+  sourceTablesDeleted: number;
 }
 
 export interface TerminateOptions extends ClearStorageOptions {


### PR DESCRIPTION
Builds on #670.

With #670, after adding a sync config to an replication stream, then processing and activating it, the existing sync config changes status to STOP. That avoids taking the sync config into account when processing new data. However, no cleanup was performed.

This implements that missing cleanup:
1. Compute unused definition ids (bucket data sources and parameter indexes).
2. Drop collections for those unused bucket_data and parameter_index definitions.
3. Remove those unused ids from source table records, and compute now-unused source tables.
4. For unused source tables, drop the related source_record collections.
5. Remove the sync config status from the replication stream.

This cleanup is implemented in an idempotent way - safe to be interrupted at any point, continuing on the next attempt.

One case that is explicitly not covered, is updating source_records after removing definitions from a source table, if the source table remains in use after that. This does lead to "orphaned" references to bucket_data and parameter_indexes in those source records, but the overhead is small enough, and removing those would be an expensive operation.

## Event-only tables

We don't currently persist any info on whether tables are used for custom checkpoint events. The code contains some workarounds to compute this, which is not great. I'll see how we can better address this in a follow-up PR.

## AI Usage

Implemented by Codex gpt-5.5 and Claude Opus 4.8, manually tweaked and reviewed.

