### PR TITLE
fix(sync-rules): CAST(real AS INTEGER) should truncate towards zero like SQLite

### DIFF
--- a/.changeset/sync-rules-cast-integer-truncation.md
+++ b/.changeset/sync-rules-cast-integer-truncation.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Fix `CAST(... AS INTEGER)` to truncate REAL values towards zero, matching SQLite. Previously a negative non-integer real was floored (`CAST(-3.7 AS INTEGER)` returned `-4` instead of `-3`), causing sync-rule expressions that cast negative reals to integer to diverge from the source database.

--- a/packages/sync-rules/src/cast.ts
+++ b/packages/sync-rules/src/cast.ts
@@ -87,7 +87,9 @@ export function cast(value: SqliteValue, to: string) {
     if (typeof value == 'string') {
       return parseBigInt(value);
     } else if (typeof value == 'number') {
-      return Number.isInteger(value) ? BigInt(value) : BigInt(Math.floor(value));
+      // SQLite truncates a REAL towards zero when casting to INTEGER (e.g. CAST(-3.7 AS INTEGER) is -3),
+      // so use Math.trunc rather than Math.floor, which would round -3.7 down to -4.
+      return Number.isInteger(value) ? BigInt(value) : BigInt(Math.trunc(value));
     } else if (typeof value == 'bigint') {
       return value;
     } else {

--- a/packages/sync-rules/test/src/sql_functions.test.ts
+++ b/packages/sync-rules/test/src/sql_functions.test.ts
@@ -217,6 +217,10 @@ describe('SQL functions', () => {
     expect(cast(1.2, 'integer')).toEqual(1n);
     expect(cast(1.2, 'numeric')).toEqual(1.2);
     expect(cast(1.2, 'real')).toEqual(1.2);
+    // SQLite truncates a REAL towards zero when casting to INTEGER, so negative reals round up, not down.
+    expect(cast(-3.7, 'integer')).toEqual(-3n);
+    expect(cast(-0.9, 'integer')).toEqual(0n);
+    expect(cast(-2.1, 'integer')).toEqual(-2n);
     // We differ from SQLite here
     expect(cast(1.2, 'blob')).toEqual(Uint8Array.of(49, 46, 50));
 


### PR DESCRIPTION
### Problem
The number→integer path of `cast()` uses `BigInt(Math.floor(value))`, which rounds towards −∞. SQLite truncates a REAL towards **zero** when casting to INTEGER, so the two diverge on every negative non-integer real:

| expression | SQLite | sync-rules (before) |
|---|---|---|
| `CAST(-3.7 AS INTEGER)` | `-3` | `-4` |
| `CAST(-0.9 AS INTEGER)` | `0` | `-1` |
| `CAST(-2.1 AS INTEGER)` | `-2` | `-3` |

Since sync-rule expressions are evaluated client-side and must agree with the source database, an integer cast over a negative real (directly or via numeric coercion) can include/exclude rows differently on the client than on the server.

### Fix
Use `Math.trunc` instead of `Math.floor`. Positive reals are unaffected (floor == trunc there), and the string/bigint cast paths are unchanged. Added regression tests; verified against the system `sqlite3` as ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)