### PR TITLE
Fix 'evicted' errors

### DIFF
--- a/.changeset/silly-news-punch.md
+++ b/.changeset/silly-news-punch.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+---
+
+Potential fix and improved stack trace for 'evicted' errors.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoSyncBucketStorage.ts
@@ -590,6 +590,9 @@ export abstract class MongoSyncBucketStorage
   >({
     max: 50,
     maxSize: 12 * 1024 * 1024,
+    // When we have more fetches than the cache size, complete the fetches instead
+    // of failing with Error('evicted').
+    ignoreFetchAbort: true,
     sizeCalculation: (value: InternalCheckpointChanges) => {
       const paramSize = [...value.updatedParameterLookups].reduce<number>((a, b) => a + b.length, 0);
       const bucketSize = [...value.updatedDataBuckets].reduce<number>((a, b) => a + b.length, 0);

--- a/packages/service-core/src/routes/endpoints/socket-route.ts
+++ b/packages/service-core/src/routes/endpoints/socket-route.ts
@@ -163,8 +163,9 @@ export const syncStreamReactive: SocketRouteGenerator = (router) =>
       } catch (ex) {
         // Convert to our standard form before responding.
         // This ensures the error can be serialized.
+        // However, use the original error for the logs, so that we have the stack trace.
         const error = new errors.InternalServerError(ex);
-        logger.error('Sync stream error', error);
+        logger.error('Sync stream error', ex);
         closeReason ??= 'stream error';
         responder.onError(error);
       } finally {


### PR DESCRIPTION
When LRUCache entries are evicted while the fetch is still in progress, it cancels the request and results in an unhelpful `'evicted'`. We've already sent the db query, so it makes more sense to just wait for the results. This is what the `ignoreFetchAbort: true` config flag does.

This also change the log message for errors like these, to include the original stack trace instead of just the place where it's wrapped in socket-route.ts.