### PR TITLE
style: Improve diagnostics when a connection exceeds the bucket limit

### DIFF
--- a/.changeset/fuzzy-buckets-report.md
+++ b/.changeset/fuzzy-buckets-report.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-core': patch
+---
+
+Clarify whether too-many-buckets log breakdowns are grouped by sync stream or legacy bucket definition, and include up
+to 100 entries.

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -2,6 +2,7 @@ import {
   BucketParameterQuerier,
   BucketPriority,
   BucketSource,
+  BucketSourceType,
   HydratedSyncConfig,
   mergeBuckets,
   QuerierError,
@@ -164,8 +165,9 @@ export class BucketChecksumState {
         const count = bucketsByDefinition.get(definition) ?? 0;
         bucketsByDefinition.set(definition, count + 1);
       }
-
-      const breakdown = formatBucketDefinitionBreakdown(bucketsByDefinition);
+      // Only 1 type is allowed per sync config
+      const bucketSourceType = this.parameterState.syncRules.bucketSourceDefinitions[0].type;
+      const breakdown = formatBucketDefinitionBreakdown(bucketsByDefinition, bucketSourceType);
       errorMessage += breakdown.message;
       logData.buckets_by_definition = breakdown.countsByDefinition;
 
@@ -795,30 +797,36 @@ function logCheckpoint(
 }
 
 /**
- * Format a breakdown of dynamic bucket by sync stream definition.
+ * Format a breakdown of dynamic buckets by sync stream or legacy bucket definition.
  *
- * Sorts definitions by count (descending), includes the top 10, and returns both the
+ * Sorts definitions by count (descending), includes the top 100, and returns both the
  * formatted message string and the counts record suitable for structured log data.
  */
-function formatBucketDefinitionBreakdown(bucketsByDefinition: Map<string, number>): {
+function formatBucketDefinitionBreakdown(
+  bucketsByDefinition: Map<string, number>,
+  bucketSourceType: BucketSourceType
+): {
   message: string;
   countsByDefinition: Record<string, number>;
 } {
-  // Sort definitions by count (descending) and take top 10
-  const allSorted = Array.from(bucketsByDefinition.entries()).sort((a, b) => b[1] - a[1]);
-  const sortedDefinitions = allSorted.slice(0, 10);
+  const maxLoggedDefinitions = 100;
 
-  let message = '\Buckets by definition:';
+  // Sort definitions by count (descending) and take the largest entries.
+  const allSorted = Array.from(bucketsByDefinition.entries()).sort((a, b) => b[1] - a[1]);
+  const sortedDefinitions = allSorted.slice(0, maxLoggedDefinitions);
+
+  const sourceLabel = bucketSourceType == BucketSourceType.SYNC_STREAM ? 'sync stream' : 'bucket definition';
+  let message = `\nBuckets by ${sourceLabel}:`;
   const countsByDefinition: Record<string, number> = {};
   for (const [definition, count] of sortedDefinitions) {
     message += `\n  ${definition}: ${count}`;
     countsByDefinition[definition] = count;
   }
 
-  if (allSorted.length > 10) {
-    const remainingResults = allSorted.slice(10).reduce((sum, [, count]) => sum + count, 0);
-    const remainingDefinitions = allSorted.length - 10;
-    message += `\n  ... and ${remainingResults} more results from ${remainingDefinitions} definitions`;
+  if (allSorted.length > maxLoggedDefinitions) {
+    const remainingResults = allSorted.slice(maxLoggedDefinitions).reduce((sum, [, count]) => sum + count, 0);
+    const remainingDefinitions = allSorted.length - maxLoggedDefinitions;
+    message += `\n  ... and ${remainingResults} more buckets from ${remainingDefinitions} ${sourceLabel}s`;
   }
 
   return { message, countsByDefinition };

--- a/packages/service-core/test/src/sync/BucketChecksumState.test.ts
+++ b/packages/service-core/test/src/sync/BucketChecksumState.test.ts
@@ -1183,7 +1183,7 @@ streams:
       ).rejects.toThrow('Too many buckets: 60 (limit of 50');
 
       // Verify error log includes breakdown
-      expect(errorMessages[0]).toContain('Buckets by definition:');
+      expect(errorMessages[0]).toContain('(limit of 50)\nBuckets by sync stream:');
       expect(errorMessages[0]).toContain('projects: 30');
       expect(errorMessages[0]).toContain('tasks: 20');
       expect(errorMessages[0]).toContain('comments: 10');
@@ -1197,15 +1197,60 @@ streams:
       });
     });
 
