### PR TITLE
Fix unhandled websocket error

### DIFF
--- a/.changeset/true-lions-smell.md
+++ b/.changeset/true-lions-smell.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-rsocket-router': patch
+---
+
+Fix uncaught error on invalid websocket frame

--- a/packages/rsocket-router/src/router/transport/WebsocketDuplexConnection.ts
+++ b/packages/rsocket-router/src/router/transport/WebsocketDuplexConnection.ts
@@ -126,6 +126,16 @@ export class WebsocketDuplexConnection extends Deferred implements DuplexConnect
     ) => Multiplexer & Demultiplexer & FrameHandler,
     rawSocket: WebSocket.WebSocket
   ): void {
+    const handleInitialError = (error: Error) => {
+      // Protocol errors can occur before ws emits the first data event and a
+      // WebsocketDuplexConnection is constructed. The duplex still needs an
+      // error listener during that window, otherwise Node treats the error as
+      // unhandled and terminates the process.
+      logger.warn(`Error in WebSocket duplex connection: ${error}`);
+      socket.end();
+    };
+    socket.on('error', handleInitialError);
+
     socket.once('data', async (buffer) => {
       let frame: Frame | undefined = undefined;
       try {
@@ -140,6 +150,7 @@ export class WebsocketDuplexConnection extends Deferred implements DuplexConnect
       }
 
       const connection = new WebsocketDuplexConnection(socket, frame, multiplexerDemultiplexerFactory, rawSocket);
+      socket.removeListener('error', handleInitialError);
       if (connection.done) {
         return;
       }

--- a/packages/rsocket-router/test/src/socket.test.ts
+++ b/packages/rsocket-router/test/src/socket.test.ts
@@ -118,6 +118,39 @@ describe('Sockets', () => {
     await vi.waitFor(() => expect(rawSocket.readyState).equals(rawSocket.CLOSED), { timeout: 3000 });
   });
 
+  it('should handle WebSocket protocol errors before the initial frame', async () => {
+    const transport = new WebsocketServerTransport({
+      wsCreator: () => server
+    });
+
+    const rSocketServer = new RSocketServer({
+      transport,
+      acceptor: {
+        accept: async () => {
+          return {};
+        }
+      }
+    });
+
+    await rSocketServer.bind();
+
+    const client = new WebSocket.WebSocket(WS_ADDRESS);
+    client.on('error', () => {});
+    await new Promise<void>((resolve) => {
+      client.once('open', () => resolve());
+    });
+
+    const closed = new Promise<number>((resolve) => {
+      client.once('close', (code) => resolve(code));
+    });
+
+    // FIN + RSV2 + RSV3 + text opcode, followed by an empty masked payload.
+    const invalidFrame = Buffer.from([0b1011_0001, 0b1000_0000, 0x00, 0x00, 0x00, 0x00]);
+    (client as any)._socket.write(invalidFrame);
+
+    expect(await closed).toEqual(1002);
+  });
+
   /**
    * The server should handle cases where the client closes the WebSocket connection
    * at any point in the handshaking process. This test will create 100 connections which


### PR DESCRIPTION
We previously fixed some unhandled websocket errors in #11. This covers an additional case: If an invalid frame is sent _before_ the first data, we crash with an error like below:

```
node:events:496
      throw er; // Unhandled 'error' event
      ^

RangeError: Invalid WebSocket frame: RSV2 and RSV3 must be clear
    at Receiver.getInfo (/home/ralf/src/powersync-service/node_modules/.pnpm/ws@8.18.0/node_modules/ws/lib/receiver.js:194:26)
    at Receiver.startLoop (/home/ralf/src/powersync-service/node_modules/.pnpm/ws@8.18.0/node_modules/ws/lib/receiver.js:155:16)
    at Receiver._write (/home/ralf/src/powersync-service/node_modules/.pnpm/ws@8.18.0/node_modules/ws/lib/receiver.js:94:10)
    at writeOrBuffer (node:internal/streams/writable:572:12)
    at _write (node:internal/streams/writable:501:10)
    at Writable.write (node:internal/streams/writable:510:10)
    at Socket.socketOnData (/home/ralf/src/powersync-service/node_modules/.pnpm/ws@8.18.0/node_modules/ws/lib/websocket.js:1355:35)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
Emitted 'error' event on Duplex instance at:
    at Duplex.duplexOnError (/home/ralf/src/powersync-service/node_modules/.pnpm/ws@8.18.0/node_modules/ws/lib/stream.js:37:10)
    at Duplex.emit (node:events:518:28)
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  code: 'WS_ERR_UNEXPECTED_RSV_2_3',
  [Symbol(status-code)]: 1002
}
```

This adds a temporary error handler right when the websocket is first opened, then deregisters it once the `WebsocketDuplexConnection` takes over.

Originally [reported on Discord](https://discord.com/channels/1138230179878154300/1531950063037972620/1531950063037972620).

## AI Usage

Used Codex gpt-5.6 to reproduce and fix the issue.

Manually reviewed and tested, in addition to the new automated test that confirms the issue.
