### PR TITLE
fix(module-postgres-storage): delete rows in batches when clearing storage

### DIFF
--- a/.changeset/clear-storage-batched-deletes.md
+++ b/.changeset/clear-storage-batched-deletes.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-postgres-storage': patch
+---
+
+Delete rows in batches when clearing storage for a replication stream. A single DELETE covering the entire group can run for hours on large deployments and never complete once it exceeds statement or socket timeouts; batched deletes make durable progress and can be safely retried or aborted.

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -49,6 +49,11 @@ export type PostgresSyncRulesStorageOptions = {
   checksumCacheTtlMs?: number;
 };
 
+/**
+ * Number of rows deleted per batch when clearing storage for a replication stream.
+ */
+export const CLEAR_BATCH_LIMIT = 50_000;
+
 export class PostgresSyncRulesStorage
   extends framework.BaseObserver<storage.SyncRulesBucketStorageListener>
   implements storage.SyncRulesBucketStorage
@@ -540,7 +545,11 @@ export class PostgresSyncRulesStorage
   }
 
   async clear(options?: storage.ClearStorageOptions): Promise<void> {
-    // TODO: Cleanly abort the cleanup when the provided signal is aborted.
+    const signal = options?.signal;
+    if (signal?.aborted) {
+      throw new framework.ReplicationAbortedError('Aborted clearing data', signal.reason);
+    }
+
     await this.db.sql`
       UPDATE sync_rules
       SET
@@ -552,25 +561,63 @@ export class PostgresSyncRulesStorage
         id = ${{ type: 'int4', value: this.replicationStreamId }}
     `.execute();
 
-    await this.db.sql`
-      DELETE FROM bucket_data
-      WHERE
-        group_id = ${{ type: 'int4', value: this.replicationStreamId }}
-    `.execute();
+    // Delete in batches - a single DELETE covering the entire group can run for
+    // hours on large deployments, never completing once it exceeds statement or
+    // socket timeouts. Each batch is its own autocommit statement, so progress
+    // is durable and a retry continues where the previous attempt stopped.
+    await this.clearBatched('bucket_data', signal, () => this.deleteGroupBatch('bucket_data'));
+    await this.clearBatched('bucket_parameters', signal, () => this.deleteGroupBatch('bucket_parameters'));
+    await this.clearBatched('current_data', signal, () =>
+      this.currentDataStore.deleteGroupRowsBatch(this.db, {
+        groupId: this.replicationStreamId,
+        limit: CLEAR_BATCH_LIMIT
+      })
+    );
+    await this.clearBatched('source_tables', signal, () => this.deleteGroupBatch('source_tables'));
+  }
 
-    await this.db.sql`
-      DELETE FROM bucket_parameters
-      WHERE
-        group_id = ${{ type: 'int4', value: this.replicationStreamId }}
-    `.execute();
+  private async clearBatched(
+    label: string,
+    signal: AbortSignal | undefined,
+    deleteBatch: () => Promise<bigint>
+  ): Promise<void> {
+    while (true) {
+      if (signal?.aborted) {
+        throw new framework.ReplicationAbortedError('Aborted clearing data', signal.reason);
+      }
+      const count = await deleteBatch();
+      if (count < CLEAR_BATCH_LIMIT) {
+        return;
+      }
+      this.logger.info(`Cleared batch of ${count} ${label} rows, continuing...`);
+    }
+  }
 
