### PR TITLE
[MongoDB Storage V3] has_clear_op

### DIFF
--- a/.changeset/puny-signs-check.md
+++ b/.changeset/puny-signs-check.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+---
+
+[MongoDB Storage V3] Add has_clear_op field and simplify checksum queries.

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
@@ -236,9 +236,6 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           $or: filters
         }
       },
-      // Sort on the complete _id so the _id index can satisfy it, and so the
-      // grouped boundary metadata comes from each bucket's first and last documents.
-      { $sort: { _id: 1 } },
       // Only document-level metadata is used below. Bucket-data operations may
       // be offloaded, and checksum queries must never inspect the ops array.
       {
@@ -261,8 +258,8 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           has_clear_op: {
             $max: { $cond: ['$has_clear_op', 1, 0] }
           },
-          first_min_op: { $first: '$min_op' },
-          last_op: { $last: '$_id.o' }
+          min_op: { $min: '$min_op' },
+          max_op: { $max: '$_id.o' }
         }
       }
     ];
@@ -280,16 +277,15 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
       const bucket = doc._id as string;
       const request = requests.get(bucket)!;
 
-      // By the ordered, disjoint range invariants on BucketDataDocumentV3,
-      // only the last matched document can straddle the end boundary. Its
-      // document-level checksum includes operations after the checkpoint, so
-      // this checkpoint cannot be calculated from document metadata.
-      if (doc.last_op > request.end) {
+      // A maximum beyond end means a matched document straddles the checkpoint.
+      // Its document-level checksum includes later operations, so this checkpoint
+      // cannot be calculated from document metadata.
+      if (doc.max_op > request.end) {
         throw new CheckpointChecksumInvalidatedError(request.end, bucket);
       }
-      // The _id filter excludes documents ending at or before start. By the
-      // same range invariants, only the first matched document can contain it.
-      if (request.start != null && doc.first_min_op <= request.start) {
+      // The _id filter excludes documents ending at or before start. A minimum
+      // at or below start therefore means a matched document straddles it.
+      if (request.start != null && doc.min_op <= request.start) {
         startStraddledBuckets.add(bucket);
         continue;
       }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
@@ -236,28 +236,9 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           $or: filters
         }
       },
-      {
-        $addFields: {
-          bucket_start: {
-            $switch: {
-              branches: Array.from(requests.entries()).map(([bucket, req]) => ({
-                case: { $eq: ['$_id.b', bucket] },
-                then: req.start ?? new bson.MinKey()
-              })),
-              default: new bson.MinKey()
-            }
-          },
-          bucket_end: {
-            $switch: {
-              branches: Array.from(requests.entries()).map(([bucket, req]) => ({
-                case: { $eq: ['$_id.b', bucket] },
-                then: req.end
-              })),
-              default: new bson.MaxKey()
-            }
-          }
-        }
-      },
+      // Sort on the complete _id so the _id index can satisfy it, and so the
+      // grouped boundary metadata comes from each bucket's first and last documents.
+      { $sort: { _id: 1 } },
       // Only document-level metadata is used below. Bucket-data operations may
       // be offloaded, and checksum queries must never inspect the ops array.
       {
@@ -267,15 +248,7 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           checksum: 1,
           count: 1,
           target_op: 1,
-          has_clear_op: 1,
-          bucket_start: 1,
-          bucket_end: 1,
-          is_start_straddle: {
-            $and: [{ $lte: ['$min_op', '$bucket_start'] }, { $gt: ['$_id.o', '$bucket_start'] }]
-          },
-          is_end_straddle: {
-            $gt: ['$_id.o', '$bucket_end']
-          }
+          has_clear_op: 1
         }
       },
       // Aggregate document metadata per bucket. A CLEAR makes the result a full
@@ -289,20 +262,9 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           has_clear_op: {
             $max: { $cond: ['$has_clear_op', 1, 0] }
           },
-          has_start_straddle: {
-            $max: { $cond: ['$is_start_straddle', 1, 0] }
-          },
-          has_end_straddle: {
-            $max: { $cond: ['$is_end_straddle', 1, 0] }
-          },
-          invalid_end_straddle: {
-            $max: {
-              $cond: ['$is_end_straddle', { $cond: [{ $gt: ['$target_op', '$bucket_end'] }, 0, 1] }, 0]
-            }
-          },
-          end_straddle_doc_op: {
-            $max: { $cond: ['$is_end_straddle', '$_id.o', null] }
-          }
+          first_min_op: { $first: '$min_op' },
+          last_op: { $last: '$_id.o' },
+          last_target_op: { $last: '$target_op' }
         }
       }
     ];
@@ -320,15 +282,15 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
       const bucket = doc._id as string;
       const request = requests.get(bucket)!;
 
-      if (doc.invalid_end_straddle) {
-        throw new ServiceAssertionError(
-          `V3 bucket-data document ${bucket}/${doc.end_straddle_doc_op} straddles checkpoint ${request.end} without target_op > checkpoint`
-        );
-      }
-      if (doc.has_end_straddle) {
+      if (doc.last_op > request.end) {
+        if (doc.last_target_op == null || doc.last_target_op <= request.end) {
+          throw new ServiceAssertionError(
+            `V3 bucket-data document ${bucket}/${doc.last_op} straddles checkpoint ${request.end} without target_op > checkpoint`
+          );
+        }
         throw new CheckpointChecksumInvalidatedError(request.end, bucket);
       }
-      if (doc.has_start_straddle) {
+      if (request.start != null && doc.first_min_op <= request.start) {
         startStraddledBuckets.add(bucket);
         continue;
       }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
@@ -1,7 +1,6 @@
 import * as lib_mongo from '@powersync/lib-service-mongodb';
 import { ServiceAssertionError } from '@powersync/lib-services-framework';
 import {
-  addChecksums,
   bson,
   BucketChecksum,
   CheckpointChecksumInvalidatedError,
@@ -13,6 +12,7 @@ import {
   SingleSyncConfigBucketDefinitionMapping
 } from '@powersync/service-core';
 import {
+  checksumFromAggregate,
   emptyChecksumForRequest,
   FetchPartialBucketChecksumByBucket,
   FetchPartialBucketChecksumByDefinition,
@@ -285,7 +285,7 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
         $group: {
           _id: '$_id.b',
           checksum_total: { $sum: '$checksum' },
-          count_total: { $sum: '$count' },
+          count: { $sum: '$count' },
           has_clear_op: {
             $max: { $cond: ['$has_clear_op', 1, 0] }
           },
@@ -333,20 +333,7 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
         continue;
       }
 
-      const checksum = normalizeDocumentChecksum(doc.checksum_total);
-      const current: PartialOrFullChecksum = doc.has_clear_op
-        ? {
-            bucket,
-            checksum,
-            count: Number(doc.count_total)
-          }
-        : {
-            bucket,
-            partialChecksum: checksum,
-            partialCount: Number(doc.count_total)
-          };
-
-      partialChecksums.set(bucket, current);
+      partialChecksums.set(bucket, checksumFromAggregate(doc));
     }
 
     const checksums = new Map<string, PartialOrFullChecksum>(
@@ -391,8 +378,4 @@ function createBucketFilter(request: Pick<FetchPartialBucketChecksumByBucket, 'b
       $lte: request.end
     }
   };
-}
-
-function normalizeDocumentChecksum(value: bigint): number {
-  return addChecksums(0, Number(value));
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
@@ -247,7 +247,6 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           min_op: 1,
           checksum: 1,
           count: 1,
-          target_op: 1,
           has_clear_op: 1
         }
       },
@@ -263,8 +262,7 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
             $max: { $cond: ['$has_clear_op', 1, 0] }
           },
           first_min_op: { $first: '$min_op' },
