### PR TITLE
Batch concurrent write checkpoint requests

### DIFF
--- a/.changeset/sour-carrots-beam.md
+++ b/.changeset/sour-carrots-beam.md
@@ -1,0 +1,10 @@
+---
+'@powersync/service-module-postgres-storage': minor
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-core-tests': minor
+'@powersync/service-module-postgres': minor
+'@powersync/service-module-mongodb': minor
+'@powersync/service-core': minor
+---
+
+Batch concurrent write checkpoint requests.

--- a/.changeset/sour-carrots-beam.md
+++ b/.changeset/sour-carrots-beam.md
@@ -1,10 +1,10 @@
 ---
-'@powersync/service-module-postgres-storage': minor
-'@powersync/service-module-mongodb-storage': minor
-'@powersync/service-core-tests': minor
-'@powersync/service-module-postgres': minor
-'@powersync/service-module-mongodb': minor
-'@powersync/service-core': minor
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core-tests': patch
+'@powersync/service-module-postgres': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-core': patch
 ---
 
-Batch concurrent write checkpoint requests.
+Batch concurrent write checkpoint requests and increase request limits to improve throughput.

--- a/modules/module-core/src/CoreModule.ts
+++ b/modules/module-core/src/CoreModule.ts
@@ -34,11 +34,8 @@ export class CoreModule extends core.modules.AbstractModule {
 
   protected registerAPIRoutes(context: core.ServiceContextContainer) {
     context.routerEngine.registerRoutes({
-      api_routes: [
-        ...core.routes.endpoints.ADMIN_ROUTES,
-        ...core.routes.endpoints.CHECKPOINT_ROUTES,
-        ...core.routes.endpoints.SYNC_RULES_ROUTES
-      ],
+      api_routes: [...core.routes.endpoints.ADMIN_ROUTES, ...core.routes.endpoints.SYNC_RULES_ROUTES],
+      checkpointing_routes: [...core.routes.endpoints.CHECKPOINT_ROUTES],
       stream_routes: [...core.routes.endpoints.SYNC_STREAM_ROUTES],
       socket_routes: [core.routes.endpoints.syncStreamReactive]
     });
@@ -66,6 +63,7 @@ export class CoreModule extends core.modules.AbstractModule {
             service_context: context,
             routes: {
               api: { routes: routes.api_routes },
+              checkpointing: { routes: routes.checkpointing_routes },
               sync_stream: {
                 routes: routes.stream_routes,
                 queue_options: {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -130,8 +130,8 @@ export abstract class MongoSyncBucketStorage
     this.writeCheckpointAPI.setWriteCheckpointMode(mode);
   }
 
-  createManagedWriteCheckpoint(checkpoint: storage.ManagedWriteCheckpointOptions): Promise<bigint> {
-    return this.writeCheckpointAPI.createManagedWriteCheckpoint(checkpoint);
+  createManagedWriteCheckpoints(checkpoints: storage.ManagedWriteCheckpointOptions[]): Promise<Map<string, bigint>> {
+    return this.writeCheckpointAPI.createManagedWriteCheckpoints(checkpoints);
   }
 
   lastWriteCheckpoint(filters: storage.SyncStorageLastWriteCheckpointFilters): Promise<bigint | null> {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoWriteCheckpointAPI.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoWriteCheckpointAPI.ts
@@ -26,30 +26,77 @@ export class MongoWriteCheckpointAPI implements storage.WriteCheckpointAPI {
     this._mode = mode;
   }
 
-  async createManagedWriteCheckpoint(checkpoint: storage.ManagedWriteCheckpointOptions): Promise<bigint> {
+  async createManagedWriteCheckpoints(
+    checkpoints: storage.ManagedWriteCheckpointOptions[]
+  ): Promise<Map<string, bigint>> {
     if (this.writeCheckpointMode !== storage.WriteCheckpointMode.MANAGED) {
       throw new framework.ServiceAssertionError(
         `Attempting to create a managed Write Checkpoint when the current Write Checkpoint mode is set to "${this.writeCheckpointMode}"`
       );
     }
 
-    const { user_id, heads: lsns } = checkpoint;
-    const doc = await this.db.write_checkpoints.findOneAndUpdate(
-      {
-        user_id: user_id
-      },
-      {
-        $set: {
-          lsns,
-          processed_at_lsn: null
+    const uniqueCheckpoints = [...new Map(checkpoints.map((checkpoint) => [checkpoint.user_id, checkpoint])).values()];
+    if (uniqueCheckpoints.length == 0) {
+      return new Map();
+    }
+
+    if (uniqueCheckpoints.length == 1) {
+      // For the common case of a single checkpoint, we can do this in a single request.
+      const { user_id, heads: lsns } = uniqueCheckpoints[0];
+      const doc = await this.db.write_checkpoints.findOneAndUpdate(
+        {
+          user_id
         },
-        $inc: {
-          client_id: 1n
+        {
+          $set: {
+            lsns,
+            processed_at_lsn: null
+          },
+          $inc: {
+            client_id: 1n
+          }
+        },
+        { upsert: true, returnDocument: 'after' }
+      );
+
+      return new Map([[doc!.user_id, doc!.client_id]]);
+    }
+
+    // For more than one checkpoint, this gives a constant 2 requests
+    await this.db.write_checkpoints.bulkWrite(
+      uniqueCheckpoints.map(({ user_id, heads: lsns }) => ({
+        updateOne: {
+          filter: { user_id },
+          update: {
+            $set: {
+              lsns,
+              processed_at_lsn: null
+            },
+            $inc: {
+              client_id: 1n
+            }
+          },
+          upsert: true
         }
-      },
-      { upsert: true, returnDocument: 'after' }
+      }))
     );
-    return doc!.client_id;
+
+    const userIds = uniqueCheckpoints.map((checkpoint) => checkpoint.user_id);
+    const docs = await this.db.write_checkpoints
+      .find(
+        {
+          user_id: { $in: userIds }
+        },
+        {
+          projection: {
+            user_id: 1,
+            client_id: 1
+          }
+        }
+      )
+      .toArray();
+
+    return new Map(docs.map((doc) => [doc.user_id, doc.client_id]));
   }
 
   async lastWriteCheckpoint(filters: storage.LastWriteCheckpointFilters): Promise<bigint | null> {

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -626,7 +626,7 @@ bucket_definitions:
       ...TEST_CONNECTION_OPTIONS
     });
     const writeCheckpointBatcher = new WriteCheckpointBatcher(
-      () => api,
+      () => (callback) => api.createReplicationHead(callback),
       () => context.factory
     );
 

--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -3,7 +3,7 @@ import { setTimeout } from 'node:timers/promises';
 import { describe, expect, test, vi } from 'vitest';
 
 import { mongo } from '@powersync/lib-service-mongodb';
-import { createWriteCheckpoint, storage } from '@powersync/service-core';
+import { createWriteCheckpoint, storage, WriteCheckpointBatcher } from '@powersync/service-core';
 import { test_utils } from '@powersync/service-core-tests';
 
 import { MongoRouteAPIAdapter } from '@module/api/MongoRouteAPIAdapter.js';
@@ -625,6 +625,10 @@ bucket_definitions:
       type: 'mongodb',
       ...TEST_CONNECTION_OPTIONS
     });
+    const writeCheckpointBatcher = new WriteCheckpointBatcher(
+      () => api,
+      () => context.factory
+    );
 
     context.startStreaming();
 
@@ -641,8 +645,7 @@ bucket_definitions:
         createWriteCheckpoint({
           userId: 'test_user',
           clientId: 'test_client' + i,
-          api,
-          storage: context.factory
+          batcher: writeCheckpointBatcher
         })
       )
     );

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -167,8 +167,8 @@ export class PostgresSyncRulesStorage
     return this.writeCheckpointAPI.setWriteCheckpointMode(mode);
   }
 
-  createManagedWriteCheckpoint(checkpoint: storage.ManagedWriteCheckpointOptions): Promise<bigint> {
-    return this.writeCheckpointAPI.createManagedWriteCheckpoint(checkpoint);
+  createManagedWriteCheckpoints(checkpoints: storage.ManagedWriteCheckpointOptions[]): Promise<Map<string, bigint>> {
+    return this.writeCheckpointAPI.createManagedWriteCheckpoints(checkpoints);
   }
 
   async getCheckpoint(): Promise<storage.ReplicationCheckpoint> {

--- a/modules/module-postgres-storage/src/storage/checkpoints/PostgresWriteCheckpointAPI.ts
+++ b/modules/module-postgres-storage/src/storage/checkpoints/PostgresWriteCheckpointAPI.ts
@@ -32,22 +32,67 @@ export class PostgresWriteCheckpointAPI implements storage.WriteCheckpointAPI {
     return batchCreateCustomWriteCheckpoints(this.db, checkpoints);
   }
 
-  async createManagedWriteCheckpoint(checkpoint: storage.ManagedWriteCheckpointOptions): Promise<bigint> {
+  async createManagedWriteCheckpoints(
+    checkpoints: storage.ManagedWriteCheckpointOptions[]
+  ): Promise<Map<string, bigint>> {
     if (this.writeCheckpointMode !== storage.WriteCheckpointMode.MANAGED) {
       throw new framework.errors.ValidationError(
         `Attempting to create a managed Write Checkpoint when the current Write Checkpoint mode is set to "${this.writeCheckpointMode}"`
       );
     }
 
-    const row = await this.db.sql`
+    const uniqueCheckpoints = [...new Map(checkpoints.map((checkpoint) => [checkpoint.user_id, checkpoint])).values()];
+    if (uniqueCheckpoints.length == 0) {
+      return new Map();
+    }
+
+    if (uniqueCheckpoints.length == 1) {
+      const checkpoint = uniqueCheckpoints[0];
+      const row = await this.db.sql`
+        INSERT INTO
+          write_checkpoints (user_id, lsns, write_checkpoint)
+        VALUES
+          (
+            ${{ type: 'varchar', value: checkpoint.user_id }},
+            ${{ type: 'jsonb', value: checkpoint.heads }},
+            ${{ type: 'int8', value: 1 }}
+          )
+        ON CONFLICT (user_id) DO UPDATE
+        SET
+          write_checkpoint = write_checkpoints.write_checkpoint + 1,
+          lsns = EXCLUDED.lsns
+        RETURNING
+          *;
+      `
+        .decoded(models.WriteCheckpoint)
+        .first();
+
+      return new Map([[row!.user_id, row!.write_checkpoint]]);
+    }
+
+    const mappedCheckpoints = uniqueCheckpoints.map((checkpoint) => ({
+      user_id: checkpoint.user_id,
+      lsns: checkpoint.heads
+    }));
+
+    const rows = await this.db.sql`
+      WITH
+        json_data AS (
+          SELECT
+          CHECKPOINT ->> 'user_id' AS user_id,
+          CHECKPOINT -> 'lsns' AS lsns
+          FROM
+            jsonb_array_elements(${{ type: 'jsonb', value: mappedCheckpoints }}) AS
+          CHECKPOINT
+        )
       INSERT INTO
         write_checkpoints (user_id, lsns, write_checkpoint)
-      VALUES
-        (
-          ${{ type: 'varchar', value: checkpoint.user_id }},
-          ${{ type: 'jsonb', value: checkpoint.heads }},
-          ${{ type: 'int8', value: 1 }}
-        )
+      SELECT
+        user_id,
+        lsns,
+        1
+      FROM
+        json_data
       ON CONFLICT (user_id) DO UPDATE
       SET
         write_checkpoint = write_checkpoints.write_checkpoint + 1,
@@ -56,8 +101,9 @@ export class PostgresWriteCheckpointAPI implements storage.WriteCheckpointAPI {
         *;
     `
       .decoded(models.WriteCheckpoint)
-      .first();
-    return row!.write_checkpoint;
+      .rows();
+
+    return new Map(rows.map((row) => [row.user_id, row.write_checkpoint]));
   }
 
   async lastWriteCheckpoint(filters: storage.LastWriteCheckpointFilters): Promise<bigint | null> {

--- a/modules/module-postgres-storage/src/storage/checkpoints/PostgresWriteCheckpointAPI.ts
+++ b/modules/module-postgres-storage/src/storage/checkpoints/PostgresWriteCheckpointAPI.ts
@@ -46,30 +46,6 @@ export class PostgresWriteCheckpointAPI implements storage.WriteCheckpointAPI {
       return new Map();
     }
 
-    if (uniqueCheckpoints.length == 1) {
-      const checkpoint = uniqueCheckpoints[0];
-      const row = await this.db.sql`
-        INSERT INTO
-          write_checkpoints (user_id, lsns, write_checkpoint)
-        VALUES
-          (
-            ${{ type: 'varchar', value: checkpoint.user_id }},
-            ${{ type: 'jsonb', value: checkpoint.heads }},
-            ${{ type: 'int8', value: 1 }}
-          )
-        ON CONFLICT (user_id) DO UPDATE
-        SET
-          write_checkpoint = write_checkpoints.write_checkpoint + 1,
-          lsns = EXCLUDED.lsns
-        RETURNING
-          *;
-      `
-        .decoded(models.WriteCheckpoint)
-        .first();
-
-      return new Map([[row!.user_id, row!.write_checkpoint]]);
-    }
-
     const mappedCheckpoints = uniqueCheckpoints.map((checkpoint) => ({
       user_id: checkpoint.user_id,
       lsns: checkpoint.heads

--- a/modules/module-postgres/test/src/checkpoints.test.ts
+++ b/modules/module-postgres/test/src/checkpoints.test.ts
@@ -1,5 +1,5 @@
 import { PostgresRouteAPIAdapter } from '@module/api/PostgresRouteAPIAdapter.js';
-import { checkpointUserId, createWriteCheckpoint } from '@powersync/service-core';
+import { checkpointUserId, createWriteCheckpoint, WriteCheckpointBatcher } from '@powersync/service-core';
 import { describe, test } from 'vitest';
 import { describeWithStorage, StorageVersionTestContext } from './util.js';
 import { WalStreamTestContext } from './wal_stream_utils.js';
@@ -22,6 +22,10 @@ const checkpointTests = ({ factory, storageVersion }: StorageVersionTestContext)
     await context.updateSyncRules(BASIC_SYNC_RULES);
     const { pool } = context;
     const api = new PostgresRouteAPIAdapter(pool);
+    const writeCheckpointBatcher = new WriteCheckpointBatcher(
+      () => api,
+      () => context.factory
+    );
     const serverVersion = await context.connectionManager.getServerVersion();
     if (serverVersion!.compareMain('14.0.0') < 0) {
       // The test is not stable on Postgres 11 or 12. See the notes on
@@ -65,8 +69,7 @@ const checkpointTests = ({ factory, storageVersion }: StorageVersionTestContext)
         const cp = await createWriteCheckpoint({
           userId: 'test_user',
           clientId: 'test_client',
-          api,
-          storage: context.factory
+          batcher: writeCheckpointBatcher
         });
 
         const start = Date.now();

--- a/modules/module-postgres/test/src/checkpoints.test.ts
+++ b/modules/module-postgres/test/src/checkpoints.test.ts
@@ -23,7 +23,7 @@ const checkpointTests = ({ factory, storageVersion }: StorageVersionTestContext)
     const { pool } = context;
     const api = new PostgresRouteAPIAdapter(pool);
     const writeCheckpointBatcher = new WriteCheckpointBatcher(
-      () => api,
+      () => (callback) => api.createReplicationHead(callback),
       () => context.factory
     );
     const serverVersion = await context.connectionManager.getServerVersion();

--- a/packages/service-core-tests/src/tests/register-data-storage-checkpoint-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-checkpoint-tests.ts
@@ -42,7 +42,7 @@ bucket_definitions:
     await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
     await writer.markAllSnapshotDone('1/1');
 
-    const writeCheckpoint = await bucketStorage.createManagedWriteCheckpoint({
+    const writeCheckpoint = await createManagedWriteCheckpoint(bucketStorage, {
       heads: { '1': '5/0' },
       user_id: 'user1'
     });
@@ -102,7 +102,7 @@ bucket_definitions:
       }
     });
 
-    const writeCheckpoint = await bucketStorage.createManagedWriteCheckpoint({
+    const writeCheckpoint = await createManagedWriteCheckpoint(bucketStorage, {
       heads: { '1': '6/0' },
       user_id: 'user1'
     });
@@ -301,4 +301,14 @@ bucket_definitions:
       }
     });
   });
+}
+
+async function createManagedWriteCheckpoint(
+  bucketStorage: storage.SyncRulesBucketStorage,
+  checkpoint: storage.ManagedWriteCheckpointOptions
+) {
+  const checkpoints = await bucketStorage.createManagedWriteCheckpoints([checkpoint]);
+  const writeCheckpoint = checkpoints.get(checkpoint.user_id);
+  expect(writeCheckpoint).not.toBeUndefined();
+  return writeCheckpoint!;
 }

--- a/packages/service-core-tests/src/tests/register-sync-tests.ts
+++ b/packages/service-core-tests/src/tests/register-sync-tests.ts
@@ -687,7 +687,7 @@ bucket_definitions:
           receivedCompletions++;
           if (receivedCompletions == 1) {
             // Trigger an empty bucket update.
-            await bucketStorage.createManagedWriteCheckpoint({ user_id: '', heads: { '1': '1/0' } });
+            await bucketStorage.createManagedWriteCheckpoints([{ user_id: '', heads: { '1': '1/0' } }]);
             await writer.commit('1/0');
           } else {
             break;
@@ -1252,10 +1252,14 @@ bucket_definitions:
     // <= the managed write checkpoint LSN below
     await writer.commit('0/1');
 
-    const checkpoint = await bucketStorage.createManagedWriteCheckpoint({
-      user_id: 'test',
-      heads: { '1': '1/0' }
-    });
+    const checkpoint = (
+      await bucketStorage.createManagedWriteCheckpoints([
+        {
+          user_id: 'test',
+          heads: { '1': '1/0' }
+        }
+      ])
+    ).get('test')!;
 
     const params: sync.SyncStreamParameters = {
       syncContext,

--- a/packages/service-core/src/routes/RouterEngine.ts
+++ b/packages/service-core/src/routes/RouterEngine.ts
@@ -11,6 +11,7 @@ export type RouterSetupResponse = {
 
 export type RouterEngineRoutes = {
   api_routes: RouteDefinition[];
+  checkpointing_routes: RouteDefinition[];
   stream_routes: RouteDefinition[];
   socket_routes: SocketRouteGenerator[];
 };
@@ -42,6 +43,7 @@ export class RouterEngine {
 
     this.routes = {
       api_routes: [],
+      checkpointing_routes: [],
       stream_routes: [],
       socket_routes: []
     };
@@ -49,13 +51,17 @@ export class RouterEngine {
 
   public registerRoutes(routes: Partial<RouterEngineRoutes>) {
     this.routes.api_routes.push(...(routes.api_routes ?? []));
+    this.routes.checkpointing_routes.push(...(routes.checkpointing_routes ?? []));
     this.routes.stream_routes.push(...(routes.stream_routes ?? []));
     this.routes.socket_routes.push(...(routes.socket_routes ?? []));
   }
 
   public get hasRoutes() {
     return (
-      this.routes.api_routes.length > 0 || this.routes.stream_routes.length > 0 || this.routes.socket_routes.length > 0
+      this.routes.api_routes.length > 0 ||
+      this.routes.checkpointing_routes.length > 0 ||
+      this.routes.stream_routes.length > 0 ||
+      this.routes.socket_routes.length > 0
     );
   }
 

--- a/packages/service-core/src/routes/configure-fastify.ts
+++ b/packages/service-core/src/routes/configure-fastify.ts
@@ -51,6 +51,7 @@ export const DEFAULT_ROUTE_OPTIONS = {
   checkpointing: {
     routes: [...CHECKPOINT_ROUTES],
     queue_options: {
+      // Note that the values here has an effect on WriteCheckpointBatcher
       concurrency: 100,
       max_queue_depth: 100
     }

--- a/packages/service-core/src/routes/configure-fastify.ts
+++ b/packages/service-core/src/routes/configure-fastify.ts
@@ -31,6 +31,7 @@ export type RouteRegistrationOptions = {
  */
 export type RouteDefinitions = {
   api?: Partial<RouteRegistrationOptions>;
+  checkpointing?: Partial<RouteRegistrationOptions>;
   sync_stream?: Partial<RouteRegistrationOptions>;
 };
 
@@ -41,10 +42,17 @@ export type FastifyServerConfig = {
 
 export const DEFAULT_ROUTE_OPTIONS = {
   api: {
-    routes: [...ADMIN_ROUTES, ...CHECKPOINT_ROUTES, ...SYNC_RULES_ROUTES, ...PROBES_ROUTES],
+    routes: [...ADMIN_ROUTES, ...SYNC_RULES_ROUTES, ...PROBES_ROUTES],
     queue_options: {
       concurrency: 10,
       max_queue_depth: 20
+    }
+  },
+  checkpointing: {
+    routes: [...CHECKPOINT_ROUTES],
+    queue_options: {
+      concurrency: 50,
+      max_queue_depth: 100
     }
   },
   sync_stream: {
@@ -87,6 +95,21 @@ export function configureFastifyServer(server: fastify.FastifyInstance, options:
     childContext.addHook(
       'onRequest',
       createRequestQueueHook(routes.api?.queue_options ?? DEFAULT_ROUTE_OPTIONS.api.queue_options)
+    );
+  });
+
+  server.register(async function (childContext) {
+    registerFastifyRoutes(
+      childContext,
+      generateContext,
+      routes.checkpointing?.routes ?? DEFAULT_ROUTE_OPTIONS.checkpointing.routes
+    );
+    registerFastifyNotFoundHandler(childContext);
+
+    // Limit the active concurrent requests
+    childContext.addHook(
+      'onRequest',
+      createRequestQueueHook(routes.checkpointing?.queue_options ?? DEFAULT_ROUTE_OPTIONS.checkpointing.queue_options)
     );
   });
 

--- a/packages/service-core/src/routes/configure-fastify.ts
+++ b/packages/service-core/src/routes/configure-fastify.ts
@@ -80,6 +80,7 @@ export function configureFastifyServer(server: fastify.FastifyInstance, options:
 
   // Set on the outer server so both child scopes inherit.
   registerFastifyErrorHandler(server);
+  registerFastifyNotFoundHandler(server);
 
   /**
    * Fastify creates an encapsulated context for each `.register` call.
@@ -89,7 +90,6 @@ export function configureFastifyServer(server: fastify.FastifyInstance, options:
    */
   server.register(async function (childContext) {
     registerFastifyRoutes(childContext, generateContext, routes.api?.routes ?? DEFAULT_ROUTE_OPTIONS.api.routes);
-    registerFastifyNotFoundHandler(childContext);
 
     // Limit the active concurrent requests
     childContext.addHook(
@@ -104,7 +104,6 @@ export function configureFastifyServer(server: fastify.FastifyInstance, options:
       generateContext,
       routes.checkpointing?.routes ?? DEFAULT_ROUTE_OPTIONS.checkpointing.routes
     );
-    registerFastifyNotFoundHandler(childContext);
 
     // Limit the active concurrent requests
     childContext.addHook(

--- a/packages/service-core/src/routes/configure-fastify.ts
+++ b/packages/service-core/src/routes/configure-fastify.ts
@@ -51,7 +51,7 @@ export const DEFAULT_ROUTE_OPTIONS = {
   checkpointing: {
     routes: [...CHECKPOINT_ROUTES],
     queue_options: {
-      concurrency: 50,
+      concurrency: 100,
       max_queue_depth: 100
     }
   },

--- a/packages/service-core/src/routes/endpoints/checkpointing.ts
+++ b/packages/service-core/src/routes/endpoints/checkpointing.ts
@@ -57,7 +57,7 @@ export const writeCheckpoint2 = routeDefinition({
     const { replicationHead, writeCheckpoint } = await util.createWriteCheckpoint({
       userId: token_payload!.userIdString,
       clientId: payload.params.client_id,
-      batcher: service_context.writeCheckpointBatcher
+      batcher: service_context.storageEngine.writeCheckpointBatcher
     });
 
     logger.info(

--- a/packages/service-core/src/routes/endpoints/checkpointing.ts
+++ b/packages/service-core/src/routes/endpoints/checkpointing.ts
@@ -54,13 +54,10 @@ export const writeCheckpoint2 = routeDefinition({
   handler: async (payload) => {
     const { token_payload, service_context } = payload.context;
 
-    const apiHandler = service_context.routerEngine.getAPI();
-
     const { replicationHead, writeCheckpoint } = await util.createWriteCheckpoint({
       userId: token_payload!.userIdString,
       clientId: payload.params.client_id,
-      api: apiHandler,
-      storage: service_context.storageEngine.activeBucketStorage
+      batcher: service_context.writeCheckpointBatcher
     });
 
     logger.info(

--- a/packages/service-core/src/storage/StorageEngine.ts
+++ b/packages/service-core/src/storage/StorageEngine.ts
@@ -1,10 +1,12 @@
 import { BaseObserver, logger, ServiceError } from '@powersync/lib-services-framework';
 import { ResolvedPowerSyncConfig } from '../util/util-index.js';
+import { CreateReplicationHead, WriteCheckpointBatcher } from '../util/write-checkpoint-batcher.js';
 import { BucketStorageFactory } from './BucketStorageFactory.js';
 import { ActiveStorage, StorageProvider } from './StorageProvider.js';
 
 export type StorageEngineOptions = {
   configuration: ResolvedPowerSyncConfig;
+  getCreateReplicationHead: () => CreateReplicationHead;
 };
 
 export interface StorageEngineListener {
@@ -16,9 +18,14 @@ export class StorageEngine extends BaseObserver<StorageEngineListener> {
   // TODO: This will need to revisited when we actually support multiple storage providers.
   private storageProviders: Map<string, StorageProvider> = new Map();
   private currentActiveStorage: ActiveStorage | null = null;
+  readonly writeCheckpointBatcher: WriteCheckpointBatcher;
 
   constructor(private options: StorageEngineOptions) {
     super();
+    this.writeCheckpointBatcher = new WriteCheckpointBatcher(
+      options.getCreateReplicationHead,
+      () => this.activeBucketStorage
+    );
   }
 
   get activeBucketStorage(): BucketStorageFactory {

--- a/packages/service-core/src/storage/WriteCheckpointAPI.ts
+++ b/packages/service-core/src/storage/WriteCheckpointAPI.ts
@@ -58,7 +58,7 @@ export type LastWriteCheckpointFilters = CustomWriteCheckpointFilters | ManagedW
 export interface BaseWriteCheckpointAPI {
   readonly writeCheckpointMode: WriteCheckpointMode;
   setWriteCheckpointMode(mode: WriteCheckpointMode): void;
-  createManagedWriteCheckpoint(checkpoint: ManagedWriteCheckpointOptions): Promise<bigint>;
+  createManagedWriteCheckpoints(checkpoints: ManagedWriteCheckpointOptions[]): Promise<Map<string, bigint>>;
 }
 
 /**

--- a/packages/service-core/src/system/ServiceContext.ts
+++ b/packages/service-core/src/system/ServiceContext.ts
@@ -19,7 +19,6 @@ export interface ServiceContext {
   storageEngine: storage.StorageEngine;
   migrations: PowerSyncMigrationManager;
   syncContext: SyncContext;
-  writeCheckpointBatcher: utils.WriteCheckpointBatcher;
   serviceMode: ServiceContextMode;
   eventsEngine: EventsEngine;
 }
@@ -51,7 +50,6 @@ export class ServiceContextContainer implements ServiceContext {
   eventsEngine: EventsEngine;
   syncContext: SyncContext;
   routerEngine: routes.RouterEngine;
-  writeCheckpointBatcher: utils.WriteCheckpointBatcher;
   serviceMode: ServiceContextMode;
 
   constructor(options: ServiceContextOptions) {
@@ -61,8 +59,16 @@ export class ServiceContextContainer implements ServiceContext {
 
     this.lifeCycleEngine = new LifeCycledSystem();
 
+    this.routerEngine = new routes.RouterEngine();
+    this.lifeCycleEngine.withLifecycle(this.routerEngine, {
+      stop: (routerEngine) => routerEngine.shutDown()
+    });
+
     this.storageEngine = new storage.StorageEngine({
-      configuration
+      configuration,
+      getCreateReplicationHead: () => {
+        return (callback) => this.routerEngine.getAPI().createReplicationHead(callback);
+      }
     });
     this.storageEngine.registerListener({
       storageFatalError: (error) => {
@@ -80,16 +86,6 @@ export class ServiceContextContainer implements ServiceContext {
       start: (storageEngine) => storageEngine.start(),
       stop: (storageEngine) => storageEngine.shutDown()
     });
-
-    this.routerEngine = new routes.RouterEngine();
-    this.lifeCycleEngine.withLifecycle(this.routerEngine, {
-      stop: (routerEngine) => routerEngine.shutDown()
-    });
-
-    this.writeCheckpointBatcher = new utils.WriteCheckpointBatcher(
-      () => this.routerEngine.getAPI(),
-      () => this.storageEngine.activeBucketStorage
-    );
 
     this.syncContext = new SyncContext({
       maxDataFetchConcurrency: configuration.api_parameters.max_data_fetch_concurrency,

--- a/packages/service-core/src/system/ServiceContext.ts
+++ b/packages/service-core/src/system/ServiceContext.ts
@@ -19,6 +19,7 @@ export interface ServiceContext {
   storageEngine: storage.StorageEngine;
   migrations: PowerSyncMigrationManager;
   syncContext: SyncContext;
+  writeCheckpointBatcher: utils.WriteCheckpointBatcher;
   serviceMode: ServiceContextMode;
   eventsEngine: EventsEngine;
 }
@@ -50,6 +51,7 @@ export class ServiceContextContainer implements ServiceContext {
   eventsEngine: EventsEngine;
   syncContext: SyncContext;
   routerEngine: routes.RouterEngine;
+  writeCheckpointBatcher: utils.WriteCheckpointBatcher;
   serviceMode: ServiceContextMode;
 
   constructor(options: ServiceContextOptions) {
@@ -83,6 +85,11 @@ export class ServiceContextContainer implements ServiceContext {
     this.lifeCycleEngine.withLifecycle(this.routerEngine, {
       stop: (routerEngine) => routerEngine.shutDown()
     });
+
+    this.writeCheckpointBatcher = new utils.WriteCheckpointBatcher(
+      () => this.routerEngine.getAPI(),
+      () => this.storageEngine.activeBucketStorage
+    );
 
     this.syncContext = new SyncContext({
       maxDataFetchConcurrency: configuration.api_parameters.max_data_fetch_concurrency,

--- a/packages/service-core/src/util/checkpointing.ts
+++ b/packages/service-core/src/util/checkpointing.ts
@@ -1,33 +1,14 @@
-import { ErrorCode, ServiceError } from '@powersync/lib-services-framework';
-import { RouteAPI } from '../api/RouteAPI.js';
-import { BucketStorageFactory } from '../storage/storage-index.js';
+import { WriteCheckpointBatcher } from './write-checkpoint-batcher.js';
 
 export interface CreateWriteCheckpointOptions {
   userId: string | undefined;
   clientId: string | undefined;
-  api: RouteAPI;
-  storage: BucketStorageFactory;
+  batcher: WriteCheckpointBatcher;
 }
 export async function createWriteCheckpoint(options: CreateWriteCheckpointOptions) {
   const full_user_id = checkpointUserId(options.userId, options.clientId);
 
-  const syncBucketStorage = (await options.storage.getActiveSyncConfig())?.storage;
-  if (!syncBucketStorage) {
-    throw new ServiceError(ErrorCode.PSYNC_S2302, `Cannot create Write Checkpoint since no sync config is active.`);
-  }
-
-  const { writeCheckpoint, currentCheckpoint } = await options.api.createReplicationHead(async (currentCheckpoint) => {
-    const writeCheckpoint = await syncBucketStorage.createManagedWriteCheckpoint({
-      user_id: full_user_id,
-      heads: { '1': currentCheckpoint }
-    });
-    return { writeCheckpoint, currentCheckpoint };
-  });
-
-  return {
-    writeCheckpoint: String(writeCheckpoint),
-    replicationHead: currentCheckpoint
-  };
+  return options.batcher.enqueue(full_user_id);
 }
 
 export function checkpointUserId(user_id: string | undefined, client_id: string | undefined) {

--- a/packages/service-core/src/util/util-index.ts
+++ b/packages/service-core/src/util/util-index.ts
@@ -8,6 +8,7 @@ export * from './protocol-types.js';
 export * from './secs.js';
 export * from './utils.js';
 export * from './version.js';
+export * from './write-checkpoint-batcher.js';
 
 export * from './config.js';
 export * from './config/compound-config-collector.js';

--- a/packages/service-core/src/util/write-checkpoint-batcher.ts
+++ b/packages/service-core/src/util/write-checkpoint-batcher.ts
@@ -2,12 +2,12 @@ import { ErrorCode, ServiceAssertionError, ServiceError } from '@powersync/lib-s
 import { RouteAPI } from '../api/RouteAPI.js';
 import { BucketStorageFactory, SyncRulesBucketStorage } from '../storage/storage-index.js';
 
-// Keep up to two source-head/storage batches executing concurrently under load.
+// Keep up to three source-head/storage batches executing concurrently under load.
 // There is intentionally no explicit batch-size cap here: the HTTP request queue
 // already bounds how many requests can be waiting in this process.
 // Smaller values here have better efficiency, while larger numbers here may give slight improvements in latency.
 // We want to limit the number of database connections in use for write checkpoints, so we keep the numbers low here.
-export const MAX_IN_FLIGHT_WRITE_CHECKPOINT_BATCHES = 3;
+const MAX_IN_FLIGHT_WRITE_CHECKPOINT_BATCHES = 3;
 
 export interface CreateWriteCheckpointResult {
   writeCheckpoint: string;

--- a/packages/service-core/src/util/write-checkpoint-batcher.ts
+++ b/packages/service-core/src/util/write-checkpoint-batcher.ts
@@ -1,0 +1,106 @@
+import { ErrorCode, ServiceAssertionError, ServiceError } from '@powersync/lib-services-framework';
+import { RouteAPI } from '../api/RouteAPI.js';
+import { BucketStorageFactory, SyncRulesBucketStorage } from '../storage/storage-index.js';
+
+// Keep up to two source-head/storage batches executing concurrently under load.
+// There is intentionally no explicit batch-size cap here: the HTTP request queue
+// already bounds how many requests can be waiting in this process.
+// Smaller values here have better efficiency, while larger numbers here may give slight improvements in latency.
+// We want to limit the number of database connections in use for write checkpoints, so we keep the numbers low here.
+export const MAX_IN_FLIGHT_WRITE_CHECKPOINT_BATCHES = 2;
+
+export interface CreateWriteCheckpointResult {
+  writeCheckpoint: string;
+  replicationHead: string;
+}
+
+interface QueuedWriteCheckpoint {
+  userId: string;
+  resolvers: PromiseWithResolvers<CreateWriteCheckpointResult>;
+}
+
+export class WriteCheckpointBatcher {
+  private pending: QueuedWriteCheckpoint[] = [];
+  private inFlight = 0;
+
+  constructor(
+    private readonly getAPI: () => RouteAPI,
+    private readonly getStorage: () => BucketStorageFactory
+  ) {}
+
+  enqueue(userId: string): Promise<CreateWriteCheckpointResult> {
+    const resolvers = Promise.withResolvers<CreateWriteCheckpointResult>();
+    this.pending.push({ userId, resolvers });
+    this.pump();
+    return resolvers.promise;
+  }
+
+  private pump() {
+    while (this.inFlight < MAX_IN_FLIGHT_WRITE_CHECKPOINT_BATCHES && this.pending.length > 0) {
+      // Dispatch immediately while capacity is available. Requests only batch
+      // together once all executing slots are saturated and the queue starts
+      // accumulating behind them.
+      const batch = this.pending;
+      this.pending = [];
+      this.inFlight++;
+
+      void this.executeBatch(batch).finally(() => {
+        this.inFlight--;
+        this.pump();
+      });
+    }
+  }
+
+  private async executeBatch(batch: QueuedWriteCheckpoint[]) {
+    try {
+      const syncBucketStorage = (await this.getStorage().getActiveSyncConfig())?.storage;
+      if (!syncBucketStorage) {
+        throw new ServiceError(ErrorCode.PSYNC_S2302, `Cannot create Write Checkpoint since no sync config is active.`);
+      }
+
+      const { writeCheckpoints, currentCheckpoint } = await this.getAPI().createReplicationHead(
+        async (currentCheckpoint) => {
+          const writeCheckpoints = await this.createBatchWriteCheckpoints(syncBucketStorage, batch, currentCheckpoint);
+          return { writeCheckpoints, currentCheckpoint };
+        }
+      );
+
+      const results = batch.map((request) => {
+        const writeCheckpoint = writeCheckpoints.get(request.userId);
+        if (writeCheckpoint == null) {
+          throw new ServiceAssertionError(
+            `Write checkpoint storage did not return a checkpoint for user ${request.userId}`
+          );
+        }
+
+        return { request, writeCheckpoint };
+      });
+
+      for (const { request, writeCheckpoint } of results) {
+        request.resolvers.resolve({
+          writeCheckpoint: String(writeCheckpoint),
+          replicationHead: currentCheckpoint
+        });
+      }
+    } catch (error) {
+      // Do not retry here. The route should pass failures through so clients can
+      // apply their normal write-checkpoint retry policy.
+      for (const request of batch) {
+        request.resolvers.reject(error);
+      }
+    }
+  }
+
+  private async createBatchWriteCheckpoints(
+    syncBucketStorage: SyncRulesBucketStorage,
+    batch: QueuedWriteCheckpoint[],
+    currentCheckpoint: string
+  ) {
+    return syncBucketStorage.createManagedWriteCheckpoints(
+      batch.map((request) => ({
+        user_id: request.userId,
+        heads: { '1': currentCheckpoint }
+      }))
+    );
+  }
+}

--- a/packages/service-core/src/util/write-checkpoint-batcher.ts
+++ b/packages/service-core/src/util/write-checkpoint-batcher.ts
@@ -7,7 +7,7 @@ import { BucketStorageFactory, SyncRulesBucketStorage } from '../storage/storage
 // already bounds how many requests can be waiting in this process.
 // Smaller values here have better efficiency, while larger numbers here may give slight improvements in latency.
 // We want to limit the number of database connections in use for write checkpoints, so we keep the numbers low here.
-export const MAX_IN_FLIGHT_WRITE_CHECKPOINT_BATCHES = 2;
+export const MAX_IN_FLIGHT_WRITE_CHECKPOINT_BATCHES = 3;
 
 export interface CreateWriteCheckpointResult {
   writeCheckpoint: string;

--- a/packages/service-core/src/util/write-checkpoint-batcher.ts
+++ b/packages/service-core/src/util/write-checkpoint-batcher.ts
@@ -22,6 +22,7 @@ interface QueuedWriteCheckpoint {
 export class WriteCheckpointBatcher {
   private pending: QueuedWriteCheckpoint[] = [];
   private inFlight = 0;
+  private scheduledPump: NodeJS.Timeout | undefined;
 
   constructor(
     private readonly getAPI: () => RouteAPI,
@@ -31,22 +32,37 @@ export class WriteCheckpointBatcher {
   enqueue(userId: string): Promise<CreateWriteCheckpointResult> {
     const resolvers = Promise.withResolvers<CreateWriteCheckpointResult>();
     this.pending.push({ userId, resolvers });
-    this.pump();
+    this.schedulePump();
     return resolvers.promise;
+  }
+
+  private schedulePump() {
+    if (this.scheduledPump != null) {
+      return;
+    }
+
+    // Delay dispatch by one timer turn so requests arriving together can share
+    // one source head and one storage write batch.
+    // While normally we wouldn't have http requests arriving at the exact same time, this is relevant when
+    // requests are queued by fastify: All current requests are typically batched together, and finish at the
+    // same time. Then we get many requests from the queue arriving at the same time. Without this delayed dispatch,
+    // the first request would form its own batch, and the rest will then wait for a new batch to become available.
+    // The delayed dispatch allow all those requests to be batched together.
+    this.scheduledPump = setTimeout(() => {
+      this.scheduledPump = undefined;
+      this.pump();
+    }, 0);
   }
 
   private pump() {
     while (this.inFlight < MAX_IN_FLIGHT_WRITE_CHECKPOINT_BATCHES && this.pending.length > 0) {
-      // Dispatch immediately while capacity is available. Requests only batch
-      // together once all executing slots are saturated and the queue starts
-      // accumulating behind them.
       const batch = this.pending;
       this.pending = [];
       this.inFlight++;
 
       void this.executeBatch(batch).finally(() => {
         this.inFlight--;
-        this.pump();
+        this.schedulePump();
       });
     }
   }

--- a/packages/service-core/src/util/write-checkpoint-batcher.ts
+++ b/packages/service-core/src/util/write-checkpoint-batcher.ts
@@ -1,5 +1,5 @@
 import { ErrorCode, ServiceAssertionError, ServiceError } from '@powersync/lib-services-framework';
-import { RouteAPI } from '../api/RouteAPI.js';
+import { ReplicationHeadCallback } from '../api/RouteAPI.js';
 import { BucketStorageFactory, SyncRulesBucketStorage } from '../storage/storage-index.js';
 
 // Keep up to three source-head/storage batches executing concurrently under load.
@@ -14,6 +14,8 @@ export interface CreateWriteCheckpointResult {
   replicationHead: string;
 }
 
+export type CreateReplicationHead = <T>(callback: ReplicationHeadCallback<T>) => Promise<T>;
+
 interface QueuedWriteCheckpoint {
   userId: string;
   resolvers: PromiseWithResolvers<CreateWriteCheckpointResult>;
@@ -25,7 +27,7 @@ export class WriteCheckpointBatcher {
   private scheduledPump: NodeJS.Timeout | undefined;
 
   constructor(
-    private readonly getAPI: () => RouteAPI,
+    private readonly getCreateReplicationHead: () => CreateReplicationHead,
     private readonly getStorage: () => BucketStorageFactory
   ) {}
 
@@ -74,7 +76,7 @@ export class WriteCheckpointBatcher {
         throw new ServiceError(ErrorCode.PSYNC_S2302, `Cannot create Write Checkpoint since no sync config is active.`);
       }
 
-      const { writeCheckpoints, currentCheckpoint } = await this.getAPI().createReplicationHead(
+      const { writeCheckpoints, currentCheckpoint } = await this.getCreateReplicationHead()(
         async (currentCheckpoint) => {
           const writeCheckpoints = await this.createBatchWriteCheckpoints(syncBucketStorage, batch, currentCheckpoint);
           return { writeCheckpoints, currentCheckpoint };

--- a/packages/service-core/test/src/util/checkpointing.test.ts
+++ b/packages/service-core/test/src/util/checkpointing.test.ts
@@ -33,7 +33,7 @@ function createBatcher(api: any, storage: any) {
 
 describe('write checkpoint batching', () => {
   test('dispatches immediately up to capacity and batches queued requests once saturated', async () => {
-    const gates = [deferred(), deferred(), deferred()];
+    const gates = [deferred(), deferred(), deferred(), deferred()];
     const { bucketStorage, storage } = createStorage();
     const api = {
       createReplicationHead: vi.fn(async (callback: (head: string) => Promise<unknown>) => {
@@ -67,37 +67,40 @@ describe('write checkpoint batching', () => {
 
     await waitForAsyncWork();
 
-    expect(api.createReplicationHead).toHaveBeenCalledTimes(2);
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(3);
     expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(1, [
       { user_id: 'user-a/client-1', heads: { '1': 'head-1' } }
     ]);
     expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(2, [
       { user_id: 'user-b', heads: { '1': 'head-2' } }
     ]);
+    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(3, [
+      { user_id: 'user-c/client-3', heads: { '1': 'head-3' } }
+    ]);
 
     gates[0].resolve();
     await first;
     await waitForAsyncWork();
 
-    expect(api.createReplicationHead).toHaveBeenCalledTimes(3);
-    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(3, [
-      { user_id: 'user-c/client-3', heads: { '1': 'head-3' } },
-      { user_id: 'user-d', heads: { '1': 'head-3' } },
-      { user_id: 'user-e', heads: { '1': 'head-3' } }
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(4);
+    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(4, [
+      { user_id: 'user-d', heads: { '1': 'head-4' } },
+      { user_id: 'user-e', heads: { '1': 'head-4' } }
     ]);
 
     gates[1].resolve();
     gates[2].resolve();
+    gates[3].resolve();
     await expect(Promise.all([second, ...queued])).resolves.toEqual([
       { writeCheckpoint: '2', replicationHead: 'head-2' },
       { writeCheckpoint: '3', replicationHead: 'head-3' },
-      { writeCheckpoint: '4', replicationHead: 'head-3' },
-      { writeCheckpoint: '5', replicationHead: 'head-3' }
+      { writeCheckpoint: '4', replicationHead: 'head-4' },
+      { writeCheckpoint: '5', replicationHead: 'head-4' }
     ]);
   });
 
-  test('allows two executing batches and queues later requests until one completes', async () => {
-    const gates = [deferred(), deferred(), deferred()];
+  test('allows three executing batches and queues later requests until one completes', async () => {
+    const gates = [deferred(), deferred(), deferred(), deferred()];
     const { storage } = createStorage();
     const api = {
       createReplicationHead: vi.fn(async (callback: (head: string) => Promise<unknown>) => {
@@ -130,20 +133,31 @@ describe('write checkpoint batching', () => {
     });
     await waitForAsyncWork();
 
-    expect(api.createReplicationHead).toHaveBeenCalledTimes(2);
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(3);
+
+    const fourth = createWriteCheckpoint({
+      userId: 'user-d',
+      clientId: undefined,
+      batcher
+    });
+    await waitForAsyncWork();
+
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(3);
 
     gates[0].resolve();
     await first;
     await waitForAsyncWork();
 
-    expect(api.createReplicationHead).toHaveBeenCalledTimes(3);
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(4);
 
     gates[1].resolve();
     gates[2].resolve();
+    gates[3].resolve();
 
-    await expect(Promise.all([second, third])).resolves.toEqual([
+    await expect(Promise.all([second, third, fourth])).resolves.toEqual([
       { writeCheckpoint: '2', replicationHead: 'head-2' },
-      { writeCheckpoint: '3', replicationHead: 'head-3' }
+      { writeCheckpoint: '3', replicationHead: 'head-3' },
+      { writeCheckpoint: '4', replicationHead: 'head-4' }
     ]);
   });
 

--- a/packages/service-core/test/src/util/checkpointing.test.ts
+++ b/packages/service-core/test/src/util/checkpointing.test.ts
@@ -1,0 +1,163 @@
+import { createWriteCheckpoint, WriteCheckpointBatcher } from '@/index.js';
+import { describe, expect, test, vi } from 'vitest';
+
+function deferred<T = void>() {
+  return Promise.withResolvers<T>();
+}
+
+async function waitForAsyncWork() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+function createStorage() {
+  let nextCheckpoint = 1n;
+  const bucketStorage = {
+    createManagedWriteCheckpoints: vi.fn(async (checkpoints: { user_id: string }[]) => {
+      return new Map(checkpoints.map((checkpoint) => [checkpoint.user_id, nextCheckpoint++]));
+    })
+  };
+
+  const storage = {
+    getActiveSyncConfig: vi.fn(async () => ({ storage: bucketStorage }))
+  };
+
+  return { bucketStorage, storage };
+}
+
+function createBatcher(api: any, storage: any) {
+  return new WriteCheckpointBatcher(
+    () => api,
+    () => storage
+  );
+}
+
+describe('write checkpoint batching', () => {
+  test('dispatches immediately up to capacity and batches queued requests once saturated', async () => {
+    const gates = [deferred(), deferred(), deferred()];
+    const { bucketStorage, storage } = createStorage();
+    const api = {
+      createReplicationHead: vi.fn(async (callback: (head: string) => Promise<unknown>) => {
+        const batch = api.createReplicationHead.mock.calls.length;
+        const result = await callback(`head-${batch}`);
+        await gates[batch - 1].promise;
+        return result;
+      })
+    };
+    const batcher = createBatcher(api, storage);
+
+    const first = createWriteCheckpoint({
+      userId: 'user-a',
+      clientId: 'client-1',
+      batcher
+    });
+    const second = createWriteCheckpoint({
+      userId: 'user-b',
+      clientId: undefined,
+      batcher
+    });
+    await waitForAsyncWork();
+
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(2);
+
+    const queued = [
+      createWriteCheckpoint({ userId: 'user-c', clientId: 'client-3', batcher }),
+      createWriteCheckpoint({ userId: 'user-d', clientId: undefined, batcher }),
+      createWriteCheckpoint({ userId: 'user-e', clientId: undefined, batcher })
+    ];
+
+    await waitForAsyncWork();
+
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(2);
+    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(1, [
+      { user_id: 'user-a/client-1', heads: { '1': 'head-1' } }
+    ]);
+    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(2, [
+      { user_id: 'user-b', heads: { '1': 'head-2' } }
+    ]);
+
+    gates[0].resolve();
+    await first;
+    await waitForAsyncWork();
+
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(3);
+    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(3, [
+      { user_id: 'user-c/client-3', heads: { '1': 'head-3' } },
+      { user_id: 'user-d', heads: { '1': 'head-3' } },
+      { user_id: 'user-e', heads: { '1': 'head-3' } }
+    ]);
+
+    gates[1].resolve();
+    gates[2].resolve();
+    await expect(Promise.all([second, ...queued])).resolves.toEqual([
+      { writeCheckpoint: '2', replicationHead: 'head-2' },
+      { writeCheckpoint: '3', replicationHead: 'head-3' },
+      { writeCheckpoint: '4', replicationHead: 'head-3' },
+      { writeCheckpoint: '5', replicationHead: 'head-3' }
+    ]);
+  });
+
+  test('allows two executing batches and queues later requests until one completes', async () => {
+    const gates = [deferred(), deferred(), deferred()];
+    const { storage } = createStorage();
+    const api = {
+      createReplicationHead: vi.fn(async (callback: (head: string) => Promise<unknown>) => {
+        const batch = api.createReplicationHead.mock.calls.length;
+        const result = await callback(`head-${batch}`);
+        await gates[batch - 1].promise;
+        return result;
+      })
+    };
+    const batcher = createBatcher(api, storage);
+
+    const first = createWriteCheckpoint({
+      userId: 'user-a',
+      clientId: undefined,
+      batcher
+    });
+    await waitForAsyncWork();
+
+    const second = createWriteCheckpoint({
+      userId: 'user-b',
+      clientId: undefined,
+      batcher
+    });
+    await waitForAsyncWork();
+
+    const third = createWriteCheckpoint({
+      userId: 'user-c',
+      clientId: undefined,
+      batcher
+    });
+    await waitForAsyncWork();
+
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(2);
+
+    gates[0].resolve();
+    await first;
+    await waitForAsyncWork();
+
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(3);
+
+    gates[1].resolve();
+    gates[2].resolve();
+
+    await expect(Promise.all([second, third])).resolves.toEqual([
+      { writeCheckpoint: '2', replicationHead: 'head-2' },
+      { writeCheckpoint: '3', replicationHead: 'head-3' }
+    ]);
+  });
+
+  test('passes batch errors through without retrying', async () => {
+    const error = new Error('source unavailable');
+    const { storage } = createStorage();
+    const api = {
+      createReplicationHead: vi.fn(async () => {
+        throw error;
+      })
+    };
+    const batcher = createBatcher(api, storage);
+
+    await expect(createWriteCheckpoint({ userId: 'user-a', clientId: undefined, batcher })).rejects.toBe(error);
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/service-core/test/src/util/checkpointing.test.ts
+++ b/packages/service-core/test/src/util/checkpointing.test.ts
@@ -6,6 +6,7 @@ function deferred<T = void>() {
 }
 
 async function waitForAsyncWork() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setImmediate(resolve));
 }
 
@@ -32,8 +33,8 @@ function createBatcher(api: any, storage: any) {
 }
 
 describe('write checkpoint batching', () => {
-  test('dispatches immediately up to capacity and batches queued requests once saturated', async () => {
-    const gates = [deferred(), deferred(), deferred(), deferred()];
+  test('coalesces same-turn requests and dispatches queued requests as capacity becomes available', async () => {
+    const gates = [deferred(), deferred()];
     const { bucketStorage, storage } = createStorage();
     const api = {
       createReplicationHead: vi.fn(async (callback: (head: string) => Promise<unknown>) => {
@@ -45,21 +46,27 @@ describe('write checkpoint batching', () => {
     };
     const batcher = createBatcher(api, storage);
 
-    const first = createWriteCheckpoint({
-      userId: 'user-a',
-      clientId: 'client-1',
-      batcher
-    });
-    const second = createWriteCheckpoint({
-      userId: 'user-b',
-      clientId: undefined,
-      batcher
-    });
+    const firstBatch = [
+      createWriteCheckpoint({
+        userId: 'user-a',
+        clientId: 'client-1',
+        batcher
+      }),
+      createWriteCheckpoint({
+        userId: 'user-b',
+        clientId: undefined,
+        batcher
+      })
+    ];
     await waitForAsyncWork();
 
-    expect(api.createReplicationHead).toHaveBeenCalledTimes(2);
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(1);
+    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(1, [
+      { user_id: 'user-a/client-1', heads: { '1': 'head-1' } },
+      { user_id: 'user-b', heads: { '1': 'head-1' } }
+    ]);
 
-    const queued = [
+    const secondBatch = [
       createWriteCheckpoint({ userId: 'user-c', clientId: 'client-3', batcher }),
       createWriteCheckpoint({ userId: 'user-d', clientId: undefined, batcher }),
       createWriteCheckpoint({ userId: 'user-e', clientId: undefined, batcher })
@@ -67,35 +74,21 @@ describe('write checkpoint batching', () => {
 
     await waitForAsyncWork();
 
-    expect(api.createReplicationHead).toHaveBeenCalledTimes(3);
-    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(1, [
-      { user_id: 'user-a/client-1', heads: { '1': 'head-1' } }
-    ]);
+    expect(api.createReplicationHead).toHaveBeenCalledTimes(2);
     expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(2, [
-      { user_id: 'user-b', heads: { '1': 'head-2' } }
-    ]);
-    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(3, [
-      { user_id: 'user-c/client-3', heads: { '1': 'head-3' } }
+      { user_id: 'user-c/client-3', heads: { '1': 'head-2' } },
+      { user_id: 'user-d', heads: { '1': 'head-2' } },
+      { user_id: 'user-e', heads: { '1': 'head-2' } }
     ]);
 
     gates[0].resolve();
-    await first;
-    await waitForAsyncWork();
-
-    expect(api.createReplicationHead).toHaveBeenCalledTimes(4);
-    expect(bucketStorage.createManagedWriteCheckpoints).toHaveBeenNthCalledWith(4, [
-      { user_id: 'user-d', heads: { '1': 'head-4' } },
-      { user_id: 'user-e', heads: { '1': 'head-4' } }
-    ]);
-
     gates[1].resolve();
-    gates[2].resolve();
-    gates[3].resolve();
-    await expect(Promise.all([second, ...queued])).resolves.toEqual([
-      { writeCheckpoint: '2', replicationHead: 'head-2' },
-      { writeCheckpoint: '3', replicationHead: 'head-3' },
-      { writeCheckpoint: '4', replicationHead: 'head-4' },
-      { writeCheckpoint: '5', replicationHead: 'head-4' }
+    await expect(Promise.all([...firstBatch, ...secondBatch])).resolves.toEqual([
+      { writeCheckpoint: '1', replicationHead: 'head-1' },
+      { writeCheckpoint: '2', replicationHead: 'head-1' },
+      { writeCheckpoint: '3', replicationHead: 'head-2' },
+      { writeCheckpoint: '4', replicationHead: 'head-2' },
+      { writeCheckpoint: '5', replicationHead: 'head-2' }
     ]);
   });
 

--- a/packages/service-core/test/src/util/checkpointing.test.ts
+++ b/packages/service-core/test/src/util/checkpointing.test.ts
@@ -27,7 +27,7 @@ function createStorage() {
 
 function createBatcher(api: any, storage: any) {
   return new WriteCheckpointBatcher(
-    () => api,
+    () => (callback) => api.createReplicationHead(callback),
     () => storage
   );
 }


### PR DESCRIPTION
We've seen some cases of users calling the `write-checkpoint2.json` API at 500 requests/s or more in peak periods. This easily exceeds the default router handler's concurrency limit of 10 and the queue limit of 20, especially if other db load is slowing down these requests. That results in high rates of 429 errors sent to clients. Clients automatically retry, but we'd rather avoid those completely.

This optimization notes that we can optimize this significantly under load:
1. If we have many concurrent write checkpoint requests, we only need to get a single "replication head" on the source database for all of them. The only condition here is that it needs to start _after_ the last call was received - we cannot add serve new requests from an existing in-flight replication head request.
2. On the storage database, we can similarly optimize this to do a single batched database call, instead of individual calls for each request.

These optimizations apply only if we get concurrent requests. Sequential requests behave the same as before, with no additional delay. Right now we support up to 2 in-flight batches - any new requests will be queued and form part of a new batch.

This now also places checkpoint requests on a separate fastify queue, with up to 50 requests processed concurrently, and an additional 100 requests queued. Since these requests typically have low overhead, and increased concurrency improves the efficiency of batching, this should not add significant overhead. The split is specifically to prevent the increased limits from affecting other APIs such as the relatively expensive diagnostic APIs.

## Benchmarks

Test case: Request 200x concurrent write-checkpoints for individual clients. Test with various fastify concurrency settings and batching settings. Added artificial MongoDB latency affecting both the source db and storage db, resulting in a single API call taking around 1s:

```js
db.adminCommand({
     configureFailPoint: "failCommand",
     mode: "alwaysOn",
     data: {
       failCommands: ["findAndModify"],
       blockConnection: true,
       blockTimeMS: 500
     }
   })
 ```


The first case here ran on the main branch, the rest on this branch. For all of these I increased the queue size to avoid 429 errors, for a fair comparison.

Not taken into account here:
1. Latency of individual requests
2. Source database and replication overhead from creating many individual checkpoint requests when not using batching.

| Fastify concurrency | Concurrent requests | Batching mode  | Duration |
| ------------------: | ------------------: | -------------- | -------: |
|                  10 |                 200 | Main branch    |    22.2s |
|                  10 |                 200 | No batching    |    21.5s |
|                  10 |                 200 | Max 2x batches |    25.4s |
|                  50 |                 200 | No batching    |    11.2s |
|                  50 |                 200 | Max 3x batches |     5.2s |
|                  50 |                 200 | Max 2x batches |     5.4s |
|                  50 |                 200 | Max 1x batch   |     6.2s |
|                 100 |                 200 | No batching    |    13.8s |
|                 **100** |                 200 | **Max 3x batches** |     **2.6s** |
|                 100 |                 200 | Max 2x batches |     2.6s |
|                 200 |                 200 | Max 2x batches |     1.6s |

It is clear from the results that increasing the fastify concurrency increases the throughput. But when not using batching, this is limited by the database connection pool size. Batching removes that bottleneck, reducing both the number of database commands and database connections in use. This would be even more relevant when there is high sync load, which typically co-occurs with high write checkpoint rates.

Note that the 200x requests here is significantly higher more than the 500/s observed in production: The 500/s is the _total_ for the instance, spread out over 20+ processes, so around 25/s per process.

## AI usage

Manually planned the implementation; used Codex gpt-5.5 to implement. Reviewed with Claude Opus 4.8.
