### PR TITLE
Remove explicit npm update from packages_release workflow

### DIFF
--- a/.github/workflows/packages_release.yaml
+++ b/.github/workflows/packages_release.yaml
@@ -34,11 +34,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Update npm
-        run: |
-          npm install -g npm@latest
-          npm --version
-
       - name: Build
         run: pnpm build:production
 


### PR DESCRIPTION
We currently use node 24.15.0, which bundles npm 11.12.1, which is recent enough to support trusted publishing. So, there is no reason to install or update npm explicitly.

In some of our other JavaScript repositories, we've seen that upgrading can actually cause issues because the latest npm version doesn't support our Node version anymore. So, we'll just use the npm version from node instead.