### PR TITLE
Revert ServiceContext ordering changes

### DIFF
--- a/modules/module-mongodb/test/src/change_stream.test.ts
+++ b/modules/module-mongodb/test/src/change_stream.test.ts
@@ -626,7 +626,7 @@ bucket_definitions:
       ...TEST_CONNECTION_OPTIONS
     });
     const writeCheckpointBatcher = new WriteCheckpointBatcher(
-      () => (callback) => api.createReplicationHead(callback),
+      () => api,
       () => context.factory
     );
 

--- a/modules/module-postgres/test/src/checkpoints.test.ts
+++ b/modules/module-postgres/test/src/checkpoints.test.ts
@@ -23,7 +23,7 @@ const checkpointTests = ({ factory, storageVersion }: StorageVersionTestContext)
     const { pool } = context;
     const api = new PostgresRouteAPIAdapter(pool);
     const writeCheckpointBatcher = new WriteCheckpointBatcher(
-      () => (callback) => api.createReplicationHead(callback),
+      () => api,
       () => context.factory
     );
     const serverVersion = await context.connectionManager.getServerVersion();

--- a/packages/service-core/src/routes/endpoints/checkpointing.ts
+++ b/packages/service-core/src/routes/endpoints/checkpointing.ts
@@ -57,7 +57,7 @@ export const writeCheckpoint2 = routeDefinition({
     const { replicationHead, writeCheckpoint } = await util.createWriteCheckpoint({
       userId: token_payload!.userIdString,
       clientId: payload.params.client_id,
-      batcher: service_context.storageEngine.writeCheckpointBatcher
+      batcher: service_context.writeCheckpointBatcher
     });
 
     logger.info(

--- a/packages/service-core/src/storage/StorageEngine.ts
+++ b/packages/service-core/src/storage/StorageEngine.ts
@@ -1,12 +1,10 @@
 import { BaseObserver, logger, ServiceError } from '@powersync/lib-services-framework';
 import { ResolvedPowerSyncConfig } from '../util/util-index.js';
-import { CreateReplicationHead, WriteCheckpointBatcher } from '../util/write-checkpoint-batcher.js';
 import { BucketStorageFactory } from './BucketStorageFactory.js';
 import { ActiveStorage, StorageProvider } from './StorageProvider.js';
 
 export type StorageEngineOptions = {
   configuration: ResolvedPowerSyncConfig;
-  getCreateReplicationHead: () => CreateReplicationHead;
 };
 
 export interface StorageEngineListener {
@@ -18,14 +16,9 @@ export class StorageEngine extends BaseObserver<StorageEngineListener> {
   // TODO: This will need to revisited when we actually support multiple storage providers.
   private storageProviders: Map<string, StorageProvider> = new Map();
   private currentActiveStorage: ActiveStorage | null = null;
-  readonly writeCheckpointBatcher: WriteCheckpointBatcher;
 
   constructor(private options: StorageEngineOptions) {
     super();
-    this.writeCheckpointBatcher = new WriteCheckpointBatcher(
-      options.getCreateReplicationHead,
-      () => this.activeBucketStorage
-    );
   }
 
   get activeBucketStorage(): BucketStorageFactory {

--- a/packages/service-core/src/system/ServiceContext.ts
+++ b/packages/service-core/src/system/ServiceContext.ts
@@ -19,6 +19,7 @@ export interface ServiceContext {
   storageEngine: storage.StorageEngine;
   migrations: PowerSyncMigrationManager;
   syncContext: SyncContext;
+  writeCheckpointBatcher: utils.WriteCheckpointBatcher;
   serviceMode: ServiceContextMode;
   eventsEngine: EventsEngine;
 }
@@ -50,6 +51,7 @@ export class ServiceContextContainer implements ServiceContext {
   eventsEngine: EventsEngine;
   syncContext: SyncContext;
   routerEngine: routes.RouterEngine;
+  writeCheckpointBatcher: utils.WriteCheckpointBatcher;
   serviceMode: ServiceContextMode;
 
   constructor(options: ServiceContextOptions) {
@@ -59,16 +61,8 @@ export class ServiceContextContainer implements ServiceContext {
 
     this.lifeCycleEngine = new LifeCycledSystem();
 
-    this.routerEngine = new routes.RouterEngine();
-    this.lifeCycleEngine.withLifecycle(this.routerEngine, {
-      stop: (routerEngine) => routerEngine.shutDown()
-    });
-
     this.storageEngine = new storage.StorageEngine({
-      configuration,
-      getCreateReplicationHead: () => {
-        return (callback) => this.routerEngine.getAPI().createReplicationHead(callback);
-      }
+      configuration
     });
     this.storageEngine.registerListener({
       storageFatalError: (error) => {
@@ -86,6 +80,16 @@ export class ServiceContextContainer implements ServiceContext {
       start: (storageEngine) => storageEngine.start(),
       stop: (storageEngine) => storageEngine.shutDown()
     });
+
+    this.routerEngine = new routes.RouterEngine();
+    this.lifeCycleEngine.withLifecycle(this.routerEngine, {
+      stop: (routerEngine) => routerEngine.shutDown()
+    });
+
+    this.writeCheckpointBatcher = new utils.WriteCheckpointBatcher(
+      () => this.routerEngine.getAPI(),
+      () => this.storageEngine.activeBucketStorage
+    );
 
     this.syncContext = new SyncContext({
       maxDataFetchConcurrency: configuration.api_parameters.max_data_fetch_concurrency,

--- a/packages/service-core/src/util/write-checkpoint-batcher.ts
+++ b/packages/service-core/src/util/write-checkpoint-batcher.ts
@@ -1,5 +1,5 @@
 import { ErrorCode, ServiceAssertionError, ServiceError } from '@powersync/lib-services-framework';
-import { ReplicationHeadCallback } from '../api/RouteAPI.js';
+import { RouteAPI } from '../api/RouteAPI.js';
 import { BucketStorageFactory, SyncRulesBucketStorage } from '../storage/storage-index.js';
 
 // Keep up to three source-head/storage batches executing concurrently under load.
@@ -14,8 +14,6 @@ export interface CreateWriteCheckpointResult {
   replicationHead: string;
 }
 
-export type CreateReplicationHead = <T>(callback: ReplicationHeadCallback<T>) => Promise<T>;
-
 interface QueuedWriteCheckpoint {
   userId: string;
   resolvers: PromiseWithResolvers<CreateWriteCheckpointResult>;
@@ -27,7 +25,7 @@ export class WriteCheckpointBatcher {
   private scheduledPump: NodeJS.Timeout | undefined;
 
   constructor(
-    private readonly getCreateReplicationHead: () => CreateReplicationHead,
+    private readonly getAPI: () => RouteAPI,
     private readonly getStorage: () => BucketStorageFactory
   ) {}
 
@@ -76,7 +74,7 @@ export class WriteCheckpointBatcher {
         throw new ServiceError(ErrorCode.PSYNC_S2302, `Cannot create Write Checkpoint since no sync config is active.`);
       }
 
-      const { writeCheckpoints, currentCheckpoint } = await this.getCreateReplicationHead()(
+      const { writeCheckpoints, currentCheckpoint } = await this.getAPI().createReplicationHead(
         async (currentCheckpoint) => {
           const writeCheckpoints = await this.createBatchWriteCheckpoints(syncBucketStorage, batch, currentCheckpoint);
           return { writeCheckpoints, currentCheckpoint };

--- a/packages/service-core/test/src/util/checkpointing.test.ts
+++ b/packages/service-core/test/src/util/checkpointing.test.ts
@@ -27,7 +27,7 @@ function createStorage() {
 
 function createBatcher(api: any, storage: any) {
   return new WriteCheckpointBatcher(
-    () => (callback) => api.createReplicationHead(callback),
+    () => api,
     () => storage
   );
 }


### PR DESCRIPTION
This reverts the final refactoring commit from #691.

The ordering change from the refactor had the effect that the router engine is closed _after_ the storage adapter is closed. That causes client errors like this:

```
info: Terminating gracefully ...
info: Successfully shut down Metrics Engine.
info: Shutting down EmitterEngine and removing all listeners for .
info: Shutting down Storage Engine...
error: Streaming sync request failed Operation interrupted because client was closed {"bson":false,"errorLabelSet":{},"rid":"h/019f138b-2a29-74a8-b3e9-c70aa85c8ff5","route":"/sync/stream","stack":"MongoClientClosedError: Operation interrupted because client was closed\n    [snip]","user_agent":"curl/8.18.0","user_id":"99"}
info: Successfully shut down Storage Engine.
info: Shutting down EmitterEngine and removing all listeners for .
info: Shutting down Router Engine...
info: Closing 0 streams.
info: Running cleanup.
info: Shutting down HTTP server...
info: HTTP server stopped
info: Successfully shut down Router Engine.
info: Exiting
```

After reverting, we get a better order again, and no errors:

```
info: Terminating gracefully ...
info: Successfully shut down Metrics Engine.
info: Shutting down EmitterEngine and removing all listeners for .
info: Shutting down Router Engine...
info: Closing 1 streams.
info: Running cleanup.
info: Shutting down HTTP server...
info: HTTP server stopped
info: Successfully shut down Router Engine.
info: Shutting down Storage Engine...
info: Sync stream complete {"bson":false,"close_reason":"process shutdown","data_sent_bytes":4158960,"data_synced_bytes":4158960,"large_buckets":{"global2|6.1.7[99]":7034},"operation_counts":{"clear":0,"move":0,"put":7049,"remove":0},"operations_synced":7049,"rid":"h/019f138c-1891-73c3-8f92-25131b7232a7","route":"/sync/stream","stream_ms":1312,"user_agent":"curl/8.18.0","user_id":"99"}
info: POST /sync/stream {"bson":false,"duration_ms":1471,"method":"POST","path":"/sync/stream","rid":"h/019f138c-1891-73c3-8f92-25131b7232a7","route":"/sync/stream","status":200,"user_agent":"curl/8.18.0","user_id":"99"}
info: Successfully shut down Storage Engine.
info: Shutting down EmitterEngine and removing all listeners for .
info: Exiting
```

The intent of the refactor was to make the `WriteCheckpointBatcher` part of `StorageEngine`, instead of a separate top-level item on `ServiceContext`. However, since it also depends on `RouterEngine`, it's not that simple, and caused issues like the above, so I don't think it's worth attempting to maintain that.

Note: This wasn't released yet, so no changeset or documentation update required for this change.