-    test('limits bucket breakdown to top 10 definitions', async () => {
-      // Create sync streams with 15 different definitions with dynamic parameters
+    test('labels the bucket breakdown as bucket definitions for legacy sync rules', async () => {
+      const legacySyncRules = SqlSyncRules.fromYaml(
+        `
+bucket_definitions:
+  projects:
+    parameters: SELECT id FROM projects WHERE user_id = request.user_id()
+    data: []
+    `,
+        { defaultSchema: 'public' }
+      ).config.hydrate({ hydrationState: versionedHydrationState(5), sqlite: nodeSqlite(sqlite) });
+
+      const storage = new MockBucketChecksumStateStorage();
+      const errorMessages: string[] = [];
+      const state = new BucketChecksumState({
+        syncContext: new SyncContext({
+          maxBuckets: 50,
+          maxParameterQueryResults: 100,
+          maxDataFetchConcurrency: 10
+        }),
+        tokenPayload: new JwtPayload({ sub: 'u1' }),
+        syncRequest,
+        syncRules: legacySyncRules,
+        bucketStorage: storage,
+        logger: {
+          info: () => {},
+          error: (message: string) => errorMessages.push(message),
+          warn: () => {},
+          debug: () => {}
+        } as any
+      });
+
+      await expect(
+        state.buildNextCheckpointLine({
+          base: storage.makeCheckpoint(1n, (lookups) => [
+            { lookup: lookups[0], rows: Array.from({ length: 60 }, (_, id) => ({ id })) }
+          ]),
+          writeCheckpoint: null,
+          update: CHECKPOINT_INVALIDATE_ALL
+        })
+      ).rejects.toThrow('Too many buckets: 60 (limit of 50)');
+
+      expect(errorMessages[0]).toContain('(limit of 50)\nBuckets by bucket definition:');
+      expect(errorMessages[0]).toContain('projects: 60');
+    });
+
+    test('limits bucket breakdown to top 100 sync streams', async () => {
+      // Create 105 sync streams with dynamic parameters.
       let yamlDefinitions = `
 config:
   edition: 3
 
 streams:
 `;
-      for (let i = 1; i <= 15; i++) {
+      for (let i = 1; i <= 105; i++) {
         yamlDefinitions += `  def${i}:\n`;
         yamlDefinitions += `    auto_subscribe: true\n`;
         yamlDefinitions += `    query: SELECT * FROM tbl WHERE b = auth.parameter('${i}')\n`;
@@ -1229,7 +1274,7 @@ streams:
       };
 
       const smallContext = new SyncContext({
-        maxBuckets: 10,
+        maxBuckets: 100,
         maxParameterQueryResults: 10,
         maxDataFetchConcurrency: 10
       });
@@ -1238,7 +1283,7 @@ streams:
         syncContext: smallContext,
         tokenPayload: new JwtPayload({
           sub: 'u1',
-          ...Object.fromEntries(Array.from({ length: 30 }, (_, i) => [i.toString(), BigInt(i)]))
+          ...Object.fromEntries(Array.from({ length: 106 }, (_, i) => [i.toString(), BigInt(i)]))
         }),
         syncRequest,
         syncRules: SYNC_RULES_MANY,
@@ -1252,15 +1297,16 @@ streams:
           writeCheckpoint: null,
           update: CHECKPOINT_INVALIDATE_ALL
         })
-      ).rejects.toThrow('Too many buckets: 15 (limit of 10)');
+      ).rejects.toThrow('Too many buckets: 105 (limit of 100)');
 
-      // Verify only top 10 are shown
+      // Verify only the first 100 are shown.
       const errorMessage = errorMessages[0];
-      expect(errorMessage).toContain('... and 5 more results from 5 definitions');
+      expect(errorMessage).toContain('Buckets by sync stream:');
+      expect(errorMessage).toContain('... and 5 more buckets from 5 sync streams');
 
-      // Count how many definitions are listed (should be exactly 10)
+      // Count how many sync streams are listed (should be exactly 100).
       const defMatches = errorMessage.match(/def\d+:/g);
-      expect(defMatches?.length).toBe(10);
+      expect(defMatches?.length).toBe(100);
     });
   });
 });


