### PR TITLE
Include table names in "Cannot mark snapshot done while source tables still require snapshotting" error

### DIFF
--- a/.changeset/cute-canyons-fry.md
+++ b/.changeset/cute-canyons-fry.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+---
+
+Include table names in "Cannot mark snapshot done while source tables still require snapshotting" error.

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoBucketBatchV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoBucketBatchV1.ts
@@ -392,17 +392,24 @@ export class MongoBucketBatchV1 extends MongoBucketBatch {
   async markSnapshotDone(no_checkpoint_before_lsn: string, options?: { throwOnConflict?: boolean }): Promise<void> {
     await this.withTransaction(async () => {
       // Protect against race conditions
-      const count = await this.db.sourceTablesV1(this.replicationStreamId).countDocuments(
-        {
-          group_id: this.replicationStreamId,
-          snapshot_done: false
-        },
-        { session: this.session }
-      );
-      if (count > 0) {
+      const blockingTables = await this.db
+        .sourceTablesV1(this.replicationStreamId)
+        .find(
+          {
+            group_id: this.replicationStreamId,
+            snapshot_done: false
+          },
+          {
+            session: this.session,
+            projection: { schema_name: 1, table_name: 1 }
+          }
+        )
+        .toArray();
+
+      if (blockingTables.length > 0) {
         if (options?.throwOnConflict ?? true) {
           throw new ReplicationAssertionError(
-            `Cannot mark snapshot done while ${count} source table${count == 1 ? '' : 's'} still require snapshotting`
+            `Cannot mark snapshot done while source tables still require snapshotting. Tables: ${blockingTables.map((t) => `${t.schema_name}.${t.table_name}`).join(', ')}`
           );
         } else {
           return;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
@@ -553,13 +553,18 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
   async markSnapshotDone(no_checkpoint_before_lsn: string, options?: { throwOnConflict?: boolean }): Promise<void> {
     await this.withTransaction(async () => {
       // Protect against race conditions
-      const count = await this.db
+      const blockingTables = await this.db
         .sourceTables(this.replicationStreamId)
-        .countDocuments(this.snapshotBlockingSourceTablesFilter(), { session: this.session });
-      if (count > 0) {
+        .find(this.snapshotBlockingSourceTablesFilter(), {
+          session: this.session,
+          projection: { schema_name: 1, table_name: 1 }
+        })
+        .toArray();
+
+      if (blockingTables.length > 0) {
         if (options?.throwOnConflict ?? true) {
           throw new ReplicationAssertionError(
-            `Cannot mark snapshot done while ${count} source table${count == 1 ? '' : 's'} still require snapshotting`
+            `Cannot mark snapshot done while source tables still require snapshotting. Tables: ${blockingTables.map((t) => `${t.schema_name}.${t.table_name}`).join(', ')}`
           );
         } else {
           return;

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -760,23 +760,22 @@ export class PostgresBucketBatch
 
   async markSnapshotDone(no_checkpoint_before_lsn: string, options?: { throwOnConflict?: boolean }): Promise<void> {
     await this.db.transaction(async (db) => {
-      const snapshotRequiredCount = await db.sql`
+      const blockingTables = await db.sql`
         SELECT
-          COUNT(*) AS count
+          schema_name,
+          table_name
         FROM
           source_tables
         WHERE
           group_id = ${{ type: 'int4', value: this.group_id }}
           AND snapshot_done = FALSE
       `
-        .decoded(t.object({ count: bigint }))
-        .first();
-      if ((snapshotRequiredCount?.count ?? 0n) > 0n) {
+        .decoded(t.object({ schema_name: t.string, table_name: t.string }))
+        .rows();
+      if (blockingTables.length > 0) {
         if (options?.throwOnConflict ?? true) {
           throw new ReplicationAssertionError(
-            `Cannot mark snapshot done while ${snapshotRequiredCount?.count} source table${
-              snapshotRequiredCount?.count == 1n ? '' : 's'
-            } still require snapshotting`
+            `Cannot mark snapshot done while source tables still require snapshotting. Tables: ${blockingTables.map((t) => `${t.schema_name}.${t.table_name}`).join(', ')}`
           );
         } else {
           return;


### PR DESCRIPTION
The assertion was added in #641. Before, we'd leave source tables in an inconsistent state in some cases: The table would be marked as snapshot not complete, which we'd ignore and never actually complete. We now rely more on the database state, so we explicitly check that each individual table is marked as complete. This helps protect against some race conditions.

There are some edge cases that hit this:
1. Start replication with a set of tables.
2. Drop one or more of those tables while still replicating.
3. Restart the replication process.

In that case, the source table is recorded, but the snapshot never completes, leading to this error.

Fixing the issue properly requires a bigger change. A current workaround is to deploy another change to force restarting replication. The change here is just a short-term workaround to indicate which table(s) are causing the issue.

## AI Usage

Implemented the change in one storage adapter manually, then let Codex implement it in the other two.