### PR TITLE
[Incremental Reprocessing] Disable clustered collections

### DIFF
--- a/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
@@ -360,11 +360,7 @@ export abstract class MongoCompactor {
             _id: {
               $gte: lowerBound,
               $lt: upperBound
-            },
-            // Workaround for a clustered collection bug where the $lt operator may include upperBound.
-            // Technically only needed for storage V3.
-            // https://jira.mongodb.org/browse/SERVER-121822
-            '_id.o': { $lt: upperBound.o }
+            }
           }
         },
         { $sort: { _id: -1 } },

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
@@ -161,8 +161,7 @@ export class MongoCompactorV3 extends MongoCompactor {
             _id: {
               $gte: lowerBound,
               $lt: upperBound
-            },
-            '_id.o': { $lt: upperBound.o }
+            }
           }
         },
         { $sort: { _id: -1 } },

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -146,14 +146,12 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     const storageIds = this.storageIds;
     for (const source of storageIds.bucketDefinitionIds) {
       const collection = this.db.bucketData(this.replicationStreamId, source).collectionName;
-      await this.db.db
-        .createCollection(collection, { clusteredIndex: { name: '_id', unique: true, key: { _id: 1 } } })
-        .catch((error) => {
-          if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceExists') {
-            return;
-          }
-          throw error;
-        });
+      await this.db.db.createCollection(collection, {}).catch((error) => {
+        if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceExists') {
+          return;
+        }
+        throw error;
+      });
     }
     for (const indexId of storageIds.parameterIndexIds) {
       await this.db.parameterIndex(this.replicationStreamId, indexId).createIndex(


### PR DESCRIPTION
MongoDB [clustered collections](https://www.mongodb.com/docs/manual/core/clustered-collections/) appeared like a great optimization for bucket_data collections:

Normal collections store documents, and a separate _id index. That means if you do a lookup by _id, MongoDB first looks up the index entry, then the associated document. And if you query with a range like `{_id: {$gt: ..., $lte: ...}}`, which we do often, MongoDB first finds the index entries, and then does a random-access lookup for each document.

Clustered collections instead store all documents ordered by _id, similar to storing all data in the _id index. That means a range query on _id would read one continuous range, without any random lookups. When we iterate over 10-100k+ tiny documents, for example to compute a checksum, this can result in significantly fewer IOPS, meaning we get much better performance - 2x to even 10x in some of my early benchmarks.

Unfortunately, the gains did not hold up when considering our full implementation. The clustered collection implementation is buggy (ran into one issue with queries returning incorrect results, fixed in the meantime), and lacks many performance optimizations that normal collections have. Specifically, I've seen:
1. `_id: {$in: [...]}` does a full collection scan.
2. `{$or: [{_id: {$gt: ..., $lte: ...}}, {_id: {$gt: ..., $lte: ...}}, ...]}` does a full collection scan.

These are some related issues I've found:
 * https://jira.mongodb.org/browse/SERVER-121822 - correctness issue, had a workaround for this, fixed in 8.0.24.
 * https://jira.mongodb.org/browse/SERVER-77601 - $or not optimized
 * https://jira.mongodb.org/browse/SERVER-75063 - multiple range scan issues
 * https://jira.mongodb.org/browse/SERVER-54969 - another range scan inefficiency

These are not theoretical issues - we have queries that scan the entire collection or a large percentage of it, instead of doing selective lookups on specific _ids or ranges. While each of these queries likely have _some_ workaround, I lost confidence in clustered collections being a good option here.

## We don't need clustered collections anymore

Another consideration is that since the restructuring in #617, the performance improvements from clustered collections are much less relevant:

Before, if you had a bucket with 100 tiny operations, iterating through them could involve the index scan + 100 random-access reads, while the clustered collection would just do one sequential read.

Now, those 100 operations would be compacted into one document with 100 nested operations. That translates into the index scan + 1 random-access read. Clustered collections give essentially no additional gain here, removing at most 1 read.

The main cases that clustered collections could still help in theory:
1. Reading many individual buckets with 1 tiny operation in each - these still require individual random-access reads. But this case also happens to be even more difficult to optimize with clustered collections, due to the mentioned issues.
2. Reading a non-compacted bucket with many tiny operations (before it is eventually compacted after say a day) - clustered collections could still have an advantage here. But we can also solve this by improving our compact process to optimize these cases faster.

## The fix

This just removes the configuration to use clustered collections, and removes the workaround for SERVER-121822.

Note that this does not change collections already created as clustered collections. Since storage V3 is still considered unstable, this is not an issue.

## AI Usage

No AI was used to create this PR.