### PR TITLE
Restructure replication locks

### DIFF
--- a/.changeset/calm-squids-push.md
+++ b/.changeset/calm-squids-push.md
@@ -1,0 +1,7 @@
+---
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+---
+
+Restructure replication locks for updated sync config.

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -458,9 +458,9 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
       },
       [...existingConfigDocs, syncConfigDoc]
     );
-    if (updateOptions.lock) {
-      await stream.lock(session);
-    }
+    // The stream already exists, so an active replication job may already hold the stream lock.
+    // Deployment only persists the appended sync config; replication job locking is handled by
+    // the replicator.
     return stream;
   }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoPersistedSyncConfigContent.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoPersistedSyncConfigContent.ts
@@ -69,7 +69,8 @@ export class MongoPersistedSyncConfigContentV1 extends MongoPersistedSyncConfigC
       replicationStreamName: doc.slot_name ?? `powersync_${doc._id}`,
       storageVersion: doc.storage_version ?? storage.LEGACY_STORAGE_VERSION,
       mapping: new SingleSyncConfigBucketDefinitionMapping(),
-      syncConfigId: null
+      syncConfigId: null,
+      syncConfigState: doc.state
     });
   }
 
@@ -98,7 +99,8 @@ export class MongoPersistedSyncConfigContentV3 extends MongoPersistedSyncConfigC
       replicationStreamName: doc.slot_name ?? `powersync_${doc._id}`,
       storageVersion: doc.storage_version,
       mapping: SingleSyncConfigBucketDefinitionMapping.fromPersistedMapping(config.rule_mapping),
-      syncConfigId: config._id
+      syncConfigId: config._id,
+      syncConfigState: state.state
     });
   }
 

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -1348,6 +1348,44 @@ streams:
     await syncRules.current_lock?.release();
   });
 
