### PR TITLE
[WIP] Graceful replication job handover

### DIFF
--- a/libs/lib-services/src/signals/termination-handler.ts
+++ b/libs/lib-services/src/signals/termination-handler.ts
@@ -13,7 +13,7 @@ type TerminationHandlerParams = {
   /**
    * A list of process signals to listen for.
    *
-   * @default ['SIGTERM', 'SIGINT', 'SIGUSR2']
+   * @default ['SIGTERM', 'SIGINT']
    */
   signals?: Signal[];
 
@@ -28,7 +28,7 @@ type TerminationHandlerParams = {
  * Calls an async handler and then kills the application.
  */
 export const createTerminationHandler = (params?: TerminationHandlerParams) => {
-  const { signals = Object.values(Signal), timeout_ms = 30000 } = params || {};
+  const { signals = [Signal.SIGTERM, Signal.SIGINT], timeout_ms = 30000 } = params || {};
 
   const handlers: Handler[] = [];
 

--- a/libs/lib-services/src/system/LifeCycledSystem.ts
+++ b/libs/lib-services/src/system/LifeCycledSystem.ts
@@ -15,6 +15,8 @@ export type LifecycleCallback<T> = (singleton: T) => Promise<void> | void;
 export type PartialLifecycle<T> = {
   start?: LifecycleCallback<T>;
   stop?: LifecycleCallback<T>;
+  stopAccepting?: LifecycleCallback<T>;
+  completed?: (singleton: T) => Promise<void>;
 };
 
 export type ComponentLifecycle<T> = PartialLifecycle<T> & {
@@ -22,8 +24,21 @@ export type ComponentLifecycle<T> = PartialLifecycle<T> & {
 };
 export type LifecycleHandler<T> = () => ComponentLifecycle<T>;
 
+export const STOP_ACCEPTING_SIGNAL: NodeJS.Signals = 'SIGUSR2';
+
 export class LifeCycledSystem {
   components: ComponentLifecycle<any>[] = [];
+  private stopPromise: Promise<void> | null = null;
+  private completionMonitor: Promise<void> | null = null;
+  private accepting = true;
+  private stopAcceptingSignalRegistered = false;
+
+  private readonly stopAcceptingSignalHandler = () => {
+    logger.info(`Received ${STOP_ACCEPTING_SIGNAL}; stopping system components from accepting new work.`);
+    this.stopAccepting().catch((error) => {
+      logger.error('Failed to stop accepting new work', error);
+    });
+  };
 
   constructor() {
     container.terminationHandler.handleTerminationSignal(() => this.stop());
@@ -38,15 +53,60 @@ export class LifeCycledSystem {
   };
 
   start = async () => {
+    if (!this.stopAcceptingSignalRegistered) {
+      process.on(STOP_ACCEPTING_SIGNAL, this.stopAcceptingSignalHandler);
+      this.stopAcceptingSignalRegistered = true;
+    }
+
+    const completions: Promise<void>[] = [];
     for (const lifecycle of this.components) {
       await lifecycle.start?.(lifecycle.component);
+      if (lifecycle.completed != null) {
+        completions.push(lifecycle.completed(lifecycle.component));
+      }
+    }
+
+    if (completions.length > 0) {
+      this.completionMonitor = Promise.all(completions)
+        .then(async () => {
+          logger.info('All running lifecycle components completed. Stopping system.');
+          await this.stop();
+        })
+        .catch(async (error) => {
+          logger.error('Lifecycle component completion failed', error);
+          await this.stop();
+        });
+    }
+  };
+
+  stopAccepting = async () => {
+    if (!this.accepting) {
+      return;
+    }
+
+    this.accepting = false;
+    for (const lifecycle of [...this.components].reverse()) {
+      await lifecycle.stopAccepting?.(lifecycle.component);
     }
   };
 
   stop = async () => {
-    for (const lifecycle of this.components.reverse()) {
-      await lifecycle.stop?.(lifecycle.component);
+    if (this.stopPromise != null) {
+      return this.stopPromise;
     }
+
+    this.stopPromise = (async () => {
+      if (this.stopAcceptingSignalRegistered) {
+        process.off(STOP_ACCEPTING_SIGNAL, this.stopAcceptingSignalHandler);
+        this.stopAcceptingSignalRegistered = false;
+      }
+
+      for (const lifecycle of [...this.components].reverse()) {
+        await lifecycle.stop?.(lifecycle.component);
+      }
+    })();
+
+    return this.stopPromise;
   };
 
   stopWithError = async (error: ServiceError) => {

--- a/libs/lib-services/test/src/lifecycle.test.ts
+++ b/libs/lib-services/test/src/lifecycle.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { container } from '../../src/container.js';
+import { LifeCycledSystem, STOP_ACCEPTING_SIGNAL } from '../../src/system/LifeCycledSystem.js';
+
+describe('LifeCycledSystem', () => {
+  beforeEach(() => {
+    container.registerDefaults();
+  });
+
+  test('stops the system once all running components complete', async () => {
+    const system = new LifeCycledSystem();
+    const first = Promise.withResolvers<void>();
+    const second = Promise.withResolvers<void>();
+    const stops: string[] = [];
+
+    system.withLifecycle('first', {
+      completed: () => first.promise,
+      stop: () => {
+        stops.push('first');
+      }
+    });
+    system.withLifecycle('not-running', {
+      stop: () => {
+        stops.push('not-running');
+      }
+    });
+    system.withLifecycle('second', {
+      completed: () => second.promise,
+      stop: () => {
+        stops.push('second');
+      }
+    });
+
+    await system.start();
+    first.resolve();
+    await Promise.resolve();
+    expect(stops).toEqual([]);
+
+    second.resolve();
+    await vi.waitFor(() => {
+      expect(stops).toEqual(['second', 'not-running', 'first']);
+    });
+  });
+
+  test('does not stop automatically when no components have completion promises', async () => {
+    const system = new LifeCycledSystem();
+    const stop = vi.fn();
+
+    system.withLifecycle('component', { stop });
+
+    await system.start();
+    await Promise.resolve();
+
+    expect(stop).not.toHaveBeenCalled();
+    await system.stop();
+  });
+
+  test('SIGUSR2 stops components from accepting new work', async () => {
+    const system = new LifeCycledSystem();
+    const stopAccepting = vi.fn();
+
+    system.withLifecycle('component', { stopAccepting });
+
+    await system.start();
+    process.emit(STOP_ACCEPTING_SIGNAL);
+
+    await vi.waitFor(() => {
+      expect(stopAccepting).toHaveBeenCalledTimes(1);
+    });
+
+    process.emit(STOP_ACCEPTING_SIGNAL);
+    expect(stopAccepting).toHaveBeenCalledTimes(1);
+
+    await system.stop();
+  });
+});

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -458,9 +458,9 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
       },
       [...existingConfigDocs, syncConfigDoc]
     );
-    if (updateOptions.lock) {
-      await stream.lock(session);
-    }
+    // The stream already exists, so an active replication job may already hold the stream lock.
+    // Deployment only persists the appended sync config; replication job locking is handled by
+    // the replicator.
     return stream;
   }
 

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -1348,6 +1348,44 @@ streams:
     await syncRules.current_lock?.release();
   });
 
+  test.runIf(storageVersion >= 3)('does not lock when appending a sync config to an existing stream', async () => {
+    await using factory = await storageConfig.factory();
+
+    const firstRules = `
+config:
+  edition: 3
+
+streams:
+  by_owner:
+    query: SELECT * FROM todos WHERE owner_id = subscription.parameter('owner_id')
+`;
+    const secondRules = `
+config:
+  edition: 3
+
+streams:
+  by_project:
+    query: SELECT * FROM todos WHERE project_id = subscription.parameter('project_id')
+`;
+
+    const first = await factory.updateSyncRules(updateSyncRulesFromYaml(firstRules, { storageVersion, lock: true }));
+    expect(first.current_lock?.sync_rules_id).toBe(first.replicationStreamId);
+    try {
+      const firstStorage = factory.getInstance(first);
+      await using firstWriter = await firstStorage.createWriter(test_utils.BATCH_OPTIONS);
+      await firstWriter.markAllSnapshotDone('1/1');
+      await firstWriter.commit('1/1');
+
+      const second = await factory.updateSyncRules(
+        updateSyncRulesFromYaml(secondRules, { storageVersion, lock: true })
+      );
+      expect(second.replicationStreamId).toBe(first.replicationStreamId);
+      expect(second.current_lock).toBeNull();
+    } finally {
+      await first.current_lock?.release();
+    }
+  });
+
   test.runIf(storageVersion < 3)('uses a single current_data collection for v1 source records', async () => {
     await using factory = await storageConfig.factory();
     const syncRules = await factory.updateSyncRules(

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -60,7 +60,9 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
   private lastPing = hrtime.bigint();
 
   private abortController: AbortController | undefined;
-  private drainingNewReplicationJobs = false;
+  private acceptingReplicationJobs = true;
+  private completedResolver = Promise.withResolvers<void>();
+  public completed: Promise<void> = this.completedResolver.promise;
 
   protected constructor(private options: AbstractReplicatorOptions) {
     this.logger = logger.child({ name: `Replicator:${options.id}` });
@@ -98,15 +100,22 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     return this.abortController?.signal.aborted;
   }
 
-  public async start(): Promise<void> {
+  public start(): void {
     this.abortController = new AbortController();
-    this.runLoop().catch((e) => {
-      this.logger.error('Fatal replication error', e);
-      container.reporter.captureException(e);
-      setTimeout(() => {
-        process.exit(1);
-      }, 1000);
-    });
+    this.completedResolver = Promise.withResolvers<void>();
+    this.completed = this.completedResolver.promise;
+    this.runLoop()
+      .then(() => {
+        this.completedResolver.resolve();
+      })
+      .catch((e) => {
+        this.logger.error('Fatal replication error', e);
+        container.reporter.captureException(e);
+        this.completedResolver.reject(e);
+        setTimeout(() => {
+          process.exit(1);
+        }, 1000);
+      });
     this.metrics.getObservableGauge(ReplicationMetric.REPLICATION_LAG_SECONDS).setValueProvider(async () => {
       try {
         const lag = this.getReplicationLagMillis();
@@ -132,11 +141,11 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
   }
 
   public stopAcceptingReplicationJobs(): void {
-    if (this.drainingNewReplicationJobs) {
+    if (!this.acceptingReplicationJobs) {
       return;
     }
 
-    this.drainingNewReplicationJobs = true;
+    this.acceptingReplicationJobs = false;
   }
 
   private async runLoop() {
@@ -218,7 +227,7 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
       } else {
         // New sync config was found (or resume after restart)
         try {
-          if (this.drainingNewReplicationJobs) {
+          if (!this.acceptingReplicationJobs) {
             if (configuredLock?.sync_rules_id == replicationStream.replicationStreamId) {
               await configuredLock.release();
               configuredLock = undefined;
@@ -274,6 +283,12 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
         // This will be retried
         job.storage.logger.warn('Failed to stop old replication job', e);
       }
+    }
+
+    if (!this.acceptingReplicationJobs && this.replicationJobs.size == 0) {
+      this.logger.info('No replication jobs remain; stopping replicator');
+      this.abortController?.abort();
+      return;
     }
 
     // Replication stream stopped previously, including by a different process.

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -60,6 +60,7 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
   private lastPing = hrtime.bigint();
 
   private abortController: AbortController | undefined;
+  private drainingNewReplicationJobs = false;
 
   protected constructor(private options: AbstractReplicatorOptions) {
     this.logger = logger.child({ name: `Replicator:${options.id}` });
@@ -130,6 +131,14 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     await Promise.all(promises);
   }
 
+  public stopAcceptingReplicationJobs(): void {
+    if (this.drainingNewReplicationJobs) {
+      return;
+    }
+
+    this.drainingNewReplicationJobs = true;
+  }
+
   private async runLoop() {
     const syncRules = await this.syncRuleProvider.get();
 
@@ -181,7 +190,7 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     }
   }
 
-  private async refresh(options?: { configured_lock?: storage.ReplicationLock }) {
+  protected async refresh(options?: { configured_lock?: storage.ReplicationLock }) {
     if (this.stopped) {
       return;
     }
@@ -209,6 +218,14 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
       } else {
         // New sync config was found (or resume after restart)
         try {
+          if (this.drainingNewReplicationJobs) {
+            if (configuredLock?.sync_rules_id == replicationStream.replicationStreamId) {
+              await configuredLock.release();
+              configuredLock = undefined;
+            }
+            continue;
+          }
+
           let lock: storage.ReplicationLock;
           if (configuredLock?.sync_rules_id == replicationStream.replicationStreamId) {
             lock = configuredLock;

--- a/packages/service-core/src/replication/ReplicationEngine.ts
+++ b/packages/service-core/src/replication/ReplicationEngine.ts
@@ -2,17 +2,10 @@ import { container, logger } from '@powersync/lib-services-framework';
 import { AbstractReplicator } from './AbstractReplicator.js';
 import { ConnectionTestResult } from './ReplicationModule.js';
 
-export const REPLICATION_HANDOVER_SIGNAL: NodeJS.Signals = 'SIGUSR2';
-
 export class ReplicationEngine {
   private readonly replicators: Map<string, AbstractReplicator> = new Map();
   private probeInterval: NodeJS.Timeout | null = null;
-  private signalHandlerRegistered = false;
-
-  private readonly handoverSignalHandler = () => {
-    logger.info(`Received ${REPLICATION_HANDOVER_SIGNAL}; stopped accepting new replication jobs`);
-    this.stopStartingReplicationJobs();
-  };
+  private completedPromise: Promise<void> = new Promise(() => {});
 
   /**
    *  Register a Replicator with the engine
@@ -32,10 +25,6 @@ export class ReplicationEngine {
    */
   public start(): void {
     logger.info('Starting Replication Engine...');
-    if (!this.signalHandlerRegistered) {
-      process.on(REPLICATION_HANDOVER_SIGNAL, this.handoverSignalHandler);
-      this.signalHandlerRegistered = true;
-    }
     for (const replicator of this.replicators.values()) {
       logger.info(`Starting Replicator: ${replicator.id}`);
       replicator.start();
@@ -50,6 +39,10 @@ export class ReplicationEngine {
           logger.error(`Failed to touch probe`, e);
         });
       }, 5_000);
+    } else {
+      this.completedPromise = Promise.all(
+        [...this.replicators.values()].map((replicator) => replicator.completed)
+      ).then(() => {});
     }
     logger.info('Successfully started Replication Engine.');
   }
@@ -59,10 +52,6 @@ export class ReplicationEngine {
    */
   public async shutDown(): Promise<void> {
     logger.info('Shutting down Replication Engine...');
-    if (this.signalHandlerRegistered) {
-      process.off(REPLICATION_HANDOVER_SIGNAL, this.handoverSignalHandler);
-      this.signalHandlerRegistered = false;
-    }
     for (const replicator of this.replicators.values()) {
       logger.info(`Stopping Replicator: ${replicator.id}`);
       await replicator.stop();
@@ -77,7 +66,11 @@ export class ReplicationEngine {
     return await Promise.all([...this.replicators.values()].map((replicator) => replicator.testConnection()));
   }
 
-  public stopStartingReplicationJobs(): void {
+  public get completed(): Promise<void> {
+    return this.completedPromise;
+  }
+
+  public stopAcceptingReplicationJobs(): void {
     for (const replicator of this.replicators.values()) {
       replicator.stopAcceptingReplicationJobs();
     }

--- a/packages/service-core/src/replication/ReplicationEngine.ts
+++ b/packages/service-core/src/replication/ReplicationEngine.ts
@@ -2,9 +2,17 @@ import { container, logger } from '@powersync/lib-services-framework';
 import { AbstractReplicator } from './AbstractReplicator.js';
 import { ConnectionTestResult } from './ReplicationModule.js';
 
+export const REPLICATION_HANDOVER_SIGNAL: NodeJS.Signals = 'SIGUSR2';
+
 export class ReplicationEngine {
   private readonly replicators: Map<string, AbstractReplicator> = new Map();
   private probeInterval: NodeJS.Timeout | null = null;
+  private signalHandlerRegistered = false;
+
+  private readonly handoverSignalHandler = () => {
+    logger.info(`Received ${REPLICATION_HANDOVER_SIGNAL}; stopped accepting new replication jobs`);
+    this.stopStartingReplicationJobs();
+  };
 
   /**
    *  Register a Replicator with the engine
@@ -24,6 +32,10 @@ export class ReplicationEngine {
    */
   public start(): void {
     logger.info('Starting Replication Engine...');
+    if (!this.signalHandlerRegistered) {
+      process.on(REPLICATION_HANDOVER_SIGNAL, this.handoverSignalHandler);
+      this.signalHandlerRegistered = true;
+    }
     for (const replicator of this.replicators.values()) {
       logger.info(`Starting Replicator: ${replicator.id}`);
       replicator.start();
@@ -47,6 +59,10 @@ export class ReplicationEngine {
    */
   public async shutDown(): Promise<void> {
     logger.info('Shutting down Replication Engine...');
+    if (this.signalHandlerRegistered) {
+      process.off(REPLICATION_HANDOVER_SIGNAL, this.handoverSignalHandler);
+      this.signalHandlerRegistered = false;
+    }
     for (const replicator of this.replicators.values()) {
       logger.info(`Stopping Replicator: ${replicator.id}`);
       await replicator.stop();
@@ -59,5 +75,11 @@ export class ReplicationEngine {
 
   public async testConnection(): Promise<ConnectionTestResult[]> {
     return await Promise.all([...this.replicators.values()].map((replicator) => replicator.testConnection()));
+  }
+
+  public stopStartingReplicationJobs(): void {
+    for (const replicator of this.replicators.values()) {
+      replicator.stopAcceptingReplicationJobs();
+    }
   }
 }

--- a/packages/service-core/test/src/replication/AbstractReplicator.test.ts
+++ b/packages/service-core/test/src/replication/AbstractReplicator.test.ts
@@ -98,6 +98,7 @@ class TestReplicator extends replication.AbstractReplicator<TestReplicationJob> 
         reportError: () => {}
       }
     });
+    (this as any).abortController = new AbortController();
   }
 
   createJob(options: replication.CreateJobOptions): TestReplicationJob {
@@ -121,10 +122,14 @@ class TestReplicator extends replication.AbstractReplicator<TestReplicationJob> 
   async refreshOnce(options?: { configured_lock?: storage.ReplicationLock }): Promise<void> {
     await this.refresh(options);
   }
+
+  get stoppedForTest() {
+    return this.stopped;
+  }
 }
 
-describe('AbstractReplicator drain mode', () => {
-  test('does not start new replication jobs after draining starts', async () => {
+describe('AbstractReplicator handover mode', () => {
+  test('does not start new replication jobs after accepting jobs stops', async () => {
     const factory = new TestBucketStorageFactory();
     const stream = new TestReplicationStream({ streamId: 1, jobId: '1:a' });
     factory.streams = [stream];
@@ -136,9 +141,10 @@ describe('AbstractReplicator drain mode', () => {
     expect(stream.lockCount).toBe(0);
     expect(factory.getInstance).not.toHaveBeenCalled();
     expect(replicator.jobs).toHaveLength(0);
+    expect(replicator.stoppedForTest).toBe(true);
   });
 
-  test('keeps existing matching replication jobs after draining starts', async () => {
+  test('keeps existing matching replication jobs after accepting jobs stops', async () => {
     const factory = new TestBucketStorageFactory();
     const lock = new TestLock(1);
     const stream = new TestReplicationStream({ streamId: 1, jobId: '1:a' }, lock);
@@ -153,6 +159,7 @@ describe('AbstractReplicator drain mode', () => {
     expect(factory.getInstance).toHaveBeenCalledTimes(1);
     expect(replicator.jobs).toHaveLength(1);
     expect(lock.releaseCount).toBe(0);
+    expect(replicator.stoppedForTest).toBe(false);
 
     await replicator.stop();
   });
@@ -175,9 +182,10 @@ describe('AbstractReplicator drain mode', () => {
     expect(newStream.lockCount).toBe(0);
     expect(factory.getInstance).toHaveBeenCalledTimes(1);
     expect(replicator.jobs).toHaveLength(1);
+    expect(replicator.stoppedForTest).toBe(true);
   });
 
-  test('releases a configured lock when draining skips the first refresh', async () => {
+  test('releases a configured lock when accepting jobs stops before the first refresh', async () => {
     const factory = new TestBucketStorageFactory();
     const stream = new TestReplicationStream({ streamId: 1, jobId: '1:a' });
     const configuredLock = new TestLock(1);
@@ -190,5 +198,6 @@ describe('AbstractReplicator drain mode', () => {
     expect(configuredLock.releaseCount).toBe(1);
     expect(stream.lockCount).toBe(0);
     expect(replicator.jobs).toHaveLength(0);
+    expect(replicator.stoppedForTest).toBe(true);
   });
 });

--- a/packages/service-core/test/src/replication/AbstractReplicator.test.ts
+++ b/packages/service-core/test/src/replication/AbstractReplicator.test.ts
@@ -1,0 +1,194 @@
+import { replication, storage } from '@/index.js';
+import { describe, expect, test, vi } from 'vitest';
+
+class TestLock implements storage.ReplicationLock {
+  releaseCount = 0;
+
+  constructor(public sync_rules_id: number) {}
+
+  async release(): Promise<void> {
+    this.releaseCount++;
+  }
+}
+
+class TestReplicationStream extends storage.PersistedReplicationStream {
+  readonly syncConfigContent: readonly storage.PersistedSyncConfigContent[] = [];
+  readonly current_lock: storage.ReplicationLock | null = null;
+  lockCount = 0;
+
+  constructor(
+    options: {
+      streamId: number;
+      jobId: string;
+      state?: storage.SyncRuleState;
+    },
+    private readonly testLock = new TestLock(options.streamId)
+  ) {
+    super({
+      replicationStreamId: options.streamId,
+      replicationStreamName: `stream_${options.streamId}`,
+      replicationJobId: options.jobId,
+      state: options.state ?? storage.SyncRuleState.PROCESSING,
+      storageVersion: storage.CURRENT_STORAGE_VERSION
+    });
+  }
+
+  async lock(): Promise<storage.ReplicationLock> {
+    this.lockCount++;
+    return this.testLock;
+  }
+
+  parsed(): storage.ParsedSyncConfigSet {
+    throw new Error('Not implemented');
+  }
+}
+
+class TestBucketStorageFactory {
+  streams: storage.PersistedReplicationStream[] = [];
+  readonly getInstance = vi.fn((stream: storage.PersistedReplicationStream) => {
+    return {
+      replicationStreamId: stream.replicationStreamId,
+      replicationStreamName: stream.replicationStreamName,
+      storageConfig: stream.getStorageConfig(),
+      logger: stream.logger
+    } as storage.SyncRulesBucketStorage;
+  });
+
+  async getReplicatingReplicationStreams(): Promise<storage.PersistedReplicationStream[]> {
+    return this.streams;
+  }
+
+  async getStoppedReplicationStreams(): Promise<storage.PersistedReplicationStream[]> {
+    return [];
+  }
+}
+
+class TestReplicationJob extends replication.AbstractReplicationJob {
+  constructor(options: replication.AbstractReplicationJobOptions) {
+    super(options);
+  }
+
+  async replicate(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      this.abortController.signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+  }
+
+  async keepAlive(): Promise<void> {}
+
+  getReplicationLagMillis(): number | undefined {
+    return undefined;
+  }
+}
+
+class TestReplicator extends replication.AbstractReplicator<TestReplicationJob> {
+  readonly jobs: TestReplicationJob[] = [];
+
+  constructor(private readonly bucketStorage: TestBucketStorageFactory) {
+    super({
+      id: 'test',
+      storageEngine: {
+        activeBucketStorage: bucketStorage
+      } as unknown as storage.StorageEngine,
+      metricsEngine: null as any,
+      syncRuleProvider: null as any,
+      rateLimiter: {
+        mayPing: () => false,
+        waitUntilAllowed: async () => {},
+        reportError: () => {}
+      }
+    });
+  }
+
+  createJob(options: replication.CreateJobOptions): TestReplicationJob {
+    const job = new TestReplicationJob({
+      id: `job_${this.jobs.length}`,
+      storage: options.storage,
+      metrics: null as any,
+      lock: options.lock,
+      rateLimiter: this.rateLimiter
+    });
+    this.jobs.push(job);
+    return job;
+  }
+
+  async cleanUp(): Promise<void> {}
+
+  async testConnection(): Promise<replication.ConnectionTestResult> {
+    return { connectionDescription: 'test' };
+  }
+
+  async refreshOnce(options?: { configured_lock?: storage.ReplicationLock }): Promise<void> {
+    await this.refresh(options);
+  }
+}
+
+describe('AbstractReplicator drain mode', () => {
+  test('does not start new replication jobs after draining starts', async () => {
+    const factory = new TestBucketStorageFactory();
+    const stream = new TestReplicationStream({ streamId: 1, jobId: '1:a' });
+    factory.streams = [stream];
+    const replicator = new TestReplicator(factory);
+
+    replicator.stopAcceptingReplicationJobs();
+    await replicator.refreshOnce();
+
+    expect(stream.lockCount).toBe(0);
+    expect(factory.getInstance).not.toHaveBeenCalled();
+    expect(replicator.jobs).toHaveLength(0);
+  });
+
+  test('keeps existing matching replication jobs after draining starts', async () => {
+    const factory = new TestBucketStorageFactory();
+    const lock = new TestLock(1);
+    const stream = new TestReplicationStream({ streamId: 1, jobId: '1:a' }, lock);
+    factory.streams = [stream];
+    const replicator = new TestReplicator(factory);
+
+    await replicator.refreshOnce();
+    replicator.stopAcceptingReplicationJobs();
+    await replicator.refreshOnce();
+
+    expect(stream.lockCount).toBe(1);
+    expect(factory.getInstance).toHaveBeenCalledTimes(1);
+    expect(replicator.jobs).toHaveLength(1);
+    expect(lock.releaseCount).toBe(0);
+
+    await replicator.stop();
+  });
+
+  test('stops an existing job whose persisted job id changed without starting the replacement', async () => {
+    const factory = new TestBucketStorageFactory();
+    const oldLock = new TestLock(1);
+    const oldStream = new TestReplicationStream({ streamId: 1, jobId: '1:old' }, oldLock);
+    factory.streams = [oldStream];
+    const replicator = new TestReplicator(factory);
+
+    await replicator.refreshOnce();
+
+    const newStream = new TestReplicationStream({ streamId: 1, jobId: '1:new' });
+    factory.streams = [newStream];
+    replicator.stopAcceptingReplicationJobs();
+    await replicator.refreshOnce();
+
+    expect(oldLock.releaseCount).toBe(1);
+    expect(newStream.lockCount).toBe(0);
+    expect(factory.getInstance).toHaveBeenCalledTimes(1);
+    expect(replicator.jobs).toHaveLength(1);
+  });
+
+  test('releases a configured lock when draining skips the first refresh', async () => {
+    const factory = new TestBucketStorageFactory();
+    const stream = new TestReplicationStream({ streamId: 1, jobId: '1:a' });
+    const configuredLock = new TestLock(1);
+    factory.streams = [stream];
+    const replicator = new TestReplicator(factory);
+
+    replicator.stopAcceptingReplicationJobs();
+    await replicator.refreshOnce({ configured_lock: configuredLock });
+
+    expect(configuredLock.releaseCount).toBe(1);
+    expect(stream.lockCount).toBe(0);
+    expect(replicator.jobs).toHaveLength(0);
+  });
+});

--- a/packages/service-core/test/src/replication/ReplicationEngine.test.ts
+++ b/packages/service-core/test/src/replication/ReplicationEngine.test.ts
@@ -1,28 +1,61 @@
 import { replication } from '@/index.js';
 import { describe, expect, test, vi } from 'vitest';
 
-describe('ReplicationEngine handover signal', () => {
-  test('SIGUSR2 stops new replication jobs from starting without shutting down replicators', async () => {
+describe('ReplicationEngine handover mode', () => {
+  test('stops accepting replication jobs without shutting down replicators', async () => {
     const engine = new replication.ReplicationEngine();
+    const completed = Promise.withResolvers<void>();
     const replicator = {
       id: 'test-replicator',
       start: vi.fn(),
       stop: vi.fn(),
-      stopStartingReplicationJobs: vi.fn(),
-      testConnection: vi.fn()
+      stopAcceptingReplicationJobs: vi.fn(),
+      testConnection: vi.fn(),
+      completed: completed.promise
     };
 
     engine.register(replicator as unknown as replication.AbstractReplicator);
     engine.start();
 
-    process.emit(replication.REPLICATION_HANDOVER_SIGNAL);
+    engine.stopAcceptingReplicationJobs();
 
-    expect(replicator.stopStartingReplicationJobs).toHaveBeenCalledTimes(1);
+    expect(replicator.stopAcceptingReplicationJobs).toHaveBeenCalledTimes(1);
     expect(replicator.stop).not.toHaveBeenCalled();
 
     await engine.shutDown();
+  });
 
-    process.emit(replication.REPLICATION_HANDOVER_SIGNAL);
-    expect(replicator.stopStartingReplicationJobs).toHaveBeenCalledTimes(1);
+  test('completed resolves when all registered replicators complete', async () => {
+    const engine = new replication.ReplicationEngine();
+    const first = Promise.withResolvers<void>();
+    const second = Promise.withResolvers<void>();
+    const makeReplicator = (id: string, completed: Promise<void>) =>
+      ({
+        id,
+        start: vi.fn(),
+        stop: vi.fn(),
+        stopAcceptingReplicationJobs: vi.fn(),
+        testConnection: vi.fn(),
+        completed
+      }) as unknown as replication.AbstractReplicator;
+
+    engine.register(makeReplicator('first', first.promise));
+    engine.register(makeReplicator('second', second.promise));
+    engine.start();
+
+    let resolved = false;
+    engine.completed.then(() => {
+      resolved = true;
+    });
+
+    first.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    second.resolve();
+    await engine.completed;
+    expect(resolved).toBe(true);
+
+    await engine.shutDown();
   });
 });

--- a/packages/service-core/test/src/replication/ReplicationEngine.test.ts
+++ b/packages/service-core/test/src/replication/ReplicationEngine.test.ts
@@ -1,0 +1,28 @@
+import { replication } from '@/index.js';
+import { describe, expect, test, vi } from 'vitest';
+
+describe('ReplicationEngine handover signal', () => {
+  test('SIGUSR2 stops new replication jobs from starting without shutting down replicators', async () => {
+    const engine = new replication.ReplicationEngine();
+    const replicator = {
+      id: 'test-replicator',
+      start: vi.fn(),
+      stop: vi.fn(),
+      stopStartingReplicationJobs: vi.fn(),
+      testConnection: vi.fn()
+    };
+
+    engine.register(replicator as unknown as replication.AbstractReplicator);
+    engine.start();
+
+    process.emit(replication.REPLICATION_HANDOVER_SIGNAL);
+
+    expect(replicator.stopStartingReplicationJobs).toHaveBeenCalledTimes(1);
+    expect(replicator.stop).not.toHaveBeenCalled();
+
+    await engine.shutDown();
+
+    process.emit(replication.REPLICATION_HANDOVER_SIGNAL);
+    expect(replicator.stopStartingReplicationJobs).toHaveBeenCalledTimes(1);
+  });
+});

--- a/service/src/runners/stream-worker.ts
+++ b/service/src/runners/stream-worker.ts
@@ -9,12 +9,18 @@ import { logBooting } from '../util/version.js';
 export const registerReplicationServices = (serviceContext: core.system.ServiceContextContainer) => {
   // Needs to be executed after shared registrations
   const replication = new core.replication.ReplicationEngine();
+  const lifecycle: core.framework.PartialLifecycle<core.replication.ReplicationEngine> = {
+    start: (replication) => replication.start(),
+    stop: (replication) => replication.shutDown(),
+    stopAccepting: (replication) => replication.stopAcceptingReplicationJobs()
+  };
+
+  if (serviceContext.serviceMode == core.system.ServiceContextMode.SYNC) {
+    lifecycle.completed = (replication) => replication.completed;
+  }
 
   serviceContext.register(core.replication.ReplicationEngine, replication);
-  serviceContext.lifeCycleEngine.withLifecycle(replication, {
-    start: (replication) => replication.start(),
-    stop: (replication) => replication.shutDown()
-  });
+  serviceContext.lifeCycleEngine.withLifecycle(replication, lifecycle);
 };
 
 export const startStreamRunner = async (runnerConfig: core.utils.RunnerConfig) => {


### PR DESCRIPTION
The first issue here was with lock handling when using incremental reprocessing: Usually, when we update sync config, we take a lock immediately, so that the job updating the config is guaranteed to get the lock. The main use case that immediate lock solves is rolling deploys: Start a new replication process with new sync config, before terminating the existing replication process. However, when the sync config is added to an existing replication stream, that lock may already be held by another replication process, which then fails the lock acquisition, which fails the entire update.

The immediate fix is simple enough: Just don't attempt to lock in that case. But we can do better.

This adds a signal handler for SIGUSR2, which lets the replicator stop accepting any new replication jobs. If sync config is added to a replication stream, that stream is restarted _in the new process_. The existing process will detect that, and stop gracefully.

This is especially useful in Kubernetes environments: We can configure a preStop command that sends `kill -USR2 1`, then waits for say 30 seconds. That will continue processing the replication stream until the new pod is taking over, or times out after 30 seconds.