### PR TITLE
Test precedence of columns in conflict with `*`

### DIFF
--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -207,6 +207,39 @@ streams:
     expect(evaluateBucketIds(desc, USERS, { id: 'foo' })).toStrictEqual(['stream|0[]']);
     expect(evaluateBucketIds(desc, COMMENTS, { id: 'foo2' })).toStrictEqual(['stream|0[]']);
   });
+
+  syncTest('aliased column and star precedence', ({ sync }) => {
+    const aliasFirst = sync.prepareSyncStreams(`
+config:
+  edition: 3
+  
+streams:
+  stream:
+    query: SELECT user_id as id, * FROM users
+`);
+    const aliasLast = sync.prepareSyncStreams(`
+config:
+  edition: 3
+  
+streams:
+  stream:
+    query: SELECT *, user_id as id FROM users
+`);
+
+    const sourceRecord = { user_id: 'uid', id: 'internal_id', name: 'username' };
+
+    {
+      const [row] = aliasFirst.evaluateRow({ sourceTable: USERS, record: sourceRecord });
+      expect(row.id).toStrictEqual('internal_id');
+      expect(row.data).toStrictEqual({ id: 'internal_id', user_id: 'uid', name: 'username' });
+    }
+
+    {
+      const [row] = aliasLast.evaluateRow({ sourceTable: USERS, record: sourceRecord });
+      expect(row.id).toStrictEqual('uid');
+      expect(row.data).toStrictEqual({ id: 'uid', user_id: 'uid', name: 'username' });
+    }
+  });
 });
 
 describe('evaluating parameters', () => {


### PR DESCRIPTION
When combining `*` result columns with explicit aliases, it's possible to end up with multiple columns having the same name. Since we sync rows as JS objects, one of those columns would then be excluded from synced data.

In the old Sync Rules system, explicit aliases would always take precedence over `*` columns. That is, `SELECT x AS a, * FROM tbl` syncs source row `{x: 'x', a: 'a'}` as `{x: 'x', a: 'x'}`.
With Sync Streams, the last column wins. `SELECT x AS a, *` gives you `{x: 'x', a: 'a'}`, `SELECT *, x AS a` results in `{x: 'x', a: 'x'}`. I don't think this was an intentional change, but it's kind of convenient to have control over predecence in such cases.

This adds test verifying the current behavior for Sync Streams. A question is whether we should revert that to the old behavior for backwards compatibility. If not, we can instead change the migration tool to move `*` to the front, ensuring explicit aliases take precedence.

For more context, see internal ticket 40171.