### PR TITLE
fix(sync-rules): length() and instr() should count code points to match SQLite

### DIFF
--- a/.changeset/sync-rules-length-instr-codepoints.md
+++ b/.changeset/sync-rules-length-instr-codepoints.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix `length()` and `instr()` to count characters (Unicode code points) rather than UTF-16 code units, matching SQLite. Previously `length('😀')` returned `2` instead of `1`, and `instr()` reported positions shifted by any non-BMP character before the match. This caused sync-rule expressions over text containing emoji or other non-BMP characters to diverge from the source database (the same class of issue as the earlier `substring()` code-point fix).

--- a/packages/sync-rules/src/sql_functions.ts
+++ b/packages/sync-rules/src/sql_functions.ts
@@ -165,8 +165,10 @@ const length: DocumentedSqlFunction = {
     } else if (value instanceof Uint8Array) {
       return BigInt(value.byteLength);
     } else {
-      value = castAsText(value);
-      return BigInt(value!.length);
+      const text = castAsText(value)!;
+      // SQLite length() counts characters (Unicode code points), not UTF-16 code units. Spreading the string
+      // iterates by code point, so e.g. length('😀') is 1, matching SQLite (rather than 2 for the surrogate pair).
+      return BigInt([...text].length);
     }
   },
   parameters: [{ name: 'value', type: ExpressionType.ANY, optional: false }],
@@ -288,8 +290,13 @@ const instr: DocumentedSqlFunction = {
     // Neither BLOB, or mixed: cast both to text
     const haystack = castAsText(x)!;
     const needle = castAsText(y)!;
-    const pos = haystack.indexOf(needle);
-    return BigInt(pos < 0 ? 0 : pos + 1);
+    const utf16Index = haystack.indexOf(needle);
+    if (utf16Index < 0) {
+      return 0n;
+    }
+    // SQLite returns the 1-indexed character (code point) position, not the UTF-16 code unit index. Count the
+    // code points preceding the match so e.g. instr('😀x', 'x') is 2 rather than 3.
+    return BigInt([...haystack.slice(0, utf16Index)].length + 1);
   },
   parameters: [
     { name: 'x', type: ExpressionType.ANY, optional: false },

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -115,6 +115,12 @@ describe('SQL functions', () => {
     expect(fn.length(123n)).toEqual(3n);
     expect(fn.length(123.4)).toEqual(5n);
     expect(fn.length(Uint8Array.of(1, 2, 3))).toEqual(3n);
+    // SQLite counts characters (code points), not UTF-16 code units. length('😀') is 1, not 2.
+    expect(fn.length('😀')).toEqual(1n);
+    expect(fn.length('a😀b')).toEqual(3n);
+    expect(fn.length('𝕏')).toEqual(1n);
+    // length() of a blob still counts bytes (the 4 UTF-8 bytes of 😀).
+    expect(fn.length(new TextEncoder().encode('😀'))).toEqual(4n);
   });
 
   test('hex', () => {
@@ -372,6 +378,12 @@ describe('SQL functions', () => {
     expect(fn.instr('path/to/file', '/')).toEqual(5n);
     expect(fn.instr('rofl 😂', '😂')).toEqual(6n);
     expect(fn.instr('😂😂', '😂')).toEqual(1n);
+
+    // Position is counted in characters (code points), not UTF-16 code units, to match SQLite. A non-BMP
+    // character *before* the match must not shift the reported position (it would with a UTF-16 index).
+    expect(fn.instr('😀x', 'x')).toEqual(2n);
+    expect(fn.instr('a😀b', 'b')).toEqual(3n);
+    expect(fn.instr('😀😀x', 'x')).toEqual(3n);
 
     // Numeric inputs (converted to string via toString)
     expect(fn.instr(12345, '3')).toEqual(3n);


### PR DESCRIPTION
Follow-up to the `substring()` code-point fix — the same UTF-16-vs-code-point divergence affects two sibling functions.

### Problem
`length()` used JS `String.length` (UTF-16 code units) and `instr()` used `String.indexOf` (a UTF-16 index), so both diverge from SQLite for text containing non-BMP characters (emoji, mathematical alphanumerics, etc.):

| expression | SQLite | sync-rules (before) |
|---|---|---|
| `length('😀')` | `1` | `2` |
| `length('a😀b')` | `3` | `4` |
| `instr('😀x', 'x')` | `2` | `3` |

Because sync-rule expressions are evaluated client-side and must agree with the source database, a filter like `length(name) > 10` or `instr(...)` over text containing emoji could include/exclude rows differently on the client than on the server — silent sync divergence.

### Fix
Both functions now iterate by code point (spreading the string / counting code points in the prefix), matching SQLite and the existing `substring()` behaviour. Blob handling is unchanged (still byte counts, which is correct per SQLite).

### Tests
Added regression cases to `sql_functions.test.ts` for `length` and `instr` covering non-BMP characters, including the case where a non-BMP character precedes the match (the one that actually diverges). Full sync-rules suite passes.

Verified against the system `sqlite3` as ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)