### PR TITLE
Tweak S3 options

### DIFF
--- a/modules/module-mongodb-storage/src/storage/implementation/MongoStorageProvider.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoStorageProvider.ts
@@ -34,6 +34,7 @@ export class MongoStorageProvider implements storage.StorageProvider {
         region: decodedConfig.object_storage.region,
         prefix: decodedConfig.object_storage.prefix,
         endpoint: decodedConfig.object_storage.endpoint,
+        forcePathStyle: decodedConfig.object_storage.force_path_style,
         accessKeyId: decodedConfig.object_storage.access_key_id,
         secretAccessKey: decodedConfig.object_storage.secret_access_key,
         concurrencyLimit: decodedConfig.object_storage.concurrency_limit

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/S3ObjectStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/S3ObjectStorage.ts
@@ -25,6 +25,7 @@ export interface S3ObjectStorageOptions {
   region?: string;
   prefix?: string;
   endpoint?: string;
+  forcePathStyle?: boolean;
   accessKeyId?: string;
   secretAccessKey?: string;
   concurrencyLimit?: number;
@@ -62,7 +63,7 @@ export class S3ObjectStorage implements ObjectStorage {
     this.client = new S3Client({
       region: options.region,
       endpoint: options.endpoint,
-      forcePathStyle: !!options.endpoint,
+      forcePathStyle: options.forcePathStyle,
       credentials:
         options.accessKeyId && options.secretAccessKey
           ? { accessKeyId: options.accessKeyId, secretAccessKey: options.secretAccessKey }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/S3ObjectStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/S3ObjectStorage.ts
@@ -22,7 +22,7 @@ const SAFE_S3_KEY_BYTES = 896;
 
 export interface S3ObjectStorageOptions {
   bucket: string;
-  region: string;
+  region?: string;
   prefix?: string;
   endpoint?: string;
   accessKeyId?: string;

--- a/modules/module-mongodb-storage/src/types/types.ts
+++ b/modules/module-mongodb-storage/src/types/types.ts
@@ -5,7 +5,7 @@ import * as t from 'ts-codec';
 const S3ObjectStorageConfig = t.object({
   type: t.literal('s3'),
   bucket: t.string,
-  region: t.string,
+  region: t.string.optional(),
   prefix: t.string.optional(),
   endpoint: t.string.optional(),
   access_key_id: t.string.optional(),

--- a/modules/module-mongodb-storage/src/types/types.ts
+++ b/modules/module-mongodb-storage/src/types/types.ts
@@ -8,6 +8,7 @@ const S3ObjectStorageConfig = t.object({
   region: t.string.optional(),
   prefix: t.string.optional(),
   endpoint: t.string.optional(),
+  force_path_style: t.boolean.optional(),
   access_key_id: t.string.optional(),
   secret_access_key: t.string.optional(),
   concurrency_limit: t.number.optional(),

--- a/modules/module-mongodb-storage/test/src/helpers/s3TestFactory.ts
+++ b/modules/module-mongodb-storage/test/src/helpers/s3TestFactory.ts
@@ -39,6 +39,7 @@ export function createS3TestStorageSuite(options: S3TestFactoryOptions) {
       region: 'us-east-1',
       prefix: `test-${process.pid}-${randomUUID()}`,
       endpoint: minioEndpoint,
+      forcePathStyle: true,
       accessKeyId: process.env.MINIO_ACCESS_KEY ?? 'minioadmin',
       secretAccessKey: process.env.MINIO_SECRET_KEY ?? 'minioadmin'
     });

--- a/modules/module-mongodb-storage/test/src/storage_s3_reading.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_s3_reading.test.ts
@@ -40,6 +40,7 @@ describe('S3 object storage reads', () => {
       region: 'test',
       accessKeyId: 'access-key',
       secretAccessKey: 'secret-key',
+      forcePathStyle: true,
       concurrencyLimit: 4
     });
 


### PR DESCRIPTION
Follow-up to #728, tweaking some options:
1. Make `storage.object_storage.region` optional. There are many cases where the AWS SDK can infer it, for example from the `AWS_REGION` environment variable.
2. Make `storage.object_storage.force_path_style` configurable. Inferring it from whether or not `endpoint` is set does not cover all cases.

On forcePathStyle, there are generally two ways a request can be made:
1. Path style - the original style for S3: `https://s3.amazonaws.com/<bucket>/<path>`. This is deprecated for AWS S3.
2. Virtualhost style - the current default: `https://<bucket>.s3.amazonaws.com/<path>`

For AWS S3, it is recommended to not use path style. However, some other compatible providers require it, notably MinIO running on localhost for tests. But it is not safe to infer it based on the endpoint - some providers need path style, while others need virtualhost style. Some examples:

| Provider            | Endpoint          | Region                   | `force_path_style` |
| ------------------- | ----------------- | ------------------------ | ------------------ |
| AWS S3              | Omit              | Actual AWS region        | `false`            |
| MinIO, basic/local  | Required          | Usually `us-east-1`      | `true`             |
| MinIO, wildcard DNS | Required          | Usually `us-east-1`      | `false`            |
| Cloudflare R2       | Account endpoint  | `auto`                   | `false`            |
| DigitalOcean Spaces | Regional endpoint | `us-east-1`              | `false`            |
| Backblaze B2        | Regional endpoint | Backblaze account region | `false`            |
| Wasabi              | Regional endpoint | Actual Wasabi region     | `true`             |
| S3 Accerelated Endpoint | `https://s3-accelerate.amazonaws.com` | AWS region | `false` |

## AI Usage

Used Codex gpt-5.6 to confirm the expected options for various providers.