### PR TITLE
Minor improvements to YAML error handling

### DIFF
--- a/packages/sync-rules/src/from_yaml.ts
+++ b/packages/sync-rules/src/from_yaml.ts
@@ -82,9 +82,9 @@ export class SyncConfigFromYaml {
   }
 
   #parseConfig(parsed: Document): SyncConfig {
-    using rootState = documentState(parsed, (e) => this.#errors.push(e)).requireMap('Sync Config must be a YAML map.');
+    const root = documentState(parsed, (e) => this.#errors.push(e)).requireMap('Sync Config must be a YAML map.');
 
-    if (parsed.errors.length > 0 || rootState == null) {
+    if (parsed.errors.length > 0 || root == null) {
       this.#errors.push(...parsed.errors.map((e) => new YamlError(e)));
       this.#throwOnErrorIfRequested();
 
@@ -92,6 +92,8 @@ export class SyncConfigFromYaml {
       // structure further.
       return new SqlSyncRules(this.yaml);
     }
+
+    using rootState = root;
 
     using declaredOptions = rootState.get('config')?.requireMap();
     let compatibility: CompatibilityContext;

--- a/packages/sync-rules/src/yaml_validation.ts
+++ b/packages/sync-rules/src/yaml_validation.ts
@@ -146,9 +146,13 @@ export function documentState(doc: Document, report: (error: YamlError) => void)
         if (matchedKeys != null) {
           for (const item of node.items) {
             const key = item.key;
-            const keyName = key instanceof Scalar ? String(key.value) : undefined;
-            if (keyName == null || !matchedKeys.has(keyName)) {
-              report(createYamlError(key as Node, `Unknown key '${keyName}'.`));
+            if (key instanceof Scalar) {
+              const keyName = String(key.value);
+              if (!matchedKeys.has(keyName)) {
+                report(createYamlError(key as Node, `Unknown key '${keyName}'.`));
+              }
+            } else {
+              report(createYamlError(key as Node, `Unexpected additional key.`));
             }
           }
         }

--- a/packages/sync-rules/test/src/from_yaml.test.ts
+++ b/packages/sync-rules/test/src/from_yaml.test.ts
@@ -80,6 +80,36 @@ streams:
 `);
   });
 
+  test('invalid key in record', () => {
+    checkErrors(`
+config:
+  edition: 3
+streams:
+  [a, b]: #error "Expected a scalar here"
+    query: SELECT * FROM users
+`);
+  });
+
+  test('invalid extra keys', () => {
+    checkErrors(`
+config:
+  edition: 3
+streams:
+  a:
+    query: SELECT * FROM users
+    illegal_option: foo #error "Unknown key 'illegal_option'."
+`);
+
+    checkErrors(`
+config:
+  edition: 3
+streams:
+  a:
+    query: SELECT * FROM users
+[a, b]: true #error "Unexpected additional key."
+`);
+  });
+
   test('priority not a number', () => {
     checkErrors(`
 config:
@@ -110,23 +140,29 @@ interface ExpectedError {
 
 const errorCommentPattern = /#error\s+"((?:[^"\\]|\\.)*)"/;
 
-function parseExpectedErrors(source: string): ExpectedError[] {
-  return source
+function parseExpectedErrors(source: string): { withoutComments: string; errors: ExpectedError[] } {
+  const yamlLines: string[] = [];
+
+  const errors = source
     .split('\n')
     .map((lineText, index): ExpectedError | null => {
       const match = errorCommentPattern.exec(lineText);
       if (match == null) {
+        yamlLines.push(lineText);
         return null;
       }
 
+      yamlLines.push(lineText.substring(0, match.index));
       return { line: index + 1, message: JSON.parse(`"${match[1]}"`) };
     })
     .filter((entry) => entry != null);
+
+  return { errors, withoutComments: yamlLines.join('\n') };
 }
 
 function checkErrors(yaml: string) {
-  const { errors } = SqlSyncRules.fromYaml(yaml, { throwOnError: false, defaultSchema: 'schema' });
-  const expectedErrors = parseExpectedErrors(yaml);
+  const { errors: expectedErrors, withoutComments: transformedYaml } = parseExpectedErrors(yaml);
+  const { errors } = SqlSyncRules.fromYaml(transformedYaml, { throwOnError: false, defaultSchema: 'schema' });
 
   // Use our own LineCounter to translate the character offsets on errors back to line numbers, so that we can match
   // them up against the #error comments (which are only aware of line numbers).


### PR DESCRIPTION
As a follow-up to https://github.com/powersync-ja/powersync-service/pull/722, this fixes a few issues in the new YAML error handler for sync configs:

- When the YAML file has a syntax error, we don't try to parse it but still have a `using` yaml map which will report a warning on every key we didn't scan, this avoids calling `Symbol.dispose` if we bail early.
- For additional non-scalar keys, emit a plain `Unexpected additional key` instead of `Unknown key 'undefined'`.

This also improves the test fixtures by stripping the `#error` expectations from YAML before parsing it. While trying to write tests for these cases, I sometimes ran into syntax errors reported by the `yaml` package which then include the error text (thus matching it), which is not what we want to test.

No changeset as the prior PR has not been released yet.