-    await this.currentDataStore.deleteGroupRows(this.db, { groupId: this.replicationStreamId });
-
-    await this.db.sql`
-      DELETE FROM source_tables
-      WHERE
-        group_id = ${{ type: 'int4', value: this.replicationStreamId }}
-    `.execute();
+  /**
+   * Delete up to {@link CLEAR_BATCH_LIMIT} rows for this group from the given table,
+   * returning the number of rows deleted.
+   */
+  private async deleteGroupBatch(table: 'bucket_data' | 'bucket_parameters' | 'source_tables'): Promise<bigint> {
+    const [row] = await this.db.queryRows<{ count: bigint }>({
+      statement: `
+        WITH batch AS (
+          SELECT ctid FROM ${table}
+          WHERE group_id = $1
+          LIMIT $2
+        ),
+        deleted AS (
+          DELETE FROM ${table}
+          WHERE ctid IN (SELECT ctid FROM batch)
+          RETURNING 1
+        )
+        SELECT COUNT(*) AS count FROM deleted
+      `,
+      params: [
+        { type: 'int4', value: this.replicationStreamId },
+        { type: 'int4', value: CLEAR_BATCH_LIMIT }
+      ]
+    });
+    return row?.count ?? 0n;
   }
 
   private async getChecksumsInternal(batch: storage.FetchPartialBucketChecksum[]): Promise<storage.PartialChecksumMap> {

--- a/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresSyncRulesStorage.ts
@@ -595,7 +595,12 @@ export class PostgresSyncRulesStorage
 
   /**
    * Delete up to {@link CLEAR_BATCH_LIMIT} rows for this group from the given table,
-   * returning the number of rows deleted.
+   * returning the number of candidate rows found by the scan.
+   *
+   * The count is taken from the scan (`batch`) rather than the delete: with a
+   * concurrent process deleting the same rows, the delete may remove fewer rows
+   * than the scan found, and counting deleted rows could stop the loop while
+   * rows remain.
    */
   private async deleteGroupBatch(table: 'bucket_data' | 'bucket_parameters' | 'source_tables'): Promise<bigint> {
     const [row] = await this.db.queryRows<{ count: bigint }>({
@@ -610,7 +615,7 @@ export class PostgresSyncRulesStorage
           WHERE ctid IN (SELECT ctid FROM batch)
           RETURNING 1
         )
-        SELECT COUNT(*) AS count FROM deleted
+        SELECT COUNT(*) AS count FROM batch
       `,
       params: [
         { type: 'int4', value: this.replicationStreamId },

--- a/modules/module-postgres-storage/src/storage/current-data-store.ts
+++ b/modules/module-postgres-storage/src/storage/current-data-store.ts
@@ -301,19 +301,72 @@ export class PostgresCurrentDataStore {
     `.execute();
   }
 
-  async deleteGroupRows(db: Queryable, options: { groupId: number }) {
+  /**
+   * Delete up to `limit` rows for the group, returning the number of rows deleted.
+   */
+  async deleteGroupRowsBatch(db: Queryable, options: { groupId: number; limit: number }): Promise<bigint> {
     if (this.softDeleteEnabled) {
-      await db.sql`
-        DELETE FROM v3_current_data
-        WHERE
-          group_id = ${{ type: 'int4', value: options.groupId }}
-      `.execute();
+      const result = await db.sql`
+        WITH
+          batch AS (
+            SELECT
+              ctid
+            FROM
+              v3_current_data
+            WHERE
+              group_id = ${{ type: 'int4', value: options.groupId }}
+            LIMIT
+              ${{ type: 'int4', value: options.limit }}
+          ),
+          deleted AS (
+            DELETE FROM v3_current_data
+            WHERE
+              ctid IN (
+                SELECT
+                  ctid
+                FROM
+                  batch
+              )
+            RETURNING
+              1
+          )
+        SELECT
+          COUNT(*) AS count
+        FROM
+          deleted
+      `.first<{ count: bigint }>();
+      return result?.count ?? 0n;
     } else {
-      await db.sql`
-        DELETE FROM current_data
-        WHERE
-          group_id = ${{ type: 'int4', value: options.groupId }}
-      `.execute();
+      const result = await db.sql`
+        WITH
+          batch AS (
+            SELECT
+              ctid
+            FROM
+              current_data
+            WHERE
+              group_id = ${{ type: 'int4', value: options.groupId }}
+            LIMIT
+              ${{ type: 'int4', value: options.limit }}
+          ),
+          deleted AS (
+            DELETE FROM current_data
+            WHERE
+              ctid IN (
+                SELECT
+                  ctid
+                FROM
+                  batch
+              )
+            RETURNING
+              1
+          )
+        SELECT
+          COUNT(*) AS count
+        FROM
+          deleted
+      `.first<{ count: bigint }>();
+      return result?.count ?? 0n;
     }
   }
 

--- a/modules/module-postgres-storage/src/storage/current-data-store.ts
+++ b/modules/module-postgres-storage/src/storage/current-data-store.ts
@@ -302,7 +302,9 @@ export class PostgresCurrentDataStore {
   }
 
   /**
-   * Delete up to `limit` rows for the group, returning the number of rows deleted.
+   * Delete up to `limit` rows for the group, returning the number of candidate
+   * rows found by the scan (see PostgresSyncRulesStorage#deleteGroupBatch for
+   * why the scan is counted rather than the delete).
    */
   async deleteGroupRowsBatch(db: Queryable, options: { groupId: number; limit: number }): Promise<bigint> {
     if (this.softDeleteEnabled) {
@@ -333,7 +335,7 @@ export class PostgresCurrentDataStore {
         SELECT
           COUNT(*) AS count
         FROM
-          deleted
+          batch
       `.first<{ count: bigint }>();
       return result?.count ?? 0n;
     } else {
@@ -364,7 +366,7 @@ export class PostgresCurrentDataStore {
         SELECT
           COUNT(*) AS count
         FROM
-          deleted
+          batch
       `.first<{ count: bigint }>();
       return result?.count ?? 0n;
     }

--- a/modules/module-postgres-storage/test/src/storage.test.ts
+++ b/modules/module-postgres-storage/test/src/storage.test.ts
@@ -2,6 +2,7 @@ import { framework, storage, updateSyncRulesFromYaml } from '@powersync/service-
 import { bucketRequest, register, test_utils } from '@powersync/service-core-tests';
 import * as t from 'ts-codec';
 import { describe, expect, test } from 'vitest';
+import { CLEAR_BATCH_LIMIT } from '../../src/storage/PostgresSyncRulesStorage.js';
 import { POSTGRES_STORAGE_FACTORY, TEST_STORAGE_VERSIONS } from './util.js';
 
 const CheckpointRequestedAtRow = t.object({
@@ -143,6 +144,89 @@ bucket_definitions:
       });
       await writer.flush();
       await expect(customRequestedAt()).resolves.toBeNull();
+    });
+
+    test('clears storage in batches', async () => {
+      await using factory = await POSTGRES_STORAGE_FACTORY.factory();
+      const syncRules = await factory.updateSyncRules(
+        updateSyncRulesFromYaml(
+          `
+bucket_definitions:
+  global:
+    data: []
+    `,
+          { storageVersion }
+        )
+      );
+      const bucketStorage = factory.getInstance(syncRules);
+      const groupId = bucketStorage.replicationStreamId;
+      const otherGroupId = groupId + 1;
+      const currentDataTable = bucketStorage.storageConfig.softDeleteCurrentData ? 'v3_current_data' : 'current_data';
+
+      // Seed more than one batch of bucket data, plus rows in the other tables,
+      // directly - clear() only depends on group_id.
+      const seed = async (gid: number, bucketDataRows: number) => {
+        await factory.db.query({
+          statement: `
+            INSERT INTO bucket_data (group_id, bucket_name, op_id, op, checksum)
+            SELECT $1, 'global[]', i, 'PUT', 0 FROM generate_series(1, $2) i
+          `,
+          params: [
+            { type: 'int4', value: gid },
+            { type: 'int4', value: bucketDataRows }
+          ]
+        });
+        await factory.db.query({
+          statement: `
+            INSERT INTO bucket_parameters (group_id, source_table, source_key, lookup, bucket_parameters)
+            SELECT $1, 'test', int4send(i), ''::bytea, '[]' FROM generate_series(1, 10) i
+          `,
+          params: [{ type: 'int4', value: gid }]
+        });
+        await factory.db.query({
+          statement: `
+            INSERT INTO ${currentDataTable} (group_id, source_table, source_key, buckets, data, lookups)
+            SELECT $1, 'test', int4send(i), '[]', ''::bytea, '{}' FROM generate_series(1, 10) i
+          `,
+          params: [{ type: 'int4', value: gid }]
+        });
+        await factory.db.query({
+          statement: `
+            INSERT INTO source_tables (id, group_id, connection_id, schema_name, table_name)
+            VALUES ($2, $1, 1, 'public', 'test')
+          `,
+          params: [
+            { type: 'int4', value: gid },
+            { type: 'varchar', value: `test-${gid}` }
+          ]
+        });
+      };
+      await seed(groupId, CLEAR_BATCH_LIMIT + 100);
+      await seed(otherGroupId, 10);
+
+      const countRows = async (table: string, gid: number) => {
+        const [row] = await factory.db.queryRows<{ count: bigint }>({
+          statement: `SELECT COUNT(*) AS count FROM ${table} WHERE group_id = $1`,
+          params: [{ type: 'int4', value: gid }]
+        });
+        return Number(row.count);
+      };
+
+      await bucketStorage.clear();
+
+      for (const table of ['bucket_data', 'bucket_parameters', currentDataTable, 'source_tables']) {
+        expect(await countRows(table, groupId), table).toEqual(0);
+      }
+      // Rows of other groups are not affected.
+      expect(await countRows('bucket_data', otherGroupId)).toEqual(10);
+      expect(await countRows('bucket_parameters', otherGroupId)).toEqual(10);
+      expect(await countRows(currentDataTable, otherGroupId)).toEqual(10);
+      expect(await countRows('source_tables', otherGroupId)).toEqual(1);
+
+      // An aborted signal stops the operation.
+      await expect(bucketStorage.clear({ signal: AbortSignal.abort() })).rejects.toThrow(
+        framework.ReplicationAbortedError
+      );
     });
 
     /**


### PR DESCRIPTION
Fixes #729.

`clear()` deleted all rows for the group in a single DELETE per table. With millions of rows in `current_data` that DELETE can run for hours and gets killed by statement or socket timeouts before finishing. When this happens during `terminate()`, the replicator retries the full delete from scratch every time, so it never completes and keeps accumulating dead tuples.

Now `clear()` deletes in batches of 50k rows, selecting `ctid` by `group_id` and running each batch as its own autocommit statement. A retry continues where the previous attempt stopped. The snapshot truncate path already works this way, and this is the interim batching mentioned in #729 until the partitioned tables planned for v4.

This also implements the existing TODO for the abort signal in `clear()`: the signal is checked between batches, like the MongoDB storage does in `clearDeleteMany`.

## Tests

Added a test seeding more than one batch (`CLEAR_BATCH_LIMIT + 100` rows) plus rows for a second group. It checks that `clear()` empties all four tables for the group, leaves the other group alone, and that an aborted signal stops the operation.