### PR DESCRIPTION
## Context

Some users create enough buckets to exceed the default limit of 1,000 buckets per connection. When that happens, the
service raises `PSYNC_S2305` and logs a breakdown intended to show which parts of the sync configuration produced those
buckets.

That breakdown is valuable because the total alone does not tell a user where to start simplifying their configuration
or subscriptions. The connection limit is evaluated against the total number of distinct buckets, while the breakdown
groups those buckets by the Sync Stream or legacy bucket definition that produced them. The counts in those groups add
up to the buckets represented by the breakdown.

However, the existing log only includes the 10 largest definition entries. On configurations with many Sync Streams or
legacy bucket definitions, this can potentially hide some of the information needed to understand the problem.

The existing wording is also _slightly_ ambiguous. It labels the entries as "definitions," even though the names being
printed are Sync Stream or Bucket definition names. For example, a user could previously see a log resembling:

```text
[PSYNC_S2305] Too many buckets: 60 (limit of 50)
Buckets by definition:
  projects: 30
  tasks: 20
  comments: 10
```

Here, `projects`, `tasks`, and `comments` are Sync Stream names, and the numbers are the distinct buckets produced by
each stream.

## What this changes

This PR does **not** change the bucket limit itself. The default remains 1,000 actual buckets per connection. It only
changes how many grouped Sync Stream or bucket-definition entries can be printed when reporting that the bucket limit
was exceeded.

The bucket-limit diagnostic becomes more useful while retaining a safeguard against excessively large log messages:

- It raises the number of logged definition entries from 10 to 100.
- It identifies whether the entries came from Sync Streams or legacy bucket definitions and labels the log accordingly.
- It retains a summary for entries beyond the 100 largest contributors.
- It preserves the existing structured `buckets_by_definition` field for compatibility with current log consumers.

The original limit of 10 was likely intended to prevent unusually large log messages. That remains a reasonable
concern, but logging more of the available counts _could_ be valuable when diagnosing. A diagnostic-entry cap of 100 keeps the output bounded while making it much more likely that the relevant stream or definition is visible.

For example, `projects: 30`, `tasks: 20`, and `comments: 10` represent 60 actual buckets across three logged definition
entries. The bucket limit applies to the total of 60; the diagnostic-entry cap applies to the three grouped lines.

## Example output

For Sync Streams, the log now names the source correctly:

```text
[PSYNC_S2305] Too many buckets: 60 (limit of 50)
Buckets by sync stream:
  projects: 30
  tasks: 20
  comments: 10
```

For a legacy Sync Rules configuration, it continues to use bucket-definition terminology:

```text
[PSYNC_S2305] Too many buckets: 60 (limit of 50)
Buckets by bucket definition:
  projects: 60
```

When more than 100 Sync Streams contribute buckets, the 100 largest entries are included and the remainder is
summarized:

```text
[PSYNC_S2305] Too many buckets: 105 (limit of 100)
Buckets by sync stream:
  def1: 1
  def2: 1
  def3: 1
  def4: 1
  def5: 1
  ...
  def96: 1
  def97: 1
  def98: 1
  def99: 1
  def100: 1
  ... and 5 more buckets from 5 sync streams
```

## Testing

The updated tests cover:

- A Sync Stream breakdown with counts from multiple streams.
- A legacy bucket-definition breakdown with the appropriate label.
- A 105-stream breakdown that logs exactly 100 entries and summarizes the remaining five.


--- 
AI usage: The changes here were implemented with Codex 5.6 Sol - I manually guided and tested the result. 