### PR TITLE
Make websocket test more robust

### DIFF
--- a/packages/rsocket-router/test/src/socket.test.ts
+++ b/packages/rsocket-router/test/src/socket.test.ts
@@ -11,13 +11,13 @@ let nextPort = 5433;
 
 describe('Sockets', () => {
   let server: WebSocket.WebSocketServer;
-  let closeServer: () => void;
+  let closeServer: () => Promise<void>;
 
   let WS_PORT = 0;
   let WS_ADDRESS = '';
 
   beforeEach(() => {
-    let closed = false;
+    let closePromise: Promise<void> | undefined;
 
     WS_PORT = process.env.WS_PORT ? parseInt(process.env.WS_PORT) : nextPort++;
     WS_ADDRESS = `ws://localhost:${WS_PORT}`;
@@ -32,16 +32,20 @@ describe('Sockets', () => {
      * after each test. This method should prevent double closing.
      */
     closeServer = () => {
-      if (closed) {
-        return;
-      }
-      server.close();
-      closed = true;
+      return (closePromise ??= new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      }));
     };
   });
 
-  afterEach(() => {
-    closeServer();
+  afterEach(async () => {
+    await closeServer();
   });
 
   it('should only not close a server that is managed externally', async () => {
@@ -69,8 +73,7 @@ describe('Sockets', () => {
 
     // This will be triggered externally when the HTTP(s) server closes
     // linked to the internal WS server.
-    closeServer();
-    await isClosedPromise;
+    await Promise.all([closeServer(), isClosedPromise]);
     expect(closeableSpy).toBeCalledTimes(1);
   });
 


### PR DESCRIPTION
Ran into this test error right after merging #738:

```
packages/rsocket-router test: Vitest caught 1 unhandled error during the test run.
packages/rsocket-router test: This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.
packages/rsocket-router test: ⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
packages/rsocket-router test: EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
packages/rsocket-router test: This error originated in "test/src/socket.test.ts" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
```

I could not actually reproduce it, but Codex recommended this fix: Wait for the websocket server to close asynchronously in the `afterEach` callback.

## AI Usage

Fix recommended and implemented by Codex gpt-5.6.