+  test.runIf(storageVersion >= 3)('does not lock when appending a sync config to an existing stream', async () => {
+    await using factory = await storageConfig.factory();
+
+    const firstRules = `
+config:
+  edition: 3
+
+streams:
+  by_owner:
+    query: SELECT * FROM todos WHERE owner_id = subscription.parameter('owner_id')
+`;
+    const secondRules = `
+config:
+  edition: 3
+
+streams:
+  by_project:
+    query: SELECT * FROM todos WHERE project_id = subscription.parameter('project_id')
+`;
+
+    const first = await factory.updateSyncRules(updateSyncRulesFromYaml(firstRules, { storageVersion, lock: true }));
+    expect(first.current_lock?.sync_rules_id).toBe(first.replicationStreamId);
+    try {
+      const firstStorage = factory.getInstance(first);
+      await using firstWriter = await firstStorage.createWriter(test_utils.BATCH_OPTIONS);
+      await firstWriter.markAllSnapshotDone('1/1');
+      await firstWriter.commit('1/1');
+
+      const second = await factory.updateSyncRules(
+        updateSyncRulesFromYaml(secondRules, { storageVersion, lock: true })
+      );
+      expect(second.replicationStreamId).toBe(first.replicationStreamId);
+      expect(second.current_lock).toBeNull();
+    } finally {
+      await first.current_lock?.release();
+    }
+  });
+
   test.runIf(storageVersion < 3)('uses a single current_data collection for v1 source records', async () => {
     await using factory = await storageConfig.factory();
     const syncRules = await factory.updateSyncRules(

--- a/modules/module-postgres-storage/src/storage/sync-rules/PostgresPersistedSyncConfigContent.ts
+++ b/modules/module-postgres-storage/src/storage/sync-rules/PostgresPersistedSyncConfigContent.ts
@@ -13,7 +13,8 @@ export class PostgresPersistedSyncConfigContent extends storage.PersistedSyncCon
       sync_rules_content: row.content,
       compiled_plan: row.sync_plan,
       replicationStreamName: row.slot_name,
-      storageVersion: row.storage_version ?? storage.LEGACY_STORAGE_VERSION
+      storageVersion: row.storage_version ?? storage.LEGACY_STORAGE_VERSION,
+      syncConfigState: row.state as storage.SyncRuleState
     });
   }
 

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -36,7 +36,7 @@ export interface AbstractReplicatorOptions {
  */
 export abstract class AbstractReplicator<T extends AbstractReplicationJob = AbstractReplicationJob> {
   protected logger: winston.Logger;
-  private lockAlerted: boolean = false;
+  private lastReplicationStreamInfoLogs = new Map<string, string>();
   /**
    *  Map of replication jobs by replication stream job id. Usually there is only one running job, but there could be two
    *  when transitioning to a new replication stream.
@@ -131,17 +131,20 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
   }
 
   private async runLoop() {
-    const syncRules = await this.syncRuleProvider.get();
+    const loadedSyncConfig = await this.syncRuleProvider.get();
 
     let configuredLock: storage.ReplicationLock | undefined = undefined;
-    if (syncRules != null) {
+    if (loadedSyncConfig != null) {
       this.logger.info('Loaded sync config');
       try {
         // Configure new sync config, if they have changed.
         // In that case, also immediately take out a lock, so that another process doesn't start replication on it.
+        // This upfront lock is mostly superseded by the replicationStreamMatchesLoadedSyncRules() check. However, that doesn't cover old
+        // versions before that check was added, so we keep the lock for now - for where te service version and sync config is updated at
+        // the same time.
 
         const { lock } = await this.storage.configureSyncRules(
-          storage.updateSyncRulesFromYaml(syncRules, { lock: true, validate: this.syncRuleProvider.exitOnError })
+          storage.updateSyncRulesFromYaml(loadedSyncConfig, { lock: true, validate: this.syncRuleProvider.exitOnError })
         );
         if (lock) {
           configuredLock = lock;
@@ -158,7 +161,7 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     while (!this.stopped) {
       await container.probes.touch();
       try {
-        await this.refresh({ configured_lock: configuredLock });
+        await this.refresh({ configuredLock, loadedSyncConfig });
         // The lock is only valid on the first refresh.
         configuredLock = undefined;
 
@@ -181,12 +184,12 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     }
   }
 
-  private async refresh(options?: { configured_lock?: storage.ReplicationLock }) {
+  private async refresh(options?: { configuredLock?: storage.ReplicationLock; loadedSyncConfig?: string }) {
     if (this.stopped) {
       return;
     }
 
-    let configuredLock = options?.configured_lock;
+    let configuredLock = options?.configuredLock;
 
     const existingJobs = new Map<string, T>(this.replicationJobs.entries());
     const replicatingStreams = await this.storage.getReplicatingReplicationStreams();
@@ -195,6 +198,12 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     for (let replicationStream of replicatingStreams) {
       const jobId = replicationStream.replicationJobId;
       const existingJob = existingJobs.get(jobId);
+      const syncConfigMismatchMessage = 'Ignoring replication stream for sync config not loaded by this process';
+      if (!this.replicationStreamMatchesLoadedSyncRules(replicationStream, options?.loadedSyncConfig)) {
+        this.logReplicationStreamInfoOnce(replicationStream, syncConfigMismatchMessage);
+        continue;
+      }
+      this.clearReplicationStreamInfoLog(replicationStream, syncConfigMismatchMessage);
       if (replicationStream.state == storage.SyncRuleState.ACTIVE && activeJob == null) {
         activeJob = existingJob;
       }
@@ -226,13 +235,10 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
           if (replicationStream.state == storage.SyncRuleState.ACTIVE) {
             activeJob = newJob;
           }
-          this.lockAlerted = false;
+          this.lastReplicationStreamInfoLogs.delete(replicationStream.replicationStreamName);
         } catch (e) {
           if (e?.errorData?.code === ErrorCode.PSYNC_S1003) {
-            if (!this.lockAlerted) {
-              replicationStream.logger.info(`[${e.errorData.code}] ${e.errorData.description}`);
-              this.lockAlerted = true;
-            }
+            this.logReplicationStreamInfoOnce(replicationStream, `[${e.errorData.code}] ${e.errorData.description}`);
           } else {
             // Could be a sync config parse error,
             // for example from stricter validation that was added.
@@ -280,6 +286,64 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
         });
       this.clearingJobs.set(replicationStream.replicationStreamId, promise);
     }
+  }
+
+  private logReplicationStreamInfoOnce(replicationStream: storage.PersistedReplicationStream, message: string) {
+    if (this.lastReplicationStreamInfoLogs.get(replicationStream.replicationStreamName) == message) {
+      return;
+    }
+
+    replicationStream.logger.info(message);
+    this.lastReplicationStreamInfoLogs.set(replicationStream.replicationStreamName, message);
+  }
+
+  private clearReplicationStreamInfoLog(replicationStream: storage.PersistedReplicationStream, message: string) {
+    if (this.lastReplicationStreamInfoLogs.get(replicationStream.replicationStreamName) == message) {
+      this.lastReplicationStreamInfoLogs.delete(replicationStream.replicationStreamName);
+    }
+  }
+
+  /**
+   * When we load sync config from the filesystem/config source, we ignore any config loaded by other processes.
+   *
+   * The idea is that if a different process loads updated config, that process should process it, not this one.
+   *
+   * This specifically helps for cases with rolling deploys.
+   *
+   * This does not apply when sync config is loaded from the database/API, instead of in the config.
+   */
+  private replicationStreamMatchesLoadedSyncRules(
+    replicationStream: storage.PersistedReplicationStream,
+    loadedSyncRules: string | undefined
+  ) {
+    if (loadedSyncRules == null) {
+      return true;
+    }
+
+    const syncConfig = this.replicationStreamSyncConfigForLoadedRulesGate(replicationStream);
+    return syncConfig == null || syncConfig.sync_rules_content == loadedSyncRules;
+  }
+
+  /**
+   * Return the "latest" sync config in a replication stream: Prioritize the "PROCESSING" one, then ACTIVE/ERRORED.
+   */
+  private replicationStreamSyncConfigForLoadedRulesGate(
+    replicationStream: storage.PersistedReplicationStream
+  ): storage.PersistedSyncConfigContent | null {
+    const processing = replicationStream.syncConfigContent.find(
+      (syncConfig) => syncConfig.syncConfigState == storage.SyncRuleState.PROCESSING
+    );
+    if (processing != null) {
+      return processing;
+    }
+
+    return (
+      replicationStream.syncConfigContent.find(
+        (syncConfig) =>
+          syncConfig.syncConfigState == storage.SyncRuleState.ACTIVE ||
+          syncConfig.syncConfigState == storage.SyncRuleState.ERRORED
+      ) ?? null
+    );
   }
 
   protected createJobId(syncRuleId: number) {

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -213,6 +213,7 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     const existingJobs = new Map<string, T>(this.replicationJobs.entries());
     const replicatingStreams = await this.storage.getReplicatingReplicationStreams();
     const newJobs = new Map<string, T>();
+    const streamsToStart: storage.PersistedReplicationStream[] = [];
     let activeJob: T | undefined = undefined;
     for (let replicationStream of replicatingStreams) {
       const jobId = replicationStream.replicationJobId;
@@ -238,47 +239,12 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
         existingJobs.delete(jobId);
       } else {
         // New sync config was found (or resume after restart)
-        try {
-          let lock: storage.ReplicationLock;
-          if (configuredLock?.sync_rules_id == replicationStream.replicationStreamId) {
-            lock = configuredLock;
-          } else {
-            lock = await replicationStream.lock();
-          }
-          const syncRuleStorage = this.storage.getInstance(replicationStream);
-          const newJob = this.createJob({
-            lock: lock,
-            storage: syncRuleStorage
-          });
-
-          newJobs.set(jobId, newJob);
-          newJob.start();
-          replicationJobStarted = true;
-          if (replicationStream.state == storage.SyncRuleState.ACTIVE) {
-            activeJob = newJob;
-          }
-          this.lastReplicationStreamInfoLogs.delete(replicationStream.replicationStreamName);
-        } catch (e) {
-          if (e?.errorData?.code === ErrorCode.PSYNC_S1003) {
-            this.logReplicationStreamInfoOnce(replicationStream, 'replication-stream-locked', () => {
-              replicationStream.logger.info(`[${e.errorData.code}] ${e.errorData.description}`);
-            });
-          } else {
-            // Could be a sync config parse error,
-            // for example from stricter validation that was added.
-            // This will be retried every couple of seconds.
-            // When new (valid) sync config is deployed and processed, this one be disabled.
-            replicationStream.logger.error('Failed to start replication for new sync config', e);
-          }
-        }
+        streamsToStart.push(replicationStream);
       }
     }
 
-    this.replicationJobs = newJobs;
-    this.activeReplicationJob = activeJob;
-
-    // Stop any orphaned jobs that no longer have a replication stream.
-    // Termination happens below
+    // Stop any orphaned jobs that no longer have a replication stream before starting replacements.
+    // Termination happens below.
     for (let job of existingJobs.values()) {
       // Old - stop and clean up
       try {
@@ -288,6 +254,46 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
         job.storage.logger.warn('Failed to stop old replication job', e);
       }
     }
+
+    for (let replicationStream of streamsToStart) {
+      const jobId = replicationStream.replicationJobId;
+      try {
+        let lock: storage.ReplicationLock;
+        if (configuredLock?.sync_rules_id == replicationStream.replicationStreamId) {
+          lock = configuredLock;
+        } else {
+          lock = await replicationStream.lock();
+        }
+        const syncRuleStorage = this.storage.getInstance(replicationStream);
+        const newJob = this.createJob({
+          lock: lock,
+          storage: syncRuleStorage
+        });
+
+        newJobs.set(jobId, newJob);
+        newJob.start();
+        replicationJobStarted = true;
+        if (replicationStream.state == storage.SyncRuleState.ACTIVE) {
+          activeJob = newJob;
+        }
+        this.lastReplicationStreamInfoLogs.delete(replicationStream.replicationStreamName);
+      } catch (e) {
+        if (e?.errorData?.code === ErrorCode.PSYNC_S1003) {
+          this.logReplicationStreamInfoOnce(replicationStream, 'replication-stream-locked', () => {
+            replicationStream.logger.info(`[${e.errorData.code}] ${e.errorData.description}`);
+          });
+        } else {
+          // Could be a sync config parse error,
+          // for example from stricter validation that was added.
+          // This will be retried every couple of seconds.
+          // When new (valid) sync config is deployed and processed, this one be disabled.
+          replicationStream.logger.error('Failed to start replication for new sync config', e);
+        }
+      }
+    }
+
+    this.replicationJobs = newJobs;
+    this.activeReplicationJob = activeJob;
 
     // Replication stream stopped previously, including by a different process.
     const stopped = await this.storage.getStoppedReplicationStreams();

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -1,6 +1,7 @@
 import { container, ErrorCode, logger } from '@powersync/lib-services-framework';
 import { ReplicationMetric } from '@powersync/service-types';
 import { hrtime } from 'node:process';
+import { setTimeout as sleep } from 'node:timers/promises';
 import winston from 'winston';
 import { MetricsEngine } from '../metrics/MetricsEngine.js';
 import * as storage from '../storage/storage-index.js';
@@ -12,6 +13,12 @@ import { ConnectionTestResult } from './ReplicationModule.js';
 
 // 1 minute
 const PING_INTERVAL = 1_000_000_000n * 60n;
+
+// In the initial startup period, we use a short refresh interval. This helps to take over replication quickly in the case
+// of rolling deploys. After the initial period, we switch to a longer refresh interval to reduce load.
+const FAST_REFRESH_INTERVAL_MS = 500;
+const FAST_REFRESH_TIMEOUT_MS = 120_000;
+const REFRESH_INTERVAL_MS = 5_000;
 
 export interface CreateJobOptions {
   lock: storage.ReplicationLock;
@@ -158,10 +165,15 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     } else {
       this.logger.info('No sync streams or rules configured - configure via API');
     }
+    let useFastRefresh = true;
+    const fastRefreshDeadline = Date.now() + FAST_REFRESH_TIMEOUT_MS;
     while (!this.stopped) {
       await container.probes.touch();
       try {
-        await this.refresh({ configuredLock, loadedSyncConfig });
+        const refreshResult = await this.refresh({ configuredLock, loadedSyncConfig });
+        if (refreshResult.replicationJobStarted || Date.now() >= fastRefreshDeadline) {
+          useFastRefresh = false;
+        }
         // The lock is only valid on the first refresh.
         configuredLock = undefined;
 
@@ -180,16 +192,23 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
       } catch (e) {
         this.logger.error('Failed to refresh replication jobs', e);
       }
-      await new Promise((resolve) => setTimeout(resolve, 5000));
+      if (Date.now() >= fastRefreshDeadline) {
+        useFastRefresh = false;
+      }
+      await sleep(useFastRefresh ? FAST_REFRESH_INTERVAL_MS : REFRESH_INTERVAL_MS);
     }
   }
 
-  private async refresh(options?: { configuredLock?: storage.ReplicationLock; loadedSyncConfig?: string }) {
+  private async refresh(options?: {
+    configuredLock?: storage.ReplicationLock;
+    loadedSyncConfig?: string;
+  }): Promise<{ replicationJobStarted: boolean }> {
     if (this.stopped) {
-      return;
+      return { replicationJobStarted: false };
     }
 
     let configuredLock = options?.configuredLock;
+    let replicationJobStarted = false;
 
     const existingJobs = new Map<string, T>(this.replicationJobs.entries());
     const replicatingStreams = await this.storage.getReplicatingReplicationStreams();
@@ -232,6 +251,7 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
 
           newJobs.set(jobId, newJob);
           newJob.start();
+          replicationJobStarted = true;
           if (replicationStream.state == storage.SyncRuleState.ACTIVE) {
             activeJob = newJob;
           }
@@ -286,6 +306,8 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
         });
       this.clearingJobs.set(replicationStream.replicationStreamId, promise);
     }
