### PR TITLE
[MongoDB Storage] Fix occasional readConcern errors when using bulk_read_preference

### DIFF
--- a/.changeset/smooth-moons-hammer.md
+++ b/.changeset/smooth-moons-hammer.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+---
+
+Fix for occasional readConcern errors when using bulk_read_preference.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoChecksums.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoChecksums.ts
@@ -59,8 +59,10 @@ export interface MongoChecksumOptions {
 interface MongoChecksumCacheReadContext {
   /**
    * (Optional) Specify a specific Timestamp for the snapshot read.
+   * Must include clusterTime as well.
    */
   snapshotTime?: mongo.Timestamp;
+  clusterTime?: mongo.ClusterTime;
 
   /**
    * Read preference. Use undefined for the default,
@@ -142,10 +144,11 @@ export abstract class MongoChecksums {
       throw new ServiceAssertionError(`context is required`);
     }
 
-    const { snapshotTime, readPreference } = context;
+    const { snapshotTime, clusterTime, readPreference } = context;
     return this.db.client.withSession({ snapshot: true }, async (session) => {
-      if (snapshotTime != null) {
+      if (snapshotTime != null && clusterTime != null) {
         setSessionSnapshotTime(session, snapshotTime);
+        session.advanceClusterTime(clusterTime);
       }
       return this.computePartialChecksumsWithSession(batch, {
         readOptions: {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -174,7 +174,7 @@ export abstract class MongoSyncBucketStorage
       }
 
       const snapshotTime = (session as any).snapshotTime as bson.Timestamp | undefined;
-      const clusterTime = session.clusterTime as mongo.ClusterTime | undefined;
+      const clusterTime = session.clusterTime;
       if (snapshotTime == null) {
         throw new ServiceAssertionError('Missing snapshotTime in getCheckpoint()');
       }

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -174,10 +174,14 @@ export abstract class MongoSyncBucketStorage
       }
 
       const snapshotTime = (session as any).snapshotTime as bson.Timestamp | undefined;
+      const clusterTime = session.clusterTime as mongo.ClusterTime | undefined;
       if (snapshotTime == null) {
         throw new ServiceAssertionError('Missing snapshotTime in getCheckpoint()');
       }
-      return new MongoReplicationCheckpoint(this, state.checkpoint, state.lsn, snapshotTime);
+      if (clusterTime == null) {
+        throw new ServiceAssertionError('Missing clusterTime in getCheckpoint()');
+      }
+      return new MongoReplicationCheckpoint(this, state.checkpoint, state.lsn, snapshotTime, clusterTime);
     });
   }
 
@@ -627,7 +631,8 @@ class MongoReplicationCheckpoint implements ReplicationCheckpoint {
     storage: MongoSyncBucketStorage,
     public readonly checkpoint: InternalOpId,
     public readonly lsn: string | null,
-    public snapshotTime: mongo.Timestamp
+    public snapshotTime: mongo.Timestamp,
+    public clusterTime: mongo.ClusterTime
   ) {
     this.#storage = storage;
   }

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -277,6 +277,7 @@ export abstract class MongoSyncBucketStorage
     const snapshotTime = mongoCheckpoint.snapshotTime; // May be undefined in tests
     return this.checksums.getChecksums(checkpoint.checkpoint, buckets, {
       snapshotTime,
+      clusterTime: mongoCheckpoint.clusterTime,
       readPreference: options?.requestHint == 'bulk' ? this.readPreference : undefined
     });
   }

--- a/modules/module-mongodb-storage/src/storage/implementation/common/MongoSyncBucketStorageCheckpoint.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/common/MongoSyncBucketStorageCheckpoint.ts
@@ -1,7 +1,9 @@
+import { mongo } from '@powersync/lib-service-mongodb';
 import { InternalOpId } from '@powersync/service-core';
 import * as bson from 'bson';
 
 export interface MongoSyncBucketStorageCheckpoint {
   checkpoint: InternalOpId;
   snapshotTime: bson.Timestamp;
+  clusterTime: mongo.ClusterTime;
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoSyncBucketStorageV1.ts
@@ -389,6 +389,7 @@ export async function* getBucketDataBatchV1(
 
   if (session != null) {
     session.advanceOperationTime(checkpoint.snapshotTime);
+    session.advanceClusterTime(checkpoint.clusterTime);
   }
 
   let filters: mongo.Filter<BucketDataDocumentV1>[] = [];

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -553,6 +553,7 @@ export async function* getBucketDataBatchV3(
 
   if (session != null) {
     session.advanceOperationTime(checkpoint.snapshotTime);
+    session.advanceClusterTime(checkpoint.clusterTime);
   }
 
   const batchLimit = options?.limit ?? storage.DEFAULT_DOCUMENT_BATCH_LIMIT;


### PR DESCRIPTION
When using `bulk_read_preference: secondaryPreferred`, these errors occasionally come up:

```
Sync stream error [PSYNC_S2001] Something went wrong
  readConcern atClusterTime value must not be greater than the current clusterTime. Requested clusterTime: { ts: Timestamp(1783421938, 355) }; current clusterTime: { ts: Timestamp(1783421938, 351) }

Sync stream error [PSYNC_S2001] Something went wrong
  [PSYNC_S2404] MongoDB server error while reading checksums: InvalidOptions
```

In #697, I originally went with this assumption from https://jira.mongodb.org/browse/DRIVERS-2860:
> No need to do session_b.advance_cluster_time(session_a.cluster_time) because the MongoClient
> already gossips the highest $clusterTime seen across all client sessions.

But it appears that assumption does not always hold here. Using `advanceClusterTime` as well is simple enough, and should resolve the issue.

Note that this effectively includes `$clusterTime` in the commands mongodb sends. It does not change how values are read, but should avoid the errors above. It may have additional implications for monotonic writes, but that should not affect our reads here.