### PR TITLE
[MongoDB Storage V3] Tweak size estimates and chunking to use actual BSON sizes

### DIFF
--- a/.changeset/neat-colts-switch.md
+++ b/.changeset/neat-colts-switch.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+---
+
+[MongoDB Storage V3] Tweak size estimates and chunking to use actual BSON sizes.

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/bucket-format.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/bucket-format.ts
@@ -1,3 +1,4 @@
+import { bson } from '@powersync/service-core';
 import { BucketDataDoc, BucketKey } from '../common/BucketDataDoc.js';
 import { BucketDataDocumentV3, BucketOperation } from './models.js';
 
@@ -6,12 +7,10 @@ export function serializeBucketData(bucket: string, operations: BucketDataDoc[])
   const maxOp = operations[operations.length - 1].o;
 
   let totalChecksum = 0n;
-  let totalSize = 0;
   let maxTargetOp: bigint | null = null;
 
   const ops: BucketOperation[] = operations.map((op) => {
     totalChecksum += op.checksum;
-    totalSize += op.data?.length ?? 0;
 
     if (op.target_op != null && (maxTargetOp == null || op.target_op > maxTargetOp)) {
       maxTargetOp = op.target_op;
@@ -29,6 +28,8 @@ export function serializeBucketData(bucket: string, operations: BucketDataDoc[])
     };
   });
 
+  const size = bson.calculateObjectSize(ops);
+
   return {
     _id: {
       b: bucket,
@@ -37,7 +38,7 @@ export function serializeBucketData(bucket: string, operations: BucketDataDoc[])
     min_op: minOp,
     checksum: totalChecksum,
     count: operations.length,
-    size: totalSize,
+    size,
     target_op: maxTargetOp,
     ops
   };

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/chunking.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/chunking.ts
@@ -1,3 +1,4 @@
+import { bson } from '@powersync/service-core';
 import { BucketDataDoc } from '../common/BucketDataDoc.js';
 
 export const DEFAULT_MAX_DOC_SIZE_BYTES = 1024 * 1024; // 1MB
@@ -18,7 +19,8 @@ export function chunkBucketData(
   let currentSize = 0;
 
   for (const op of operations) {
-    const opSize = op.data?.length ?? 0;
+    // Add 5 to account for array index up to 4 digits (9999) plus null byte.
+    const opSize = bson.calculateObjectSize(op) + 5;
 
     if (currentSize + opSize > maxDocSizeBytes && currentChunk.length > 0) {
       chunks.push(currentChunk);

--- a/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
@@ -422,7 +422,7 @@ bucket_definitions:
     expect(doc.min_op).toBe(3n);
     expect(doc.count).toBe(3);
     expect(doc.checksum).toBe(60n);
-    expect(doc.size).toBe(4 + 5 + 8);
+    expect(doc.size).toBe(bson.calculateObjectSize(doc.ops));
   });
 
   test('2. range metadata consistency - after compaction', async () => {
@@ -440,7 +440,7 @@ bucket_definitions:
       expect(doc.min_op).toBe(doc.ops.reduce((min, op) => (op.o < min ? op.o : min), doc.ops[0].o));
       expect(doc.count).toBe(doc.ops.length);
       expect(doc.checksum).toBe(doc.ops.reduce((sum, op) => sum + op.checksum, 0n));
-      expect(doc.size).toBe(doc.ops.reduce((sum, op) => sum + (op.data?.length ?? 0), 0));
+      expect(doc.size).toBe(bson.calculateObjectSize(doc.ops));
     }
   });
 
@@ -1368,8 +1368,9 @@ bucket_definitions:
     expect(putOps.every((op) => op.data != null)).toBe(true);
 
     expect(docs.length).toBe(1);
-    const putSize = putOps.reduce((sum, op) => sum + (op.data?.length ?? 0), 0);
-    expect(docs[0].size).toBe(putSize);
+    // Size calculation is not exact - we just check for a range
+    expect(docs[0].size).toBeGreaterThan(1_000_000);
+    expect(docs[0].size).toBeLessThan(1_001_000);
   });
 
   test('tombstones and survivors end up in same document after rechunking', async () => {


### PR DESCRIPTION
This uses actual BSON sizes for estimating operation sizes for:
1. Estimating chunk sizes when chunking operations.
2. Calculating the `size` field for the chunk when persisting.

Previously only the `data` length was used, which meant that MOVE and REMOVE operations did not get considered in the size at all. In theory that could lead to a situation where a chunk contains 100k MOVE operations and then exceeds the 16MB limit.

The calculations here are not meant to be exact, but it should be a better estimate than what we had.

This does add some overhead, but that should be small compared to the actual persistence overhead.

## AI Usage

Used Codex gpt-5.5 to investigate and suggest changes, but implemented the changes myself.