### PR TITLE
fix(module-postgres-storage): clear replication error outside the flush transaction

### DIFF
--- a/.changeset/clear-error-outside-transaction.md
+++ b/.changeset/clear-error-outside-transaction.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-postgres-storage': patch
+---
+
+Clear the replication error flag outside the flush transaction. Clearing it inside the REPEATABLE READ replication transaction conflicts with concurrent keepalive updates on the same sync_rules row, causing serialization failures that retry the entire flush when multiple writers are active.

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -464,12 +464,11 @@ export class PostgresBucketBatch
         }
         const { flushedAny } = await persistedBatch.flush(db);
         clearedError = flushedAny && !this.clearedError;
-        if (clearedError) {
-          // No need to clear an error more than once per batch, since an error would always result in restarting the batch.
-          await this.clearError(db);
-        }
       });
       if (clearedError) {
+        // No need to clear an error more than once per batch, since an error would always result in restarting the batch.
+        // Cleared outside the replication transaction - see flushInner.
+        await this.clearError();
         this.clearedError = true;
       }
     }
@@ -536,6 +535,10 @@ export class PostgresBucketBatch
     });
 
     if (clearedError) {
+      // Clear the error outside the replication transaction (plain autocommit update,
+      // like the keepalive), to avoid serialization conflicts on the sync_rules row
+      // when multiple writers flush concurrently.
+      await this.clearError();
       this.clearedError = true;
     }
 
@@ -1038,10 +1041,8 @@ export class PostgresBucketBatch
       }
     }
 
+    // The error itself is cleared by the caller, outside the replication transaction - see flushInner.
     const clearedError = didFlush && !this.clearedError;
-    if (clearedError) {
-      await this.clearError(db);
-    }
 
     // Don't return empty batches
     return {


### PR DESCRIPTION
As discussed in https://github.com/orgs/powersync-ja/discussions/448.

### Problem

`clearError()` runs inside the REPEATABLE READ replication transaction (`withReplicationTransaction`) on a writer's first flush, updating the `sync_rules` row. The keepalive in `withReplicationTransaction`'s `finally` block updates that same row after every flush of every writer. With more than one live writer this produces 40001 serialization failures, and each retry redoes the entire flush (current_data lookup plus writes).

We hit this running concurrent snapshot writers (the prototype from #448): each writer's first flush conflicted almost deterministically, producing a retry storm at startup.

### Fix

Clear the error flag after the transaction commits, as a plain autocommit update, same as the keepalive. This also avoids clearing the flag for a transaction that ends up rolled back. Applies to both `flushInner` and the truncate path.

With the fix, full re-replication runs with 4 concurrent writers show zero serialization failures (previously dozens at startup). Single-writer behavior is unchanged apart from the update moving outside the transaction.

### Tests

module-postgres-storage suite passes against real Postgres (237 tests). Changeset included (patch).
