### PR TITLE
Remove action to auto-update the dockerhub description

### DIFF
--- a/.github/workflows/docker-stable.yaml
+++ b/.github/workflows/docker-stable.yaml
@@ -65,15 +65,3 @@ jobs:
             --tag "${{ vars.DOCKER_REGISTRY }}:${{ steps.version.outputs.major }}" \
             --tag "${{ vars.DOCKER_REGISTRY }}:latest" \
             "${{ vars.DOCKER_REGISTRY }}:${{ steps.version.outputs.version }}-next"
-
-      # Updates the README section on the DockerHub page
-      - name: Update repo description
-        #  Note that this 3rd party extention is recommended in the DockerHub docs:
-        #  https://docs.docker.com/build/ci/github-actions/update-dockerhub-desc/
-        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae # v4.0.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ vars.DOCKER_REGISTRY }}
-          #   This is the contents of what will be shown on DockerHub
-          readme-filepath: ./service/README.md


### PR DESCRIPTION
This doesn't work with organization access tokens - see failure here: https://github.com/powersync-ja/powersync-service/actions/runs/28650741644

Personal access tokens are too broad, so I don't want to go back to that. For now we'll just have to update the page manually when needed.

See issue: https://github.com/peter-evans/dockerhub-description/issues/294