-          last_op: { $last: '$_id.o' },
-          last_target_op: { $last: '$target_op' }
+          last_op: { $last: '$_id.o' }
         }
       }
     ];
@@ -283,15 +281,10 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
       const request = requests.get(bucket)!;
 
       // By the ordered, disjoint range invariants on BucketDataDocumentV3,
-      // only the last matched document can straddle the end boundary. Original
-      // append-only documents cannot contain a valid checkpoint boundary, so a
-      // straddle must carry a compaction target beyond the invalid checkpoint.
+      // only the last matched document can straddle the end boundary. Its
+      // document-level checksum includes operations after the checkpoint, so
+      // this checkpoint cannot be calculated from document metadata.
       if (doc.last_op > request.end) {
-        if (doc.last_target_op == null || doc.last_target_op <= request.end) {
-          throw new ServiceAssertionError(
-            `V3 bucket-data document ${bucket}/${doc.last_op} straddles checkpoint ${request.end} without target_op > checkpoint`
-          );
-        }
         throw new CheckpointChecksumInvalidatedError(request.end, bucket);
       }
       // The _id filter excludes documents ending at or before start. By the

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
@@ -1,7 +1,10 @@
 import * as lib_mongo from '@powersync/lib-service-mongodb';
+import { ServiceAssertionError } from '@powersync/lib-services-framework';
 import {
+  addChecksums,
   bson,
   BucketChecksum,
+  CheckpointChecksumInvalidatedError,
   FetchPartialBucketChecksum,
   InternalOpId,
   isPartialChecksum,
@@ -10,7 +13,6 @@ import {
   SingleSyncConfigBucketDefinitionMapping
 } from '@powersync/service-core';
 import {
-  checksumFromAggregate,
   emptyChecksumForRequest,
   FetchPartialBucketChecksumByBucket,
   FetchPartialBucketChecksumByDefinition,
@@ -179,9 +181,42 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
       requests.set(request.bucket, request);
     }
 
-    const pipeline = this.buildPartialChecksumPipeline(requests);
-    const aggregate = await collection
-      .aggregate(pipeline, {
+    const aggregate = await this.aggregatePartialChecksums(collection, requests, context);
+    const { checksums, startStraddledBuckets } = this.normalizePartialChecksumResults(batch, aggregate);
+
+    if (startStraddledBuckets.size == 0) {
+      return checksums;
+    }
+
+    // A cached base ends inside a compaction-produced document. Its checksum cannot
+    // be safely combined with the document-level checksum, so recalculate this
+    // bucket from the beginning. A full result replaces the cached base upstream.
+    const fullRequests = batch
+      .filter((request) => startStraddledBuckets.has(request.bucket))
+      .map((request) => ({ ...request, start: undefined }));
+    const fullRequestMap = new Map(fullRequests.map((request) => [request.bucket, request]));
+    const fullAggregate = await this.aggregatePartialChecksums(collection, fullRequestMap, context);
+    const fullResults = this.normalizePartialChecksumResults(fullRequests, fullAggregate);
+
+    if (fullResults.startStraddledBuckets.size > 0) {
+      throw new ServiceAssertionError(
+        `Unexpected start-boundary straddle while recalculating bucket(s) ${[...fullResults.startStraddledBuckets].join(', ')}`
+      );
+    }
+    for (const [bucket, checksum] of fullResults.checksums) {
+      checksums.set(bucket, checksum);
+    }
+
+    return checksums;
+  }
+
+  private async aggregatePartialChecksums(
+    collection: lib_mongo.mongo.Collection<BucketDataDocumentV3>,
+    requests: Map<string, FetchPartialBucketChecksumByBucket>,
+    context: MongoChecksumSessionContext
+  ): Promise<bson.Document[]> {
+    return collection
+      .aggregate(this.buildPartialChecksumPipeline(requests), {
         ...context.readOptions,
         maxTimeMS: lib_mongo.MONGO_CHECKSUM_TIMEOUT_MS
       })
@@ -189,8 +224,6 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
       .catch((e) => {
         throw lib_mongo.mapQueryError(e, 'while reading checksums');
       });
-
-    return this.normalizePartialChecksumResults(batch, aggregate);
   }
 
   private buildPartialChecksumPipeline(requests: Map<string, FetchPartialBucketChecksumByBucket>): bson.Document[] {
@@ -203,6 +236,9 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           $or: filters
         }
       },
+      // Keep documents in bucket/op order. Sorting by the complete compound
+      // key allows MongoDB to satisfy this from the _id index.
+      { $sort: { _id: 1 } },
       {
         $addFields: {
           bucket_start: {
@@ -225,106 +261,74 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           }
         }
       },
-      // Determine if document is fully included within [start, end] range
+      // Only document-level metadata is used below. Bucket-data operations may
+      // be offloaded, and checksum queries must never inspect the ops array.
       {
         $project: {
           _id: 1,
           min_op: 1,
           checksum: 1,
           count: 1,
-          ops: 1,
+          target_op: 1,
+          has_clear_op: 1,
           bucket_start: 1,
           bucket_end: 1,
-          is_fully_included: {
-            $and: [{ $gt: ['$min_op', '$bucket_start'] }, { $lte: ['$_id.o', '$bucket_end'] }]
+          is_start_straddle: {
+            $and: [{ $lte: ['$min_op', '$bucket_start'] }, { $gt: ['$_id.o', '$bucket_start'] }]
+          },
+          is_end_straddle: {
+            $gt: ['$_id.o', '$bucket_end']
           }
         }
-      },
-      // Compute included checksum, count, and clear op detection
-      {
-        $project: {
-          _id: 1,
-          checksum_total: {
-            $cond: {
-              if: '$is_fully_included',
-              then: '$checksum',
-              else: {
-                $sum: {
-                  $map: {
-                    input: {
-                      $filter: {
-                        input: '$ops',
-                        cond: {
-                          $and: [{ $gt: ['$$this.o', '$bucket_start'] }, { $lte: ['$$this.o', '$bucket_end'] }]
-                        }
-                      }
-                    },
-                    in: '$$this.checksum'
-                  }
-                }
-              }
-            }
-          },
-          count_total: {
-            $cond: {
-              if: '$is_fully_included',
-              then: '$count',
-              else: {
-                $size: {
-                  $filter: {
-                    input: '$ops',
-                    cond: {
-                      $and: [{ $gt: ['$$this.o', '$bucket_start'] }, { $lte: ['$$this.o', '$bucket_end'] }]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          has_clear_op: {
-            $max: {
-              $map: {
-                input: {
-                  $filter: {
-                    input: '$ops',
-                    cond: {
-                      $and: [{ $gt: ['$$this.o', '$bucket_start'] }, { $lte: ['$$this.o', '$bucket_end'] }]
-                    }
-                  }
-                },
-                in: { $cond: [{ $eq: ['$$this.op', 'CLEAR'] }, 1, 0] }
-              }
-            }
-          },
-          last_op: { $max: '$_id.o' }
-        }
-      },
-      // Group by bucket
-      {
-        $group: {
-          _id: '$_id.b',
-          checksum_total: { $sum: '$checksum_total' },
-          count: { $sum: '$count_total' },
-          has_clear_op: { $max: '$has_clear_op' },
-          last_op: { $max: '$last_op' }
-        }
-      },
-      // $sort results
-      { $sort: { _id: 1 } }
+      }
     ];
   }
 
   private normalizePartialChecksumResults(
     batch: FetchPartialBucketChecksumByBucket[],
     aggregate: bson.Document[]
-  ): PartialChecksumMap {
+  ): { checksums: PartialChecksumMap; startStraddledBuckets: Set<string> } {
+    const requests = new Map(batch.map((request) => [request.bucket, request]));
+    const startStraddledBuckets = new Set<string>();
     const partialChecksums = new Map<string, PartialOrFullChecksum>();
+
     for (let doc of aggregate) {
-      const bucket = doc._id;
-      partialChecksums.set(bucket, checksumFromAggregate(doc));
+      const bucket = doc._id.b as string;
+      const request = requests.get(bucket)!;
+
+      if (doc.is_end_straddle) {
+        const targetOp = doc.target_op as bigint | null | undefined;
+        if (targetOp == null || targetOp <= request.end) {
+          throw new ServiceAssertionError(
+            `V3 bucket-data document ${bucket}/${doc._id.o} straddles checkpoint ${request.end} without target_op > checkpoint`
+          );
+        }
+        throw new CheckpointChecksumInvalidatedError(request.end, bucket);
+      }
+      if (doc.is_start_straddle) {
+        startStraddledBuckets.add(bucket);
+        continue;
+      }
+
+      const previous = partialChecksums.get(bucket);
+      const checksum = normalizeDocumentChecksum(doc.checksum);
+      const current: PartialOrFullChecksum = doc.has_clear_op
+        ? {
+            bucket,
+            checksum,
+            count: Number(doc.count)
+          }
+        : {
+            bucket,
+            partialChecksum: checksum,
+            partialCount: Number(doc.count)
+          };
+
+      const merged = previous == null ? current : mergeDocumentChecksums(bucket, previous, current);
+      partialChecksums.set(bucket, merged);
     }
 
-    return new Map<string, PartialOrFullChecksum>(
+    const checksums = new Map<string, PartialOrFullChecksum>(
       batch.map((request) => {
         const bucket = request.bucket;
         let partialChecksum = partialChecksums.get(bucket);
@@ -346,6 +350,7 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
         return [bucket, partialChecksum];
       })
     );
+    return { checksums, startStraddledBuckets };
   }
 }
 
@@ -364,5 +369,31 @@ function createBucketFilter(request: Pick<FetchPartialBucketChecksumByBucket, 'b
     min_op: {
       $lte: request.end
     }
+  };
+}
+
+function normalizeDocumentChecksum(value: bigint): number {
+  return addChecksums(0, Number(value));
+}
+
+function mergeDocumentChecksums(
+  bucket: string,
+  previous: PartialOrFullChecksum,
+  current: PartialOrFullChecksum
+): PartialOrFullChecksum {
+  if (!isPartialChecksum(current)) {
+    return current;
+  }
+  if (!isPartialChecksum(previous)) {
+    return {
+      bucket,
+      checksum: addChecksums(previous.checksum, current.partialChecksum),
+      count: previous.count + current.partialCount
+    };
+  }
+  return {
+    bucket,
+    partialChecksum: addChecksums(previous.partialChecksum, current.partialChecksum),
+    partialCount: previous.partialCount + current.partialCount
   };
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
@@ -236,9 +236,6 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
           $or: filters
         }
       },
-      // Keep documents in bucket/op order. Sorting by the complete compound
-      // key allows MongoDB to satisfy this from the _id index.
-      { $sort: { _id: 1 } },
       {
         $addFields: {
           bucket_start: {
@@ -280,6 +277,33 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
             $gt: ['$_id.o', '$bucket_end']
           }
         }
+      },
+      // Aggregate document metadata per bucket. A CLEAR makes the result a full
+      // checksum that replaces any cached prefix; storage guarantees that
+      // documents preceding the CLEAR have already been removed.
+      {
+        $group: {
+          _id: '$_id.b',
+          checksum_total: { $sum: '$checksum' },
+          count_total: { $sum: '$count' },
+          has_clear_op: {
+            $max: { $cond: ['$has_clear_op', 1, 0] }
+          },
+          has_start_straddle: {
+            $max: { $cond: ['$is_start_straddle', 1, 0] }
+          },
+          has_end_straddle: {
+            $max: { $cond: ['$is_end_straddle', 1, 0] }
+          },
+          invalid_end_straddle: {
+            $max: {
+              $cond: ['$is_end_straddle', { $cond: [{ $gt: ['$target_op', '$bucket_end'] }, 0, 1] }, 0]
+            }
+          },
+          end_straddle_doc_op: {
+            $max: { $cond: ['$is_end_straddle', '$_id.o', null] }
+          }
+        }
       }
     ];
   }
@@ -292,40 +316,37 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
     const startStraddledBuckets = new Set<string>();
     const partialChecksums = new Map<string, PartialOrFullChecksum>();
 
-    for (let doc of aggregate) {
-      const bucket = doc._id.b as string;
+    for (const doc of aggregate) {
+      const bucket = doc._id as string;
       const request = requests.get(bucket)!;
 
-      if (doc.is_end_straddle) {
-        const targetOp = doc.target_op as bigint | null | undefined;
-        if (targetOp == null || targetOp <= request.end) {
-          throw new ServiceAssertionError(
-            `V3 bucket-data document ${bucket}/${doc._id.o} straddles checkpoint ${request.end} without target_op > checkpoint`
-          );
-        }
+      if (doc.invalid_end_straddle) {
+        throw new ServiceAssertionError(
+          `V3 bucket-data document ${bucket}/${doc.end_straddle_doc_op} straddles checkpoint ${request.end} without target_op > checkpoint`
+        );
+      }
+      if (doc.has_end_straddle) {
         throw new CheckpointChecksumInvalidatedError(request.end, bucket);
       }
-      if (doc.is_start_straddle) {
+      if (doc.has_start_straddle) {
         startStraddledBuckets.add(bucket);
         continue;
       }
 
-      const previous = partialChecksums.get(bucket);
-      const checksum = normalizeDocumentChecksum(doc.checksum);
+      const checksum = normalizeDocumentChecksum(doc.checksum_total);
       const current: PartialOrFullChecksum = doc.has_clear_op
         ? {
             bucket,
             checksum,
-            count: Number(doc.count)
+            count: Number(doc.count_total)
           }
         : {
             bucket,
             partialChecksum: checksum,
-            partialCount: Number(doc.count)
+            partialCount: Number(doc.count_total)
           };
 
-      const merged = previous == null ? current : mergeDocumentChecksums(bucket, previous, current);
-      partialChecksums.set(bucket, merged);
+      partialChecksums.set(bucket, current);
     }
 
     const checksums = new Map<string, PartialOrFullChecksum>(
@@ -374,26 +395,4 @@ function createBucketFilter(request: Pick<FetchPartialBucketChecksumByBucket, 'b
 
 function normalizeDocumentChecksum(value: bigint): number {
   return addChecksums(0, Number(value));
-}
-
-function mergeDocumentChecksums(
-  bucket: string,
-  previous: PartialOrFullChecksum,
-  current: PartialOrFullChecksum
-): PartialOrFullChecksum {
-  if (!isPartialChecksum(current)) {
-    return current;
-  }
-  if (!isPartialChecksum(previous)) {
-    return {
-      bucket,
-      checksum: addChecksums(previous.checksum, current.partialChecksum),
-      count: previous.count + current.partialCount
-    };
-  }
-  return {
-    bucket,
-    partialChecksum: addChecksums(previous.partialChecksum, current.partialChecksum),
-    partialCount: previous.partialCount + current.partialCount
-  };
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoChecksumsV3.ts
@@ -282,6 +282,10 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
       const bucket = doc._id as string;
       const request = requests.get(bucket)!;
 
+      // By the ordered, disjoint range invariants on BucketDataDocumentV3,
+      // only the last matched document can straddle the end boundary. Original
+      // append-only documents cannot contain a valid checkpoint boundary, so a
+      // straddle must carry a compaction target beyond the invalid checkpoint.
       if (doc.last_op > request.end) {
         if (doc.last_target_op == null || doc.last_target_op <= request.end) {
           throw new ServiceAssertionError(
@@ -290,6 +294,8 @@ export class MongoChecksumsV3 extends MongoChecksums implements DefinitionChecks
         }
         throw new CheckpointChecksumInvalidatedError(request.end, bucket);
       }
+      // The _id filter excludes documents ending at or before start. By the
+      // same range invariants, only the first matched document can contain it.
       if (request.start != null && doc.first_min_op <= request.start) {
         startStraddledBuckets.add(bucket);
         continue;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
@@ -726,8 +726,8 @@ export class MongoCompactorV3 extends MongoCompactor {
 
   /**
    * Compaction may combine operations that were visible at different checkpoints.
-   * target_op marks the resulting document's upper bound so checkpoints inside it
-   * are invalidated rather than returning a partial document checksum.
+   * target_op marks the resulting document's upper bound so bucket-data reads for
+   * checkpoints inside it are invalidated.
    */
   private serializeCompactedBucketData(bucket: string, operations: BucketDataDoc[]): BucketDataDocumentV3 {
     return serializeBucketData(bucket, operations, {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
@@ -312,7 +312,7 @@ export class MongoCompactorV3 extends MongoCompactor {
 
       // --- Rechunk survivors into new V3 documents ---
       const chunks = chunkBucketData(surviving);
-      const newDocs = chunks.map((chunk) => serializeBucketData(bucket, chunk));
+      const newDocs = chunks.map((chunk) => this.serializeCompactedBucketData(bucket, chunk));
 
       if (lastNotPut == null) {
         clearBoundaryDocId = null;
@@ -589,7 +589,7 @@ export class MongoCompactorV3 extends MongoCompactor {
           data: null,
           target_op: maxTargetOp
         } satisfies BucketDataDoc;
-        await collection.insertOne(serializeBucketData(bucket, [clearOp]), { session });
+        await collection.insertOne(this.serializeCompactedBucketData(bucket, [clearOp]), { session });
 
         opCountDiff = -clearedOpCount + 1;
       },
@@ -704,10 +704,12 @@ export class MongoCompactorV3 extends MongoCompactor {
           data: null,
           target_op: maxTargetOp
         } satisfies BucketDataDoc;
-        await collection.insertOne(serializeBucketData(bucket, [clearOp]), { session });
+        await collection.insertOne(this.serializeCompactedBucketData(bucket, [clearOp]), { session });
 
         if (boundarySurvivors.length > 0) {
-          const survivingDocs = chunkBucketData(boundarySurvivors).map((chunk) => serializeBucketData(bucket, chunk));
+          const survivingDocs = chunkBucketData(boundarySurvivors).map((chunk) =>
+            this.serializeCompactedBucketData(bucket, chunk)
+          );
           await collection.insertMany(survivingDocs, { session });
         }
 
@@ -720,5 +722,16 @@ export class MongoCompactorV3 extends MongoCompactor {
     );
 
     return opCountDiff;
+  }
+
+  /**
+   * Compaction may combine operations that were visible at different checkpoints.
+   * target_op marks the resulting document's upper bound so checkpoints inside it
+   * are invalidated rather than returning a partial document checksum.
+   */
+  private serializeCompactedBucketData(bucket: string, operations: BucketDataDoc[]): BucketDataDocumentV3 {
+    return serializeBucketData(bucket, operations, {
+      compactionTargetOp: operations[operations.length - 1].o
+    });
   }
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/bucket-format.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/bucket-format.ts
@@ -2,18 +2,26 @@ import { bson } from '@powersync/service-core';
 import { BucketDataDoc, BucketKey } from '../common/BucketDataDoc.js';
 import { BucketDataDocumentV3, BucketOperation } from './models.js';
 
-export function serializeBucketData(bucket: string, operations: BucketDataDoc[]): BucketDataDocumentV3 {
+export function serializeBucketData(
+  bucket: string,
+  operations: BucketDataDoc[],
+  options?: { compactionTargetOp?: bigint }
+): BucketDataDocumentV3 {
   const minOp = operations[0].o;
   const maxOp = operations[operations.length - 1].o;
 
   let totalChecksum = 0n;
-  let maxTargetOp: bigint | null = null;
+  let maxTargetOp: bigint | null = options?.compactionTargetOp ?? null;
+  let hasClearOp = false;
 
   const ops: BucketOperation[] = operations.map((op) => {
     totalChecksum += op.checksum;
 
     if (op.target_op != null && (maxTargetOp == null || op.target_op > maxTargetOp)) {
       maxTargetOp = op.target_op;
+    }
+    if (op.op == 'CLEAR') {
+      hasClearOp = true;
     }
 
     return {
@@ -40,6 +48,7 @@ export function serializeBucketData(bucket: string, operations: BucketDataDoc[])
     count: operations.length,
     size,
     target_op: maxTargetOp,
+    ...(hasClearOp ? { has_clear_op: true as const } : {}),
     ops
   };
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/bucket-format.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/bucket-format.ts
@@ -2,6 +2,11 @@ import { bson } from '@powersync/service-core';
 import { BucketDataDoc, BucketKey } from '../common/BucketDataDoc.js';
 import { BucketDataDocumentV3, BucketOperation } from './models.js';
 
+/**
+ * Serialize a non-empty list of operations in strictly ascending `o` order.
+ * Preserving that order establishes the {@link BucketDataDocumentV3} range
+ * invariants used by metadata-only queries.
+ */
 export function serializeBucketData(
   bucket: string,
   operations: BucketDataDoc[],

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
@@ -199,7 +199,8 @@ export interface BucketDataDocumentV3 {
   size: number;
   /**
    * The greatest operation boundary that influenced this document's contents.
-   * A checkpoint below this value is invalid if the document straddles it.
+   * Bucket-data reads propagate it so serving an earlier checkpoint can be
+   * invalidated when compaction changed the operations being returned.
    */
   target_op?: bigint | null;
   /**

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
@@ -183,6 +183,8 @@ export interface BucketDataDocumentV3 {
   count: number;
   size: number;
   target_op?: bigint | null;
+  /** Present and true when this document contains a CLEAR operation. */
+  has_clear_op?: true;
   ops: BucketOperation[];
 }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
@@ -176,14 +176,37 @@ export interface BucketOperation {
   data: string | null;
 }
 
+/**
+ * A non-empty chunk of a bucket's ordered operation stream.
+ *
+ * All writers maintain these invariants:
+ *
+ * - `ops` is non-empty and strictly ordered by `o`.
+ * - `min_op` is `ops[0].o` and `_id.o` is `ops[ops.length - 1].o`.
+ * - Documents for the same bucket have ordered, disjoint operation ranges,
+ *   although gaps between ranges are allowed.
+ * - `checksum` is the sum of every operation checksum and `count` is
+ *   `ops.length`.
+ *
+ * Metadata-only checksum and data queries rely on these invariants to identify
+ * boundary-straddling documents without reading `ops`.
+ */
 export interface BucketDataDocumentV3 {
   _id: BucketDataKey;
   min_op: bigint;
   checksum: bigint;
   count: number;
   size: number;
+  /**
+   * The greatest operation boundary that influenced this document's contents.
+   * A checkpoint below this value is invalid if the document straddles it.
+   */
   target_op?: bigint | null;
-  /** Present and true when this document contains a CLEAR operation. */
+  /**
+   * Present (and always true) when this document contains a CLEAR operation.
+   * In that case, this is the first document in the bucket: all preceding
+   * documents have been removed.
+   */
   has_clear_op?: true;
   ops: BucketOperation[];
 }

--- a/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
@@ -937,19 +937,25 @@ bucket_definitions:
     const clear = { ...makeOp(20, 'clear', '', ctx, sourceTableId), op: 'CLEAR' as const, checksum: 101n, data: null };
     const afterClear = makeOp(30, 'B', 'b1', ctx, sourceTableId);
 
-    await collection.insertMany([
-      serializeBucketData(BUCKET, [beforeClear]),
-      serializeBucketData(BUCKET, [clear, afterClear])
-    ]);
+    await collection.insertOne(serializeBucketData(BUCKET, [beforeClear]));
     await bucketStateCollection.insertOne({
       _id: { d: definitionId, b: BUCKET },
-      last_op: 30n,
-      estimate_since_compact: { count: 3, bytes: 100 }
+      last_op: 10n,
+      estimate_since_compact: { count: 1, bytes: 100 }
     });
 
     const request = checksumRequest();
     const before = await bucketStorage.getChecksums(test_utils.testCheckpoint(10n), [request]);
     expect(before.get(BUCKET)).toEqual({ bucket: BUCKET, checksum: 70, count: 1 });
+
+    // Compaction replaces everything preceding CLEAR, while the checksum cache
+    // still contains the old checkpoint.
+    await collection.deleteMany({});
+    await collection.insertOne(serializeBucketData(BUCKET, [clear, afterClear]));
+    await bucketStateCollection.updateOne(
+      { _id: { d: definitionId, b: BUCKET } },
+      { $set: { last_op: 30n, 'estimate_since_compact.count': 2 } }
+    );
 
     const after = await bucketStorage.getChecksums(test_utils.testCheckpoint(30n), [request]);
     expect(after.get(BUCKET)).toEqual({

--- a/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
@@ -872,7 +872,7 @@ bucket_definitions:
     expect(cached.get(BUCKET)).toMatchObject({ count: 3 });
 
     // Compaction rechunks the bucket into one document spanning the cached
-    // checkpoint. Its target_op makes the current endpoint valid.
+    // checkpoint. The requested endpoint is the end of the new document.
     await collection.deleteMany({});
     await collection.insertOne(serializeBucketData(BUCKET, ops, { compactionTargetOp: 60n }));
 
@@ -915,7 +915,7 @@ bucket_definitions:
     expect(result.get(BUCKET)).toEqual({ bucket: BUCKET, checksum: checksumAllOps, count: 3 });
   });
 
-  test('end straddle without a future target_op fails its storage invariant', async () => {
+  test('end straddle without target_op also invalidates the old checkpoint', async () => {
     const { bucketStorage, collection, bucketStateCollection, definitionId, sourceTableId, ctx } = await setup();
     const ops = [makeOp(40, 'D', 'd1', ctx, sourceTableId), makeOp(60, 'F', 'f1', ctx, sourceTableId)];
     await collection.insertOne(serializeBucketData(BUCKET, ops));
@@ -926,8 +926,8 @@ bucket_definitions:
     });
 
     const request = checksumRequest();
-    await expect(bucketStorage.getChecksums(test_utils.testCheckpoint(45n), [request])).rejects.toThrow(
-      'straddles checkpoint 45 without target_op > checkpoint'
+    await expect(bucketStorage.getChecksums(test_utils.testCheckpoint(45n), [request])).rejects.toBeInstanceOf(
+      CheckpointChecksumInvalidatedError
     );
   });
 

--- a/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
@@ -4,7 +4,13 @@ import { loadBucketDataDocument, serializeBucketData } from '@module/storage/imp
 import { chunkBucketData, DEFAULT_MAX_DOC_SIZE_BYTES } from '@module/storage/implementation/v3/chunking.js';
 import { BucketDataDocumentV3 } from '@module/storage/implementation/v3/models.js';
 import { VersionedPowerSyncMongoV3 } from '@module/storage/implementation/v3/VersionedPowerSyncMongoV3.js';
-import { addChecksums, storage, SyncRulesBucketStorage, updateSyncRulesFromYaml } from '@powersync/service-core';
+import {
+  addChecksums,
+  CheckpointChecksumInvalidatedError,
+  storage,
+  SyncRulesBucketStorage,
+  updateSyncRulesFromYaml
+} from '@powersync/service-core';
 import { bucketRequest, register, test_utils } from '@powersync/service-core-tests';
 import * as bson from 'bson';
 import { describe, expect, test } from 'vitest';
@@ -425,6 +431,14 @@ bucket_definitions:
     expect(doc.size).toBe(bson.calculateObjectSize(doc.ops));
   });
 
+  test('2. has_clear_op is only stored when true', () => {
+    const putDoc = serializeBucketData('test[]', [makeBucketDataDoc({ o: 1n })]);
+    const clearDoc = serializeBucketData('test[]', [makeBucketDataDoc({ o: 2n, op: 'CLEAR', data: null })]);
+
+    expect(putDoc).not.toHaveProperty('has_clear_op');
+    expect(clearDoc.has_clear_op).toBe(true);
+  });
+
   test('2. range metadata consistency - after compaction', async () => {
     const { bucketStorage, collection, bucketStateCollection, ctx, sourceTableId } = await setupV3Storage();
     const ops = [makeOp(10, 'A', 'a1', ctx, sourceTableId), makeOp(20, 'B', 'b1', ctx, sourceTableId)];
@@ -814,9 +828,23 @@ bucket_definitions:
     };
   }
 
-  test('partial checksum with start straddling multi-op document', async () => {
-    const { bucketStorage, syncRules, collection, bucketStateCollection, definitionId, sourceTableId, ctx } =
-      await setup();
+  function checksumRequest(): storage.BucketChecksumRequest {
+    return {
+      bucket: BUCKET,
+      source: {
+        uniqueName: 'global',
+        bucketParameters: [],
+        getSourceTables: () => new Set(),
+        tableSyncsData: () => false,
+        evaluateRow: () => [],
+        inferSchema: () => ({ objects: {} }),
+        bucketQuery: () => ({ ast: {} as any, parameters: [] })
+      } as any
+    };
+  }
+
+  test('start straddle recalculates a cached checksum from the beginning', async () => {
+    const { bucketStorage, collection, bucketStateCollection, definitionId, sourceTableId, ctx } = await setup();
 
     // Single document with ops 10-60, min_op=10, _id.o=60
     const ops = [
@@ -827,57 +855,37 @@ bucket_definitions:
       makeOp(50, 'E', 'e1', ctx, sourceTableId),
       makeOp(60, 'F', 'f1', ctx, sourceTableId)
     ];
-    const doc = serializeBucketData(BUCKET, ops);
-    await collection.insertMany([doc]);
+    // Cache the first half before compaction changes the document boundary.
+    const firstDoc = serializeBucketData(BUCKET, ops.slice(0, 3));
+    await collection.insertOne(firstDoc);
 
-    // Set compacted_state.op_id = 30 to create a partial range starting at 30.
-    // The pipeline will query ops where o > 30 and o <= 60.
-    // The document has min_op=10 < 30, so it's partially included.
-    // The pipeline must $filter ops to only sum those with o > 30 (ops 40, 50, 60).
     const fullChecksum = ops.reduce((sum, op) => addChecksums(sum, Number(op.checksum)), 0);
-    const partialChecksum = ops
-      .filter((op) => op.o > 30n)
-      .reduce((sum, op) => addChecksums(sum, Number(op.checksum)), 0);
-
-    // Partial and full must differ, otherwise the document is fully included and no straddling occurs.
-    expect(partialChecksum).not.toBe(fullChecksum);
-
     await bucketStateCollection.insertOne({
       _id: { d: definitionId, b: BUCKET },
       last_op: 30n,
-      compacted_state: {
-        op_id: 30n,
-        count: 3,
-        checksum: BigInt(
-          ops.filter((op) => op.o <= 30n).reduce((sum, op) => addChecksums(sum, Number(op.checksum)), 0)
-        ),
-        bytes: null
-      },
       estimate_since_compact: { count: 3, bytes: 100 }
     });
 
-    const request: storage.BucketChecksumRequest = {
-      bucket: BUCKET,
-      source: {
-        uniqueName: 'global',
-        bucketParameters: [],
-        getSourceTables: () => new Set(),
-        tableSyncsData: () => false,
-        evaluateRow: () => [],
-        inferSchema: () => ({ objects: {} }),
-        bucketQuery: () => ({ ast: {} as any, parameters: [] })
-      } as any
-    };
+    const request = checksumRequest();
+
+    const cached = await bucketStorage.getChecksums(test_utils.testCheckpoint(30n), [request]);
+    expect(cached.get(BUCKET)).toMatchObject({ count: 3 });
+
+    // Compaction rechunks the bucket into one document spanning the cached
+    // checkpoint. Its target_op makes the current endpoint valid.
+    await collection.deleteMany({});
+    await collection.insertOne(serializeBucketData(BUCKET, ops, { compactionTargetOp: 60n }));
 
     const result = await bucketStorage.getChecksums(test_utils.testCheckpoint(60n), [request]);
     const checksumResult = result.get(BUCKET)!;
 
-    // The total checksum should be: compacted (ops 10,20,30) + partial (ops 40,50,60)
+    // The cached checkpoint at 30 is inside the new document. The full result
+    // must replace it rather than add the document checksum to it.
     expect(checksumResult.checksum).toBe(fullChecksum);
     expect(checksumResult.count).toBe(6);
   });
 
-  test('partial checksum with end straddling multi-op document', async () => {
+  test('end straddle invalidates the old checkpoint and a later checkpoint succeeds', async () => {
     const { bucketStorage, collection, bucketStateCollection, definitionId, sourceTableId, ctx } = await setup();
 
     // Document with ops 40-60, _id.o=60, min_op=40
@@ -886,22 +894,10 @@ bucket_definitions:
       makeOp(50, 'E', 'e1', ctx, sourceTableId),
       makeOp(60, 'F', 'f1', ctx, sourceTableId)
     ];
-    const doc = serializeBucketData(BUCKET, ops);
+    const doc = serializeBucketData(BUCKET, ops, { compactionTargetOp: 60n });
     await collection.insertMany([doc]);
 
-    // No compacted_state — start from beginning, so the full document is in range.
-    // Request checksums with checkpoint=45 (falls between ops 40 and 50).
-    // createBucketFilter produces _id.o <= 45.
-    // This document has _id.o=60 > 45, so the filter excludes it.
-    // But the document contains op 40 which should be included (40 <= 45).
-    const checksumUpTo45 = ops
-      .filter((op) => op.o <= 45n)
-      .reduce((sum, op) => addChecksums(sum, Number(op.checksum)), 0);
-
     const checksumAllOps = ops.reduce((sum, op) => addChecksums(sum, Number(op.checksum)), 0);
-
-    // The straddling is real: op 40 is <= 45 but the document's _id.o=60 is > 45
-    expect(checksumUpTo45).not.toBe(checksumAllOps);
 
     await bucketStateCollection.insertOne({
       _id: { d: definitionId, b: BUCKET },
@@ -909,26 +905,58 @@ bucket_definitions:
       estimate_since_compact: { count: 0, bytes: 0 }
     });
 
-    const request: storage.BucketChecksumRequest = {
+    const request = checksumRequest();
+
+    await expect(bucketStorage.getChecksums(test_utils.testCheckpoint(45n), [request])).rejects.toBeInstanceOf(
+      CheckpointChecksumInvalidatedError
+    );
+
+    const result = await bucketStorage.getChecksums(test_utils.testCheckpoint(60n), [request]);
+    expect(result.get(BUCKET)).toEqual({ bucket: BUCKET, checksum: checksumAllOps, count: 3 });
+  });
+
+  test('end straddle without a future target_op fails its storage invariant', async () => {
+    const { bucketStorage, collection, bucketStateCollection, definitionId, sourceTableId, ctx } = await setup();
+    const ops = [makeOp(40, 'D', 'd1', ctx, sourceTableId), makeOp(60, 'F', 'f1', ctx, sourceTableId)];
+    await collection.insertOne(serializeBucketData(BUCKET, ops));
+    await bucketStateCollection.insertOne({
+      _id: { d: definitionId, b: BUCKET },
+      last_op: 0n,
+      estimate_since_compact: { count: 0, bytes: 0 }
+    });
+
+    const request = checksumRequest();
+    await expect(bucketStorage.getChecksums(test_utils.testCheckpoint(45n), [request])).rejects.toThrow(
+      'straddles checkpoint 45 without target_op > checkpoint'
+    );
+  });
+
+  test('has_clear_op replaces a cached checksum', async () => {
+    const { bucketStorage, collection, bucketStateCollection, definitionId, sourceTableId, ctx } = await setup();
+    const beforeClear = makeOp(10, 'A', 'a1', ctx, sourceTableId);
+    const clear = { ...makeOp(20, 'clear', '', ctx, sourceTableId), op: 'CLEAR' as const, checksum: 101n, data: null };
+    const afterClear = makeOp(30, 'B', 'b1', ctx, sourceTableId);
+
+    await collection.insertMany([
+      serializeBucketData(BUCKET, [beforeClear]),
+      serializeBucketData(BUCKET, [clear, afterClear])
+    ]);
+    await bucketStateCollection.insertOne({
+      _id: { d: definitionId, b: BUCKET },
+      last_op: 30n,
+      estimate_since_compact: { count: 3, bytes: 100 }
+    });
+
+    const request = checksumRequest();
+    const before = await bucketStorage.getChecksums(test_utils.testCheckpoint(10n), [request]);
+    expect(before.get(BUCKET)).toEqual({ bucket: BUCKET, checksum: 70, count: 1 });
+
+    const after = await bucketStorage.getChecksums(test_utils.testCheckpoint(30n), [request]);
+    expect(after.get(BUCKET)).toEqual({
       bucket: BUCKET,
-      source: {
-        uniqueName: 'global',
-        bucketParameters: [],
-        getSourceTables: () => new Set(),
-        tableSyncsData: () => false,
-        evaluateRow: () => [],
-        inferSchema: () => ({ objects: {} }),
-        bucketQuery: () => ({ ast: {} as any, parameters: [] })
-      } as any
-    };
-
-    const result = await bucketStorage.getChecksums(test_utils.testCheckpoint(45n), [request]);
-    const checksumResult = result.get(BUCKET)!;
-
-    // If createBucketFilter's _id.o <= 45 excludes this document,
-    // the checksum will be 0 instead of checksumUpTo45.
-    expect(checksumResult.checksum).toBe(checksumUpTo45);
-    expect(checksumResult.count).toBe(1);
+      checksum: addChecksums(Number(clear.checksum), Number(afterClear.checksum)),
+      count: 2
+    });
   });
 });
 

--- a/packages/service-core-tests/src/tests/register-sync-tests.ts
+++ b/packages/service-core-tests/src/tests/register-sync-tests.ts
@@ -12,7 +12,7 @@ import { JSONBig } from '@powersync/service-jsonbig';
 import path from 'path';
 import * as timers from 'timers/promises';
 import { fileURLToPath } from 'url';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import * as test_utils from '../test-utils/test-utils-index.js';
 import { bucketRequest, METRICS_HELPER } from '../test-utils/test-utils-index.js';
 
@@ -1088,6 +1088,92 @@ bucket_definitions:
 
     const expLines = await getCheckpointLines(iter);
     expect(expLines).toMatchSnapshot();
+  });
+
+  test('checksum invalidation skips the candidate checkpoint', async (context) => {
+    await using f = await factory();
+
+    const syncRules = await updateSyncRules(f, {
+      content: BASIC_SYNC_RULES
+    });
+
+    const bucketStorage = await f.getInstance(syncRules);
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const testTable = await test_utils.resolveTestTable(writer, 'test', ['id'], config);
+
+    await writer.markAllSnapshotDone('0/1');
+    await writer.save({
+      sourceTable: testTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 't1',
+        description: 'Test 1'
+      },
+      afterReplicaId: 't1'
+    });
+    await writer.commit('0/1');
+
+    let resolveInvalidatedChecksum!: () => void;
+    const invalidatedChecksum = new Promise<void>((resolve) => {
+      resolveInvalidatedChecksum = resolve;
+    });
+    const checksumSpy = vi.spyOn(bucketStorage, 'getChecksums').mockImplementationOnce(async (checkpoint, buckets) => {
+      resolveInvalidatedChecksum();
+      throw new storage.CheckpointChecksumInvalidatedError(checkpoint.checkpoint, buckets[0].bucket);
+    });
+
+    const stream = sync.streamResponse({
+      syncContext,
+      bucketStorage,
+      syncRules: bucketStorage.getParsedSyncRules(test_utils.PARSE_OPTIONS),
+      params: {
+        buckets: [],
+        include_checksum: true,
+        raw_data: true
+      },
+      tracker,
+      token: new JwtPayload({ sub: '', exp: Date.now() / 1000 + 10 }),
+      isEncodingAsBson: false
+    });
+
+    const iter = stream[Symbol.asyncIterator]();
+    context.onTestFinished(() => {
+      iter.return?.();
+    });
+
+    const linesPromise = getCheckpointLines(iter, { consume: true });
+    await invalidatedChecksum;
+
+    // The first candidate was discarded before CheckpointLine.advance(). A later
+    // checkpoint must therefore be calculated from the original connection state.
+    await writer.save({
+      sourceTable: testTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: {
+        id: 't2',
+        description: 'Test 2'
+      },
+      afterReplicaId: 't2'
+    });
+    await writer.commit('0/2');
+
+    const lines = await linesPromise;
+    expect(checksumSpy).toHaveBeenCalledTimes(2);
+    expect(lines[0]).toEqual({
+      checkpoint: expect.objectContaining({
+        last_op_id: '2'
+      })
+    });
+    expect(lines).not.toContainEqual({
+      checkpoint: expect.objectContaining({
+        last_op_id: '1'
+      })
+    });
+    expect(lines.at(-1)).toEqual({
+      checkpoint_complete: expect.objectContaining({
+        last_op_id: '2'
+      })
+    });
   });
 
   test('compacting data - invalidate checkpoint', async (context) => {

--- a/packages/service-core/src/storage/CheckpointChecksumInvalidatedError.ts
+++ b/packages/service-core/src/storage/CheckpointChecksumInvalidatedError.ts
@@ -1,0 +1,17 @@
+import { InternalOpId } from '../util/util-index.js';
+
+/**
+ * A checkpoint cannot be served because compaction rewrote a bucket-data
+ * document across its end boundary.
+ *
+ * The sync loop must skip this checkpoint before it sends its checkpoint line.
+ */
+export class CheckpointChecksumInvalidatedError extends Error {
+  constructor(
+    public readonly checkpoint: InternalOpId,
+    public readonly bucket: string
+  ) {
+    super(`Checkpoint ${checkpoint} was invalidated by compaction in bucket ${bucket}`);
+    this.name = 'CheckpointChecksumInvalidatedError';
+  }
+}

--- a/packages/service-core/src/storage/storage-index.ts
+++ b/packages/service-core/src/storage/storage-index.ts
@@ -2,6 +2,7 @@ export * from './bson.js';
 export * from './BucketStorage.js';
 export * from './BucketStorageBatch.js';
 export * from './BucketStorageFactory.js';
+export * from './CheckpointChecksumInvalidatedError.js';
 export * from './ChecksumCache.js';
 export * from './ParsedSyncConfigSet.js';
 export * from './PersistedReplicationStream.js';

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -77,6 +77,12 @@ export class BucketChecksumState {
   private lastChecksums: util.ChecksumMap | null = null;
   private lastWriteCheckpoint: bigint | null = null;
   /**
+   * The next storage checkpoint diff may be relative to a checksum-invalidated
+   * checkpoint that was never sent to the client. Re-check every bucket once
+   * instead of applying that diff to the last client-visible checksums.
+   */
+  private forceFullChecksumForNextCheckpoint = false;
+  /**
    * Once we've sent the first full checkpoint line including all {@link util.Checkpoint.streams} that the user is
    * subscribed to, we keep an index of the stream names to their index in that array.
    *
@@ -117,6 +123,10 @@ export class BucketChecksumState {
     }
   }
 
+  invalidateChecksumBaseline() {
+    this.forceFullChecksumForNextCheckpoint = true;
+  }
+
   /**
    * Build a new checkpoint line for an underlying storage checkpoint update if any buckets have changed.
    *
@@ -141,6 +151,7 @@ export class BucketChecksumState {
 
     const update = await this.parameterState.getCheckpointUpdate(next, tracer);
     const { buckets: allBuckets, updatedBuckets, usedParameterResults } = update;
+    const forceFullChecksum = this.forceFullChecksumForNextCheckpoint;
 
     /** Set of all buckets in this checkpoint. */
     const bucketDescriptionMap = new Map(allBuckets.map((b) => [b.bucket, b]));
@@ -176,7 +187,7 @@ export class BucketChecksumState {
     }
 
     let checksumMap: util.ChecksumMap;
-    if (updatedBuckets != INVALIDATE_ALL_BUCKETS) {
+    if (!forceFullChecksum && updatedBuckets != INVALIDATE_ALL_BUCKETS) {
       if (this.lastChecksums == null) {
         throw new ServiceAssertionError(`Bucket diff received without existing checksums`);
       }
@@ -250,6 +261,9 @@ export class BucketChecksumState {
         diff.updatedBuckets.length == 0
       ) {
         // No changes - don't send anything to the client
+        if (forceFullChecksum) {
+          this.forceFullChecksumForNextCheckpoint = false;
+        }
         return null;
       }
 
@@ -404,6 +418,9 @@ export class BucketChecksumState {
         this.lastChecksums = checksumMap;
         this.lastWriteCheckpoint = writeCheckpoint;
         this.pendingBucketDownloads = pendingBucketDownloads;
+        if (forceFullChecksum) {
+          this.forceFullChecksumForNextCheckpoint = false;
+        }
         deferredLog();
       },
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -153,6 +153,8 @@ async function* streamResponseInner(
         // The checksum was not usable, so buildNextCheckpointLine has not advanced
         // the connection state. Drop this candidate and wait for a checkpoint that
         // is not split by a compaction-produced bucket-data document.
+        // This is different from other checkpoint_invalidated cases in that we hit
+        // this during checksum calculation, instead of on data read.
         trace.span.end();
         logger.info(`checkpoint_invalidated: ${cp.checkpoint}`, {
           reason: 'compacted_before_checkpoint_line',

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -156,6 +156,7 @@ async function* streamResponseInner(
         // This is different from other checkpoint_invalidated cases in that we hit
         // this during checksum calculation, instead of on data read.
         trace.span.end();
+        checksumState.invalidateChecksumBaseline();
         logger.info(`checkpoint_invalidated: ${cp.checkpoint}`, {
           reason: 'compacted_before_checkpoint_line',
           bucket: e.bucket,

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -149,6 +149,19 @@ async function* streamResponseInner(
       const line = await checksumState.buildNextCheckpointLine(next.value, trace.tracer);
       return { done: false, value: { checkpoint: cp, line, trace: line == null ? null : trace } };
     } catch (e) {
+      if (e instanceof storage.CheckpointChecksumInvalidatedError) {
+        // The checksum was not usable, so buildNextCheckpointLine has not advanced
+        // the connection state. Drop this candidate and wait for a checkpoint that
+        // is not split by a compaction-produced bucket-data document.
+        trace.span.end();
+        logger.info(`checkpoint_invalidated: ${cp.checkpoint}`, {
+          reason: 'compacted_before_checkpoint_line',
+          bucket: e.bucket,
+          checkpoint: cp.checkpoint,
+          user_id: tokenPayload.userIdJson
+        });
+        return { done: false, value: { checkpoint: cp, line: null, trace: null } };
+      }
       // Only end the span if we error. If we return normally, we pass ownership on to the caller.
       trace.span.end();
       throw e;


### PR DESCRIPTION
This adds the `has_clear_op` flag from #673. The goal is to never use the `ops` array for checksum calculation, since that would be stored on S3 in many cases once S3 storage is implemented. In theory this also allows us to use a covering index to perform the checksum queries, but I haven't tested the trade-offs of that yet.

The implementation diverges from the approach in #673 in a couple of ways:
1. Only store `has_clear_op: true` or omit the field, never store `has_clear_op: false`. This avoids any storage overhead for the common case (there is only ever one clear op per bucket).
2. Avoiding reading the `ops` array at all, i.e. no need to touch S3 storage when we start using that.
3. Continue using `$group` to aggregate checksums on the mongodb side.

To avoid reading `ops`, we use some different trade-offs. The latter two of these cases are all to protect against cases where the queried range for checksums does not cleanly align with the bucket_data chunks, which only happen when querying concurrently with compacting. The first case of `has_clear_op` is related to partial checksum updates after compacting, but does not require querying concurrently with compacting.

1. `has_clear_op` remains a simple indicator of whether or not the results start with a clear operation. We use the fact that a clear operation can only ever be the first operation in the results.
2. If we hit a start boundary straddle (e.g. we query for op > 150, and find a chunk for ops 100 -> 200), we fall back to computing the full checksum, rather than a partial update of the cache.
3. If we hit an end boundary straddle (e.g. we query for op <= 150, and find a chunk for ops 100 -> 200), we invalidate the checkpoint, and let the client use the next one. This condition can only happen if a compact was triggered while the client is reading the checkpoint, and a newer checkpoint is already available. This should be rare in practice.

In addition, this simplifies the checks for boundary straddles. The previous implementation to compute `bucket_start` and `bucket_end` in the pipeline could generate a large pipeline and slow query. We now do those checks in JS, just using the overall min and max operation ids from the results.

## AI Usage

Manually planned the changes. Verified the ideas against Codex 5.6 and implemented using the same. Reviewed using Claude Opus 4.8.