### PR TITLE
fix(postgres-storage): Fix stale checkpoint events when connections a…

### DIFF
--- a/.changeset/quiet-lions-listen.md
+++ b/.changeset/quiet-lions-listen.md
@@ -5,4 +5,4 @@
 '@powersync/service-module-postgres-storage': patch
 ---
 
-Reconnect PostgreSQL notification connections and restore `LISTEN` subscriptions when the underlying connection is terminated.
+Reconnect PostgreSQL notification connections and restore `LISTEN` subscriptions when the underlying connection is terminated. Harden connection-slot retries and lease handling, and publish checkpoint notifications atomically with checkpoint updates.

--- a/.changeset/quiet-lions-listen.md
+++ b/.changeset/quiet-lions-listen.md
@@ -1,6 +1,6 @@
 ---
 '@powersync/lib-service-postgres': patch
-'@powersync/service-core': patch
+'@powersync/service-image': patch
 '@powersync/service-jpgwire': patch
 '@powersync/service-module-postgres-storage': patch
 ---

--- a/.changeset/quiet-lions-listen.md
+++ b/.changeset/quiet-lions-listen.md
@@ -1,0 +1,8 @@
+---
+'@powersync/lib-service-postgres': patch
+'@powersync/service-core': patch
+'@powersync/service-jpgwire': patch
+'@powersync/service-module-postgres-storage': patch
+---
+
+Reconnect PostgreSQL notification connections and restore `LISTEN` subscriptions when the underlying connection is terminated.

--- a/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
+++ b/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
@@ -16,6 +16,15 @@ export interface NotificationListener {
   notificationChannelsRegistered?: () => Promise<void>;
 }
 
+/**
+ * Listener keys that operate on the notification connection. These are handled
+ * on the dedicated notification slot rather than the general connection pool.
+ */
+export const NOTIFICATION_LISTENER_KEYS = [
+  'notification',
+  'notificationChannelsRegistered'
+] as const satisfies readonly (keyof NotificationListener)[];
+
 export interface ConnectionSlotListener extends NotificationListener {
   connectionAvailable?: () => void;
   connectionError?: (exception: any) => void;
@@ -71,7 +80,11 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
      * Subscribing to notifications, even without a registered listener, should not add much overhead.
      */
     await this.configureConnectionNotifications(connection);
-    connection.whenDestroyed.then(() => this.handleConnectionDestroyed(connection));
+    // whenDestroyed normally resolves, but guard against a rejection becoming an
+    // unhandled promise rejection. Either outcome means the connection is gone.
+    connection.whenDestroyed
+      .catch((error) => framework.logger.debug('Postgres connection destroyed with an error', error))
+      .then(() => this.handleConnectionDestroyed(connection));
     return connection;
   }
 
@@ -120,7 +133,7 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
   };
 
   protected hasNotificationListener() {
-    return !!Object.values(this.listeners).find((l) => !!l.notification);
+    return !!Object.values(this.listeners).find((l) => NOTIFICATION_LISTENER_KEYS.some((key) => !!l[key]));
   }
 
   /**

--- a/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
+++ b/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
@@ -1,5 +1,6 @@
 import * as framework from '@powersync/lib-services-framework';
 import * as pgwire from '@powersync/service-jpgwire';
+import * as timers from 'node:timers/promises';
 
 export type NotificationEvent =
   | { type: 'notification'; notification: pgwire.PgNotification }
@@ -15,6 +16,7 @@ export interface NotificationListener {
 
 export interface ConnectionSlotListener extends NotificationListener {
   connectionAvailable?: () => void;
+  /** Reports that this slot exhausted its connection attempts. */
   connectionError?: (exception: any) => void;
   connectionCreated?: (connection: pgwire.PgConnection) => Promise<void>;
 }
@@ -31,22 +33,23 @@ export type ConnectionSlotOptions = {
 };
 
 export const MAX_CONNECTION_ATTEMPTS = 5;
+const CONNECTION_RETRY_DELAY_MS = 100;
 
 export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListener> {
-  isAvailable: boolean;
   isPoking: boolean;
 
   closed: boolean;
 
   protected connection: pgwire.PgConnection | null;
   protected connectingPromise: Promise<pgwire.PgConnection> | null;
+  protected activeLease: symbol | null;
 
   constructor(protected options: ConnectionSlotOptions) {
     super();
-    this.isAvailable = false;
     this.connection = null;
     this.isPoking = false;
     this.connectingPromise = null;
+    this.activeLease = null;
     this.closed = false;
   }
 
@@ -54,41 +57,8 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
     return !!this.connection;
   }
 
