### PR TITLE
Fix plan version for row metadata inputs in table-valued functions

### DIFF
--- a/packages/sync-rules/src/sync_plan/serialize.ts
+++ b/packages/sync-rules/src/sync_plan/serialize.ts
@@ -70,7 +70,15 @@ export function serializeSyncPlan(plan: SyncPlan): SerializedSyncPlan {
   function serializeTableValued(source: TableProcessor): TableProcessorTableValuedFunction[] {
     return source.tableValuedFunctions.map((fn, i) => {
       addedTableValuedFunctions.set(fn, i);
-      return fn;
+
+      return {
+        functionName: fn.functionName,
+        functionInputs: fn.functionInputs.map(
+          // Since we don't support table-valued functions as inputs to other table-valued functions, this doesn't
+          // change expressions. It ensures we track row metadata use in any input, though.
+          (s) => serializeTableProcessorDataExpr(s) as SqlExpression<ColumnSqlParameterValue>
+        )
+      };
     });
   }
 

--- a/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
+++ b/packages/sync-rules/test/src/sync_plan/evaluator/evaluator.test.ts
@@ -10,6 +10,7 @@ import {
   ParameterLookupRows,
   PrecompiledSyncConfig,
   ScopedParameterLookup,
+  serializeSyncPlan,
   SourceTableRef,
   SqliteRow,
   SqliteValue
@@ -1434,6 +1435,37 @@ streams:
         bucket: 'stream|0[]',
         id: 'foo',
         data: { id: 'foo', suffix: 's' },
+        table: 'users'
+      }
+    ]);
+  });
+
+  syncTest('table_suffix() as a table-valued function', ({ sync }) => {
+    const config = sync.prepareWithoutHydration(`
+config:
+  edition: 3
+
+streams:
+  stream:
+      query: SELECT users.id FROM "user%" users WHERE auth.parameter('p') IN users.table_suffix()
+`) as PrecompiledSyncConfig;
+
+    expect(serializeSyncPlan(config.plan)).toMatchObject({ version: 2 });
+    const hydrated = config.hydrate({ hydrationState: DEFAULT_HYDRATION_STATE, sqlite: nodeSqlite(sqlite) });
+
+    expect(
+      hydrated.evaluateRow({ sourceTable: new TestSourceTable('user["foo","bar"]'), record: { id: 'x' } })
+    ).toStrictEqual([
+      {
+        bucket: 'stream|0["foo"]',
+        id: 'x',
+        data: { id: 'x' },
+        table: 'users'
+      },
+      {
+        bucket: 'stream|0["bar"]',
+        id: 'x',
+        data: { id: 'x' },
         table: 'users'
       }
     ]);


### PR DESCRIPTION
We're supposed to emit sync plans with version 2 when row metadata functions (`.schema()`, `.table_suffix()`, `.table_name()`) are used anywhere in the plan (https://github.com/powersync-ja/powersync-service/pull/717 for context).

`serializeSyncPlan` missed cases where these functions are used as inputs to table-valued functions. That would be a somewhat absurd Sync Stream, e.g. using `FROM "users%" users JOIN json_each(users.table_suffix()) suffix WHERE suffix.value = auth.parameter('x')` which then allows expanding a table named `users["foo", "bar"]` into two buckets for `foo` and `bar`.

AI use: Found by Codex security, fix and test written by hand.