+
+    return { replicationJobStarted };
   }
 
   private logReplicationStreamInfoOnce(replicationStream: storage.PersistedReplicationStream, message: string) {

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -219,10 +219,12 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
       const existingJob = existingJobs.get(jobId);
       const syncConfigMismatchMessage = 'Ignoring replication stream for sync config not loaded by this process';
       if (!this.shouldHandleReplicationStream(replicationStream, options?.loadedSyncConfig)) {
-        this.logReplicationStreamInfoOnce(replicationStream, syncConfigMismatchMessage);
+        this.logReplicationStreamInfoOnce(replicationStream, 'sync-config-mismatch', () => {
+          replicationStream.logger.info(syncConfigMismatchMessage);
+        });
         continue;
       }
-      this.clearReplicationStreamInfoLog(replicationStream, syncConfigMismatchMessage);
+      this.clearReplicationStreamInfoLog(replicationStream, 'sync-config-mismatch');
       if (replicationStream.state == storage.SyncRuleState.ACTIVE && activeJob == null) {
         activeJob = existingJob;
       }
@@ -258,7 +260,9 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
           this.lastReplicationStreamInfoLogs.delete(replicationStream.replicationStreamName);
         } catch (e) {
           if (e?.errorData?.code === ErrorCode.PSYNC_S1003) {
-            this.logReplicationStreamInfoOnce(replicationStream, `[${e.errorData.code}] ${e.errorData.description}`);
+            this.logReplicationStreamInfoOnce(replicationStream, 'replication-stream-locked', () => {
+              replicationStream.logger.info(`[${e.errorData.code}] ${e.errorData.description}`);
+            });
           } else {
             // Could be a sync config parse error,
             // for example from stricter validation that was added.
@@ -310,17 +314,21 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
     return { replicationJobStarted };
   }
 
-  private logReplicationStreamInfoOnce(replicationStream: storage.PersistedReplicationStream, message: string) {
-    if (this.lastReplicationStreamInfoLogs.get(replicationStream.replicationStreamName) == message) {
+  private logReplicationStreamInfoOnce(
+    replicationStream: storage.PersistedReplicationStream,
+    category: string,
+    log: () => void
+  ) {
+    if (this.lastReplicationStreamInfoLogs.get(replicationStream.replicationStreamName) == category) {
       return;
     }
 
-    replicationStream.logger.info(message);
-    this.lastReplicationStreamInfoLogs.set(replicationStream.replicationStreamName, message);
+    log();
+    this.lastReplicationStreamInfoLogs.set(replicationStream.replicationStreamName, category);
   }
 
-  private clearReplicationStreamInfoLog(replicationStream: storage.PersistedReplicationStream, message: string) {
-    if (this.lastReplicationStreamInfoLogs.get(replicationStream.replicationStreamName) == message) {
+  private clearReplicationStreamInfoLog(replicationStream: storage.PersistedReplicationStream, category: string) {
+    if (this.lastReplicationStreamInfoLogs.get(replicationStream.replicationStreamName) == category) {
       this.lastReplicationStreamInfoLogs.delete(replicationStream.replicationStreamName);
     }
   }

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -146,7 +146,7 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
       try {
         // Configure new sync config, if they have changed.
         // In that case, also immediately take out a lock, so that another process doesn't start replication on it.
-        // This upfront lock is mostly superseded by the replicationStreamMatchesLoadedSyncRules() check. However, that doesn't cover old
+        // This upfront lock is mostly superseded by the replicationStreamLoadedSyncConfigMatch() check. However, that doesn't cover old
         // versions before that check was added, so we keep the lock for now - for where te service version and sync config is updated at
         // the same time.
 
@@ -218,7 +218,7 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
       const jobId = replicationStream.replicationJobId;
       const existingJob = existingJobs.get(jobId);
       const syncConfigMismatchMessage = 'Ignoring replication stream for sync config not loaded by this process';
-      if (!this.replicationStreamMatchesLoadedSyncRules(replicationStream, options?.loadedSyncConfig)) {
+      if (!this.shouldHandleReplicationStream(replicationStream, options?.loadedSyncConfig)) {
         this.logReplicationStreamInfoOnce(replicationStream, syncConfigMismatchMessage);
         continue;
       }
@@ -327,14 +327,13 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
 
   /**
    * When we load sync config from the filesystem/config source, we ignore any config loaded by other processes.
-   *
    * The idea is that if a different process loads updated config, that process should process it, not this one.
    *
    * This specifically helps for cases with rolling deploys.
    *
    * This does not apply when sync config is loaded from the database/API, instead of in the config.
    */
-  private replicationStreamMatchesLoadedSyncRules(
+  private shouldHandleReplicationStream(
     replicationStream: storage.PersistedReplicationStream,
     loadedSyncRules: string | undefined
   ) {
@@ -342,30 +341,10 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
       return true;
     }
 
-    const syncConfig = this.replicationStreamSyncConfigForLoadedRulesGate(replicationStream);
-    return syncConfig == null || syncConfig.sync_rules_content == loadedSyncRules;
-  }
-
-  /**
-   * Return the "latest" sync config in a replication stream: Prioritize the "PROCESSING" one, then ACTIVE/ERRORED.
-   */
-  private replicationStreamSyncConfigForLoadedRulesGate(
-    replicationStream: storage.PersistedReplicationStream
-  ): storage.PersistedSyncConfigContent | null {
-    const processing = replicationStream.syncConfigContent.find(
+    const processingConfig = replicationStream.syncConfigContent.find(
       (syncConfig) => syncConfig.syncConfigState == storage.SyncRuleState.PROCESSING
     );
-    if (processing != null) {
-      return processing;
-    }
-
-    return (
-      replicationStream.syncConfigContent.find(
-        (syncConfig) =>
-          syncConfig.syncConfigState == storage.SyncRuleState.ACTIVE ||
-          syncConfig.syncConfigState == storage.SyncRuleState.ERRORED
-      ) ?? null
-    );
+    return processingConfig == null || processingConfig.sync_rules_content == loadedSyncRules;
   }
 
   protected createJobId(syncRuleId: number) {

--- a/packages/service-core/src/routes/endpoints/admin.ts
+++ b/packages/service-core/src/routes/endpoints/admin.ts
@@ -241,7 +241,8 @@ export const validate = routeDefinition({
       replicationStreamName: '',
       storageVersion: storage.LEGACY_STORAGE_VERSION,
       sync_rules_content: content,
-      compiled_plan: null
+      compiled_plan: null,
+      syncConfigState: storage.SyncRuleState.PROCESSING
     });
 
     const connectionStatus = await apiHandler.getConnectionStatus();

--- a/packages/service-core/src/storage/PersistedSyncConfigContent.ts
+++ b/packages/service-core/src/storage/PersistedSyncConfigContent.ts
@@ -17,6 +17,7 @@ import {
 } from '@powersync/service-sync-rules';
 import * as sqlite from 'node:sqlite';
 import { Logger } from 'winston';
+import { SyncRuleState } from './BucketStorage.js';
 import { SerializedSyncPlan, UpdateSyncRulesOptions } from './BucketStorageFactory.js';
 import { ParsedSyncConfigSet } from './ParsedSyncConfigSet.js';
 import { PersistedSyncConfigStatus } from './PersistedSyncConfigStatus.js';
@@ -91,6 +92,7 @@ export abstract class PersistedSyncConfigContent implements PersistedSyncConfigC
   readonly storageVersion: number;
   readonly logger: Logger;
   readonly syncConfigId: PersistedSyncConfigId | null;
+  readonly syncConfigState: SyncRuleState;
 
   constructor(data: PersistedSyncConfigContentData) {
     this.replicationStreamId = data.replicationStreamId;
@@ -99,6 +101,7 @@ export abstract class PersistedSyncConfigContent implements PersistedSyncConfigC
     this.replicationStreamName = data.replicationStreamName;
     this.storageVersion = data.storageVersion;
     this.syncConfigId = data.syncConfigId ?? null;
+    this.syncConfigState = data.syncConfigState;
     this.logger = defaultLogger.child({ prefix: `[${this.replicationStreamName}] ` });
   }
 
@@ -181,6 +184,7 @@ export interface PersistedSyncConfigContentData {
   readonly storageVersion: number;
 
   readonly syncConfigId?: PersistedSyncConfigId | null;
+  readonly syncConfigState: SyncRuleState;
 }
 export type PersistedSyncConfigId = string;
 export interface ParseSyncConfigOptions {

--- a/packages/service-core/test/src/diagnostics.test.ts
+++ b/packages/service-core/test/src/diagnostics.test.ts
@@ -18,6 +18,17 @@ function makeSyncRulesContent(overrides?: {
   status?: storage.PersistedSyncConfigStatus;
 }): storage.PersistedSyncConfigContent {
   // We don't implement the entire interface correctly here - just enough to test the diagnostics logic.
+  const status = overrides?.status ?? {
+    id: '1',
+    replicationStreamId: 1,
+    state: storage.SyncRuleState.ACTIVE,
+    last_checkpoint_lsn: 'some_lsn',
+    last_fatal_error: null,
+    last_fatal_error_ts: null,
+    last_keepalive_ts: new Date(),
+    last_checkpoint_ts: new Date()
+  };
+
   return {
     replicationStreamId: 1,
     syncConfigId: null,
@@ -25,6 +36,7 @@ function makeSyncRulesContent(overrides?: {
     sync_rules_content: MINIMAL_SYNC_RULES,
     compiled_plan: null,
     storageVersion: 1,
+    syncConfigState: status.state,
     parsed(options?: any) {
       const syncRules = SqlSyncRules.fromYaml(MINIMAL_SYNC_RULES, {
         ...options,
@@ -38,18 +50,7 @@ function makeSyncRulesContent(overrides?: {
     asUpdateOptions: null as any,
     getStorageConfig: null as any,
     async getSyncConfigStatus() {
-      return (
-        overrides?.status ?? {
-          id: '1',
-          replicationStreamId: 1,
-          state: storage.SyncRuleState.ACTIVE,
-          last_checkpoint_lsn: 'some_lsn',
-          last_fatal_error: null,
-          last_fatal_error_ts: null,
-          last_keepalive_ts: new Date(),
-          last_checkpoint_ts: new Date()
-        }
-      );
+      return status;
     }
   } as storage.PersistedSyncConfigContent;
 }

--- a/packages/service-core/test/src/routes/admin.test.ts
+++ b/packages/service-core/test/src/routes/admin.test.ts
@@ -41,6 +41,16 @@ describe('admin routes', () => {
     const state = active ? storage.SyncRuleState.ACTIVE : storage.SyncRuleState.PROCESSING;
     const lastKeepaliveTs = new Date('2026-01-01T00:00:00.000Z');
     const lastCheckpointTs = new Date('2026-01-01T00:00:00.000Z');
+    const syncConfigStatus = {
+      id: syncConfigId,
+      replicationStreamId: id,
+      state,
+      last_checkpoint_lsn: null,
+      last_fatal_error: null,
+      last_fatal_error_ts: null,
+      last_keepalive_ts: lastKeepaliveTs,
+      last_checkpoint_ts: lastCheckpointTs
+    };
     const content = {
       replicationStreamId: id,
       syncConfigId,
@@ -55,6 +65,7 @@ bucket_definitions:
 `,
       compiled_plan: null,
       storageVersion: storage.LEGACY_STORAGE_VERSION,
+      syncConfigState: syncConfigStatus.state,
       parsed(options?: any) {
         const syncRules = SqlSyncRules.fromYaml(content.sync_rules_content, {
           ...options,
@@ -67,16 +78,7 @@ bucket_definitions:
       asUpdateOptions: vi.fn(),
       getStorageConfig: vi.fn(),
       async getSyncConfigStatus() {
-        return {
-          id: syncConfigId,
-          replicationStreamId: id,
-          state,
-          last_checkpoint_lsn: null,
-          last_fatal_error: null,
-          last_fatal_error_ts: null,
-          last_keepalive_ts: lastKeepaliveTs,
-          last_checkpoint_ts: lastCheckpointTs
-        };
+        return syncConfigStatus;
       }
     };
     return content as unknown as storage.PersistedSyncConfigContent;


### PR DESCRIPTION
The primary issue here was with lock handling when using incremental reprocessing: Usually, when we update sync config, we take a lock immediately, so that the job updating the config is guaranteed to get the lock. The main use case that immediate lock solves is rolling deploys: Start a new replication process with new sync config, before terminating the existing replication process. However, when the sync config is added to an existing replication stream, that lock may already be held by another replication process, which then fails the lock acquisition, which fails the entire update.

The immediate fix is simple enough: Just don't attempt to lock in that case. But that's not ideal for rolling updates: An older process can start the replication job, potentially running an older service version.

This changes how the replication process picks jobs: If a process updated the sync config from loaded config (filesystem or env vars), we ignore any replication streams that has a different "processing" sync config. We do still handle different "active" sync configs (i.e. older sync config).

This also tweaks the polling interval for replication streams: For the first 2 minutes, or until the first replication job is started, we use a shorter 500ms polling interval. This helps to reduce the handover time on rolling deploys, without increasing steady-state load. This does not yet address the slow polling interval for fail-over purposes - those are more complex to handle without increasing load.

Then we also re-order replication jobs: We now stop existing jobs before starting new ones. This specifically helps to restart a replication stream when the active config changes, without waiting for another refresh cycle.

## AI usage

Implemented by Codex gpt-5.5; manually reviewed and simplified.