-  protected async connect() {
-    this.connectingPromise = pgwire.connectPgWire(this.options.config, {
-      type: 'standard',
-      applicationName: this.options.applicationName
-    });
-    const connection = await this.connectingPromise;
-    this.connectingPromise = null;
-    await this.iterateAsyncListeners(async (l) => l.connectionCreated?.(connection));
-
-    /**
-     * Configure the Postgres connection to listen to notifications.
-     * Subscribing to notifications, even without a registered listener, should not add much overhead.
-     */
-    await this.configureConnectionNotifications(connection);
-    // whenDestroyed normally resolves, but guard against a rejection becoming an
-    // unhandled promise rejection. Either outcome means the connection is gone.
-    connection.whenDestroyed
-      .catch((error) => framework.logger.debug('Postgres connection destroyed with an error', error))
-      .then(() => this.handleConnectionDestroyed(connection));
-    return connection;
-  }
-
-  protected handleConnectionDestroyed(connection: pgwire.PgConnection) {
-    if (this.connection != connection) {
-      return;
-    }
-
-    this.connection = null;
-    this.isAvailable = false;
-
-    if (this.hasNotificationListener() && !this.closed) {
-      // Notification connections need to be restored proactively. Other slots
-      // are reconnected lazily when the next connection lease is requested.
-      this.poke();
-    }
+  get isAvailable() {
+    return this.connection != null && this.activeLease == null && !this.closed;
   }
 
   async [Symbol.asyncDispose]() {
@@ -96,6 +66,113 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
     const connection = this.connection ?? (await this.connectingPromise);
     await connection?.end();
     super.clearListeners();
+  }
+
+  /**
+   * Ensure this slot has a connection and signal when it can be leased.
+   */
+  async poke() {
+    if (this.closed || this.connection || this.isPoking) {
+      return;
+    }
+
+    this.isPoking = true;
+    try {
+      for (let retryCounter = 0; retryCounter <= MAX_CONNECTION_ATTEMPTS; retryCounter++) {
+        try {
+          const connection = await this.connect();
+
+          if (this.closed) {
+            connection.destroy();
+            return;
+          }
+
+          this.connection = connection;
+
+          // Register this only after the slot owns the connection. If
+          // `whenDestroyed` has already settled, its callback runs in a later
+          // microtask and must see this exact connection assigned. Registering
+          // it before assignment could ignore the destruction and leave the
+          // slot holding an already-destroyed connection.
+          connection.whenDestroyed
+            .catch((error) => framework.logger.debug('Postgres connection destroyed with an error', error))
+            .then(() => this.handleConnectionDestroyed(connection));
+
+          if (this.activeLease == null) {
+            this.notifyConnectionAvailable();
+          }
+          break;
+        } catch (ex) {
+          if (retryCounter >= MAX_CONNECTION_ATTEMPTS) {
+            this.iterateListeners((cb) => {
+              cb.connectionError?.(ex);
+              cb.notificationEvent?.({ type: 'connection-error', error: ex });
+            });
+          } else {
+            await timers.setTimeout(CONNECTION_RETRY_DELAY_MS);
+            if (this.closed) {
+              return;
+            }
+          }
+        }
+      }
+    } finally {
+      this.isPoking = false;
+    }
+  }
+
+  protected async connect() {
+    // Only allow a single connect to run at-a-time
+    if (this.connectingPromise) {
+      return this.connectingPromise;
+    }
+
+    const connectInternal = async () => {
+      let connection: pgwire.PgConnection | null = null;
+      try {
+        const connected = await pgwire.connectPgWire(this.options.config, {
+          type: 'standard',
+          applicationName: this.options.applicationName
+        });
+        connection = connected;
+
+        await this.iterateAsyncListeners(async (l) => l.connectionCreated?.(connected));
+
+        /**
+         * Configure the Postgres connection to listen to notifications.
+         * Subscribing to notifications, even without a registered listener, should not add much overhead.
+         */
+        await this.configureConnectionNotifications(connected);
+
+        return connected;
+      } catch (error) {
+        connection?.destroy();
+        throw error;
+      }
+    };
+
+    this.connectingPromise = connectInternal();
+    try {
+      return await this.connectingPromise;
+    } finally {
+      this.connectingPromise = null;
+    }
+  }
+
+  protected handleConnectionDestroyed(connection: pgwire.PgConnection) {
+    // Guard that the closed connection is actually the one in use by the slot.
+    if (this.connection != connection) {
+      return;
+    }
+
+    // Clear the slot reference, marking the slot as unavailable
+    this.connection = null;
+
+    // Notification slots must restore their LISTEN subscriptions immediately.
+    // Other slots reconnect lazily when the next lease is requested.
+    if (!this.closed && this.options.notificationChannels?.length) {
+      this.poke().catch((error) => framework.logger.error('Failed to restore Postgres notification connection', error));
+    }
   }
 
   protected async configureConnectionNotifications(connection: pgwire.PgConnection) {
@@ -120,70 +197,37 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
     this.iterateListeners((l) => l.notificationEvent?.({ type: 'notification', notification: payload }));
   };
 
-  protected hasNotificationListener() {
-    return !!Object.values(this.listeners).find((listener) => !!listener.notificationEvent);
-  }
-
-  /**
-   * Test the connection if it can be reached.
-   */
-  async poke() {
-    if (this.isPoking || (this.isConnected && this.isAvailable == false) || this.closed) {
-      return;
-    }
-    this.isPoking = true;
-    for (let retryCounter = 0; retryCounter <= MAX_CONNECTION_ATTEMPTS; retryCounter++) {
-      try {
-        const connection = this.connection ?? (await this.connect());
-
-        await connection.query({
-          statement: 'SELECT 1'
-        });
-
-        if (!this.connection) {
-          this.connection = connection;
-          this.setAvailable();
-        } else if (this.isAvailable) {
-          this.iterateListeners((cb) => cb.connectionAvailable?.());
-        }
-
-        // Connection is alive and healthy
-        break;
-      } catch (ex) {
-        // Should be valid for all cases
-        this.isAvailable = false;
-        if (this.connection) {
-          this.connection.onnotification = () => {};
-          this.connection.destroy();
-          this.connection = null;
-        }
-        if (retryCounter >= MAX_CONNECTION_ATTEMPTS) {
-          this.iterateListeners((cb) => {
-            cb.connectionError?.(ex);
-            cb.notificationEvent?.({ type: 'connection-error', error: ex });
-          });
-        }
-      }
-    }
-    this.isPoking = false;
-  }
-
-  protected setAvailable() {
-    this.isAvailable = true;
+  protected notifyConnectionAvailable() {
     this.iterateListeners((l) => l.connectionAvailable?.());
   }
 
   lock(): ConnectionLease | null {
-    if (!this.isAvailable || !this.connection || this.closed) {
+    if (!this.isAvailable || !this.connection || this.activeLease != null || this.closed) {
       return null;
     }
 
-    this.isAvailable = false;
+    // Create a unique symbol to identify this lease
+    const lease = Symbol();
+    this.activeLease = lease;
 
     return {
       connection: this.connection,
       release: () => {
-        this.setAvailable();
+        // Only release if this lease is the current active lease
+        if (this.activeLease != lease) {
+          return;
+        }
+        this.activeLease = null;
+        if (this.closed) {
+          return;
+        }
+        if (this.connection) {
+          this.notifyConnectionAvailable();
+        } else {
+          // The leased connection was destroyed. Reconnect now in case a
+          // request was queued while this slot still held the lease.
+          this.poke().catch((error) => framework.logger.error('Failed to restore Postgres connection', error));
+        }
       }
     };
   }

--- a/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
+++ b/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
@@ -2,7 +2,18 @@ import * as framework from '@powersync/lib-services-framework';
 import * as pgwire from '@powersync/service-jpgwire';
 
 export interface NotificationListener {
+  /**
+   * Called when Postgres emits a notification on one of the configured channels.
+   */
   notification?: (payload: pgwire.PgNotification) => void;
+
+  /**
+   * Called after the notification connection has successfully executed LISTEN for
+   * every configured channel. This runs after both initial connection setup and
+   * reconnection, allowing consumers to recover notifications missed while the
+   * connection was unavailable.
+   */
+  notificationChannelsRegistered?: () => Promise<void>;
 }
 
 export interface ConnectionSlotListener extends NotificationListener {
@@ -89,10 +100,15 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
   protected async configureConnectionNotifications(connection: pgwire.PgConnection) {
     connection.onnotification = this.handleNotification;
 
-    for (const channelName of this.options.notificationChannels ?? []) {
+    const notificationChannels = this.options.notificationChannels ?? [];
+    for (const channelName of notificationChannels) {
       await connection.query({
         statement: `LISTEN ${channelName}`
       });
+    }
+
+    if (notificationChannels.length > 0) {
+      await this.iterateAsyncListeners(async (l) => l.notificationChannelsRegistered?.());
     }
   }
 

--- a/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
+++ b/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
@@ -1,29 +1,17 @@
 import * as framework from '@powersync/lib-services-framework';
 import * as pgwire from '@powersync/service-jpgwire';
 
+export type NotificationEvent =
+  | { type: 'notification'; notification: pgwire.PgNotification }
+  | { type: 'channels-registered' }
+  | { type: 'connection-error'; error: unknown };
+
 export interface NotificationListener {
   /**
-   * Called when Postgres emits a notification on one of the configured channels.
+   * Reports notifications and notification-connection lifecycle events.
    */
-  notification?: (payload: pgwire.PgNotification) => void;
-
-  /**
-   * Called after the notification connection has successfully executed LISTEN for
-   * every configured channel. This runs after both initial connection setup and
-   * reconnection, allowing consumers to recover notifications missed while the
-   * connection was unavailable.
-   */
-  notificationChannelsRegistered?: () => Promise<void>;
+  notificationEvent?: (event: NotificationEvent) => void;
 }
-
-/**
- * Listener keys that operate on the notification connection. These are handled
- * on the dedicated notification slot rather than the general connection pool.
- */
-export const NOTIFICATION_LISTENER_KEYS = [
-  'notification',
-  'notificationChannelsRegistered'
-] as const satisfies readonly (keyof NotificationListener)[];
 
 export interface ConnectionSlotListener extends NotificationListener {
   connectionAvailable?: () => void;
@@ -121,7 +109,7 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
     }
 
     if (notificationChannels.length > 0) {
-      await this.iterateAsyncListeners(async (l) => l.notificationChannelsRegistered?.());
+      this.iterateListeners((l) => l.notificationEvent?.({ type: 'channels-registered' }));
     }
   }
 
@@ -129,11 +117,11 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
     if (!this.options.notificationChannels?.includes(payload.channel)) {
       return;
     }
-    this.iterateListeners((l) => l.notification?.(payload));
+    this.iterateListeners((l) => l.notificationEvent?.({ type: 'notification', notification: payload }));
   };
 
   protected hasNotificationListener() {
-    return !!Object.values(this.listeners).find((l) => NOTIFICATION_LISTENER_KEYS.some((key) => !!l[key]));
+    return !!Object.values(this.listeners).find((listener) => !!listener.notificationEvent);
   }
 
   /**
@@ -170,7 +158,10 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
           this.connection = null;
         }
         if (retryCounter >= MAX_CONNECTION_ATTEMPTS) {
-          this.iterateListeners((cb) => cb.connectionError?.(ex));
+          this.iterateListeners((cb) => {
+            cb.connectionError?.(ex);
+            cb.notificationEvent?.({ type: 'connection-error', error: ex });
+          });
         }
       }
     }

--- a/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
+++ b/libs/lib-postgres/src/db/connection/ConnectionSlot.ts
@@ -60,7 +60,23 @@ export class ConnectionSlot extends framework.BaseObserver<ConnectionSlotListene
      * Subscribing to notifications, even without a registered listener, should not add much overhead.
      */
     await this.configureConnectionNotifications(connection);
+    connection.whenDestroyed.then(() => this.handleConnectionDestroyed(connection));
     return connection;
+  }
+
+  protected handleConnectionDestroyed(connection: pgwire.PgConnection) {
+    if (this.connection != connection) {
+      return;
+    }
+
+    this.connection = null;
+    this.isAvailable = false;
+
+    if (this.hasNotificationListener() && !this.closed) {
+      // Notification connections need to be restored proactively. Other slots
+      // are reconnected lazily when the next connection lease is requested.
+      this.poke();
+    }
   }
 
   async [Symbol.asyncDispose]() {

--- a/libs/lib-postgres/src/db/connection/DatabaseClient.ts
+++ b/libs/lib-postgres/src/db/connection/DatabaseClient.ts
@@ -2,7 +2,7 @@ import * as lib_postgres from '@powersync/lib-service-postgres';
 import { DO_NOT_LOG } from '@powersync/lib-services-framework';
 import * as pgwire from '@powersync/service-jpgwire';
 import { AbstractPostgresConnection, sql } from './AbstractPostgresConnection.js';
-import { ConnectionLease, ConnectionSlot, NotificationListener } from './ConnectionSlot.js';
+import { ConnectionLease, ConnectionSlot, NOTIFICATION_LISTENER_KEYS, NotificationListener } from './ConnectionSlot.js';
 import { WrappedConnection } from './WrappedConnection.js';
 
 export type DatabaseClientOptions = {
@@ -24,13 +24,6 @@ export type DatabaseClientListener = NotificationListener & {
 };
 
 export const TRANSACTION_CONNECTION_COUNT = 5;
-
-// These listeners are forwarded to the first connection slot, which owns the
-// database client's notification channels.
-const NOTIFICATION_LISTENER_KEYS = [
-  'notification',
-  'notificationChannelsRegistered'
-] as const satisfies readonly (keyof NotificationListener)[];
 
 /**
  * This provides access to Postgres via the PGWire library.

--- a/libs/lib-postgres/src/db/connection/DatabaseClient.ts
+++ b/libs/lib-postgres/src/db/connection/DatabaseClient.ts
@@ -42,6 +42,8 @@ export class DatabaseClient extends AbstractPostgresConnection<DatabaseClientLis
 
   protected initialized: Promise<void>;
   protected queue: PromiseWithResolvers<ConnectionLease>[];
+  /** Latest exhausted connection attempt for each slot in the current attempt round. */
+  protected failedConnectionSlots: Map<ConnectionSlot, unknown>;
 
   constructor(protected options: DatabaseClientOptions) {
     super();
@@ -50,6 +52,7 @@ export class DatabaseClient extends AbstractPostgresConnection<DatabaseClientLis
       maxSize: options.config.max_pool_size,
       applicationName: options.applicationName
     });
+    this.failedConnectionSlots = new Map();
     this.connections = Array.from({ length: TRANSACTION_CONNECTION_COUNT }, (v, index) => {
       // Only listen to notifications on a single (the first) connection
       const notificationChannels = index == 0 ? options.notificationChannels : [];
@@ -59,8 +62,8 @@ export class DatabaseClient extends AbstractPostgresConnection<DatabaseClientLis
         applicationName: options.applicationName
       });
       slot.registerListener({
-        connectionAvailable: () => this.processConnectionQueue(),
-        connectionError: (ex) => this.handleConnectionError(ex),
+        connectionAvailable: () => this.handleConnectionAvailable(slot),
+        connectionError: (ex) => this.handleConnectionError(slot, ex),
         connectionCreated: (connection) => this.iterateAsyncListeners(async (l) => l.connectionCreated?.(connection))
       });
       return slot;
@@ -200,14 +203,23 @@ export class DatabaseClient extends AbstractPostgresConnection<DatabaseClientLis
     const deferred = Promise.withResolvers<ConnectionLease>();
     this.queue.push(deferred);
 
+    // Try already-connected slots first. poke() only creates missing
+    // connections and does not emit another availability event for an existing
+    // connection, so skipping this could leave the request queued indefinitely.
+    this.processConnectionQueue();
     this.pokeSlots();
 
     return deferred.promise;
   }
 
   protected pokeSlots() {
-    // Poke the slots to check if they are alive
+    // Ensure the slots have connections and notify any queued requests.
     for (const slot of this.connections) {
+      if (!slot.isConnected && !slot.isPoking) {
+        // This slot is starting a fresh attempt, so a failure from an earlier
+        // attempt must not count against the current request.
+        this.failedConnectionSlots.delete(slot);
+      }
       // No need to await this. Errors are reported asynchronously
       slot.poke();
     }
@@ -242,12 +254,26 @@ export class DatabaseClient extends AbstractPostgresConnection<DatabaseClientLis
     }
   }
 
+  protected handleConnectionAvailable(slot: ConnectionSlot) {
+    // This slot recovered, so its earlier failure must no longer contribute to
+    // deciding whether the shared lease queue is unreachable.
+    this.failedConnectionSlots.delete(slot);
+    this.processConnectionQueue();
+  }
+
   /**
-   * Reports connection errors which might occur from bad configuration or
-   * a server which is no longer available.
-   * This fails all pending requests.
+   * Lease requests wait in one shared queue and are not assigned to a slot
+   * until that slot becomes available. A failure from one slot therefore
+   * cannot fail a particular request: another slot may still serve it.
    */
-  protected handleConnectionError(exception: any) {
+  protected handleConnectionError(slot: ConnectionSlot, exception: any) {
+    this.failedConnectionSlots.set(slot, exception);
+    if (this.failedConnectionSlots.size < this.connections.length) {
+      return;
+    }
+
+    // Every slot has exhausted its attempts, so no slot can currently make
+    // progress on the shared queue.
     for (const q of this.queue) {
       q.reject(exception);
     }

--- a/libs/lib-postgres/src/db/connection/DatabaseClient.ts
+++ b/libs/lib-postgres/src/db/connection/DatabaseClient.ts
@@ -2,7 +2,7 @@ import * as lib_postgres from '@powersync/lib-service-postgres';
 import { DO_NOT_LOG } from '@powersync/lib-services-framework';
 import * as pgwire from '@powersync/service-jpgwire';
 import { AbstractPostgresConnection, sql } from './AbstractPostgresConnection.js';
-import { ConnectionLease, ConnectionSlot, NOTIFICATION_LISTENER_KEYS, NotificationListener } from './ConnectionSlot.js';
+import { ConnectionLease, ConnectionSlot, NotificationListener } from './ConnectionSlot.js';
 import { WrappedConnection } from './WrappedConnection.js';
 
 export type DatabaseClientOptions = {
@@ -85,18 +85,13 @@ export class DatabaseClient extends AbstractPostgresConnection<DatabaseClientLis
 
   registerListener(listener: Partial<DatabaseClientListener>): () => void {
     let disposeNotification: (() => void) | null = null;
-    if (NOTIFICATION_LISTENER_KEYS.some((key) => key in listener)) {
+    if ('notificationEvent' in listener) {
       // Pass this on to the first connection slot
       // It will only actively listen on the connection once a listener has been registered
-      const notificationListener = Object.fromEntries(
-        NOTIFICATION_LISTENER_KEYS.map((key) => [key, listener[key]])
-      ) as Partial<NotificationListener>;
-      disposeNotification = this.connections[0].registerListener(notificationListener);
+      disposeNotification = this.connections[0].registerListener({ notificationEvent: listener.notificationEvent });
       this.pokeSlots();
 
-      for (const key of NOTIFICATION_LISTENER_KEYS) {
-        delete listener[key];
-      }
+      delete listener.notificationEvent;
     }
 
     const superDispose = super.registerListener(listener);

--- a/libs/lib-postgres/src/db/connection/DatabaseClient.ts
+++ b/libs/lib-postgres/src/db/connection/DatabaseClient.ts
@@ -25,6 +25,13 @@ export type DatabaseClientListener = NotificationListener & {
 
 export const TRANSACTION_CONNECTION_COUNT = 5;
 
+// These listeners are forwarded to the first connection slot, which owns the
+// database client's notification channels.
+const NOTIFICATION_LISTENER_KEYS = [
+  'notification',
+  'notificationChannelsRegistered'
+] as const satisfies readonly (keyof NotificationListener)[];
+
 /**
  * This provides access to Postgres via the PGWire library.
  * A connection pool is used for individual query executions while
@@ -85,15 +92,18 @@ export class DatabaseClient extends AbstractPostgresConnection<DatabaseClientLis
 
   registerListener(listener: Partial<DatabaseClientListener>): () => void {
     let disposeNotification: (() => void) | null = null;
-    if ('notification' in listener) {
+    if (NOTIFICATION_LISTENER_KEYS.some((key) => key in listener)) {
       // Pass this on to the first connection slot
       // It will only actively listen on the connection once a listener has been registered
-      disposeNotification = this.connections[0].registerListener({
-        notification: listener.notification
-      });
+      const notificationListener = Object.fromEntries(
+        NOTIFICATION_LISTENER_KEYS.map((key) => [key, listener[key]])
+      ) as Partial<NotificationListener>;
+      disposeNotification = this.connections[0].registerListener(notificationListener);
       this.pokeSlots();
 
-      delete listener['notification'];
+      for (const key of NOTIFICATION_LISTENER_KEYS) {
+        delete listener[key];
+      }
     }
 
     const superDispose = super.registerListener(listener);

--- a/libs/lib-postgres/test/src/ConnectionSlot.test.ts
+++ b/libs/lib-postgres/test/src/ConnectionSlot.test.ts
@@ -28,3 +28,284 @@ test('reports an error when the notification connection cannot be restored', asy
   expect(notificationEvent).toHaveBeenCalledOnce();
   expect(notificationEvent).toHaveBeenCalledWith({ type: 'connection-error', error: connectionError });
 });
+
+test('reports a slot connection error when background notification restoration fails', async () => {
+  const originalDestroyed = Promise.withResolvers<void>();
+  const originalConnection = {
+    whenDestroyed: originalDestroyed.promise
+  } as pgwire.PgConnection;
+  const connectionError = new Error('connection unavailable');
+  const generalConnectionError = vi.fn();
+  const notificationEvent = vi.fn();
+
+  class FailingNotificationSlot extends ConnectionSlot {
+    attempts = 0;
+
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      if (this.attempts++ === 0) {
+        return originalConnection;
+      }
+      throw connectionError;
+    }
+  }
+
+  const slot = new FailingNotificationSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    notificationChannels: ['checkpoints'],
+    applicationName: 'test'
+  });
+  slot.registerListener({ connectionError: generalConnectionError, notificationEvent });
+
+  await slot.poke();
+  originalDestroyed.resolve();
+
+  await vi.waitFor(() => expect(notificationEvent).toHaveBeenCalledOnce());
+  expect(slot.attempts).toBe(MAX_CONNECTION_ATTEMPTS + 2);
+  expect(notificationEvent).toHaveBeenCalledWith({ type: 'connection-error', error: connectionError });
+  expect(generalConnectionError).toHaveBeenCalledOnce();
+  expect(generalConnectionError).toHaveBeenCalledWith(connectionError);
+});
+
+test('keeps a replacement connection unavailable while the slot has an outstanding lease', async () => {
+  const originalDestroyed = Promise.withResolvers<void>();
+  const originalConnection = {
+    whenDestroyed: originalDestroyed.promise
+  } as pgwire.PgConnection;
+  const replacementConnection = {
+    whenDestroyed: new Promise<void>(() => {})
+  } as pgwire.PgConnection;
+
+  class TestConnectionSlot extends ConnectionSlot {
+    attempts = 0;
+
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      return [originalConnection, replacementConnection][this.attempts++];
+    }
+  }
+
+  const slot = new TestConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    notificationChannels: ['checkpoints'],
+    applicationName: 'test'
+  });
+  await slot.poke();
+  const originalLease = slot.lock()!;
+
+  originalDestroyed.resolve();
+  await vi.waitFor(() => expect(slot.attempts).toBe(2));
+  await vi.waitFor(() => expect(slot.isConnected).toBe(true));
+
+  // Should not be able to get the lock, since it's in use.
+  expect(slot.lock()).toBeNull();
+
+  originalLease.release();
+  expect(slot.isAvailable).toBe(true);
+
+  const replacementLease = slot.lock()!;
+  expect(replacementLease.connection).toBe(replacementConnection);
+  replacementLease.release();
+  expect(slot.isAvailable).toBe(true);
+});
+
+test('releasing a lease twice does not release a later lease', async () => {
+  const connection = {
+    whenDestroyed: new Promise<void>(() => {})
+  } as pgwire.PgConnection;
+
+  class TestConnectionSlot extends ConnectionSlot {
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      return connection;
+    }
+  }
+
+  const slot = new TestConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    applicationName: 'test'
+  });
+  await slot.poke();
+
+  const firstLease = slot.lock()!;
+  firstLease.release();
+  const secondLease = slot.lock()!;
+
+  firstLease.release();
+  expect(slot.isAvailable).toBe(false);
+
+  secondLease.release();
+  expect(slot.isAvailable).toBe(true);
+});
+
+test('resets the poking state after failed connection attempts', async () => {
+  class FailingConnectionSlot extends ConnectionSlot {
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      throw new Error('connection failed');
+    }
+  }
+
+  const slot = new FailingConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    applicationName: 'test'
+  });
+
+  await slot.poke();
+
+  expect(slot.isPoking).toBe(false);
+});
+
+test('restores a destroyed connection without probing it', async () => {
+  const originalDestroyed = Promise.withResolvers<void>();
+  const originalConnection = {
+    whenDestroyed: originalDestroyed.promise
+  } as pgwire.PgConnection;
+  const replacementConnection = {
+    whenDestroyed: new Promise<void>(() => {})
+  } as pgwire.PgConnection;
+
+  class RestoringConnectionSlot extends ConnectionSlot {
+    attempts = 0;
+
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      return [originalConnection, replacementConnection][this.attempts++];
+    }
+  }
+
+  const slot = new RestoringConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    notificationChannels: ['checkpoints'],
+    applicationName: 'test'
+  });
+  await slot.poke();
+  originalDestroyed.resolve();
+
+  await vi.waitFor(() => expect(slot.attempts).toBe(2));
+  await vi.waitFor(() => expect(slot.isAvailable).toBe(true));
+  const lease = slot.lock()!;
+  expect(lease.connection).toBe(replacementConnection);
+});
+
+test('restores a transaction connection lazily after it is destroyed', async () => {
+  const originalDestroyed = Promise.withResolvers<void>();
+  const originalConnection = {
+    whenDestroyed: originalDestroyed.promise
+  } as pgwire.PgConnection;
+  const replacementConnection = {
+    whenDestroyed: new Promise<void>(() => {})
+  } as pgwire.PgConnection;
+
+  class LazyConnectionSlot extends ConnectionSlot {
+    attempts = 0;
+
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      return [originalConnection, replacementConnection][this.attempts++];
+    }
+  }
+
+  const slot = new LazyConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    applicationName: 'test'
+  });
+
+  await slot.poke();
+  originalDestroyed.resolve();
+  await vi.waitFor(() => expect(slot.isConnected).toBe(false));
+
+  expect(slot.attempts).toBe(1);
+
+  await slot.poke();
+  expect(slot.attempts).toBe(2);
+  expect(slot.lock()?.connection).toBe(replacementConnection);
+});
+
+test('restores a destroyed transaction connection when its lease is released', async () => {
+  const originalDestroyed = Promise.withResolvers<void>();
+  const originalConnection = {
+    whenDestroyed: originalDestroyed.promise
+  } as pgwire.PgConnection;
+  const replacementConnection = {
+    whenDestroyed: new Promise<void>(() => {})
+  } as pgwire.PgConnection;
+
+  class LazyConnectionSlot extends ConnectionSlot {
+    attempts = 0;
+
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      return [originalConnection, replacementConnection][this.attempts++];
+    }
+  }
+
+  const slot = new LazyConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    applicationName: 'test'
+  });
+
+  await slot.poke();
+  const lease = slot.lock()!;
+  originalDestroyed.resolve();
+  await vi.waitFor(() => expect(slot.isConnected).toBe(false));
+
+  lease.release();
+
+  await vi.waitFor(() => expect(slot.attempts).toBe(2));
+  await vi.waitFor(() => expect(slot.isAvailable).toBe(true));
+  expect(slot.lock()?.connection).toBe(replacementConnection);
+});
+
+test('does not start another connection setup while poke is in progress', async () => {
+  const setupStarted = Promise.withResolvers<void>();
+  const allowSetup = Promise.withResolvers<void>();
+  const connection = {
+    whenDestroyed: new Promise<void>(() => {})
+  } as pgwire.PgConnection;
+  const connectPgWire = vi.spyOn(pgwire, 'connectPgWire').mockImplementation(async () => {
+    setupStarted.resolve();
+    await allowSetup.promise;
+    return connection;
+  });
+
+  const slot = new ConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    applicationName: 'test'
+  });
+
+  try {
+    const first = slot.poke();
+    await setupStarted.promise;
+    const second = slot.poke();
+    allowSetup.resolve();
+
+    await Promise.all([first, second]);
+    expect(connectPgWire).toHaveBeenCalledOnce();
+  } finally {
+    connectPgWire.mockRestore();
+  }
+});
+
+test('destroys a connection that finishes connecting after the slot is disposed', async () => {
+  const setupStarted = Promise.withResolvers<void>();
+  const allowSetup = Promise.withResolvers<void>();
+  const connection = {
+    destroy: vi.fn()
+  } as unknown as pgwire.PgConnection;
+
+  class DisposedConnectionSlot extends ConnectionSlot {
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      setupStarted.resolve();
+      await allowSetup.promise;
+      return connection;
+    }
+  }
+
+  const slot = new DisposedConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    applicationName: 'test'
+  });
+
+  const poke = slot.poke();
+  await setupStarted.promise;
+  await slot[Symbol.asyncDispose]();
+  allowSetup.resolve();
+  await poke;
+
+  expect(connection.destroy).toHaveBeenCalledOnce();
+  expect(slot.isConnected).toBe(false);
+});

--- a/libs/lib-postgres/test/src/ConnectionSlot.test.ts
+++ b/libs/lib-postgres/test/src/ConnectionSlot.test.ts
@@ -1,0 +1,30 @@
+import * as pgwire from '@powersync/service-jpgwire';
+import { expect, test, vi } from 'vitest';
+import { ConnectionSlot, MAX_CONNECTION_ATTEMPTS } from '../../src/db/connection/ConnectionSlot.js';
+
+test('reports an error when the notification connection cannot be restored', async () => {
+  const connectionError = new Error('connection unavailable');
+  const notificationEvent = vi.fn();
+
+  class FailingConnectionSlot extends ConnectionSlot {
+    attempts = 0;
+
+    protected override async connect(): Promise<pgwire.PgConnection> {
+      this.attempts++;
+      throw connectionError;
+    }
+  }
+
+  const slot = new FailingConnectionSlot({
+    config: {} as pgwire.NormalizedConnectionConfig,
+    notificationChannels: ['checkpoints'],
+    applicationName: 'test'
+  });
+  slot.registerListener({ notificationEvent });
+
+  await slot.poke();
+
+  expect(slot.attempts).toBe(MAX_CONNECTION_ATTEMPTS + 1);
+  expect(notificationEvent).toHaveBeenCalledOnce();
+  expect(notificationEvent).toHaveBeenCalledWith({ type: 'connection-error', error: connectionError });
+});

--- a/libs/lib-postgres/test/src/DatabaseClient.test.ts
+++ b/libs/lib-postgres/test/src/DatabaseClient.test.ts
@@ -1,0 +1,43 @@
+import * as lib_postgres from '@powersync/lib-service-postgres';
+import { expect, test } from 'vitest';
+import { ConnectionLease, ConnectionSlot } from '../../src/db/connection/ConnectionSlot.js';
+import { DatabaseClient } from '../../src/db/connection/DatabaseClient.js';
+
+test('rejects queued leases only after every connection slot fails', async () => {
+  class TestDatabaseClient extends DatabaseClient {
+    get slots() {
+      return this.connections;
+    }
+
+    get queuedRequests() {
+      return this.queue.length;
+    }
+
+    queueLease() {
+      const deferred = Promise.withResolvers<ConnectionLease>();
+      this.queue.push(deferred);
+      return deferred.promise;
+    }
+
+    reportConnectionError(slot: ConnectionSlot, error: unknown) {
+      this.handleConnectionError(slot, error);
+    }
+  }
+
+  await using client = new TestDatabaseClient({
+    config: {} as lib_postgres.NormalizedBasePostgresConnectionConfig,
+    applicationName: 'test'
+  });
+  const error = new Error('connection unavailable');
+  const pendingLease = client.queueLease();
+  const rejectedLease = expect(pendingLease).rejects.toBe(error);
+
+  for (const slot of client.slots.slice(0, -1)) {
+    client.reportConnectionError(slot, error);
+  }
+  expect(client.queuedRequests).toBe(1);
+
+  client.reportConnectionError(client.slots.at(-1)!, error);
+  await rejectedLease;
+  expect(client.queuedRequests).toBe(0);
+});

--- a/modules/module-postgres-storage/src/storage/PostgresBucketStorageFactory.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresBucketStorageFactory.ts
@@ -8,7 +8,6 @@ import { models, NormalizedPostgresStorageConfig } from '../types/types.js';
 
 import { getStorageApplicationName } from '../utils/application-name.js';
 import { NOTIFICATION_CHANNEL, STORAGE_SCHEMA_NAME } from '../utils/db.js';
-import { notifySyncRulesUpdate } from './batch/PostgresBucketBatch.js';
 import { PostgresSyncRulesStorage } from './PostgresSyncRulesStorage.js';
 import { PostgresPersistedReplicationStream } from './sync-rules/PostgresPersistedSyncConfigContent.js';
 
@@ -219,8 +218,6 @@ export class PostgresBucketStorageFactory extends storage.BucketStorageFactory {
       `
         .decoded(models.SyncRules)
         .first();
-
-      await notifySyncRulesUpdate(this.db, newSyncRulesRow!);
 
       return new PostgresPersistedReplicationStream(this.db, newSyncRulesRow!);
     });

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -31,6 +31,8 @@ import * as framework from '@powersync/lib-services-framework';
 import { StatementParam } from '@powersync/service-jpgwire';
 import { wrapWithAbort } from 'ix/asynciterable/operators/withabort.js';
 import * as t from 'ts-codec';
+import { ActiveCheckpointDecoded } from '../types/models/ActiveCheckpoint.js';
+import * as checkpointUtils from '../utils/checkpoints.js';
 import { pick } from '../utils/ts-codec.js';
 import { PostgresBucketBatch } from './batch/PostgresBucketBatch.js';
 import { PostgresWriteCheckpointAPI } from './checkpoints/PostgresWriteCheckpointAPI.js';
@@ -634,25 +636,8 @@ export class PostgresSyncRulesStorage
   }
 
   async getActiveCheckpoint(): Promise<storage.ReplicationCheckpoint> {
-    const activeCheckpoint = await this.db.sql`
-      SELECT
-        id,
-        last_checkpoint,
-        last_checkpoint_lsn
-      FROM
-        sync_rules
-      WHERE
-        state = ${{ value: storage.SyncRuleState.ACTIVE, type: 'varchar' }}
-        OR state = ${{ value: storage.SyncRuleState.ERRORED, type: 'varchar' }}
-      ORDER BY
-        id DESC
-      LIMIT
-        1
-    `
-      .decoded(models.ActiveCheckpoint)
-      .first();
-
-    return this.makeActiveCheckpoint(activeCheckpoint);
+    const activeCheckpointDocument = await checkpointUtils.getActiveCheckpointDocument({ db: this.db });
+    return this.makeActiveCheckpoint(activeCheckpointDocument);
   }
 
   async *watchCheckpointChanges(options: WatchWriteCheckpointOptions): AsyncIterable<storage.StorageCheckpointUpdate> {
@@ -698,54 +683,62 @@ export class PostgresSyncRulesStorage
   }
 
   protected async *watchActiveCheckpoint(signal: AbortSignal): AsyncIterable<storage.ReplicationCheckpoint> {
-    const doc = await this.db.sql`
-      SELECT
-        id,
-        last_checkpoint,
-        last_checkpoint_lsn
-      FROM
-        sync_rules
-      WHERE
-        state = ${{ value: storage.SyncRuleState.ACTIVE, type: 'varchar' }}
-        OR state = ${{ value: storage.SyncRuleState.ERRORED, type: 'varchar' }}
-      LIMIT
-        1
-    `
-      .decoded(models.ActiveCheckpoint)
-      .first();
+    const sink = new LastValueSink<string | null>(null);
 
-    if (doc == null) {
-      // Abort the connections - clients will have to retry later.
-      throw new framework.ServiceError(framework.ErrorCode.PSYNC_S2302, 'No active replication stream available');
-    }
-
-    const sink = new LastValueSink<string>(undefined);
-
+    // Listen for changes before reading the initial doc
     const disposeListener = this.db.registerListener({
-      notification: (notification) => sink.write(notification.payload)
+      notification: (notification) => sink.write(notification.payload),
+      // Add a null value to the stream, indicating the loop should query the value
+      notificationChannelsRegistered: async () => sink.write(null)
     });
 
     try {
-      yield this.makeActiveCheckpoint(doc);
+      const initialCheckpointDocument = requireActiveCheckpointDocument(
+        await checkpointUtils.getActiveCheckpointDocument({ db: this.db })
+      );
+      const initialCheckpoint = this.makeActiveCheckpoint(initialCheckpointDocument);
+      let lastOp = initialCheckpoint;
 
-      let lastOp: storage.ReplicationCheckpoint | null = null;
+      yield initialCheckpoint;
+
       for await (const payload of sink.withSignal(signal)) {
         if (signal.aborted) {
           return;
         }
 
-        const notification = models.ActiveCheckpointNotification.decode(payload);
-        if (notification.active_checkpoint == null) {
-          continue;
+        let baseActiveCheckpoint: ActiveCheckpointDecoded | null = null;
+        if (payload == null) {
+          // Manually should check the checkpoint
+          baseActiveCheckpoint = requireActiveCheckpointDocument(
+            await checkpointUtils.getActiveCheckpointDocument({ db: this.db })
+          );
+        } else {
+          const notification = models.ActiveCheckpointNotification.decode(payload);
+          if (notification.active_checkpoint == null) {
+            continue;
+          }
+          baseActiveCheckpoint = notification.active_checkpoint;
         }
-        if (Number(notification.active_checkpoint.id) != doc.id) {
+
+        if (Number(baseActiveCheckpoint.id) != initialCheckpointDocument.id) {
           // Active replication stream changed - abort and restart the stream
           break;
         }
 
-        const activeCheckpoint = this.makeActiveCheckpoint(notification.active_checkpoint);
+        const activeCheckpoint = this.makeActiveCheckpoint(baseActiveCheckpoint);
 
-        if (lastOp == null || activeCheckpoint.lsn != lastOp.lsn || activeCheckpoint.checkpoint != lastOp.checkpoint) {
+        const checkpointAdvanced = activeCheckpoint.checkpoint > lastOp.checkpoint;
+        const checkpointRegressed = activeCheckpoint.checkpoint < lastOp.checkpoint;
+        const lsnAdvanced =
+          lastOp.lsn == null
+            ? activeCheckpoint.lsn != null
+            : activeCheckpoint.lsn != null && activeCheckpoint.lsn > lastOp.lsn;
+        const lsnRegressed = lastOp.lsn != null && (activeCheckpoint.lsn == null || activeCheckpoint.lsn < lastOp.lsn);
+
+        // Notifications buffered before a query or reconnect may be stale. Neither
+        // coordinate may regress, but only one needs to advance: an empty checkpoint
+        // updates the LSN while keeping the operation checkpoint unchanged.
+        if (!checkpointRegressed && !lsnRegressed && (checkpointAdvanced || lsnAdvanced)) {
           lastOp = activeCheckpoint;
           yield activeCheckpoint;
         }
@@ -784,3 +777,12 @@ const parameterSetsRow = t.object({
   index: bigint,
   bucket_parameters: t.string
 });
+
+function requireActiveCheckpointDocument(doc: models.ActiveCheckpointDecoded | null): models.ActiveCheckpointDecoded {
+  if (doc == null) {
+    // Abort the connections - clients will have to retry later.
+    throw new framework.ServiceError(framework.ErrorCode.PSYNC_S2302, 'No active replication stream available');
+  }
+
+  return doc;
+}

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -708,19 +708,30 @@ export class PostgresSyncRulesStorage
 
         let baseActiveCheckpoint: ActiveCheckpointDecoded | null = null;
         if (payload == null) {
-          // Manually should check the checkpoint
-          baseActiveCheckpoint = requireActiveCheckpointDocument(
-            await checkpointUtils.getActiveCheckpointDocument({ db: this.db })
-          );
+          // Reconnected (or manually triggered) - re-query the current checkpoint.
+          // Unlike the initial read, a missing document here (e.g. sync rules being
+          // replaced) must not abort the stream: keep waiting for the next notification.
+          baseActiveCheckpoint = await checkpointUtils.getActiveCheckpointDocument({ db: this.db });
+          if (baseActiveCheckpoint == null) {
+            continue;
+          }
         } else {
-          const notification = models.ActiveCheckpointNotification.decode(payload);
+          let notification: models.ActiveCheckpointNotificationDecoded;
+          try {
+            notification = models.ActiveCheckpointNotification.decode(payload);
+          } catch (error) {
+            // A malformed payload must not abort the shared stream for every
+            // subscriber. Skip it and wait for the next notification.
+            this.logger.warn('Failed to decode active checkpoint notification, ignoring', error);
+            continue;
+          }
           if (notification.active_checkpoint == null) {
             continue;
           }
           baseActiveCheckpoint = notification.active_checkpoint;
         }
 
-        if (Number(baseActiveCheckpoint.id) != initialCheckpointDocument.id) {
+        if (baseActiveCheckpoint.id != initialCheckpointDocument.id) {
           // Active replication stream changed - abort and restart the stream
           break;
         }
@@ -780,7 +791,9 @@ const parameterSetsRow = t.object({
 
 function requireActiveCheckpointDocument(doc: models.ActiveCheckpointDecoded | null): models.ActiveCheckpointDecoded {
   if (doc == null) {
-    // Abort the connections - clients will have to retry later.
+    // Used for the initial checkpoint read only: with no active replication stream
+    // at stream start, fail fast so clients disconnect and retry later. Mid-stream
+    // reconnects tolerate a transiently missing document instead of aborting.
     throw new framework.ServiceError(framework.ErrorCode.PSYNC_S2302, 'No active replication stream available');
   }
 

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -725,34 +725,33 @@ export class PostgresSyncRulesStorage
       notification: (notification) => sink.write(notification.payload)
     });
 
-    signal.addEventListener('aborted', async () => {
+    try {
+      yield this.makeActiveCheckpoint(doc);
+
+      let lastOp: storage.ReplicationCheckpoint | null = null;
+      for await (const payload of sink.withSignal(signal)) {
+        if (signal.aborted) {
+          return;
+        }
+
+        const notification = models.ActiveCheckpointNotification.decode(payload);
+        if (notification.active_checkpoint == null) {
+          continue;
+        }
+        if (Number(notification.active_checkpoint.id) != doc.id) {
+          // Active replication stream changed - abort and restart the stream
+          break;
+        }
+
+        const activeCheckpoint = this.makeActiveCheckpoint(notification.active_checkpoint);
+
+        if (lastOp == null || activeCheckpoint.lsn != lastOp.lsn || activeCheckpoint.checkpoint != lastOp.checkpoint) {
+          lastOp = activeCheckpoint;
+          yield activeCheckpoint;
+        }
+      }
+    } finally {
       disposeListener();
-      sink.end();
-    });
-
-    yield this.makeActiveCheckpoint(doc);
-
-    let lastOp: storage.ReplicationCheckpoint | null = null;
-    for await (const payload of sink.withSignal(signal)) {
-      if (signal.aborted) {
-        return;
-      }
-
-      const notification = models.ActiveCheckpointNotification.decode(payload);
-      if (notification.active_checkpoint == null) {
-        continue;
-      }
-      if (Number(notification.active_checkpoint.id) != doc.id) {
-        // Active replication stream changed - abort and restart the stream
-        break;
-      }
-
-      const activeCheckpoint = this.makeActiveCheckpoint(notification.active_checkpoint);
-
-      if (lastOp == null || activeCheckpoint.lsn != lastOp.lsn || activeCheckpoint.checkpoint != lastOp.checkpoint) {
-        lastOp = activeCheckpoint;
-        yield activeCheckpoint;
-      }
     }
   }
 

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -687,9 +687,22 @@ export class PostgresSyncRulesStorage
 
     // Listen for changes before reading the initial doc
     const disposeListener = this.db.registerListener({
-      notification: (notification) => sink.write(notification.payload),
-      // Add a null value to the stream, indicating the loop should query the value
-      notificationChannelsRegistered: async () => sink.write(null)
+      notificationEvent: (event) => {
+        switch (event.type) {
+          case 'notification':
+            sink.write(event.notification.payload);
+            break;
+          case 'channels-registered':
+            // Add a null value to the stream, indicating the loop should query the value.
+            sink.write(null);
+            break;
+          case 'connection-error':
+            // End the watcher after reconnect attempts are exhausted. Consumers will
+            // retry the watcher, which registers a new listener and pokes the slot.
+            sink.error(event.error);
+            break;
+        }
+      }
     });
 
     try {

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -60,7 +60,6 @@ export interface PostgresBucketBatchOptions {
  * via the Postgres NOTIFY protocol.
  */
 const StatefulCheckpoint = models.ActiveCheckpoint.and(t.object({ state: t.Enum(storage.SyncRuleState) }));
-type StatefulCheckpointDecoded = t.Decoded<typeof StatefulCheckpoint>;
 
 const CheckpointWithStatus = StatefulCheckpoint.and(
   t.object({
@@ -562,136 +561,144 @@ export class PostgresBucketBatch
 
     const persisted_op = this.persisted_op ?? null;
 
-    const result = await this.db.sql`
-      WITH
-        selected AS (
-          SELECT
-            id,
-            state,
-            last_checkpoint,
-            last_checkpoint_lsn,
-            snapshot_done,
-            no_checkpoint_before,
-            keepalive_op,
-            (
-              snapshot_done = TRUE
+    // Transaction failures restart replication from the last durable checkpoint.
+    const result = await this.db.transaction(async (db) => {
+      const checkpoint = await db.sql`
+        WITH
+          selected AS (
+            SELECT
+              id,
+              state,
+              last_checkpoint,
+              last_checkpoint_lsn,
+              snapshot_done,
+              no_checkpoint_before,
+              keepalive_op,
+              (
+                snapshot_done = TRUE
+                AND (
+                  last_checkpoint_lsn IS NULL
+                  OR last_checkpoint_lsn <= ${{ type: 'varchar', value: lsn }}
+                )
+                AND (
+                  no_checkpoint_before IS NULL
+                  OR no_checkpoint_before <= ${{ type: 'varchar', value: lsn }}
+                )
+              ) AS can_checkpoint
+            FROM
+              sync_rules
+            WHERE
+              id = ${{ type: 'int4', value: this.group_id }}
+            FOR UPDATE
+          ),
+          computed AS (
+            SELECT
+              selected.*,
+              CASE
+                WHEN selected.can_checkpoint THEN GREATEST(
+                  selected.last_checkpoint,
+                  ${{ type: 'int8', value: persisted_op }},
+                  selected.keepalive_op,
+                  0
+                )
+                ELSE selected.last_checkpoint
+              END AS new_last_checkpoint,
+              CASE
+                WHEN selected.can_checkpoint THEN NULL
+                ELSE GREATEST(
+                  selected.keepalive_op,
+                  ${{ type: 'int8', value: persisted_op }},
+                  0
+                )
+              END AS new_keepalive_op
+            FROM
+              selected
+          ),
+          updated AS (
+            UPDATE sync_rules AS sr
+            SET
+              last_checkpoint_lsn = CASE
+                WHEN computed.can_checkpoint THEN ${{ type: 'varchar', value: lsn }}
+                ELSE sr.last_checkpoint_lsn
+              END,
+              last_checkpoint_ts = CASE
+                WHEN computed.can_checkpoint THEN ${{ type: 1184, value: now }}
+                ELSE sr.last_checkpoint_ts
+              END,
+              last_keepalive_ts = ${{ type: 1184, value: now }},
+              last_fatal_error = CASE
+                WHEN computed.can_checkpoint THEN NULL
+                ELSE sr.last_fatal_error
+              END,
+              keepalive_op = computed.new_keepalive_op,
+              last_checkpoint = computed.new_last_checkpoint,
+              snapshot_lsn = CASE
+                WHEN computed.can_checkpoint THEN NULL
+                ELSE sr.snapshot_lsn
+              END
+            FROM
+              computed
+            WHERE
+              sr.id = computed.id
               AND (
-                last_checkpoint_lsn IS NULL
-                OR last_checkpoint_lsn <= ${{ type: 'varchar', value: lsn }}
+                sr.keepalive_op IS DISTINCT FROM computed.new_keepalive_op
+                OR sr.last_checkpoint IS DISTINCT FROM computed.new_last_checkpoint
+                OR ${{ type: 'bool', value: createEmptyCheckpoints }}
               )
-              AND (
-                no_checkpoint_before IS NULL
-                OR no_checkpoint_before <= ${{ type: 'varchar', value: lsn }}
-              )
-            ) AS can_checkpoint
-          FROM
-            sync_rules
-          WHERE
-            id = ${{ type: 'int4', value: this.group_id }}
-          FOR UPDATE
-        ),
-        computed AS (
-          SELECT
-            selected.*,
-            CASE
-              WHEN selected.can_checkpoint THEN GREATEST(
-                selected.last_checkpoint,
-                ${{ type: 'int8', value: persisted_op }},
-                selected.keepalive_op,
-                0
-              )
-              ELSE selected.last_checkpoint
-            END AS new_last_checkpoint,
-            CASE
-              WHEN selected.can_checkpoint THEN NULL
-              ELSE GREATEST(
-                selected.keepalive_op,
-                ${{ type: 'int8', value: persisted_op }},
-                0
-              )
-            END AS new_keepalive_op
-          FROM
-            selected
-        ),
-        updated AS (
-          UPDATE sync_rules AS sr
-          SET
-            last_checkpoint_lsn = CASE
-              WHEN computed.can_checkpoint THEN ${{ type: 'varchar', value: lsn }}
-              ELSE sr.last_checkpoint_lsn
-            END,
-            last_checkpoint_ts = CASE
-              WHEN computed.can_checkpoint THEN ${{ type: 1184, value: now }}
-              ELSE sr.last_checkpoint_ts
-            END,
-            last_keepalive_ts = ${{ type: 1184, value: now }},
-            last_fatal_error = CASE
-              WHEN computed.can_checkpoint THEN NULL
-              ELSE sr.last_fatal_error
-            END,
-            keepalive_op = computed.new_keepalive_op,
-            last_checkpoint = computed.new_last_checkpoint,
-            snapshot_lsn = CASE
-              WHEN computed.can_checkpoint THEN NULL
-              ELSE sr.snapshot_lsn
-            END
-          FROM
-            computed
-          WHERE
-            sr.id = computed.id
-            AND (
-              sr.keepalive_op IS DISTINCT FROM computed.new_keepalive_op
-              OR sr.last_checkpoint IS DISTINCT FROM computed.new_last_checkpoint
-              OR ${{ type: 'bool', value: createEmptyCheckpoints }}
-            )
-          RETURNING
-            sr.id,
-            sr.state,
-            sr.last_checkpoint,
-            sr.last_checkpoint_lsn,
-            sr.snapshot_done,
-            sr.no_checkpoint_before,
-            computed.can_checkpoint,
-            computed.keepalive_op,
-            computed.new_last_checkpoint
-        )
-      SELECT
-        id,
-        state,
-        last_checkpoint,
-        last_checkpoint_lsn,
-        snapshot_done,
-        no_checkpoint_before,
-        can_checkpoint,
-        keepalive_op,
-        new_last_checkpoint,
-        TRUE AS created_checkpoint
-      FROM
-        updated
-      UNION ALL
-      SELECT
-        id,
-        state,
-        new_last_checkpoint AS last_checkpoint,
-        last_checkpoint_lsn,
-        snapshot_done,
-        no_checkpoint_before,
-        can_checkpoint,
-        keepalive_op,
-        new_last_checkpoint,
-        FALSE AS created_checkpoint
-      FROM
-        computed
-      WHERE
-        NOT EXISTS (
-          SELECT
-            1
-          FROM
-            updated
-        )
-    `
-      .decoded(CheckpointWithStatus)
-      .first();
+            RETURNING
+              sr.id,
+              sr.state,
+              sr.last_checkpoint,
+              sr.last_checkpoint_lsn,
+              sr.snapshot_done,
+              sr.no_checkpoint_before,
+              computed.can_checkpoint,
+              computed.keepalive_op,
+              computed.new_last_checkpoint
+          )
+        SELECT
+          id,
+          state,
+          last_checkpoint,
+          last_checkpoint_lsn,
+          snapshot_done,
+          no_checkpoint_before,
+          can_checkpoint,
+          keepalive_op,
+          new_last_checkpoint,
+          TRUE AS created_checkpoint
+        FROM
+          updated
+        UNION ALL
+        SELECT
+          id,
+          state,
+          new_last_checkpoint AS last_checkpoint,
+          last_checkpoint_lsn,
+          snapshot_done,
+          no_checkpoint_before,
+          can_checkpoint,
+          keepalive_op,
+          new_last_checkpoint,
+          FALSE AS created_checkpoint
+        FROM
+          computed
+        WHERE
+          NOT EXISTS (
+            SELECT
+              1
+            FROM
+              updated
+          )
+      `
+        .decoded(CheckpointWithStatus)
+        .first();
+
+      if (checkpoint?.can_checkpoint && checkpoint.state == storage.SyncRuleState.ACTIVE) {
+        await notifySyncRulesUpdate(db, checkpoint);
+      }
+      return checkpoint;
+    });
 
     if (result == null) {
       throw new ReplicationAssertionError('Failed to update sync_rules during checkpoint');
@@ -723,10 +730,8 @@ export class PostgresBucketBatch
         });
       }
     }
-    await this.autoActivate(lsn);
-    await notifySyncRulesUpdate(this.db, {
+    await this.autoActivate(lsn, {
       id: result.id,
-      state: result.state,
       last_checkpoint: result.last_checkpoint,
       last_checkpoint_lsn: result.last_checkpoint_lsn
     });
@@ -1305,14 +1310,13 @@ export class PostgresBucketBatch
    *
    * Called on new commits.
    */
-  private async autoActivate(lsn: string): Promise<void> {
+  private async autoActivate(lsn: string, checkpoint: models.ActiveCheckpointDecoded): Promise<void> {
     if (!this.needsActivation) {
       // Already activated
       return;
     }
 
-    let didActivate = false;
-    await this.db.transaction(async (db) => {
+    const activationResult = await this.db.transaction(async (db) => {
       const syncRulesRow = await db.sql`
         SELECT
           state,
@@ -1346,13 +1350,18 @@ export class PostgresBucketBatch
             )
             AND id != ${{ type: 'int4', value: this.group_id }}
         `.execute();
-        didActivate = true;
-        this.needsActivation = false;
+        await notifySyncRulesUpdate(db, checkpoint);
+        return 'activated';
       } else if (syncRulesRow?.state != storage.SyncRuleState.PROCESSING) {
-        this.needsActivation = false;
+        return 'not-processing';
       }
+      return 'pending';
     });
-    if (didActivate) {
+
+    if (activationResult != 'pending') {
+      this.needsActivation = false;
+    }
+    if (activationResult == 'activated') {
       this.logger.info(`Activated new replication stream at ${lsn}`);
     }
   }
@@ -1438,12 +1447,17 @@ export class PostgresBucketBatch
  * Uses Postgres' NOTIFY functionality to update different processes when the
  * active checkpoint has been updated.
  */
-export const notifySyncRulesUpdate = async (db: lib_postgres.DatabaseClient, update: StatefulCheckpointDecoded) => {
-  if (update.state != storage.SyncRuleState.ACTIVE) {
-    return;
-  }
+export const notifySyncRulesUpdate = async (
+  db: lib_postgres.AbstractPostgresConnection,
+  update: models.ActiveCheckpointDecoded
+) => {
+  const payload = models.ActiveCheckpointNotification.encode({ active_checkpoint: update });
 
-  await db.query({
-    statement: `NOTIFY ${NOTIFICATION_CHANNEL}, '${models.ActiveCheckpointNotification.encode({ active_checkpoint: update })}'`
-  });
+  await db.sql`
+    SELECT
+      pg_notify (
+        ${{ type: 'varchar', value: NOTIFICATION_CHANNEL }},
+        ${{ type: 'varchar', value: payload }}
+      )
+  `.execute();
 };

--- a/modules/module-postgres-storage/src/utils/checkpoints.ts
+++ b/modules/module-postgres-storage/src/utils/checkpoints.ts
@@ -1,0 +1,31 @@
+import * as lib_postgres from '@powersync/lib-service-postgres';
+import { storage } from '@powersync/service-core';
+import { models } from '../types/types.js';
+
+/**
+ * Gets the latest active checkpoint document.
+ * This is mainly exported for mocking in tests.
+ */
+export async function getActiveCheckpointDocument({
+  db
+}: {
+  db: lib_postgres.DatabaseClient;
+}): Promise<models.ActiveCheckpointDecoded | null> {
+  return db.sql`
+    SELECT
+      id,
+      last_checkpoint,
+      last_checkpoint_lsn
+    FROM
+      sync_rules
+    WHERE
+      state = ${{ value: storage.SyncRuleState.ACTIVE, type: 'varchar' }}
+      OR state = ${{ value: storage.SyncRuleState.ERRORED, type: 'varchar' }}
+    ORDER BY
+      id DESC
+    LIMIT
+      1
+  `
+    .decoded(models.ActiveCheckpoint)
+    .first();
+}

--- a/modules/module-postgres-storage/test/src/checkpoint_notifications.test.ts
+++ b/modules/module-postgres-storage/test/src/checkpoint_notifications.test.ts
@@ -22,6 +22,7 @@ import { POSTGRES_STORAGE_FACTORY } from './util.js';
  */
 test('checkpoint stream catches up in order after the notification connection is recreated', async (context) => {
   await using factory = await POSTGRES_STORAGE_FACTORY.factory();
+  await requireIdleSessionTimeout(factory, context);
   const reconnect = controlNotificationReconnect(factory, context);
 
   const syncRules = await factory.configureSyncRules(
@@ -126,6 +127,7 @@ bucket_definitions:
  */
 test('checkpoint stream emits the latest value when the checkpoint advances during the reconnect query', async (context) => {
   await using factory = await POSTGRES_STORAGE_FACTORY.factory();
+  await requireIdleSessionTimeout(factory, context);
   const reconnect = controlNotificationReconnect(factory, context);
 
   const syncRules = await factory.configureSyncRules(
@@ -257,6 +259,7 @@ bucket_definitions:
  */
 test('active checkpoint stream does not duplicate an unchanged checkpoint after reconnect', async (context) => {
   await using factory = await POSTGRES_STORAGE_FACTORY.factory();
+  await requireIdleSessionTimeout(factory, context);
   const reconnect = controlNotificationReconnect(factory, context);
 
   const syncRules = await factory.configureSyncRules(
@@ -416,6 +419,14 @@ bucket_definitions:
 }, 15_000);
 
 type PostgresTestFactory = Awaited<ReturnType<typeof POSTGRES_STORAGE_FACTORY.factory>>;
+
+async function requireIdleSessionTimeout(factory: PostgresTestFactory, context: TestContext) {
+  const result = await factory.db.query('SHOW server_version_num');
+  const serverVersionNumber = Number(result.rows[0].decodeWithoutCustomTypes(0));
+  if (serverVersionNumber < 140_000) {
+    context.skip('idle_session_timeout requires PostgreSQL 14 or newer');
+  }
+}
 
 function controlNotificationReconnect(factory: PostgresTestFactory, context: TestContext) {
   const firstListen = Promise.withResolvers<pgwire.PgConnection>();

--- a/modules/module-postgres-storage/test/src/checkpoint_notifications.test.ts
+++ b/modules/module-postgres-storage/test/src/checkpoint_notifications.test.ts
@@ -357,6 +357,64 @@ bucket_definitions:
   }
 }, 15_000);
 
+test('active checkpoint stream closes when a new replication stream is activated', async (context) => {
+  await using factory = await POSTGRES_STORAGE_FACTORY.factory();
+
+  const initialSyncRules = await factory.configureSyncRules(
+    updateSyncRulesFromYaml(
+      `
+bucket_definitions:
+  initial:
+    data: []
+`,
+      { validate: false }
+    )
+  );
+  const initialStorage = factory.getInstance(initialSyncRules.persisted_sync_rules!);
+
+  await using initialWriter = await initialStorage.createWriter(test_utils.BATCH_OPTIONS);
+  await initialWriter.markAllSnapshotDone('1/0');
+  await initialWriter.keepalive('1/0');
+
+  const abortController = new AbortController();
+  context.onTestFinished(() => abortController.abort());
+  const iterator = (
+    initialStorage as unknown as {
+      watchActiveCheckpoint(signal: AbortSignal): AsyncIterable<storage.ReplicationCheckpoint>;
+    }
+  )
+    .watchActiveCheckpoint(abortController.signal)
+    [Symbol.asyncIterator]();
+
+  await expect(
+    resolvesWithin({ promise: iterator.next(), description: 'Initial active checkpoint should be returned' })
+  ).resolves.toMatchObject({
+    done: false,
+    value: { checkpoint: 0n, lsn: '1/0' }
+  });
+
+  const streamClosed = iterator.next();
+  const nextSyncRules = await factory.configureSyncRules(
+    updateSyncRulesFromYaml(
+      `
+bucket_definitions:
+  replacement:
+    data: []
+`,
+      { validate: false }
+    )
+  );
+  const nextStorage = factory.getInstance(nextSyncRules.persisted_sync_rules!);
+
+  await using nextWriter = await nextStorage.createWriter(test_utils.BATCH_OPTIONS);
+  await nextWriter.markAllSnapshotDone('2/0');
+  await nextWriter.keepalive('2/0');
+
+  await expect(
+    resolvesWithin({ promise: streamClosed, description: 'Old active checkpoint stream should close on activation' })
+  ).resolves.toEqual({ done: true, value: undefined });
+}, 15_000);
+
 type PostgresTestFactory = Awaited<ReturnType<typeof POSTGRES_STORAGE_FACTORY.factory>>;
 
 function controlNotificationReconnect(factory: PostgresTestFactory, context: TestContext) {

--- a/modules/module-postgres-storage/test/src/checkpoint_notifications.test.ts
+++ b/modules/module-postgres-storage/test/src/checkpoint_notifications.test.ts
@@ -1,0 +1,450 @@
+import { storage, updateSyncRulesFromYaml } from '@powersync/service-core';
+import { test_utils } from '@powersync/service-core-tests';
+import * as pgwire from '@powersync/service-jpgwire';
+import { expect, test, TestContext, vi } from 'vitest';
+import * as checkpointUtils from '../../src/utils/checkpoints.js';
+import { POSTGRES_STORAGE_FACTORY } from './util.js';
+
+/**
+ * Reproduces checkpoints being committed while the Postgres notification connection is unavailable:
+ *
+ * 1. Start the checkpoint stream at 1/0 and configure a short idle session timeout on the connection
+ *    that executed LISTEN.
+ * 2. Wait for Postgres to destroy that connection and verify its `whenDestroyed` callback fires.
+ * 3. Pause the replacement connection immediately before it executes LISTEN, then commit 2/0 and 3/0.
+ *    Those notifications cannot be received because no notification channel is registered at that point.
+ * 4. Allow LISTEN to complete. The `notificationChannelsRegistered` callback writes `null` to the watcher, which
+ *    must re-query storage and recover the latest missed checkpoint, 3/0.
+ * 5. Commit 4/0 after the channel is restored and verify it is delivered as a normal live notification.
+ *
+ * The stream must therefore emit 1/0, 3/0, and 4/0 in order, proving that reconnect catches up to the
+ * latest persisted state without emitting a stale missed checkpoint or losing later live notifications.
+ */
+test('checkpoint stream catches up in order after the notification connection is recreated', async (context) => {
+  await using factory = await POSTGRES_STORAGE_FACTORY.factory();
+  const reconnect = controlNotificationReconnect(factory, context);
+
+  const syncRules = await factory.configureSyncRules(
+    updateSyncRulesFromYaml(
+      `
+bucket_definitions:
+  global:
+    data: []
+`,
+      { validate: false }
+    )
+  );
+  const bucketStorage = factory.getInstance(syncRules.persisted_sync_rules!);
+
+  await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+  await writer.markAllSnapshotDone('1/0');
+  await writer.keepalive('1/0');
+
+  const abortController = new AbortController();
+  context.onTestFinished(() => abortController.abort());
+  const iterator = bucketStorage
+    .watchCheckpointChanges({ user_id: 'user', signal: abortController.signal })
+    [Symbol.asyncIterator]();
+
+  await expect(
+    resolvesWithin({ promise: iterator.next(), description: 'Initial checkpoint should be returned' })
+  ).resolves.toMatchObject({
+    done: false,
+    value: { base: { checkpoint: 0n, lsn: '1/0' } }
+  });
+
+  const notificationConnection = await resolvesWithin({
+    promise: reconnect.initialConnection,
+    description: 'Notification connection should register LISTEN'
+  });
+  await notificationConnection.query({ statement: `SET idle_session_timeout = '250ms'` });
+  await resolvesWithin({
+    promise: notificationConnection.whenDestroyed,
+    description: 'Notification connection should be destroyed after the idle timeout'
+  });
+  expect(reconnect.connectionDestroyed).toHaveBeenCalledOnce();
+
+  try {
+    // Hold the replacement connection immediately before LISTEN so these updates
+    // cannot produce notifications for this process.
+    await resolvesWithin({ promise: reconnect.listenStarted, description: 'Connection pool should try to listen' });
+    const recoveredWriteCheckpoint = await createManagedWriteCheckpoint(bucketStorage, '3/0');
+    await writer.keepalive('2/0');
+    await writer.keepalive('3/0');
+    await expect(bucketStorage.getCheckpoint()).resolves.toMatchObject({ checkpoint: 0n, lsn: '3/0' });
+
+    const recoveredCheckpoint = iterator.next();
+    reconnect.allowListen();
+    await resolvesWithin({ promise: reconnect.listenCompleted, description: 'Replacement LISTEN should complete' });
+
+    await expect(
+      resolvesWithin({ promise: recoveredCheckpoint, description: 'The checkpoint should be emitted after recovery' })
+    ).resolves.toMatchObject({
+      done: false,
+      value: {
+        base: { checkpoint: 0n, lsn: '3/0' },
+        writeCheckpoint: recoveredWriteCheckpoint
+      }
+    });
+
+    const liveWriteCheckpoint = await createManagedWriteCheckpoint(bucketStorage, '4/0');
+    await writer.keepalive('4/0');
+    await expect(
+      resolvesWithin({
+        promise: iterator.next(),
+        description: 'Live checkpoint should be emitted after LISTEN is restored'
+      })
+    ).resolves.toMatchObject({
+      done: false,
+      value: {
+        base: { checkpoint: 0n, lsn: '4/0' },
+        writeCheckpoint: liveWriteCheckpoint
+      }
+    });
+  } finally {
+    reconnect.allowListen();
+  }
+}, 15_000);
+
+/**
+ * Reproduces the checkpoint advancing while the reconnect-triggered storage query is already in flight:
+ *
+ * 1. Recreate the notification connection as above, commit 2/0 while LISTEN is unavailable, then allow
+ *    LISTEN to complete so its `null` event starts the recovery query.
+ * 2. Let that query read 2/0 from Postgres, but pause it before returning the result to the watcher.
+ * 3. While the query is paused and LISTEN is active, commit 3/0. Its notification is buffered behind the
+ *    in-flight 2/0 query result.
+ * 4. Release the stale 2/0 query result. The last-value-buffered public stream must emit the newer 3/0,
+ *    rather than exposing 3/0 followed later by the stale 2/0.
+ * 5. Commit 4/0 and verify it is emitted next, proving no delayed result can regress the stream afterward.
+ *
+ * This covers the boundary between reconnect recovery and normal notifications: concurrent progress may
+ * supersede an in-flight query result, but observable checkpoints must remain monotonic and converge on the
+ * latest persisted value. The immediate supersession of 2/0 by 3/0 is primarily provided by the
+ * last-value-buffered sink; the monotonic watcher comparison is the additional guard that prevents an older
+ * result from being emitted after a newer checkpoint.
+ */
+test('checkpoint stream emits the latest value when the checkpoint advances during the reconnect query', async (context) => {
+  await using factory = await POSTGRES_STORAGE_FACTORY.factory();
+  const reconnect = controlNotificationReconnect(factory, context);
+
+  const syncRules = await factory.configureSyncRules(
+    updateSyncRulesFromYaml(
+      `
+bucket_definitions:
+  global:
+    data: []
+`,
+      { validate: false }
+    )
+  );
+  const bucketStorage = factory.getInstance(syncRules.persisted_sync_rules!);
+
+  await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+  await writer.markAllSnapshotDone('1/0');
+  await writer.keepalive('1/0');
+
+  const abortController = new AbortController();
+  context.onTestFinished(() => abortController.abort());
+  const iterator = bucketStorage
+    .watchCheckpointChanges({ user_id: 'user', signal: abortController.signal })
+    [Symbol.asyncIterator]();
+
+  await expect(
+    resolvesWithin({ promise: iterator.next(), description: 'Initial checkpoint should be returned' })
+  ).resolves.toMatchObject({
+    done: false,
+    value: { base: { checkpoint: 0n, lsn: '1/0' } }
+  });
+
+  const notificationConnection = await resolvesWithin({
+    promise: reconnect.initialConnection,
+    description: 'Notification connection should register LISTEN'
+  });
+  await notificationConnection.query({ statement: `SET idle_session_timeout = '250ms'` });
+  await resolvesWithin({
+    promise: notificationConnection.whenDestroyed,
+    description: 'Notification connection should be destroyed after the idle timeout'
+  });
+  expect(reconnect.connectionDestroyed).toHaveBeenCalledOnce();
+
+  const queryResultCaptured = Promise.withResolvers<void>();
+  const allowQueryResult = Promise.withResolvers<void>();
+  const originalQuery = checkpointUtils.getActiveCheckpointDocument;
+  let delayActiveCheckpointQuery = true;
+  const activeCheckpointQuerySpy = vi
+    .spyOn(checkpointUtils, 'getActiveCheckpointDocument')
+    .mockImplementation(async (options) => {
+      const result = await originalQuery(options);
+      if (delayActiveCheckpointQuery) {
+        delayActiveCheckpointQuery = false;
+        queryResultCaptured.resolve();
+        await allowQueryResult.promise;
+      }
+      return result;
+    });
+
+  try {
+    await resolvesWithin({
+      promise: reconnect.listenStarted,
+      description: 'Replacement connection should attempt LISTEN'
+    });
+
+    await createManagedWriteCheckpoint(bucketStorage, '2/0');
+    await writer.keepalive('2/0');
+
+    const firstRecoveredCheckpoint = iterator.next();
+    reconnect.allowListen();
+    await resolvesWithin({ promise: reconnect.listenCompleted, description: 'Replacement LISTEN should complete' });
+    await resolvesWithin({
+      promise: queryResultCaptured.promise,
+      description: 'Recovery query should read the active checkpoint'
+    });
+    await expect(bucketStorage.getCheckpoint()).resolves.toMatchObject({ checkpoint: 0n, lsn: '2/0' });
+
+    // The query has read 2/0 but has not returned it to the watcher yet. Advance
+    // to 3/0 so its notification is buffered behind the in-flight query result.
+    const secondWriteCheckpoint = await createManagedWriteCheckpoint(bucketStorage, '3/0');
+    await writer.keepalive('3/0');
+    allowQueryResult.resolve();
+
+    // The public stream is last-value buffered, so 3/0 supersedes the stale 2/0
+    // query result before it is emitted to this consumer.
+    await expect(
+      resolvesWithin({
+        promise: firstRecoveredCheckpoint,
+        description: 'Latest checkpoint should supersede the delayed query result'
+      })
+    ).resolves.toMatchObject({
+      done: false,
+      value: {
+        base: { checkpoint: 0n, lsn: '3/0' },
+        writeCheckpoint: secondWriteCheckpoint
+      }
+    });
+
+    const liveWriteCheckpoint = await createManagedWriteCheckpoint(bucketStorage, '4/0');
+    await writer.keepalive('4/0');
+    await expect(
+      resolvesWithin({ promise: iterator.next(), description: 'Subsequent live checkpoint should be emitted' })
+    ).resolves.toMatchObject({
+      done: false,
+      value: {
+        base: { checkpoint: 0n, lsn: '4/0' },
+        writeCheckpoint: liveWriteCheckpoint
+      }
+    });
+  } finally {
+    reconnect.allowListen();
+    allowQueryResult.resolve();
+    activeCheckpointQuerySpy.mockRestore();
+  }
+}, 15_000);
+
+/**
+ * Reproduces reconnecting when no checkpoint was committed during the notification outage:
+ *
+ * 1. Start the active-checkpoint watcher at 1/0, destroy its LISTEN connection, and pause the replacement
+ *    connection before it restores LISTEN.
+ * 2. Restore LISTEN without committing anything. The registration callback writes `null`, causing the
+ *    watcher to query storage and read the same 1/0 checkpoint it emitted before the disconnect.
+ * 3. Verify the next iterator read remains pending after that query completes. Re-registering the channel
+ *    must not turn an unchanged persisted checkpoint into a duplicate stream event.
+ * 4. Commit 2/0 and verify the already-pending read resolves with that actual advancement.
+ *
+ * This test observes the internal active-checkpoint stream directly so the public write-checkpoint layer's
+ * separate deduplication cannot hide a duplicate produced by the reconnect watcher itself.
+ */
+test('active checkpoint stream does not duplicate an unchanged checkpoint after reconnect', async (context) => {
+  await using factory = await POSTGRES_STORAGE_FACTORY.factory();
+  const reconnect = controlNotificationReconnect(factory, context);
+
+  const syncRules = await factory.configureSyncRules(
+    updateSyncRulesFromYaml(
+      `
+bucket_definitions:
+  global:
+    data: []
+`,
+      { validate: false }
+    )
+  );
+  const bucketStorage = factory.getInstance(syncRules.persisted_sync_rules!);
+
+  await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+  await writer.markAllSnapshotDone('1/0');
+  await writer.keepalive('1/0');
+
+  const abortController = new AbortController();
+  context.onTestFinished(() => abortController.abort());
+
+  // Observe the protected watcher directly for this assertion. watchCheckpointChanges()
+  // independently suppresses unchanged operation and write checkpoints, which would hide
+  // a duplicate emitted by watchActiveCheckpoint() and let this regression test pass incorrectly.
+  const iterator = (
+    bucketStorage as unknown as {
+      watchActiveCheckpoint(signal: AbortSignal): AsyncIterable<storage.ReplicationCheckpoint>;
+    }
+  )
+    .watchActiveCheckpoint(abortController.signal)
+    [Symbol.asyncIterator]();
+
+  await expect(
+    resolvesWithin({ promise: iterator.next(), description: 'Initial active checkpoint should be returned' })
+  ).resolves.toMatchObject({
+    done: false,
+    value: { checkpoint: 0n, lsn: '1/0' }
+  });
+
+  const notificationConnection = await resolvesWithin({
+    promise: reconnect.initialConnection,
+    description: 'Notification connection should register LISTEN'
+  });
+  // Simulate a small idle timeout, which will cause the notification conection to close
+  await notificationConnection.query({ statement: `SET idle_session_timeout = '250ms'` });
+  await resolvesWithin({
+    promise: notificationConnection.whenDestroyed,
+    description: 'Notification connection should be destroyed after the idle timeout'
+  });
+  expect(reconnect.connectionDestroyed).toHaveBeenCalledOnce();
+
+  const unchangedCheckpointQueried = Promise.withResolvers<void>();
+  const originalQuery = checkpointUtils.getActiveCheckpointDocument;
+  let observeActiveCheckpointQuery = true;
+  const activeCheckpointQuerySpy = vi
+    .spyOn(checkpointUtils, 'getActiveCheckpointDocument')
+    .mockImplementation(async (options) => {
+      const result = await originalQuery(options);
+      if (observeActiveCheckpointQuery) {
+        observeActiveCheckpointQuery = false;
+        unchangedCheckpointQueried.resolve();
+      }
+      return result;
+    });
+
+  try {
+    await resolvesWithin({
+      promise: reconnect.listenStarted,
+      description: 'Replacement connection should attempt LISTEN'
+    });
+    const nextCheckpoint = iterator.next();
+    reconnect.allowListen();
+    await resolvesWithin({ promise: reconnect.listenCompleted, description: 'Replacement LISTEN should complete' });
+    await resolvesWithin({
+      promise: unchangedCheckpointQueried.promise,
+      description: 'Reconnect query should return the unchanged active checkpoint'
+    });
+
+    const duplicateEmitted = await Promise.race([
+      nextCheckpoint.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 100))
+    ]);
+    expect(duplicateEmitted).toBe(false);
+
+    await writer.keepalive('2/0');
+    await expect(
+      resolvesWithin({
+        promise: nextCheckpoint,
+        description: 'Pending iterator should resolve after the checkpoint advances'
+      })
+    ).resolves.toMatchObject({
+      done: false,
+      value: { checkpoint: 0n, lsn: '2/0' }
+    });
+  } finally {
+    reconnect.allowListen();
+    activeCheckpointQuerySpy.mockRestore();
+  }
+}, 15_000);
+
+type PostgresTestFactory = Awaited<ReturnType<typeof POSTGRES_STORAGE_FACTORY.factory>>;
+
+function controlNotificationReconnect(factory: PostgresTestFactory, context: TestContext) {
+  const firstListen = Promise.withResolvers<pgwire.PgConnection>();
+  const reconnectListenStarted = Promise.withResolvers<void>();
+  const allowReconnectListen = Promise.withResolvers<void>();
+  const reconnectListenCompleted = Promise.withResolvers<void>();
+  const notificationConnectionDestroyed = vi.fn();
+  let listenCount = 0;
+  let notificationRegistrationCount = 0;
+
+  context.onTestFinished(() => allowReconnectListen.resolve());
+  const disposeConnectionListener = factory.db.registerListener({
+    notificationChannelsRegistered: async () => {
+      notificationRegistrationCount++;
+      if (notificationRegistrationCount === 2) {
+        reconnectListenCompleted.resolve();
+      }
+    },
+    connectionCreated: async (connection) => {
+      const originalQuery = connection.query.bind(connection) as (...args: any[]) => Promise<any>;
+
+      vi.spyOn(connection, 'query').mockImplementation(async (...args: any[]) => {
+        const statement = args[0]?.statement;
+        if (typeof statement === 'string' && statement.startsWith('LISTEN ')) {
+          listenCount++;
+
+          if (listenCount === 1) {
+            const result = await originalQuery(...args);
+            connection.whenDestroyed.then(notificationConnectionDestroyed);
+            firstListen.resolve(connection);
+            return result;
+          }
+
+          if (listenCount === 2) {
+            reconnectListenStarted.resolve();
+            await allowReconnectListen.promise;
+          }
+        }
+
+        return originalQuery(...args);
+      });
+    }
+  });
+  context.onTestFinished(disposeConnectionListener);
+
+  return {
+    initialConnection: firstListen.promise,
+    listenStarted: reconnectListenStarted.promise,
+    listenCompleted: reconnectListenCompleted.promise,
+    allowListen: () => allowReconnectListen.resolve(),
+    connectionDestroyed: notificationConnectionDestroyed
+  };
+}
+
+async function createManagedWriteCheckpoint(
+  bucketStorage: storage.SyncRulesBucketStorage,
+  lsn: string
+): Promise<bigint> {
+  const checkpoints = await bucketStorage.createManagedWriteCheckpoints([
+    {
+      heads: { '1': lsn },
+      user_id: 'user'
+    }
+  ]);
+  const checkpoint = checkpoints.get('user');
+  expect(checkpoint).toBeDefined();
+  return checkpoint!;
+}
+
+async function resolvesWithin<T>({
+  promise,
+  description,
+  timeoutMs = 5_000
+}: {
+  promise: Promise<T>;
+  description: string;
+  timeoutMs?: number;
+}): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${description}`)), timeoutMs);
+      })
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/modules/module-postgres-storage/test/src/checkpoint_notifications.test.ts
+++ b/modules/module-postgres-storage/test/src/checkpoint_notifications.test.ts
@@ -13,7 +13,7 @@ import { POSTGRES_STORAGE_FACTORY } from './util.js';
  * 2. Wait for Postgres to destroy that connection and verify its `whenDestroyed` callback fires.
  * 3. Pause the replacement connection immediately before it executes LISTEN, then commit 2/0 and 3/0.
  *    Those notifications cannot be received because no notification channel is registered at that point.
- * 4. Allow LISTEN to complete. The `notificationChannelsRegistered` callback writes `null` to the watcher, which
+ * 4. Allow LISTEN to complete. The `channels-registered` event writes `null` to the watcher, which
  *    must re-query storage and recover the latest missed checkpoint, 3/0.
  * 5. Commit 4/0 after the channel is restored and verify it is delivered as a normal live notification.
  *
@@ -370,7 +370,10 @@ function controlNotificationReconnect(factory: PostgresTestFactory, context: Tes
 
   context.onTestFinished(() => allowReconnectListen.resolve());
   const disposeConnectionListener = factory.db.registerListener({
-    notificationChannelsRegistered: async () => {
+    notificationEvent: (event) => {
+      if (event.type != 'channels-registered') {
+        return;
+      }
       notificationRegistrationCount++;
       if (notificationRegistrationCount === 2) {
         reconnectListenCompleted.resolve();

--- a/modules/module-postgres-storage/test/tsconfig.json
+++ b/modules/module-postgres-storage/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../../tsconfig.tests.json",
   "compilerOptions": {
-    "lib": ["ES2022", "esnext.disposable"],
+    "lib": ["ES2024", "esnext.disposable"],
     "rootDir": "src"
   },
   "include": ["src"],

--- a/packages/jpgwire/src/legacy_pgwire_types.ts
+++ b/packages/jpgwire/src/legacy_pgwire_types.ts
@@ -65,6 +65,8 @@ export interface PgClient {
 }
 
 export interface PgConnection extends PgClient {
+  /** Resolves after the connection's background I/O loop has ended. */
+  readonly whenDestroyed: Promise<void>;
   logicalReplication(options: LogicalReplicationOptions): ReplicationStream;
   /** ID of postgres backend process. */
   readonly pid: number | null;


### PR DESCRIPTION
Fixes https://github.com/powersync-ja/powersync-service/issues/718

# Overview

Postgres bucket storage uses `LISTEN` to notify API runners about new checkpoints. This communication channel bridges the `sync` and `api` runners, which can run in different processes, machines, or pods.

If the underlying Postgres connection is terminated, for any reason, we no longer receive checkpoint notifications. This can cause clients to continue using stale checkpoint state and lead to serious syncing issues.

One way for this connection to close is through `idle_session_timeout`. The linked issue was reproducible by setting the idle session timeout to a short value.

## Fix

The initial fix used the existing pgwire `whenDestroyed` event to detect when the notification connection had closed. We then reconnect that slot and restore its `LISTEN` subscriptions.

Reconnecting by itself was not enough, since checkpoints may be committed while no connection is listening. Once `LISTEN` has been restored, we now notify the checkpoint watcher so that it queries the latest persisted checkpoint and catches up on anything it missed. The listener is registered before the initial checkpoint query, and stale or duplicate events are ignored, which covers checkpoints changing around the initial query and reconnection boundaries.

Checkpoint notifications are now parameterized and committed atomically with the state they describe. Processing sync configs no longer emit active-checkpoint notifications, and activating a replacement config closes the old checkpoint stream immediately.

The reconnect path also exposed a few assumptions in `ConnectionSlot`. Previously, `poke()` issued a `SELECT 1` query to check whether a connection was still usable. The pgwire `whenDestroyed` event now provides that lifecycle signal directly, allowing us to clear and restore a destroyed connection without the additional query.

A lease belongs to the slot rather than a particular underlying connection, so a replacement connection must remain unavailable until the outstanding slot lease is released. Connection setup is deduplicated, late connections are closed during disposal, and failures are tracked per slot so one failed notification connection does not reject work that another healthy slot can serve. Notification connections reconnect proactively to restore `LISTEN`; ordinary transaction connections reconnect lazily so server-side idle timeouts do not create a permanent reconnect loop. A short delay is applied between failed connection attempts.

## Testing

The integration tests reproduce the original idle-timeout failure and pause the replacement connection before `LISTEN` is restored. They verify that missed checkpoints are recovered in order, checkpoints changing during the recovery query do not regress the stream, unchanged checkpoints are not emitted twice, and the old stream closes when a replacement sync config becomes active.

Additional connection-slot tests cover lease ownership across replacement connections, proactive and lazy reconnection, concurrent connection attempts, slot-scoped failures, retry exhaustion, and disposal while a connection is still opening.

---

AI disclosure: Codex GPT 5.6 assisted in fixing this issue. I reviewed and verified the work.
