### PR TITLE
Log checkpoint_complete / Fix checkpoint invalidation bug

### DIFF
--- a/.changeset/cyan-readers-bathe.md
+++ b/.changeset/cyan-readers-bathe.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core-tests': patch
+'@powersync/service-core': patch
+---
+
+Add logs for checkpoint_complete to assist with debugging. Remove "sync lock" logs.

--- a/.changeset/modern-socks-pull.md
+++ b/.changeset/modern-socks-pull.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core-tests': patch
+'@powersync/service-core': patch
+---
+
+Fix edge case where the service can return incomplete data. This could happen when using bucket priorities, and a checkpoint is invalidated by the compact process while syncing.

--- a/packages/service-core-tests/src/tests/register-sync-tests.ts
+++ b/packages/service-core-tests/src/tests/register-sync-tests.ts
@@ -1238,6 +1238,150 @@ bucket_definitions:
     });
   });
 
+  test('compacting high-priority data invalidates checkpoint before lower priorities', async (context) => {
+    // Scenario:
+    // 1. Bucket priorities are used.
+    // 2. Client syncs a high-priority bucket.
+    // 3. Due to a concurrent compaction, the checkpoint is invalidated (via target_op).
+    // 4. The service picks up that invalidation, and the batch stops, without emitting a "partial_checkpoint_complete". The intention is continuing with the next checkpoint.
+    // 5. However, the loop handling priorities does not see that invalidation, it only sees "bucket data for this priority is done".
+    // 6. The priority loop incorrectly continues with the next priority.
+    // 7. The service emits the data, as well as a final checkpoint_complete.
+    // 8. The client now received a checkpoint_complete without the full data for that checkpoint. It would pick up the missing data in the checksum check, requiring a full re-download of the affected buckets.
+    await using f = await factory();
+
+    const syncRules = await updateSyncRules(f, {
+      content: `
+bucket_definitions:
+  high_priority:
+    priority: 1
+    data:
+      - SELECT * FROM test WHERE substring(id, 1, 4) = 'high';
+  low_priority:
+    priority: 2
+    data:
+      - SELECT * FROM test WHERE id = 'low';
+    `
+    });
+
+    const bucketStorage = await f.getInstance(syncRules);
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const testTable = await test_utils.resolveTestTable(writer, 'test', ['id'], config);
+
+    await writer.markAllSnapshotDone('0/1');
+    await writer.save({
+      sourceTable: testTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'high1',
+        description: 'High priority 1'
+      },
+      afterReplicaId: 'high1'
+    });
+    await writer.save({
+      sourceTable: testTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'high2',
+        description: 'High priority 2'
+      },
+      afterReplicaId: 'high2'
+    });
+    await writer.save({
+      sourceTable: testTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 'low',
+        description: 'Low priority'
+      },
+      afterReplicaId: 'low'
+    });
+    await writer.commit('0/1');
+
+    const stream = sync.streamResponse({
+      syncContext,
+      bucketStorage,
+      syncRules: bucketStorage.getParsedSyncRules(test_utils.PARSE_OPTIONS),
+      params: {
+        buckets: [],
+        include_checksum: true,
+        raw_data: true
+      },
+      tracker,
+      token: new JwtPayload({ sub: '', exp: Date.now() / 1000 + 10 }),
+      isEncodingAsBson: false
+    });
+
+    const iter = stream[Symbol.asyncIterator]();
+    await using _ = {
+      async [Symbol.asyncDispose]() {
+        await iter.return?.();
+      }
+    };
+
+    const checkpoint = await consumeIterator(iter, {
+      consume: false,
+      isDone: (line) => (line as any)?.checkpoint != null
+    });
+    expect(checkpoint[0]).toEqual({
+      checkpoint: expect.objectContaining({
+        last_op_id: '3'
+      })
+    });
+
+    await writer.save({
+      sourceTable: testTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      after: {
+        id: 'high1',
+        description: 'Updated high priority 1'
+      },
+      afterReplicaId: 'high1'
+    });
+    await writer.save({
+      sourceTable: testTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      after: {
+        id: 'high2',
+        description: 'Updated high priority 2'
+      },
+      afterReplicaId: 'high2'
+    });
+    await writer.commit('0/2');
+
+    await bucketStorage.compact({
+      minBucketChanges: 1,
+      minChangeRatio: 0
+    });
+
+    const lines = await getCheckpointLines(iter, { consume: true });
+    const nextCheckpointIndex = lines.findIndex((line) => (line as any)?.checkpoint_diff != null);
+    expect(nextCheckpointIndex).toBeGreaterThan(0);
+
+    const invalidatedCheckpointLines = lines.slice(0, nextCheckpointIndex);
+    expect(invalidatedCheckpointLines).not.toContainEqual(
+      expect.objectContaining({ checkpoint_complete: expect.anything() })
+    );
+    expect(invalidatedCheckpointLines).not.toContainEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          bucket: expect.stringContaining('low_priority')
+        })
+      })
+    );
+
+    expect(lines[nextCheckpointIndex]).toEqual({
+      checkpoint_diff: expect.objectContaining({
+        last_op_id: '5'
+      })
+    });
+    expect(lines.at(-1)).toEqual({
+      checkpoint_complete: expect.objectContaining({
+        last_op_id: '5'
+      })
+    });
+  });
+
   test('write checkpoint', async () => {
     await using f = await factory();
 

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -22,8 +22,18 @@ import {
 } from '@powersync/lib-services-framework';
 import { JwtPayload } from '../auth/JwtPayload.js';
 import { ParameterSetLimitExceededError } from '../storage/storage-index.js';
+import { PerformanceTracer } from '../tracing/PerformanceTracer.js';
 import { SyncContext } from './SyncContext.js';
 import { getIntersection, hasIntersection } from './util.js';
+
+export type SyncCheckpointTraceCategory =
+  | 'checkpoint'
+  | 'parameters'
+  | 'checksum'
+  | 'bucket_data'
+  | 'sync_lock'
+  | 'sync_data'
+  | 'client';
 
 export interface BucketChecksumStateOptions {
   syncContext: SyncContext;
@@ -112,13 +122,18 @@ export class BucketChecksumState {
    * @param next The updated checkpoint
    * @returns A {@link CheckpointLine} if any of the buckets watched by this connected was updated, or otherwise `null`.
    */
-  async buildNextCheckpointLine(next: storage.StorageCheckpointUpdate): Promise<CheckpointLine | null> {
+  async buildNextCheckpointLine(
+    next: storage.StorageCheckpointUpdate,
+    tracer?: PerformanceTracer<SyncCheckpointTraceCategory>
+  ): Promise<CheckpointLine | null> {
+    tracer ??= new PerformanceTracer<SyncCheckpointTraceCategory>(`sync checkpoint ${next.base.checkpoint}`);
+
     const { writeCheckpoint, base } = next;
     const userIdForLogs = this.parameterState.syncParams.userId;
 
     const storage = this.bucketStorage;
 
-    const update = await this.parameterState.getCheckpointUpdate(next);
+    const update = await this.parameterState.getCheckpointUpdate(next, tracer);
     const { buckets: allBuckets, updatedBuckets, usedParameterResults } = update;
 
     /** Set of all buckets in this checkpoint. */
@@ -181,7 +196,11 @@ export class BucketChecksumState {
 
       if (checksumLookups.length > 0) {
         const requestHint: storage.BucketRequestHint = hasNewBucket ? 'bulk' : 'incremental';
-        let updatedChecksums = await storage.getChecksums(base, checksumLookups, { requestHint });
+        let updatedChecksums: util.ChecksumMap;
+
+        using _ = tracer.span('checksum');
+        updatedChecksums = await storage.getChecksums(base, checksumLookups, { requestHint });
+
         for (let [bucket, value] of updatedChecksums.entries()) {
           newChecksums.set(bucket, value);
         }
@@ -197,6 +216,8 @@ export class BucketChecksumState {
         bucket: b.bucket,
         source: b.source
       }));
+
+      using _ = tracer.span('checksum');
       checksumMap = await storage.getChecksums(base, bucketList, { requestHint });
     }
 
@@ -535,12 +556,15 @@ export class BucketParameterState {
     return (desc.subscribedToByDefault && this.includeDefaultStreams) || this.subscribedStreamNames.has(desc.name);
   }
 
-  async getCheckpointUpdate(checkpoint: storage.StorageCheckpointUpdate): Promise<CheckpointUpdate> {
+  async getCheckpointUpdate(
+    checkpoint: storage.StorageCheckpointUpdate,
+    tracer: PerformanceTracer<SyncCheckpointTraceCategory>
+  ): Promise<CheckpointUpdate> {
     const querier = this.querier;
     let update: CheckpointUpdate;
     if (querier.hasDynamicBuckets) {
       try {
-        update = await this.getCheckpointUpdateDynamic(checkpoint);
+        update = await this.getCheckpointUpdateDynamic(checkpoint, tracer);
       } catch (e: unknown) {
         if (e instanceof ParameterSetLimitExceededError) {
           // Too many parameter results, create a breakdown of which streams are responsible for the most queries and
@@ -603,7 +627,10 @@ export class BucketParameterState {
   /**
    * For dynamic buckets, we need to re-query the list of buckets every time.
    */
-  private async getCheckpointUpdateDynamic(checkpoint: storage.StorageCheckpointUpdate): Promise<CheckpointUpdate> {
+  private async getCheckpointUpdateDynamic(
+    checkpoint: storage.StorageCheckpointUpdate,
+    tracer: PerformanceTracer<SyncCheckpointTraceCategory>
+  ): Promise<CheckpointUpdate> {
     const querier = this.querier;
     const staticBuckets = this.staticBuckets.values();
     const update = checkpoint.update;
@@ -659,6 +686,7 @@ export class BucketParameterState {
           }
 
           try {
+            using _ = tracer.span('parameters', definition);
             const results = await checkpoint.base.getParameterSets(lookups, remainingBudget);
             const numRows = results.reduce((a, b) => a + b.rows.length, 0);
 

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -27,11 +27,17 @@ import { SyncContext } from './SyncContext.js';
 import { getIntersection, hasIntersection } from './util.js';
 
 export type SyncCheckpointTraceCategory =
+  // buildNextCheckpointLine, excluding parameter computation and checksum lookups
   | 'checkpoint'
+  // Parameter lookups
   | 'parameters'
+  // Checksum calculations
   | 'checksum'
-  | 'bucket_data'
+  // Waiting for a data lock to become available
   | 'acquiring_lock'
+  // Data fetches. Holds one data lock for this period.
+  | 'bucket_data'
+  // Sending data to client, may include serialization overhead. Holds one data lock for this period in most cases.
   | 'sending';
 
 export interface BucketChecksumStateOptions {

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -31,9 +31,8 @@ export type SyncCheckpointTraceCategory =
   | 'parameters'
   | 'checksum'
   | 'bucket_data'
-  | 'sync_lock'
-  | 'sync_data'
-  | 'client';
+  | 'acquiring_lock'
+  | 'sending';
 
 export interface BucketChecksumStateOptions {
   syncContext: SyncContext;

--- a/packages/service-core/src/sync/RequestTracker.ts
+++ b/packages/service-core/src/sync/RequestTracker.ts
@@ -15,6 +15,8 @@ export class RequestTracker {
   largeBuckets: Record<string, number> = {};
 
   private encoding: string | undefined = undefined;
+  private lastCheckpointLogOperationsSynced = 0;
+  private lastCheckpointLogDataSyncedBytes = 0;
 
   constructor(private metrics: MetricsEngine) {
     this.metrics = metrics;
@@ -68,6 +70,19 @@ export class RequestTracker {
       encoding: this.encoding
     };
   }
+
+  getIncrementalCheckpointStats(): CheckpointLogStats {
+    const operationsSynced = this.operationsSynced - this.lastCheckpointLogOperationsSynced;
+    const dataSyncedBytes = this.dataSyncedBytes - this.lastCheckpointLogDataSyncedBytes;
+
+    this.lastCheckpointLogOperationsSynced = this.operationsSynced;
+    this.lastCheckpointLogDataSyncedBytes = this.dataSyncedBytes;
+
+    return {
+      operations_synced: operationsSynced,
+      data_synced_bytes: dataSyncedBytes
+    };
+  }
 }
 
 export interface OperationCounts {
@@ -81,6 +96,11 @@ export interface OperationsSentStats {
   bucket: string;
   operations: OperationCounts;
   total: number;
+}
+
+export interface CheckpointLogStats {
+  operations_synced: number;
+  data_synced_bytes: number;
 }
 
 export function statsForBatch(batch: SyncBucketData): OperationsSentStats {

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -420,6 +420,11 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
             }
           };
           yield { data: line, done: true };
+          logger.info(`partial_checkpoint_complete: ${checkpoint.checkpoint}`, {
+            checkpoint: checkpoint.checkpoint,
+            priority: request.forPriority,
+            user_id: request.userIdForLogs
+          });
         } else {
           const line: util.StreamingSyncCheckpointComplete = {
             checkpoint_complete: {
@@ -427,6 +432,10 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
             }
           };
           yield { data: line, done: true };
+          logger.info(`checkpoint_complete: ${checkpoint.checkpoint}`, {
+            checkpoint: checkpoint.checkpoint,
+            user_id: request.userIdForLogs
+          });
         }
       }
     }

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -141,12 +141,8 @@ async function* streamResponseInner(
     const trace = startCheckpointTrace(next.value.base.checkpoint);
     try {
       const line = await checksumState.buildNextCheckpointLine(next.value, trace.tracer);
-      if (line == null) {
-        finishCheckpointTrace(trace);
-      }
       return { done: false, value: { checkpoint: next.value.base, line, trace: line == null ? null : trace } };
     } catch (e) {
-      finishCheckpointTrace(trace);
       throw e;
     }
   }
@@ -180,7 +176,7 @@ async function* streamResponseInner(
       // Since yielding can block, we update the state just before yielding the line.
       line.advance();
       {
-        using _ = trace.tracer.span('client', 'checkpoint');
+        using _ = trace.tracer.span('sending', 'checkpoint');
         yield checkpointLine;
       }
 
@@ -190,6 +186,7 @@ async function* streamResponseInner(
       // the new checkpoint.
       const abortCheckpointController = new AbortController();
       let syncedOperations = 0;
+      let checkpointInvalidationReason: CheckpointInvalidationResult | null = null;
 
       const abortCheckpointSignal = AbortSignal.any([abortCheckpointController.signal, signal]);
 
@@ -212,6 +209,7 @@ async function* streamResponseInner(
             while (true) {
               const next = await settledPromise(waitForNewCheckpointLine());
               if (next.status == 'rejected') {
+                checkpointInvalidationReason = 'invalidated_next_checkpoint_error';
                 abortCheckpointController.abort();
               } else if (!next.value.done) {
                 if (next.value.value.line == null) {
@@ -222,6 +220,7 @@ async function* streamResponseInner(
 
                 // A new sync line can be emitted. Stop running the bucketDataInBatches() iterations, making the
                 // main flow reach the new checkpoint.
+                checkpointInvalidationReason = 'invalidated_new_checkpoint';
                 abortCheckpointController.abort();
               }
 
@@ -237,6 +236,7 @@ async function* streamResponseInner(
         maybeRaceForNewCheckpoint();
       }
 
+      let checkpointResult: CheckpointResult | null = null;
       // This incrementally updates dataBuckets with each individual bucket position.
       // At the end of this, we can be sure that all buckets have data up to the checkpoint.
       for (const [priority, buckets] of priorityBatches) {
@@ -245,7 +245,7 @@ async function* streamResponseInner(
           break;
         }
 
-        yield* bucketDataInBatches({
+        checkpointResult = yield* bucketDataInBatches({
           syncContext: syncContext,
           bucketStorage: bucketStorage,
           checkpoint: next.value.value.checkpoint,
@@ -264,17 +264,26 @@ async function* streamResponseInner(
           tracker,
           trace
         });
+        if (checkpointResult == 'complete' || isInvalidatedCheckpointResult(checkpointResult)) {
+          break;
+        }
       }
 
-      if (abortCheckpointController.signal.aborted && !trace.span.ended) {
-        logger.info(`checkpoint_invalidated: ${next.value.value.checkpoint.checkpoint}`, {
+      if (checkpointResult == 'complete') {
+        logger.info(`checkpoint_complete: ${next.value.value.checkpoint.checkpoint}`, {
           checkpoint: next.value.value.checkpoint.checkpoint,
           user_id: tokenPayload.userIdJson,
-          t: finishCheckpointTrace(trace),
+          t: getCheckpointTraceTimings(trace),
           ...tracker.getIncrementalCheckpointStats()
         });
-      } else if (!trace.span.ended) {
-        finishCheckpointTrace(trace);
+      } else if (isInvalidatedCheckpointResult(checkpointResult) || checkpointInvalidationReason != null) {
+        logger.info(`checkpoint_invalidated: ${next.value.value.checkpoint.checkpoint}`, {
+          checkpoint: next.value.value.checkpoint.checkpoint,
+          reason: isInvalidatedCheckpointResult(checkpointResult) ? checkpointResult : checkpointInvalidationReason,
+          user_id: tokenPayload.userIdJson,
+          t: getCheckpointTraceTimings(trace),
+          ...tracker.getIncrementalCheckpointStats()
+        });
       }
 
       if (!abortCheckpointSignal.aborted) {
@@ -313,7 +322,22 @@ interface BucketDataRequest {
   trace: ActiveCheckpointTrace;
 }
 
-async function* bucketDataInBatches(request: BucketDataRequest) {
+type CheckpointResult =
+  | 'partial_complete'
+  | 'complete'
+  | 'invalidated_bucket_data_target_op'
+  | 'invalidated_new_checkpoint'
+  | 'invalidated_next_checkpoint_error';
+
+type CheckpointInvalidationResult = Extract<CheckpointResult, `invalidated_${string}`>;
+
+function isInvalidatedCheckpointResult(result: CheckpointResult | null): result is CheckpointInvalidationResult {
+  return result?.startsWith('invalidated_') ?? false;
+}
+
+async function* bucketDataInBatches(
+  request: BucketDataRequest
+): AsyncGenerator<util.StreamingSyncLine | string | null, CheckpointResult | null> {
   let isDone = false;
   while (!request.abort_batch.aborted && !isDone) {
     // The code below is functionally the same as this for-await loop below.
@@ -330,10 +354,13 @@ async function* bucketDataInBatches(request: BucketDataRequest) {
       while (true) {
         const { value, done: iterDone } = await iter.next();
         if (iterDone) {
+          if (value != null) {
+            return value;
+          }
           break;
         } else {
           const { done, data } = value;
-          using _ = request.trace.tracer.span('client', 'data');
+          using _ = request.trace.tracer.span('sending', 'data');
           yield data;
           if (done) {
             isDone = true;
@@ -341,9 +368,10 @@ async function* bucketDataInBatches(request: BucketDataRequest) {
         }
       }
     } finally {
-      await iter.return();
+      await iter.return(null);
     }
   }
+  return null;
 }
 
 interface BucketDataBatchResult {
@@ -354,7 +382,9 @@ interface BucketDataBatchResult {
 /**
  * Extracted as a separate internal function just to avoid memory leaks.
  */
-async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<BucketDataBatchResult, void> {
+async function* bucketDataBatch(
+  request: BucketDataRequest
+): AsyncGenerator<BucketDataBatchResult, CheckpointResult | null> {
   const {
     syncContext,
     bucketStorage: storage,
@@ -376,19 +406,17 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
   if (syncContext.syncSemaphore.isLocked()) {
     logger.info('Sync concurrency limit reached, waiting for lock', { user_id: request.userIdForLogs });
   }
-  const acquired = await request.trace.tracer.span('sync_lock').with(async () => {
+  const acquired = await request.trace.tracer.span('acquiring_lock').with(async () => {
     return acquireSemaphoreAbortable(syncContext.syncSemaphore, AbortSignal.any([abort_batch]));
   });
   if (acquired === 'aborted') {
-    return;
+    return null;
   }
 
   const [value, release] = acquired;
-  let checkpointInvalidationComplete = false;
-  let checkpointComplete = false;
   try {
+    using _ = tracer.span('bucket_data');
     let has_more = false;
-    using _ = tracer.span('sync_data');
     if (value <= 3) {
       // This can be noisy, so we only log when we get close to the
       // concurrency limit.
@@ -401,13 +429,10 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
     // For the first batch, this will be all buckets.
     const filteredBuckets = checkpointLine.getFilteredBucketPositions(bucketsToFetch);
     const dataBatches = storage.getBucketDataBatch(checkpoint, filteredBuckets, { requestHint });
-
     for await (let { chunkData: r, targetOp } of dataBatches) {
-      using _ = tracer.span('bucket_data');
-
       // Abort in current batch if the connection is closed
       if (abort_connection.aborted) {
-        return;
+        return null;
       }
       if (r.has_more) {
         has_more = true;
@@ -451,7 +476,7 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
       // Check if syncing bucket data is supposed to stop before fetching more data
       // from storage.
       if (abort_batch.aborted) {
-        return;
+        return null;
       }
     }
 
@@ -460,8 +485,8 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
         // Checkpoint invalidated by a CLEAR or MOVE op.
         // Don't send the checkpoint_complete line in this case.
         // More data should be available immediately for a new checkpoint.
-        checkpointInvalidationComplete = true;
         yield { data: null, done: true };
+        return 'invalidated_bucket_data_target_op';
       } else {
         if (request.forPriority != null) {
           const line: util.StreamingSyncCheckpointPartiallyComplete = {
@@ -477,6 +502,7 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
             user_id: request.userIdForLogs,
             ...request.tracker.getIncrementalCheckpointStats()
           });
+          return 'partial_complete';
         } else {
           const line: util.StreamingSyncCheckpointComplete = {
             checkpoint_complete: {
@@ -484,7 +510,7 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
             }
           };
           yield { data: line, done: true };
-          checkpointComplete = true;
+          return 'complete';
         }
       }
     }
@@ -498,24 +524,7 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
     }
     release();
   }
-
-  if (checkpointInvalidationComplete) {
-    logger.info(`checkpoint_invalidated: ${checkpoint.checkpoint}`, {
-      checkpoint: checkpoint.checkpoint,
-      user_id: request.userIdForLogs,
-      t: finishCheckpointTrace(request.trace),
-      ...request.tracker.getIncrementalCheckpointStats()
-    });
-  }
-  if (checkpointComplete) {
-    const timings = finishCheckpointTrace(request.trace);
-    logger.info(`checkpoint_complete: ${checkpoint.checkpoint}`, {
-      checkpoint: checkpoint.checkpoint,
-      user_id: request.userIdForLogs,
-      t: timings,
-      ...request.tracker.getIncrementalCheckpointStats()
-    });
-  }
+  return null;
 }
 
 function startCheckpointTrace(checkpoint: util.InternalOpId): ActiveCheckpointTrace {
@@ -526,11 +535,7 @@ function startCheckpointTrace(checkpoint: util.InternalOpId): ActiveCheckpointTr
   };
 }
 
-function finishCheckpointTrace(trace: ActiveCheckpointTrace): CheckpointTiming {
-  if (trace.span.ended) {
-    return {};
-  }
-
+function getCheckpointTraceTimings(trace: ActiveCheckpointTrace): CheckpointTiming {
   const timings = trace.span.end();
   const result: CheckpointTiming = { ...timings };
   addTiming(result, 'other', trace.span.selfDuration);

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -264,9 +264,16 @@ async function* streamResponseInner(
           // sync complete message instead.
           forPriority: !isLast ? priority : null,
           logger,
-          tracker,
           tracer
         });
+        if (checkpointResult == 'partial_complete') {
+          logger.info(`partial_checkpoint_complete: ${next.value.value.checkpoint.checkpoint}`, {
+            checkpoint: next.value.value.checkpoint.checkpoint,
+            priority,
+            user_id: tokenPayload.userIdJson,
+            ...tracker.getIncrementalCheckpointStats()
+          });
+        }
         if (checkpointResult == 'complete' || isInvalidatedCheckpointResult(checkpointResult)) {
           break;
         }
@@ -321,7 +328,6 @@ interface BucketDataRequest {
   forPriority: BucketPriority | null;
   onRowsSent: (stats: OperationsSentStats) => void;
   logger: Logger;
-  tracker: RequestTracker;
   tracer: PerformanceTracer<SyncCheckpointTraceCategory>;
 }
 
@@ -488,12 +494,6 @@ async function* bucketDataBatch(
             }
           };
           yield { data: line, done: true };
-          logger.info(`partial_checkpoint_complete: ${checkpoint.checkpoint}`, {
-            checkpoint: checkpoint.checkpoint,
-            priority: request.forPriority,
-            user_id: request.userIdForLogs,
-            ...request.tracker.getIncrementalCheckpointStats()
-          });
           return 'partial_complete';
         } else {
           const line: util.StreamingSyncCheckpointComplete = {

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -403,9 +403,6 @@ async function* bucketDataBatch(
 
   let checkpointInvalidated = false;
 
-  if (syncContext.syncSemaphore.isLocked()) {
-    logger.info('Sync concurrency limit reached, waiting for lock', { user_id: request.userIdForLogs });
-  }
   const acquired = await request.trace.tracer.span('acquiring_lock').with(async () => {
     return acquireSemaphoreAbortable(syncContext.syncSemaphore, AbortSignal.any([abort_batch]));
   });
@@ -413,18 +410,10 @@ async function* bucketDataBatch(
     return null;
   }
 
-  const [value, release] = acquired;
+  const [, release] = acquired;
   try {
     using _ = tracer.span('bucket_data');
     let has_more = false;
-    if (value <= 3) {
-      // This can be noisy, so we only log when we get close to the
-      // concurrency limit.
-      logger.info(`Got sync lock. Slots available: ${value - 1}`, {
-        user_id: request.userIdForLogs,
-        sync_data_slots: value - 1
-      });
-    }
     // Optimization: Only fetch buckets for which the checksums have changed since the last checkpoint
     // For the first batch, this will be all buckets.
     const filteredBuckets = checkpointLine.getFilteredBucketPositions(bucketsToFetch);
@@ -515,13 +504,6 @@ async function* bucketDataBatch(
       }
     }
   } finally {
-    if (value <= 3) {
-      // This can be noisy, so we only log when we get close to the
-      // concurrency limit.
-      logger.info(`Releasing sync lock`, {
-        user_id: request.userIdForLogs
-      });
-    }
     release();
   }
   return null;

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -190,7 +190,8 @@ async function* streamResponseInner(
       // the new checkpoint.
       const abortCheckpointController = new AbortController();
       let syncedOperations = 0;
-      let checkpointInvalidationReason: CheckpointInvalidationResult | null = null;
+
+      let checkpointResult: CheckpointResult | null = null;
 
       const abortCheckpointSignal = AbortSignal.any([abortCheckpointController.signal, signal]);
 
@@ -213,7 +214,7 @@ async function* streamResponseInner(
             while (true) {
               const next = await settledPromise(waitForNewCheckpointLine());
               if (next.status == 'rejected') {
-                checkpointInvalidationReason = 'invalidated_next_checkpoint_error';
+                checkpointResult = { result: 'invalidated', invalidationReason: 'checkpoint_error' };
                 abortCheckpointController.abort();
               } else if (!next.value.done) {
                 if (next.value.value.line == null) {
@@ -224,7 +225,7 @@ async function* streamResponseInner(
 
                 // A new sync line can be emitted. Stop running the bucketDataInBatches() iterations, making the
                 // main flow reach the new checkpoint.
-                checkpointInvalidationReason = 'invalidated_new_checkpoint';
+                checkpointResult = { result: 'invalidated', invalidationReason: 'checkpoint_superseded' };
                 abortCheckpointController.abort();
               }
 
@@ -248,7 +249,6 @@ async function* streamResponseInner(
         };
       }
 
-      let checkpointResult: CheckpointResult | null = null;
       // This incrementally updates dataBuckets with each individual bucket position.
       // At the end of this, we can be sure that all buckets have data up to the checkpoint.
       for (const [priority, buckets] of priorityBatches) {
@@ -257,7 +257,7 @@ async function* streamResponseInner(
           break;
         }
 
-        checkpointResult = yield* bucketDataInBatches({
+        const batchResult = yield* bucketDataInBatches({
           syncContext: syncContext,
           bucketStorage: bucketStorage,
           checkpoint,
@@ -275,30 +275,30 @@ async function* streamResponseInner(
           logger,
           tracer
         });
-        if (checkpointResult == 'partial_complete') {
+        if (batchResult?.result == 'partial_checkpoint_complete') {
           // We don't specifically include timing details here, since that would end the span.
           // Timings are included in the checkpoint_complete following this.
           logger.info(`partial_checkpoint_complete: ${checkpoint.checkpoint}`, {
             priority,
             ...checkpointLogDetails(checkpoint)
           });
-        }
-        if (checkpointResult == 'complete' || isInvalidatedCheckpointResult(checkpointResult)) {
+        } else if (batchResult?.result != null) {
+          checkpointResult = batchResult;
           break;
         }
       }
 
-      if (checkpointResult == 'complete') {
+      if (checkpointResult?.result == 'checkpoint_complete') {
         logger.info(`checkpoint_complete: ${checkpoint.checkpoint}`, {
           // Incremental stats since the last checkpoint_complete, partial_checkpoint_complete or checkpoint_invalidated
           ...checkpointLogDetails(checkpoint),
           // Timings since the last checkpoint or checkpoint_diff
           t: getCheckpointTraceTimings(trace.span)
         });
-      } else if (isInvalidatedCheckpointResult(checkpointResult) || checkpointInvalidationReason != null) {
+      } else if (checkpointResult?.result == 'invalidated') {
         // A new checkpoint and checkpoint_complete should follow soon, but we log the stats already
         logger.info(`checkpoint_invalidated: ${checkpoint.checkpoint}`, {
-          reason: isInvalidatedCheckpointResult(checkpointResult) ? checkpointResult : checkpointInvalidationReason,
+          reason: checkpointResult.invalidationReason,
           ...checkpointLogDetails(checkpoint),
           t: getCheckpointTraceTimings(trace.span)
         });
@@ -340,17 +340,12 @@ interface BucketDataRequest {
 }
 
 type CheckpointResult =
-  | 'partial_complete'
-  | 'complete'
-  | 'invalidated_bucket_data_target_op'
-  | 'invalidated_new_checkpoint'
-  | 'invalidated_next_checkpoint_error';
-
-type CheckpointInvalidationResult = Extract<CheckpointResult, `invalidated_${string}`>;
-
-function isInvalidatedCheckpointResult(result: CheckpointResult | null): result is CheckpointInvalidationResult {
-  return result?.startsWith('invalidated_') ?? false;
-}
+  | { result: 'partial_checkpoint_complete' }
+  | { result: 'checkpoint_complete' }
+  | {
+      result: 'invalidated';
+      invalidationReason: 'compacted' | 'checkpoint_error' | 'checkpoint_superseded';
+    };
 
 async function* bucketDataInBatches(
   request: BucketDataRequest
@@ -492,7 +487,7 @@ async function* bucketDataBatch(
         // Don't send the checkpoint_complete line in this case.
         // More data should be available immediately for a new checkpoint.
         yield { data: null, done: true };
-        return 'invalidated_bucket_data_target_op';
+        return { result: 'invalidated', invalidationReason: 'compacted' };
       } else {
         if (request.forPriority != null) {
           const line: util.StreamingSyncCheckpointPartiallyComplete = {
@@ -502,7 +497,7 @@ async function* bucketDataBatch(
             }
           };
           yield { data: line, done: true };
-          return 'partial_complete';
+          return { result: 'partial_checkpoint_complete' };
         } else {
           const line: util.StreamingSyncCheckpointComplete = {
             checkpoint_complete: {
@@ -510,7 +505,7 @@ async function* bucketDataBatch(
             }
           };
           yield { data: line, done: true };
-          return 'complete';
+          return { result: 'checkpoint_complete' };
         }
       }
     }

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -172,6 +172,7 @@ async function* streamResponseInner(
         continue;
       }
       const trace = next.value.value.trace!;
+      const checkpoint = next.value.value.checkpoint;
       const tracer = trace.tracer;
 
       const { checkpointLine, bucketsToFetch, bucketDataRequestHint } = line;
@@ -239,6 +240,14 @@ async function* streamResponseInner(
         maybeRaceForNewCheckpoint();
       }
 
+      function checkpointLogDetails(cp: storage.ReplicationCheckpoint) {
+        return {
+          checkpoint: cp.checkpoint,
+          user_id: tokenPayload.userIdJson,
+          ...tracker.getIncrementalCheckpointStats()
+        };
+      }
+
       let checkpointResult: CheckpointResult | null = null;
       // This incrementally updates dataBuckets with each individual bucket position.
       // At the end of this, we can be sure that all buckets have data up to the checkpoint.
@@ -251,7 +260,7 @@ async function* streamResponseInner(
         checkpointResult = yield* bucketDataInBatches({
           syncContext: syncContext,
           bucketStorage: bucketStorage,
-          checkpoint: next.value.value.checkpoint,
+          checkpoint,
           bucketsToFetch: buckets,
           requestHint: bucketDataRequestHint,
           checkpointLine: line,
@@ -267,11 +276,11 @@ async function* streamResponseInner(
           tracer
         });
         if (checkpointResult == 'partial_complete') {
-          logger.info(`partial_checkpoint_complete: ${next.value.value.checkpoint.checkpoint}`, {
-            checkpoint: next.value.value.checkpoint.checkpoint,
+          // We don't specifically include timing details here, since that would end the span.
+          // Timings are included in the checkpoint_complete following this.
+          logger.info(`partial_checkpoint_complete: ${checkpoint.checkpoint}`, {
             priority,
-            user_id: tokenPayload.userIdJson,
-            ...tracker.getIncrementalCheckpointStats()
+            ...checkpointLogDetails(checkpoint)
           });
         }
         if (checkpointResult == 'complete' || isInvalidatedCheckpointResult(checkpointResult)) {
@@ -280,19 +289,18 @@ async function* streamResponseInner(
       }
 
       if (checkpointResult == 'complete') {
-        logger.info(`checkpoint_complete: ${next.value.value.checkpoint.checkpoint}`, {
-          checkpoint: next.value.value.checkpoint.checkpoint,
-          user_id: tokenPayload.userIdJson,
-          t: getCheckpointTraceTimings(trace.span),
-          ...tracker.getIncrementalCheckpointStats()
+        logger.info(`checkpoint_complete: ${checkpoint.checkpoint}`, {
+          // Incremental stats since the last checkpoint_complete, partial_checkpoint_complete or checkpoint_invalidated
+          ...checkpointLogDetails(checkpoint),
+          // Timings since the last checkpoint or checkpoint_diff
+          t: getCheckpointTraceTimings(trace.span)
         });
       } else if (isInvalidatedCheckpointResult(checkpointResult) || checkpointInvalidationReason != null) {
-        logger.info(`checkpoint_invalidated: ${next.value.value.checkpoint.checkpoint}`, {
-          checkpoint: next.value.value.checkpoint.checkpoint,
+        // A new checkpoint and checkpoint_complete should follow soon, but we log the stats already
+        logger.info(`checkpoint_invalidated: ${checkpoint.checkpoint}`, {
           reason: isInvalidatedCheckpointResult(checkpointResult) ? checkpointResult : checkpointInvalidationReason,
-          user_id: tokenPayload.userIdJson,
-          t: getCheckpointTraceTimings(trace.span),
-          ...tracker.getIncrementalCheckpointStats()
+          ...checkpointLogDetails(checkpoint),
+          t: getCheckpointTraceTimings(trace.span)
         });
       }
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -9,10 +9,18 @@ import * as util from '../util/util-index.js';
 
 import { Logger, logger as defaultLogger } from '@powersync/lib-services-framework';
 import { mergeAsyncIterables } from '../streams/streams-index.js';
-import { BucketChecksumState, CheckpointLine } from './BucketChecksumState.js';
+import { PerformanceTracer, type Span } from '../tracing/PerformanceTracer.js';
+import { BucketChecksumState, CheckpointLine, type SyncCheckpointTraceCategory } from './BucketChecksumState.js';
 import { OperationsSentStats, RequestTracker, statsForBatch } from './RequestTracker.js';
 import { SyncContext } from './SyncContext.js';
 import { TokenStreamOptions, acquireSemaphoreAbortable, settledPromise, tokenStream } from './util.js';
+
+type CheckpointTiming = Record<string, number>;
+
+interface ActiveCheckpointTrace {
+  tracer: PerformanceTracer<SyncCheckpointTraceCategory>;
+  span: Span;
+}
 
 export interface SyncStreamParameters {
   syncContext: SyncContext;
@@ -121,6 +129,7 @@ async function* streamResponseInner(
   type CheckpointAndLine = {
     checkpoint: storage.ReplicationCheckpoint;
     line: CheckpointLine | null;
+    trace: ActiveCheckpointTrace | null;
   };
 
   async function waitForNewCheckpointLine(): Promise<IteratorResult<CheckpointAndLine>> {
@@ -129,8 +138,17 @@ async function* streamResponseInner(
       return { done: true, value: undefined };
     }
 
-    const line = await checksumState.buildNextCheckpointLine(next.value);
-    return { done: false, value: { checkpoint: next.value.base, line } };
+    const trace = startCheckpointTrace(next.value.base.checkpoint);
+    try {
+      const line = await checksumState.buildNextCheckpointLine(next.value, trace.tracer);
+      if (line == null) {
+        finishCheckpointTrace(trace);
+      }
+      return { done: false, value: { checkpoint: next.value.base, line, trace: line == null ? null : trace } };
+    } catch (e) {
+      finishCheckpointTrace(trace);
+      throw e;
+    }
   }
 
   try {
@@ -155,12 +173,16 @@ async function* streamResponseInner(
         // No update to sync
         continue;
       }
+      const trace = next.value.value.trace!;
 
       const { checkpointLine, bucketsToFetch, bucketDataRequestHint } = line;
 
       // Since yielding can block, we update the state just before yielding the line.
       line.advance();
-      yield checkpointLine;
+      {
+        using _ = trace.tracer.span('client', 'checkpoint');
+        yield checkpointLine;
+      }
 
       // Start syncing data for buckets up to the checkpoint. As soon as we have completed at least one priority and
       // at least 1000 operations, we also start listening for new checkpoints concurrently. When a new checkpoint comes
@@ -239,8 +261,20 @@ async function* streamResponseInner(
           // sync complete message instead.
           forPriority: !isLast ? priority : null,
           logger,
-          tracker
+          tracker,
+          trace
         });
+      }
+
+      if (abortCheckpointController.signal.aborted && !trace.span.ended) {
+        logger.info(`checkpoint_invalidated: ${next.value.value.checkpoint.checkpoint}`, {
+          checkpoint: next.value.value.checkpoint.checkpoint,
+          user_id: tokenPayload.userIdJson,
+          t: finishCheckpointTrace(trace),
+          ...tracker.getIncrementalCheckpointStats()
+        });
+      } else if (!trace.span.ended) {
+        finishCheckpointTrace(trace);
       }
 
       if (!abortCheckpointSignal.aborted) {
@@ -276,6 +310,7 @@ interface BucketDataRequest {
   onRowsSent: (stats: OperationsSentStats) => void;
   logger: Logger;
   tracker: RequestTracker;
+  trace: ActiveCheckpointTrace;
 }
 
 async function* bucketDataInBatches(request: BucketDataRequest) {
@@ -298,6 +333,7 @@ async function* bucketDataInBatches(request: BucketDataRequest) {
           break;
         } else {
           const { done, data } = value;
+          using _ = request.trace.tracer.span('client', 'data');
           yield data;
           if (done) {
             isDone = true;
@@ -333,18 +369,26 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
     logger
   } = request;
 
+  const tracer = request.trace.tracer;
+
   let checkpointInvalidated = false;
 
   if (syncContext.syncSemaphore.isLocked()) {
     logger.info('Sync concurrency limit reached, waiting for lock', { user_id: request.userIdForLogs });
   }
-  const acquired = await acquireSemaphoreAbortable(syncContext.syncSemaphore, AbortSignal.any([abort_batch]));
+  const acquired = await request.trace.tracer.span('sync_lock').with(async () => {
+    return acquireSemaphoreAbortable(syncContext.syncSemaphore, AbortSignal.any([abort_batch]));
+  });
   if (acquired === 'aborted') {
     return;
   }
 
   const [value, release] = acquired;
+  let checkpointInvalidationComplete = false;
+  let checkpointComplete = false;
   try {
+    let has_more = false;
+    using _ = tracer.span('sync_data');
     if (value <= 3) {
       // This can be noisy, so we only log when we get close to the
       // concurrency limit.
@@ -358,9 +402,9 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
     const filteredBuckets = checkpointLine.getFilteredBucketPositions(bucketsToFetch);
     const dataBatches = storage.getBucketDataBatch(checkpoint, filteredBuckets, { requestHint });
 
-    let has_more = false;
-
     for await (let { chunkData: r, targetOp } of dataBatches) {
+      using _ = tracer.span('bucket_data');
+
       // Abort in current batch if the connection is closed
       if (abort_connection.aborted) {
         return;
@@ -376,7 +420,11 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
         // storage can emit an empty chunk for a bucket that has no operations in the
         // requested range, and its position must advance so the bucket is not
         // re-requested indefinitely.
-        checkpointLine.updateBucketPosition({ bucket: r.bucket, nextAfter: BigInt(r.next_after), hasMore: r.has_more });
+        checkpointLine.updateBucketPosition({
+          bucket: r.bucket,
+          nextAfter: BigInt(r.next_after),
+          hasMore: r.has_more
+        });
         continue;
       }
       logger.debug(`Sending data for ${r.bucket}`);
@@ -412,6 +460,7 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
         // Checkpoint invalidated by a CLEAR or MOVE op.
         // Don't send the checkpoint_complete line in this case.
         // More data should be available immediately for a new checkpoint.
+        checkpointInvalidationComplete = true;
         yield { data: null, done: true };
       } else {
         if (request.forPriority != null) {
@@ -435,11 +484,7 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
             }
           };
           yield { data: line, done: true };
-          logger.info(`checkpoint_complete: ${checkpoint.checkpoint}`, {
-            checkpoint: checkpoint.checkpoint,
-            user_id: request.userIdForLogs,
-            ...request.tracker.getIncrementalCheckpointStats()
-          });
+          checkpointComplete = true;
         }
       }
     }
@@ -452,6 +497,50 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
       });
     }
     release();
+  }
+
+  if (checkpointInvalidationComplete) {
+    logger.info(`checkpoint_invalidated: ${checkpoint.checkpoint}`, {
+      checkpoint: checkpoint.checkpoint,
+      user_id: request.userIdForLogs,
+      t: finishCheckpointTrace(request.trace),
+      ...request.tracker.getIncrementalCheckpointStats()
+    });
+  }
+  if (checkpointComplete) {
+    const timings = finishCheckpointTrace(request.trace);
+    logger.info(`checkpoint_complete: ${checkpoint.checkpoint}`, {
+      checkpoint: checkpoint.checkpoint,
+      user_id: request.userIdForLogs,
+      t: timings,
+      ...request.tracker.getIncrementalCheckpointStats()
+    });
+  }
+}
+
+function startCheckpointTrace(checkpoint: util.InternalOpId): ActiveCheckpointTrace {
+  const tracer = new PerformanceTracer<SyncCheckpointTraceCategory>(`sync checkpoint ${checkpoint}`);
+  return {
+    tracer,
+    span: tracer.span('checkpoint')
+  };
+}
+
+function finishCheckpointTrace(trace: ActiveCheckpointTrace): CheckpointTiming {
+  if (trace.span.ended) {
+    return {};
+  }
+
+  const timings = trace.span.end();
+  const result: CheckpointTiming = { ...timings };
+  addTiming(result, 'other', trace.span.selfDuration);
+  addTiming(result, 'total', trace.span.endAt - trace.span.startAt);
+  return result;
+}
+
+function addTiming(timings: CheckpointTiming, key: string, duration: number) {
+  if (duration > 0) {
+    timings[key] = (timings[key] ?? 0) + duration;
   }
 }
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -137,11 +137,17 @@ async function* streamResponseInner(
     if (next.done) {
       return { done: true, value: undefined };
     }
+    const cp = next.value.base;
 
-    const trace = startCheckpointTrace(next.value.base.checkpoint);
+    const tracer = new PerformanceTracer<SyncCheckpointTraceCategory>(`sync checkpoint ${cp.checkpoint}`);
+    const trace = {
+      tracer,
+      span: tracer.span('checkpoint')
+    };
+
     try {
       const line = await checksumState.buildNextCheckpointLine(next.value, trace.tracer);
-      return { done: false, value: { checkpoint: next.value.base, line, trace: line == null ? null : trace } };
+      return { done: false, value: { checkpoint: cp, line, trace: line == null ? null : trace } };
     } catch (e) {
       // Only end the span if we error. If we return normally, we pass ownership on to the caller.
       trace.span.end();
@@ -517,14 +523,6 @@ async function* bucketDataBatch(
     release();
   }
   return null;
-}
-
-function startCheckpointTrace(checkpoint: util.InternalOpId): ActiveCheckpointTrace {
-  const tracer = new PerformanceTracer<SyncCheckpointTraceCategory>(`sync checkpoint ${checkpoint}`);
-  return {
-    tracer,
-    span: tracer.span('checkpoint')
-  };
 }
 
 function getCheckpointTraceTimings(span: Span): CheckpointTiming {

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -238,7 +238,8 @@ async function* streamResponseInner(
           // Passing null here will emit a full sync complete message at the end. If we pass a priority, we'll emit a partial
           // sync complete message instead.
           forPriority: !isLast ? priority : null,
-          logger
+          logger,
+          tracker
         });
       }
 
@@ -274,6 +275,7 @@ interface BucketDataRequest {
   forPriority: BucketPriority | null;
   onRowsSent: (stats: OperationsSentStats) => void;
   logger: Logger;
+  tracker: RequestTracker;
 }
 
 async function* bucketDataInBatches(request: BucketDataRequest) {
@@ -423,7 +425,8 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
           logger.info(`partial_checkpoint_complete: ${checkpoint.checkpoint}`, {
             checkpoint: checkpoint.checkpoint,
             priority: request.forPriority,
-            user_id: request.userIdForLogs
+            user_id: request.userIdForLogs,
+            ...request.tracker.getIncrementalCheckpointStats()
           });
         } else {
           const line: util.StreamingSyncCheckpointComplete = {
@@ -434,7 +437,8 @@ async function* bucketDataBatch(request: BucketDataRequest): AsyncGenerator<Buck
           yield { data: line, done: true };
           logger.info(`checkpoint_complete: ${checkpoint.checkpoint}`, {
             checkpoint: checkpoint.checkpoint,
-            user_id: request.userIdForLogs
+            user_id: request.userIdForLogs,
+            ...request.tracker.getIncrementalCheckpointStats()
           });
         }
       }

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -170,13 +170,14 @@ async function* streamResponseInner(
         continue;
       }
       const trace = next.value.value.trace!;
+      const tracer = trace.tracer;
 
       const { checkpointLine, bucketsToFetch, bucketDataRequestHint } = line;
 
       // Since yielding can block, we update the state just before yielding the line.
       line.advance();
       {
-        using _ = trace.tracer.span('sending', 'checkpoint');
+        using _ = tracer.span('sending', 'checkpoint');
         yield checkpointLine;
       }
 
@@ -262,7 +263,7 @@ async function* streamResponseInner(
           forPriority: !isLast ? priority : null,
           logger,
           tracker,
-          trace
+          tracer
         });
         if (checkpointResult == 'complete' || isInvalidatedCheckpointResult(checkpointResult)) {
           break;
@@ -273,7 +274,7 @@ async function* streamResponseInner(
         logger.info(`checkpoint_complete: ${next.value.value.checkpoint.checkpoint}`, {
           checkpoint: next.value.value.checkpoint.checkpoint,
           user_id: tokenPayload.userIdJson,
-          t: getCheckpointTraceTimings(trace),
+          t: getCheckpointTraceTimings(trace.span),
           ...tracker.getIncrementalCheckpointStats()
         });
       } else if (isInvalidatedCheckpointResult(checkpointResult) || checkpointInvalidationReason != null) {
@@ -281,7 +282,7 @@ async function* streamResponseInner(
           checkpoint: next.value.value.checkpoint.checkpoint,
           reason: isInvalidatedCheckpointResult(checkpointResult) ? checkpointResult : checkpointInvalidationReason,
           user_id: tokenPayload.userIdJson,
-          t: getCheckpointTraceTimings(trace),
+          t: getCheckpointTraceTimings(trace.span),
           ...tracker.getIncrementalCheckpointStats()
         });
       }
@@ -319,7 +320,7 @@ interface BucketDataRequest {
   onRowsSent: (stats: OperationsSentStats) => void;
   logger: Logger;
   tracker: RequestTracker;
-  trace: ActiveCheckpointTrace;
+  tracer: PerformanceTracer<SyncCheckpointTraceCategory>;
 }
 
 type CheckpointResult =
@@ -360,7 +361,7 @@ async function* bucketDataInBatches(
           break;
         } else {
           const { done, data } = value;
-          using _ = request.trace.tracer.span('sending', 'data');
+          using _ = request.tracer.span('sending', 'data');
           yield data;
           if (done) {
             isDone = true;
@@ -399,11 +400,11 @@ async function* bucketDataBatch(
     logger
   } = request;
 
-  const tracer = request.trace.tracer;
+  const tracer = request.tracer;
 
   let checkpointInvalidated = false;
 
-  const acquired = await request.trace.tracer.span('acquiring_lock').with(async () => {
+  const acquired = await tracer.span('acquiring_lock').with(async () => {
     return acquireSemaphoreAbortable(syncContext.syncSemaphore, AbortSignal.any([abort_batch]));
   });
   if (acquired === 'aborted') {
@@ -517,11 +518,11 @@ function startCheckpointTrace(checkpoint: util.InternalOpId): ActiveCheckpointTr
   };
 }
 
-function getCheckpointTraceTimings(trace: ActiveCheckpointTrace): CheckpointTiming {
-  const timings = trace.span.end();
+function getCheckpointTraceTimings(span: Span): CheckpointTiming {
+  const timings = span.end();
   const result: CheckpointTiming = { ...timings };
-  addTiming(result, 'other', trace.span.selfDuration);
-  addTiming(result, 'total', trace.span.endAt - trace.span.startAt);
+  addTiming(result, 'other', span.selfDuration);
+  addTiming(result, 'total', span.endAt - span.startAt);
   return result;
 }
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -143,6 +143,8 @@ async function* streamResponseInner(
       const line = await checksumState.buildNextCheckpointLine(next.value, trace.tracer);
       return { done: false, value: { checkpoint: next.value.base, line, trace: line == null ? null : trace } };
     } catch (e) {
+      // Only end the span if we error. If we return normally, we pass ownership on to the caller.
+      trace.span.end();
       throw e;
     }
   }

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -214,7 +214,11 @@ async function* streamResponseInner(
             while (true) {
               const next = await settledPromise(waitForNewCheckpointLine());
               if (next.status == 'rejected') {
-                checkpointResult = { result: 'invalidated', invalidationReason: 'checkpoint_error' };
+                if (next.reason instanceof AbortError) {
+                  checkpointResult = { result: 'invalidated', invalidationReason: 'checkpoint_cancelled' };
+                } else {
+                  checkpointResult = { result: 'invalidated', invalidationReason: 'checkpoint_error' };
+                }
                 abortCheckpointController.abort();
               } else if (!next.value.done) {
                 if (next.value.value.line == null) {
@@ -293,14 +297,14 @@ async function* streamResponseInner(
           // Incremental stats since the last checkpoint_complete, partial_checkpoint_complete or checkpoint_invalidated
           ...checkpointLogDetails(checkpoint),
           // Timings since the last checkpoint or checkpoint_diff
-          t: getCheckpointTraceTimings(trace.span)
+          ms: getCheckpointTraceTimings(trace.span)
         });
       } else if (checkpointResult?.result == 'invalidated') {
         // A new checkpoint and checkpoint_complete should follow soon, but we log the stats already
         logger.info(`checkpoint_invalidated: ${checkpoint.checkpoint}`, {
           reason: checkpointResult.invalidationReason,
           ...checkpointLogDetails(checkpoint),
-          t: getCheckpointTraceTimings(trace.span)
+          ms: getCheckpointTraceTimings(trace.span)
         });
       }
 
@@ -344,7 +348,7 @@ type CheckpointResult =
   | { result: 'checkpoint_complete' }
   | {
       result: 'invalidated';
-      invalidationReason: 'compacted' | 'checkpoint_error' | 'checkpoint_superseded';
+      invalidationReason: 'compacted' | 'checkpoint_error' | 'checkpoint_superseded' | 'checkpoint_cancelled';
     };
 
 async function* bucketDataInBatches(
@@ -525,15 +529,19 @@ function startCheckpointTrace(checkpoint: util.InternalOpId): ActiveCheckpointTr
 
 function getCheckpointTraceTimings(span: Span): CheckpointTiming {
   const timings = span.end();
-  const result: CheckpointTiming = { ...timings };
+  const result: CheckpointTiming = {};
+  for (let key in timings) {
+    addTiming(result, key, timings[key]);
+  }
   addTiming(result, 'other', span.selfDuration);
   addTiming(result, 'total', span.endAt - span.startAt);
   return result;
 }
 
-function addTiming(timings: CheckpointTiming, key: string, duration: number) {
-  if (duration > 0) {
-    timings[key] = (timings[key] ?? 0) + duration;
+function addTiming(timings: CheckpointTiming, key: string, durationMicros: number) {
+  const ms = Math.round(durationMicros / 1000);
+  if (ms > 0) {
+    timings[key] = (timings[key] ?? 0) + ms;
   }
 }
 

--- a/packages/service-core/src/tracing/PerformanceTracer.ts
+++ b/packages/service-core/src/tracing/PerformanceTracer.ts
@@ -14,11 +14,6 @@ export interface Span extends Disposable {
   endAt: number;
 
   /**
-   * True if the span has ended (.end() called or disposed).
-   */
-  ended: boolean;
-
-  /**
    * Time spent not in nested spans, in microseconds.
    */
   selfDuration: number;
@@ -150,10 +145,6 @@ export class PerformanceTracer<K extends string> {
 
       get durationMillis() {
         return Math.ceil((this.endAt - this.startAt) / 1000);
-      },
-
-      get ended() {
-        return this.endAt != 0;
       },
 
       [Symbol.dispose]() {

--- a/packages/service-core/src/tracing/PerformanceTracer.ts
+++ b/packages/service-core/src/tracing/PerformanceTracer.ts
@@ -8,8 +8,16 @@ export interface Span extends Disposable {
   startAt: number;
   /**
    * End time in microseconds since an arbitrary epoch.
+   *
+   * 0 if the span hasn't ended yet.
    */
   endAt: number;
+
+  /**
+   * True if the span has ended (.end() called or disposed).
+   */
+  ended: boolean;
+
   /**
    * Time spent not in nested spans.
    */
@@ -36,6 +44,11 @@ export interface Span extends Disposable {
    * Returns an aggregate record of category -> "selfDuration", in microseconds.
    */
   end(): Record<string, number>;
+
+  /**
+   * Call a nested function, then end the span, returning the function's result.
+   */
+  with<T>(cb: () => Promise<T>): Promise<T>;
 }
 
 function now() {
@@ -138,8 +151,21 @@ export class PerformanceTracer<K extends string> {
       get durationMillis() {
         return Math.ceil((this.endAt - this.startAt) / 1000);
       },
+
+      get ended() {
+        return this.endAt != 0;
+      },
+
       [Symbol.dispose]() {
         this.end();
+      },
+
+      async with<T>(cb: () => Promise<T>): Promise<T> {
+        try {
+          return await cb();
+        } finally {
+          this.end();
+        }
       }
     };
     this.stack.push(s);

--- a/packages/service-core/src/tracing/PerformanceTracer.ts
+++ b/packages/service-core/src/tracing/PerformanceTracer.ts
@@ -19,7 +19,7 @@ export interface Span extends Disposable {
   ended: boolean;
 
   /**
-   * Time spent not in nested spans.
+   * Time spent not in nested spans, in microseconds.
    */
   selfDuration: number;
 


### PR DESCRIPTION
This adds additional logs to help debug sync issues and performance.

## Example Scenarios

Scenario 1: A user says sync is not working - they're not seeing the latest data. We're trying to debug from service logs. Logs show no errors, shows there was a checkpoint was sent, and an eventual "Sync stream complete". But we have no further visibility: Did the client finish syncing? Were they still downloading data?

Scenario 2: A user says there is a significant delay in getting new data, and we're trying to find the source of the delay. There is no replication lag. Storage database shows high load, but we can't tell whether that is an issue. Logs show checkpoints are sent, but no timing info. We see some `Sync concurrency limit reached, waiting for lock` messages, which give some indication that there could be high load, but there is nothing definitive.

## New logs

This add logs for:
1. checkpoint_complete
2. partial_checkpoint_complete
3. checkpoint_invalidated

With these, we include stats on operations and bytes synced, as well as timing info. This helps to get better visibility into what is happening while syncing, instead of only at the end of the sync connection.

This then removes logs for `Got sync lock`, `Releasing sync lock` and `Sync concurrency limit reached, waiting for lock`. These were extremely noisy, are not actionable, and introduce confusion. The new logs above indicate aggregate timings that indicate (1) how long the connection was waiting for locks, and (2) how long the connection was holding a lock (implicitly via `bucket_data` and `client` timings), which is much easier to interpret than the individual sync lock messages.

In some cases, these changes could lead to doubling log volumes. But there are also many cases where the sync lock logs were a lot more noisy than the checkpoint logs, so removing those compensates for the increased volumes somewhat. I've seen cases where 86% of log lines are "sync lock" lines, with only 12% being checkpoint-related. In cases like that, even with the checkpoint lines being doubled, the total log lines would still be around 25% of what it was before.

### Future potential: Reducing log volumes

If the log volumes are still too high, we can consider merging the "new/updated checkpoint" logs into these new logs, instead of effectively logging two messages for each checkpoint. We have much more useful timing and data volume info at the time of "checkpoint_complete" than at the time we send the checkpoint. However, there are many potential edge cases where that change can result in reduced visibility. For example, if a client takes 10 minutes to download the data, we won't get any info on what is happening until the end.

One possibility may be to _delay_ the "new/updated checkpoint" messages, and merge the two messages when they're close together, but still keep the current split if it takes longer than a couple of seconds to complete the checkpoint. That would reduce noise if there are many tiny checkpoint updates, while preserving the useful split when large volumes of data is synced.

## Fixed bug: missing data on checkpoint invalidation with priorities

There was one rare consistency bug that is fixed as a side-effect from this. This scenario could happen:
1. Bucket priorities are used.
2. Client syncs a high-priority bucket.
3. Due to a concurrent compaction, the checkpoint is invalidated (via target_op).
4. The service picks up that invalidation, and the batch stops, without emitting a "partial_checkpoint_complete". The intention is continuing with the next checkpoint.
5. However, the loop handling priorities does not see that invalidation, it only sees "bucket data for this priority is done".
6. The priority loop incorrectly continues with the next priority.
7. The service emits the data, as well as a final checkpoint_complete.
8. The client now received a checkpoint_complete without the full data for that checkpoint. It would pick up the missing data in the checksum check, requiring a full re-download of the affected buckets.

This bug is now fixed by properly aborting the priority loop if the checkpoint is invalidated.

## Example logs

_Some of these logs are from tests, since it's tricky to produce the exact scenario in practice._

Example timings under contention (many concurrent bulk sync requests):
```js
info: checkpoint_complete: 4125837 {"bson":false,"checkpoint":4125837,"client_id":"load-test-20","data_synced_bytes":90432986,"ms":{"acquiring_lock":7025,"bucket_data":2989,"checksum":62,"other":1,"sending":751,"total":10828},"operations_synced":5984,"rid":"h/019f1cab-32c6-7758-9a34-800dade4fa7e","route":"/sync/stream","user_id":"3"}
```

Example for bucket priorities:

```js
info: New checkpoint: 2 | write: null | buckets: 2 | param_results: 0 ["b0.1.1[]","b1.1.2[]"] {"buckets":2,"checkpoint":2,"parameter_query_results":0,"user_id":"test"}
info: partial_checkpoint_complete: 2 {"checkpoint":2,"data_synced_bytes":234,"operations_synced":1,"priority":1,"user_id":"test"}
info: checkpoint_complete: 2 {"checkpoint":2,"data_synced_bytes":123,"ms":{"bucket_data":1,"checksum":4,"total":6},"operations_synced":1,"user_id":"test"}
```

Checkpoint interrupted with higher-priority data:

```js
info: New checkpoint: 10001 | write: null | buckets: 2 | param_results: 0 ["b0.1.1[]","b1.1.2[]"] {"buckets":2,"checkpoint":10001,"parameter_query_results":0,"user_id":""}
info: partial_checkpoint_complete: 10001 {"checkpoint":10001,"data_synced_bytes":0,"operations_synced":1,"priority":1,"user_id":""}
info: checkpoint_invalidated: 10001 {"checkpoint":10001,"data_synced_bytes":0,"ms":{"bucket_data":29,"checksum":6,"sending":7,"total":43},"operations_synced":3000,"reason":"checkpoint_superseded","user_id":""}
info: Updated checkpoint: 10002 | write: null | buckets: 2 | param_results: 0 | updated: ["b1.1.2[]"] | removed: [] {"buckets":2,"checkpoint":10002,"parameter_query_results":0,"removed":0,"updated":1,"user_id":""}
info: partial_checkpoint_complete: 10002 {"checkpoint":10002,"data_synced_bytes":0,"operations_synced":1,"priority":1,"user_id":""}
info: checkpoint_complete: 10002 {"checkpoint":10002,"data_synced_bytes":0,"ms":{"bucket_data":43,"checksum":6,"other":7,"total":57},"operations_synced":7000,"user_id":""}
```

Connection closed by client before completing checkpoint:

```js
info: Sync stream started {"bson":false,"client_id":"load-test-0","rid":"h/019f1ca7-4656-723a-bf3d-084bc26f96bd","route":"/sync/stream","user_id":"3"}
info: New checkpoint: 4125837 | write: null | buckets: 5 | param_results: 0 ["4#global2|0[]","4#by_user1|0[3]","4#by_user3|0[3]","4#location|0[3]","4#synth|0[3]"] {"bson":false,"buckets":5,"checkpoint":4125837,"client_id":"load-test-0","parameter_query_results":0,"rid":"h/019f1ca7-4656-723a-bf3d-084bc26f96bd","route":"/sync/stream","user_id":"3"}
info: Sync stream complete {"bson":false,"client_id":"load-test-0","close_reason":"client closing stream","data_sent_bytes":53137612,"data_synced_bytes":53137612,"large_buckets":{"4#location|0[3]":5535},"operation_counts":{"clear":0,"move":0,"put":5798,"remove":0},"operations_synced":5798,"rid":"h/019f1ca7-4656-723a-bf3d-084bc26f96bd","route":"/sync/stream","stream_ms":653,"user_id":"3"}
info: POST /sync/stream {"bson":false,"client_id":"load-test-0","duration_ms":654,"method":"POST","path":"/sync/stream","rid":"h/019f1ca7-4656-723a-bf3d-084bc26f96bd","route":"/sync/stream","status":200,"user_id":"3"}
info: checkpoint_invalidated: 4125837 {"bson":false,"checkpoint":4125837,"client_id":"load-test-0","data_synced_bytes":53137612,"ms":{"bucket_data":530,"sending":129,"total":660},"operations_synced":5798,"reason":"checkpoint_cancelled","rid":"h/019f1ca7-4656-723a-bf3d-084bc26f96bd","route":"/sync/stream","user_id":"3"}
```

## AI Usage

Manually designed the new behavior and tracking. Used Codex gpt-5.5 for some of the implementation.
