### PR TITLE
Add sync plan version 2

### DIFF
--- a/.changeset/yummy-showers-agree.md
+++ b/.changeset/yummy-showers-agree.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Improve error message when trying to load Sync Streams deployed with a more recent service version on older services.

--- a/packages/service-core/src/storage/BucketStorageFactory.ts
+++ b/packages/service-core/src/storage/BucketStorageFactory.ts
@@ -1,8 +1,8 @@
 import { BaseObserver, logger } from '@powersync/lib-services-framework';
 import {
   PrecompiledSyncConfig,
+  SerializedSyncPlan as RawSerializedSyncPlan,
   SerializedCompatibilityContext,
-  SerializedSyncPlanV1,
   serializeSyncPlan,
   SqlSyncRules,
   SyncConfigWithErrors
@@ -171,7 +171,7 @@ export interface SerializedSyncPlan {
   /**
    * The serialized plan, from {@link serializeSyncPlan}.
    */
-  plan: SerializedSyncPlanV1;
+  plan: RawSerializedSyncPlan;
   compatibility: SerializedCompatibilityContext;
   /**
    * Event descriptors are not currently represented in the sync plan because they don't use the sync streams compiler

--- a/packages/service-core/src/storage/implementation/BucketDefinitionMapping.ts
+++ b/packages/service-core/src/storage/implementation/BucketDefinitionMapping.ts
@@ -10,13 +10,13 @@ import {
   SerializedParameterIndexLookupCreator,
   serializedStreamBucketDataSourceEquality,
   serializedStreamParameterIndexLookupCreatorEquality,
-  SerializedSyncPlanV1,
+  SerializedSyncPlan,
   SourceTableRef,
   SyncConfigWithErrors
 } from '@powersync/service-sync-rules';
 
 export interface SerializedSyncConfigWithMapping {
-  plan: SerializedSyncPlanV1;
+  plan: SerializedSyncPlan;
   mapping: SingleSyncConfigBucketDefinitionMapping;
 }
 
@@ -131,7 +131,7 @@ export class SingleSyncConfigBucketDefinitionMapping implements BucketDefinition
    */
   static constructIncrementalMappingFromSerializedPlans(
     compatibleConfigs: SerializedSyncConfigWithMapping[],
-    newPlan: SerializedSyncPlanV1,
+    newPlan: SerializedSyncPlan,
     reservedMappings: SingleSyncConfigBucketDefinitionMapping[]
   ): SingleSyncConfigBucketDefinitionMapping {
     return this.constructIncrementalMappingWithChanges(compatibleConfigs, newPlan, reservedMappings).mapping;
@@ -139,7 +139,7 @@ export class SingleSyncConfigBucketDefinitionMapping implements BucketDefinition
 
   static constructIncrementalMappingWithChanges(
     compatibleConfigs: SerializedSyncConfigWithMapping[],
-    newPlan: SerializedSyncPlanV1,
+    newPlan: SerializedSyncPlan,
     reservedMappings: SingleSyncConfigBucketDefinitionMapping[]
   ): IncrementalMappingResult {
     let nextBucketDefinitionId =

--- a/packages/sync-rules/src/sync_plan/serialize.ts
+++ b/packages/sync-rules/src/sync_plan/serialize.ts
@@ -32,17 +32,20 @@ import {
  * queriers to bucket creators. To represent this efficiently, we assign numbers to referenced elements while
  * serializing instead of duplicating definitions.
  */
-export function serializeSyncPlan(plan: SyncPlan): SerializedSyncPlanV1 {
+export function serializeSyncPlan(plan: SyncPlan): SerializedSyncPlan {
   const dataSourceIndex = new Map<StreamDataSource, number>();
   const bucketIndex = new Map<StreamBucketDataSource, number>();
   const parameterIndex = new Map<StreamParameterIndexLookupCreator, number>();
   const expandingLookups = new Map<ExpandingLookup, LookupReference>();
   const addedTableValuedFunctions = new Map<TableProcessorTableValuedFunction, number>();
+  let usesRowMetadataSqlValue = false;
 
   const replaceFunctionReferenceWithIndex = new MapSourceVisitor<
     ColumnSqlParameterValue | RowMetadataSqlValue | TableProcessorTableValuedFunctionOutput,
     ColumnSqlParameterValue | RowMetadataSqlValue | SerializedTableProcessorTableValuedFunctionOutput
   >((value) => {
+    usesRowMetadataSqlValue ||= 'metadata' in value;
+
     if ('function' in value) {
       return { function: addedTableValuedFunctions.get(value.function)!, outputName: value.outputName };
     } else {
@@ -168,7 +171,6 @@ export function serializeSyncPlan(plan: SyncPlan): SerializedSyncPlanV1 {
   }
 
   return {
-    version: 1,
     dataSources: serializeDataSources(),
     buckets: plan.buckets.map((bkt, index) => {
       bucketIndex.set(bkt, index);
@@ -182,13 +184,20 @@ export function serializeSyncPlan(plan: SyncPlan): SerializedSyncPlanV1 {
     streams: plan.streams.map((s) => ({
       stream: s.stream,
       queriers: s.queriers.map(serializeStreamQuerier)
-    }))
+    })),
+    version: usesRowMetadataSqlValue ? 2 : 1
   };
 }
 
 export function deserializeSyncPlan(serialized: unknown): SyncPlan {
-  if ((serialized as SerializedSyncPlanV1).version != 1) {
+  const { version } = serialized as SerializedSyncPlan;
+  if (version < 1) {
     throw new Error('Unknown sync plan version passed to deserializeSyncPlan()');
+  }
+  if (version > maxSupportedSyncPlanVersion) {
+    throw new Error(
+      `Encountered a sync plan with version ${version}, the maximum supported version is ${maxSupportedSyncPlanVersion}. This can happen when the PowerSync service version is downgraded after deploying Sync Streams, consider upgrading or re-deploying.`
+    );
   }
 
   function deserializeTablePattern(pattern: SerializedTablePattern): ImplicitSchemaTablePattern {
@@ -224,7 +233,7 @@ export function deserializeSyncPlan(serialized: unknown): SyncPlan {
     });
   }
 
-  const plan = serialized as SerializedSyncPlanV1;
+  const plan = serialized as SerializedSyncPlan;
   const dataSources = plan.dataSources.map((source): StreamDataSource => {
     const functions = (tableValuedFunctionsInScope = source.tableValuedFunctions);
 
@@ -333,8 +342,28 @@ export function deserializeSyncPlan(serialized: unknown): SyncPlan {
   };
 }
 
-export interface SerializedSyncPlanV1 {
-  version: number;
+/**
+ * Every change to the format of {@link SerializedSyncPlan} needs a version bump and a changelog entry in this
+ * documentation comment. Even for seemingly backward-compatible changes, like adding new fields, older services would
+ * be unaware of them and thus interpret the sync plan incorrectly. Increasing this version ensures that older services
+ * wouldn't even try to deserialize sync plans.
+ *
+ * ### Version 2
+ *
+ * - Add {@link RowMetadataSqlValue} to data for row and parameter evaluators, exposing the exact table and schema name
+ *   when matching on wildcard table patterns.
+ *   The deserialization logic can remain the same for v1 and v2.
+ *
+ * ### Version 1
+ *
+ * - Initial version
+ */
+export type SerializedSyncPlanVersion = 1 | 2;
+
+export const maxSupportedSyncPlanVersion: SerializedSyncPlanVersion = 2;
+
+export interface SerializedSyncPlan {
+  version: SerializedSyncPlanVersion;
   dataSources: SerializedDataSource[];
   buckets: SerializedBucketDataSource[];
   parameterIndexes: SerializedParameterIndexLookupCreator[];

--- a/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
@@ -3510,6 +3510,94 @@ exports[`new sync stream features > order-independent parameters 1`] = `
 }
 `;
 
+exports[`new sync stream features > row metadata 1`] = `
+{
+  "buckets": [
+    {
+      "hash": 524705252,
+      "sources": [
+        0,
+      ],
+      "uniqueName": "stream|0",
+    },
+  ],
+  "dataSources": [
+    {
+      "columns": [
+        "star",
+        {
+          "alias": "suffix",
+          "expr": {
+            "source": {
+              "metadata": "table_suffix",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "filters": [],
+      "hash": 352817177,
+      "outputTableName": "source",
+      "partitionBy": [
+        {
+          "expr": {
+            "source": {
+              "metadata": "schema",
+            },
+            "type": "data",
+          },
+        },
+      ],
+      "table": {
+        "connection": "default",
+        "schema": "%",
+        "table": "users_%",
+      },
+      "tableValuedFunctions": [],
+    },
+  ],
+  "parameterIndexes": [],
+  "streams": [
+    {
+      "queriers": [
+        {
+          "bucket": 0,
+          "lookupStages": [],
+          "requestFilters": [],
+          "sourceInstantiation": [
+            {
+              "expr": {
+                "function": "->>",
+                "parameters": [
+                  {
+                    "source": {
+                      "request": "auth",
+                    },
+                    "type": "data",
+                  },
+                  {
+                    "type": "lit_string",
+                    "value": "schema",
+                  },
+                ],
+                "type": "function",
+              },
+              "type": "request",
+            },
+          ],
+        },
+      ],
+      "stream": {
+        "isSubscribedByDefault": true,
+        "name": "stream",
+        "priority": 3,
+      },
+    },
+  ],
+  "version": 2,
+}
+`;
+
 exports[`new sync stream features > table-valued functions > partition on data 1`] = `
 {
   "buckets": [

--- a/packages/sync-rules/test/src/compiler/advanced.test.ts
+++ b/packages/sync-rules/test/src/compiler/advanced.test.ts
@@ -343,4 +343,14 @@ streams:
       ).toMatchSnapshot();
     });
   });
+
+  test('row metadata', () => {
+    const serialized = compileSingleStreamAndSerialize(
+      `SELECT *, source.table_suffix() AS suffix FROM "%"."users_%" source WHERE source.schema() = auth.parameter('schema')`
+    );
+
+    // Should not be v1 if .schema() or .table_suffix() is used.
+    expect(serialized.version).toStrictEqual(2);
+    expect(serialized).toMatchSnapshot();
+  });
 });

--- a/packages/sync-rules/test/src/compiler/utils.ts
+++ b/packages/sync-rules/test/src/compiler/utils.ts
@@ -4,6 +4,7 @@ import {
   getLocation,
   ParsingErrorListener,
   PrecompiledSyncConfig,
+  SerializedSyncPlan,
   serializeSyncPlan,
   SqlSyncRules,
   SyncPlan,
@@ -18,7 +19,7 @@ interface TranslationError {
   startOffset?: number;
 }
 
-export function compileSingleStreamAndSerialize(...sql: string[]): unknown {
+export function compileSingleStreamAndSerialize(...sql: string[]): SerializedSyncPlan {
   const [errors, plan] = compileSingleStream(...sql);
   expect(errors).toStrictEqual([]);
   return serializeSyncPlan(plan);

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -1,9 +1,11 @@
 import * as sqlite from 'node:sqlite';
-import { describe, expect } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import {
   DEFAULT_HYDRATION_STATE,
   DEFAULT_TAG,
+  deserializeSyncPlan,
   HydratedSyncConfig,
+  maxSupportedSyncPlanVersion,
   nodeSqlite,
   ParameterLookupRows,
   PrecompiledSyncConfig,
@@ -1459,6 +1461,11 @@ streams:
       }
     ]);
   });
+});
+
+test('refuses to load unknown sync plan versions', () => {
+  expect(() => deserializeSyncPlan({ version: 0 })).toThrow();
+  expect(() => deserializeSyncPlan({ version: maxSupportedSyncPlanVersion + 1 })).toThrow();
 });
 
 function evaluateBucketIds(source: HydratedSyncConfig, sourceTable: SourceTableRef, record: SqliteRow) {


### PR DESCRIPTION
#703 introduced syntax exposing table and schema names to bucket data and parameter creators, a change that requires changes to the serialized form of sync plans.

Older service versions would not load these correctly, so they should reject those plans outright. The version field added to sync plans helps here, older services throw if it's not `1`. This PR:

1. Introduces version `2` for sync plans, used when `.schema()`, `.table_suffix()` or `.table_name()` are used in an expression of the sync plan. Existing deployments not using the new row metadata functions are unaffected.
2. Improves the error message when we encounter sync plan versions the current service doesn't understand (this only starts being relevant when we increase the version again in the future, but it's helpful to have).

By continuing to use plan version 1 where possible, we allow service downgrades as long as the new functions aren't used in sync plans (if there are, there's no way an older service could implement those streams either way).