### PR TITLE
Warn for `*` column after alias

### DIFF
--- a/.changeset/short-spiders-remain.md
+++ b/.changeset/short-spiders-remain.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Warn when using a `*` column in Sync Streams might overwrite an earlier alias.

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -471,7 +471,7 @@ export class StreamQueryParser {
             selectsFrom(resolved, column.expr);
             if (seenExplicitAlias) {
               this.errors.report(
-                `A '*' column after aliased columns may give unexpected results: If the synced row contains a column named '${seenExplicitAlias}', '*' would overwrite it.`,
+                `A '*' column after aliased columns may give unexpected results: If the source row contains a column named '${seenExplicitAlias}', '*' would overwrite it.`,
                 column.expr,
                 { isWarning: true }
               );

--- a/packages/sync-rules/src/compiler/parser.ts
+++ b/packages/sync-rules/src/compiler/parser.ts
@@ -462,12 +462,20 @@ export class StreamQueryParser {
       }
     };
 
+    let seenExplicitAlias: string | undefined;
     for (const column of columns) {
       if (column.expr.type == 'ref' && column.expr.name == '*') {
         const resolved = this.resolveTableName(column.expr, column.expr.table?.name);
         if (resolved != null) {
           if (resolved instanceof BaseSourceResultSet) {
             selectsFrom(resolved, column.expr);
+            if (seenExplicitAlias) {
+              this.errors.report(
+                `A '*' column after aliased columns may give unexpected results: If the synced row contains a column named '${seenExplicitAlias}', '*' would overwrite it.`,
+                column.expr,
+                { isWarning: true }
+              );
+            }
             this.resultColumns.push(StarColumnSource.instance);
           } else {
             // Selecting from a subquery, add all columns.
@@ -477,6 +485,9 @@ export class StreamQueryParser {
           }
         }
       } else {
+        if (column.alias?.name) {
+          seenExplicitAlias = column.alias?.name;
+        }
         const expr = this.parseExpression(column.expr);
         const outputName = this.inferColumnName(column);
         addColumn(expr, outputName);

--- a/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
@@ -2906,6 +2906,7 @@ exports[`new sync stream features > json-each of cte 1`] = `
   "dataSources": [
     {
       "columns": [
+        "star",
         {
           "alias": "id",
           "expr": {
@@ -2949,7 +2950,6 @@ exports[`new sync stream features > json-each of cte 1`] = `
             "type": "function",
           },
         },
-        "star",
       ],
       "filters": [],
       "hash": 288003166,

--- a/packages/sync-rules/test/src/compiler/advanced.test.ts
+++ b/packages/sync-rules/test/src/compiler/advanced.test.ts
@@ -271,10 +271,10 @@ streams:
           AND 'Scene' IN connection.parameter('synced_objects')
     queries:
       - |
-        SELECT "Scene"._id as id,
+        SELECT "Scene".*,
+        "Scene"._id as id,
         unixepoch("Scene"."createdOn") as "createdOnSortable",
-        IFNULL("Scene".archived, 0) as "archived",
-        "Scene".*
+        IFNULL("Scene".archived, 0) as "archived"
         FROM "Scene", available_projects
         WHERE "Scene".project IN available_projects.project
 `);

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -283,6 +283,22 @@ streams:
     ]);
   });
 
+  test('warns when * appears after aliased columns', () => {
+    expect(compilationErrorsForSingleStream('select user_id as id, * from users')).toStrictEqual([
+      {
+        message: `A '*' column after aliased columns may give unexpected results: If the synced row contains a column named 'id', '*' would overwrite it.`,
+        source: '*',
+        isWarning: true
+      }
+    ]);
+
+    // The explicit column references here are superfluous, but harmless.
+    expect(compilationErrorsForSingleStream('select id, name, * from users')).toStrictEqual([]);
+
+    // No warning when * comes first.
+    expect(compilationErrorsForSingleStream('select *, user_id as id from users')).toStrictEqual([]);
+  });
+
   test('request parameter wrong count', () => {
     expect(
       compilationErrorsForSingleStream("select * from users where id = auth.parameter('foo', 'bar')")

--- a/packages/sync-rules/test/src/compiler/errors.test.ts
+++ b/packages/sync-rules/test/src/compiler/errors.test.ts
@@ -286,7 +286,7 @@ streams:
   test('warns when * appears after aliased columns', () => {
     expect(compilationErrorsForSingleStream('select user_id as id, * from users')).toStrictEqual([
       {
-        message: `A '*' column after aliased columns may give unexpected results: If the synced row contains a column named 'id', '*' would overwrite it.`,
+        message: `A '*' column after aliased columns may give unexpected results: If the source row contains a column named 'id', '*' would overwrite it.`,
         source: '*',
         isWarning: true
       }

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -209,14 +209,18 @@ streams:
   });
 
   syncTest('aliased column and star precedence', ({ sync }) => {
-    const aliasFirst = sync.prepareSyncStreams(`
+    const aliasFirst = sync.prepareSyncStreams(
+      `
 config:
   edition: 3
   
 streams:
   stream:
     query: SELECT user_id as id, * FROM users
-`);
+`,
+      undefined,
+      { allowWarnings: true }
+    );
     const aliasLast = sync.prepareSyncStreams(`
 config:
   edition: 3

--- a/packages/sync-rules/test/src/sync_plan/evaluator/utils.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/utils.ts
@@ -10,22 +10,32 @@ import {
   SyncConfig
 } from '../../../../src/index.js';
 
+interface PrepareStreamsOptions {
+  allowWarnings: boolean;
+}
+
 interface SyncTest {
-  prepareWithoutHydration(yaml: string): SyncConfig;
-  prepareSyncStreams(yaml: string, params?: HydrateSyncConfigParams): HydratedSyncConfig;
+  prepareWithoutHydration(yaml: string, options?: PrepareStreamsOptions): SyncConfig;
+  prepareSyncStreams(
+    yaml: string,
+    params?: HydrateSyncConfigParams,
+    options?: PrepareStreamsOptions
+  ): HydratedSyncConfig;
 }
 
 export const syncTest = test.extend<{ sync: SyncTest }>({
   sync: async ({}, use) => {
     await use({
-      prepareWithoutHydration: (inputs) => {
+      prepareWithoutHydration: (inputs, options) => {
         const { config, errors } = SqlSyncRules.fromYaml(inputs, { defaultSchema: 'test_schema', throwOnError: false });
-        expect(errors).toStrictEqual([]);
+        if (!options?.allowWarnings) {
+          expect(errors).toStrictEqual([]);
+        }
 
         return config;
       },
-      prepareSyncStreams(inputs, params?: HydrateSyncConfigParams) {
-        return this.prepareWithoutHydration(inputs).hydrate(
+      prepareSyncStreams(inputs, params?: HydrateSyncConfigParams, options?: PrepareStreamsOptions) {
+        return this.prepareWithoutHydration(inputs, options).hydrate(
           params ?? { hydrationState: DEFAULT_HYDRATION_STATE, sqlite: nodeSqlite(sqlite) }
         );
       }


### PR DESCRIPTION
As mentioned in https://github.com/powersync-ja/powersync-service/pull/685, queries like `SELECT public_id AS id, *` can be problematic as the `*` can overwrite `AS id`.

This adds a warning for that case. It's possible to be smarter about this by consulting the actual schema of resolved tables, but that can then cause issues for deployed Sync Streams if a conflicting column is added later. So this simple check should be good enough, and we probably don't want to encourage putting `*` last in any case given the risk.

I used Claude Code with minor manual revisions to generate this.