### PR TITLE
Fix parameter errors for wildcard patterns

### DIFF
--- a/.changeset/rare-places-knock.md
+++ b/.changeset/rare-places-knock.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix error responses when a Sync Stream parameter selects from a table with a wildcard pattern.

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -424,7 +424,7 @@ export class StreamQueryParser {
           this.primaryResultSet = source;
         } else if (this.primaryResultSet !== source) {
           this.errors.report(
-            `Sync streams can only select from a single table, and this one already selects from '${this.primaryResultSet.tablePattern.name}'.`,
+            `Sync streams can only select from a single table, and this one already selects from '${this.primaryResultSet.tablePattern.tablePattern}'.`,
             node
           );
           return false;

--- a/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
+++ b/packages/sync-rules/src/sync_plan/evaluator/parameter_evaluator.ts
@@ -532,7 +532,7 @@ class FullInstantiator extends PartialInstantiator<InstantiationInput> {
 
       const outputs = await this.input.source.getParameterSets(
         [...lookupsToProvenance.keys()],
-        `Stream ${this.evaluators.stream.name} evaluating parameter on ${resolvedLookup.sourceTable.name}`
+        `Stream ${this.evaluators.stream.name} evaluating parameter on ${resolvedLookup.sourceTable.tablePattern}`
       );
 
       // Stream parameters generate an output row like {0: <expr>, 1: <expr>, ...}.

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -144,6 +144,13 @@ streams:
         source: 'orgs.*'
       }
     ]);
+
+    expect(compilationErrorsForSingleStream('SELECT u.*, orgs.* FROM "users_%" u, orgs')).toStrictEqual([
+      {
+        message: "Sync streams can only select from a single table, and this one already selects from 'users_%'.",
+        source: 'orgs.*'
+      }
+    ]);
   });
 
   test('subexpressions from different rows', () => {

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -553,6 +553,48 @@ streams:
     expect(buckets.map((b) => b.bucket)).toStrictEqual(['stream|0["issue"]']);
   });
 
+  syncTest('wildcard table in parameter query', async ({ sync }) => {
+    const desc = sync.prepareSyncStreams(`
+config:
+  edition: 3
+  
+streams:
+  stream:
+    auto_subscribe: true
+    query: SELECT * FROM comments WHERE list IN (SELECT id FROM "li%" AS lists)
+`);
+
+    const list0 = new TestSourceTable('lists0');
+    const list1 = new TestSourceTable('lists1');
+
+    expect(desc.tableSyncsParameters(list0)).toBeTruthy();
+    expect(desc.tableSyncsParameters(list1)).toBeTruthy();
+    expect(desc.tableSyncsParameters(COMMENTS)).toBeFalsy();
+
+    const { querier, errors } = desc.getBucketParameterQuerier({
+      globalParameters: requestParameters({ sub: 'user' }),
+      hasDefaultStreams: true,
+      streams: {}
+    });
+    expect(errors).toStrictEqual([]);
+    const buckets = await querier.queryDynamicBucketDescriptions({
+      getParameterSets: async function (
+        lookups: ScopedParameterLookup[],
+        debugDefinition: string
+      ): Promise<ParameterLookupRows[]> {
+        expect(debugDefinition).toContain('evaluating parameter on li%');
+        expect(lookups).toHaveLength(1);
+        return [
+          {
+            lookup: lookups[0],
+            rows: [{ '0': 'list' }]
+          }
+        ];
+      }
+    });
+    expect(buckets.map((b) => b.bucket)).toStrictEqual(['stream|0["list"]']);
+  });
+
   syncTest('preserves correlation across lookup output columns', async ({ sync }) => {
     const desc = sync.prepareSyncStreams(`
 config:


### PR DESCRIPTION
Calling `TablePattern.name` on a wildcard pattern throws. This PR fixes two cases where Sync Streams didn't deal with those patterns correctly:

1. In the error message when selecting from multiple tables, this bug exists since Sync Streams v1.
2. In the debug context for querier lookups, this bug was introduced in https://github.com/powersync-ja/powersync-service/pull/630 (version 1.21.0).

Neither of those cases affects semantics, so we can just include the original table name in error messages and descriptions.

This was reported through ticket 40145.