### PR TITLE
Configurable heartbeat interval

### DIFF
--- a/.changeset/better-hoops-cut.md
+++ b/.changeset/better-hoops-cut.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-postgres': minor
+'@powersync/service-module-mongodb': minor
+'@powersync/service-core': minor
+'@powersync/service-module-mssql': minor
+---
+
+Configurable heartbeat_interval_seconds for MongoDB, Postgres, SQL Server.

--- a/modules/module-mongodb/src/module/MongoModule.ts
+++ b/modules/module-mongodb/src/module/MongoModule.ts
@@ -39,7 +39,8 @@ export class MongoModule extends replication.ReplicationModule<types.MongoConnec
       storageEngine: context.storageEngine,
       metricsEngine: context.metricsEngine,
       connectionFactory: connectionFactory,
-      rateLimiter: new MongoErrorRateLimiter()
+      rateLimiter: new MongoErrorRateLimiter(),
+      heartbeatIntervalSeconds: normalisedConfig.heartbeat_interval_seconds
     });
   }
 

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -940,6 +940,7 @@ export class ChangeStream {
             await batch.setResumeLsn(lsn);
 
             if (timestamp != null) {
+              // Note that this timestamp provided by MongoDB is not exact - it can be around 10s behind.
               this.lastPersistedResumeTimestamp = timestamp.getTime();
             } else {
               // DocumentDB: No timestamp associated with the resumeToken. Just use the current time.
@@ -986,8 +987,11 @@ export class ChangeStream {
     const staleResumeLsn = Date.now() - this.lastPersistedResumeTimestamp > this.keepaliveIntervalMs * 1.1;
 
     // When there is replication lag, that resumeToken can get too outdated. In that case, we periodically create a
-    // new back checkpoint. We track that using lastBatchCheckpoint.
-    const staleBatchCheckpoint = Date.now() - this.lastBatchCheckpoint > this.keepaliveIntervalMs;
+    // new back checkpoint. This interval is controlled by the frequency of the keepAlive() call,
+    // while also skipping if there was another call to createBatchCheckpoint().
+    // We use a factor of 0.9 here, to make sure this is called on every keepAlive() interval, unless there
+    // was another call to createBatchCheckpoint().
+    const staleBatchCheckpoint = Date.now() - this.lastBatchCheckpoint > this.keepaliveIntervalMs * 0.9;
 
     // We don't use oldestUncommittedChange here, since that may be unset in some edge cases where we do need
     // to persist new checkpoints.

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -940,6 +940,14 @@ export class ChangeStream {
     return this.replicationLag.getLagMillis();
   }
 
+  async keepAlive() {
+    // This writes to _powersync_checkpoints
+    // Main use case: When there are massive bulk writes to another database or collection, the change stream may
+    // start timing out due to reading through too much data in one batch. This breaks up those bulk writes,
+    // allowing the change stream to make progress.
+    await this._checkpointImplementation?.createBatchCheckpoint();
+  }
+
   private lastTouchedAt = performance.now();
 
   private touch() {

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -123,15 +123,27 @@ export class ChangeStream {
 
   private isDocumentDb = false;
   private _checkpointImplementation: CheckpointImplementation | null = null;
+  /**
+   * Last persisted resume timestamp as Date.now(). This represents the equivalent timestamp from the
+   * source database, rather than the time when we persisted it.
+   */
+  private lastPersistedResumeTimestamp = 0;
+  private lastBatchCheckpoint = 0;
 
   constructor(options: ChangeStreamOptions) {
     this.storage = options.storage;
     this.metrics = options.metrics;
     this.group_id = options.storage.replicationStreamId;
     this.connections = options.connections;
-    this.maxAwaitTimeMS = options.maxAwaitTimeMS ?? 10_000;
     this.snapshotChunkLength = options.snapshotChunkLength ?? 6_000;
     this.keepaliveIntervalMs = options.keepaliveIntervalMs ?? 60_000;
+    if (options.maxAwaitTimeMS) {
+      this.maxAwaitTimeMS = options.maxAwaitTimeMS;
+    } else {
+      // Default to 10s, unless keepaliveIntervalMs is shorter. In that case, use keepaliveIntervalMs,
+      // but add a bit of a margin, so that our keepalive logic is triggered on each empty change stream batch.
+      this.maxAwaitTimeMS = Math.min(10_000, this.keepaliveIntervalMs + 100);
+    }
     this.storageHooks = options.storageHooks;
     this.client = this.connections.client;
     this.defaultDb = this.connections.db;
@@ -598,6 +610,12 @@ export class ChangeStream {
     return this.sourceRowConverter.rawToSqliteRow(row);
   }
 
+  private async createBatchCheckpoint() {
+    const checkpoint = await this.checkpointImplementation.createBatchCheckpoint();
+    this.lastBatchCheckpoint = Date.now();
+    return checkpoint;
+  }
+
   async streamChangesInternal() {
     await this.ensureDetected();
     const transactionsReplicatedMetric = this.metrics.getCounter(ReplicationMetric.TRANSACTIONS_REPLICATED);
@@ -643,7 +661,7 @@ export class ChangeStream {
         // Always start with a checkpoint.
         // This helps us to clear errors when restarting, even if there is
         // no data to replicate.
-        let waitForCheckpointLsn: string | null = await this.checkpointImplementation.createBatchCheckpoint();
+        let waitForCheckpointLsn: string | null = await this.createBatchCheckpoint();
 
         let splitDocument: ProjectedChangeStreamDocument | null = null;
 
@@ -663,11 +681,15 @@ export class ChangeStream {
           }
           this.touch();
           if (events.length == 0) {
-            // No changes in this batch, but we still want to keep the connection alive.
+            // No changes in this batch, but we still want to persist progress.
             // We do this by persisting a keepalive checkpoint.
             // If we don't update it on empty events, we do keep consistency, but resuming the stream
             // with old tokens may cause connection timeouts.
-            if (waitForCheckpointLsn == null && performance.now() - lastEmptyResume > this.keepaliveIntervalMs) {
+            const hadRecentKeepalive = performance.now() - lastEmptyResume < this.keepaliveIntervalMs;
+            if (waitForCheckpointLsn == null && !hadRecentKeepalive) {
+              // Case 1: We have no changes, and we are not waiting for a checkpoint to be created,
+              // and we have not recently persisted a keepalive. Persist one now, and call setResumeLsn() below.
+              // This is the normal case for an idle stream.
               // The implementation persists a keepalive (timestamp) or bumps the
               // sentinel so a later event commits (sentinel). Logging is handled
               // inside the implementation.
@@ -675,12 +697,15 @@ export class ChangeStream {
               this.touch();
               lastEmptyResume = performance.now();
               this.replicationLag.markStarted();
-            }
-
-            // If we have no changes, we can just persist the keepalive.
-            // This is throttled to once per interval.
-            if (performance.now() - lastEmptyResume < this.keepaliveIntervalMs) {
+            } else if (hadRecentKeepalive) {
+              // Case 2: We have no changes, and may or may not be waiting for a checkpoint to be created.
+              // We have recently persisted a keepalive.
+              // Continue waiting.
               continue;
+            } else {
+              // Case 3: Waiting for a checkpoint; have not had a recent keepalive.
+              // We cannot call checkpointImplementation.keepalive() here, but we do call
+              // setResumeLsn() below.
             }
           }
 
@@ -802,7 +827,7 @@ export class ChangeStream {
                 if (hasBufferedChanges && waitForCheckpointLsn == null) {
                   // Buffered changes - create a new batch checkpoint to rate limit commits
                   using _ = tracer.span('source_checkpoint');
-                  waitForCheckpointLsn = await this.checkpointImplementation.createBatchCheckpoint();
+                  waitForCheckpointLsn = await this.createBatchCheckpoint();
                   continue;
                 } else if (waitForCheckpointLsn != null) {
                   // Skip this checkpoint - wait for the batch checkpoint.
@@ -836,7 +861,7 @@ export class ChangeStream {
             ) {
               if (waitForCheckpointLsn == null) {
                 using _ = tracer.span('source_checkpoint');
-                waitForCheckpointLsn = await this.checkpointImplementation.createBatchCheckpoint();
+                waitForCheckpointLsn = await this.createBatchCheckpoint();
               }
 
               const rel = getMongoRelation(changeDocument.ns, this.connections.connectionTag);
@@ -909,10 +934,17 @@ export class ChangeStream {
             // Batches are generally large (64MB or 6000 events, whichever comes first),
             // so this is a good natural point to flush and mark progress.
             // We avoid this when splitDocument is set, since we cannot resume in the middle of a split event.
-            const lsn = this.checkpointImplementation.lsnFromResumeToken(resumeToken);
+            const { lsn, timestamp } = this.checkpointImplementation.lsnFromResumeToken(resumeToken);
             await batch.flush({ oldestUncommittedChange: this.replicationLag.oldestUncommittedChange });
             // TODO: We should consider making this standard behavior of flush().
             await batch.setResumeLsn(lsn);
+
+            if (timestamp != null) {
+              this.lastPersistedResumeTimestamp = timestamp.getTime();
+            } else {
+              // DocumentDB: No timestamp associated with the resumeToken. Just use the current time.
+              this.lastPersistedResumeTimestamp = Date.now();
+            }
           }
 
           batchSpan.end();
@@ -941,11 +973,28 @@ export class ChangeStream {
   }
 
   async keepAlive() {
-    // This writes to _powersync_checkpoints
+    // This is called on an interval of keepaliveIntervalMs.
+
+    // This writes to _powersync_checkpoints.
     // Main use case: When there are massive bulk writes to another database or collection, the change stream may
     // start timing out due to reading through too much data in one batch. This breaks up those bulk writes,
     // allowing the change stream to make progress.
-    await this._checkpointImplementation?.createBatchCheckpoint();
+
+    // When there is low replication traffic, regular calls to setResumeLsn() with recent resume tokens make this unnecessary.
+    // We track that using lastPersistedResumeTimestamp.
+    // We add a bit of a margin here, since setResumeLsn is not called on an exact interval.
+    const staleResumeLsn = Date.now() - this.lastPersistedResumeTimestamp > this.keepaliveIntervalMs * 1.1;
+
+    // When there is replication lag, that resumeToken can get too outdated. In that case, we periodically create a
+    // new back checkpoint. We track that using lastBatchCheckpoint.
+    const staleBatchCheckpoint = Date.now() - this.lastBatchCheckpoint > this.keepaliveIntervalMs;
+
+    // We don't use oldestUncommittedChange here, since that may be unset in some edge cases where we do need
+    // to persist new checkpoints.
+    if (staleResumeLsn && staleBatchCheckpoint) {
+      await this.ensureDetected();
+      await this.createBatchCheckpoint();
+    }
   }
 
   private lastTouchedAt = performance.now();

--- a/modules/module-mongodb/src/replication/ChangeStreamReplicationJob.ts
+++ b/modules/module-mongodb/src/replication/ChangeStreamReplicationJob.ts
@@ -71,6 +71,7 @@ export class ChangeStreamReplicationJob extends replication.AbstractReplicationJ
         storage: this.options.storage,
         metrics: this.options.metrics,
         connections: connectionManager,
+        keepaliveIntervalMs: connectionManager.options.heartbeat_interval_seconds * 1_000,
         logger: this.logger
       });
       this.lastStream = stream;

--- a/modules/module-mongodb/src/replication/ChangeStreamReplicationJob.ts
+++ b/modules/module-mongodb/src/replication/ChangeStreamReplicationJob.ts
@@ -24,7 +24,7 @@ export class ChangeStreamReplicationJob extends replication.AbstractReplicationJ
   }
 
   async keepAlive() {
-    // Nothing needed here
+    await this.lastStream?.keepAlive();
   }
 
   async replicate() {

--- a/modules/module-mongodb/src/replication/checkpoints/CheckpointImplementation.ts
+++ b/modules/module-mongodb/src/replication/checkpoints/CheckpointImplementation.ts
@@ -128,7 +128,7 @@ export interface CheckpointImplementation {
    * The timestamp implementation parses the timestamp embedded in the token.
    * The sentinel implementation pairs the token with the current coordinate.
    */
-  lsnFromResumeToken(resumeToken: mongo.ResumeToken): string;
+  lsnFromResumeToken(resumeToken: mongo.ResumeToken): { lsn: string; timestamp: Date | null };
 
   /**
    * Source-side replication head for write checkpoints. The LSN passed to the

--- a/modules/module-mongodb/src/replication/checkpoints/SentinelCheckpointImplementation.ts
+++ b/modules/module-mongodb/src/replication/checkpoints/SentinelCheckpointImplementation.ts
@@ -108,11 +108,11 @@ export class SentinelCheckpointImplementation implements CheckpointImplementatio
     );
   }
 
-  lsnFromResumeToken(resumeToken: mongo.ResumeToken): string {
+  lsnFromResumeToken(resumeToken: mongo.ResumeToken) {
     // Pair the bare token with the current coordinate. The coordinate is
     // frozen between checkpoint events, so a per-batch resume marker only
     // advances the token; that is all resumption needs (see the design doc).
-    return new SentinelLSN({ sentinel: this.position, resume_token: resumeToken }).comparable;
+    return { lsn: new SentinelLSN({ sentinel: this.position, resume_token: resumeToken }).comparable, timestamp: null };
   }
 
   async createReplicationHead<T>(callback: ReplicationHeadCallback<T>): Promise<T> {

--- a/modules/module-mongodb/src/replication/checkpoints/TimestampCheckpointImplementation.ts
+++ b/modules/module-mongodb/src/replication/checkpoints/TimestampCheckpointImplementation.ts
@@ -67,9 +67,10 @@ export class TimestampCheckpointImplementation implements CheckpointImplementati
     );
   }
 
-  lsnFromResumeToken(resumeToken: mongo.ResumeToken): string {
+  lsnFromResumeToken(resumeToken: mongo.ResumeToken) {
     // The timestamp is embedded in the resume token.
-    return MongoLSN.fromResumeToken(resumeToken).comparable;
+    const lsn = MongoLSN.fromResumeToken(resumeToken);
+    return { lsn: lsn.comparable, timestamp: timestampToDate(lsn.timestamp) };
   }
 
   async createReplicationHead<T>(callback: ReplicationHeadCallback<T>): Promise<T> {

--- a/modules/module-mongodb/src/types/types.ts
+++ b/modules/module-mongodb/src/types/types.ts
@@ -41,9 +41,9 @@ export enum PostImagesOption {
   READ_ONLY = 'read_only'
 }
 
-const DEFAULT_PING_INTERVAL_SECONDS = 0;
+const DEFAULT_PING_INTERVAL_SECONDS = 60;
 const MIN_PING_INTERVAL_SECONDS = 5;
-const MAX_PING_INTERVAL_SECONDS = 300;
+const MAX_PING_INTERVAL_SECONDS = 60;
 
 export interface NormalizedMongoConnectionConfig {
   id: string;
@@ -69,7 +69,7 @@ export const MongoConnectionConfig = service_types.configFile.DataSourceConfig.a
     // Replication specific settings
     post_images: t.literal('off').or(t.literal('auto_configure')).or(t.literal('read_only')).optional(),
     /**
-     * Interval in seconds between source connection heartbeats. Null or omitted defaults to 0 (disabled).
+     * Interval in seconds between source connection heartbeats. Null or omitted defaults to 60 seconds.
      */
     heartbeat_interval_seconds: t.number.or(t.Null).optional()
   })
@@ -107,13 +107,10 @@ function normalizeHeartbeatInterval(value: number | null | undefined): number {
   if (value == null) {
     return DEFAULT_PING_INTERVAL_SECONDS;
   }
-  if (value === 0) {
-    return 0;
-  }
   if (!Number.isFinite(value) || value < MIN_PING_INTERVAL_SECONDS || value > MAX_PING_INTERVAL_SECONDS) {
     throw new ServiceError(
       ErrorCode.PSYNC_S1109,
-      `MongoDB connection: heartbeat_interval_seconds must be 0 or between ${MIN_PING_INTERVAL_SECONDS} and ${MAX_PING_INTERVAL_SECONDS} seconds; null or omitted defaults to 0`
+      `MongoDB connection: heartbeat_interval_seconds must be between ${MIN_PING_INTERVAL_SECONDS} and ${MAX_PING_INTERVAL_SECONDS} seconds; null or omitted defaults to ${DEFAULT_PING_INTERVAL_SECONDS}`
     );
   }
   return value;

--- a/modules/module-mongodb/src/types/types.ts
+++ b/modules/module-mongodb/src/types/types.ts
@@ -1,5 +1,6 @@
 import type { MongoConnectionParams } from '@powersync/lib-service-mongodb/types';
 import * as lib_mongo from '@powersync/lib-service-mongodb/types';
+import { ErrorCode, ServiceError } from '@powersync/lib-services-framework';
 import * as service_types from '@powersync/service-types';
 import { LookupFunction } from 'node:net';
 import * as t from 'ts-codec';
@@ -40,6 +41,10 @@ export enum PostImagesOption {
   READ_ONLY = 'read_only'
 }
 
+const DEFAULT_PING_INTERVAL_SECONDS = 0;
+const MIN_PING_INTERVAL_SECONDS = 5;
+const MAX_PING_INTERVAL_SECONDS = 300;
+
 export interface NormalizedMongoConnectionConfig {
   id: string;
   tag: string;
@@ -54,13 +59,19 @@ export interface NormalizedMongoConnectionConfig {
 
   postImages: PostImagesOption;
 
+  heartbeat_interval_seconds: number;
+
   connectionParams: MongoConnectionParams;
 }
 
 export const MongoConnectionConfig = service_types.configFile.DataSourceConfig.and(lib_mongo.BaseMongoConfig).and(
   t.object({
     // Replication specific settings
-    post_images: t.literal('off').or(t.literal('auto_configure')).or(t.literal('read_only')).optional()
+    post_images: t.literal('off').or(t.literal('auto_configure')).or(t.literal('read_only')).optional(),
+    /**
+     * Interval in seconds between source connection heartbeats. Null or omitted defaults to 0 (disabled).
+     */
+    heartbeat_interval_seconds: t.number.or(t.Null).optional()
   })
 );
 
@@ -87,6 +98,23 @@ export function normalizeConnectionConfig(options: MongoConnectionConfigDecoded)
     ...base,
     id: options.id ?? 'default',
     tag: options.tag ?? 'default',
-    postImages: (options.post_images as PostImagesOption | undefined) ?? PostImagesOption.OFF
+    postImages: (options.post_images as PostImagesOption | undefined) ?? PostImagesOption.OFF,
+    heartbeat_interval_seconds: normalizeHeartbeatInterval(options.heartbeat_interval_seconds)
   };
+}
+
+function normalizeHeartbeatInterval(value: number | null | undefined): number {
+  if (value == null) {
+    return DEFAULT_PING_INTERVAL_SECONDS;
+  }
+  if (value === 0) {
+    return 0;
+  }
+  if (!Number.isFinite(value) || value < MIN_PING_INTERVAL_SECONDS || value > MAX_PING_INTERVAL_SECONDS) {
+    throw new ServiceError(
+      ErrorCode.PSYNC_S1109,
+      `MongoDB connection: heartbeat_interval_seconds must be 0 or between ${MIN_PING_INTERVAL_SECONDS} and ${MAX_PING_INTERVAL_SECONDS} seconds; null or omitted defaults to 0`
+    );
+  }
+  return value;
 }

--- a/modules/module-mongodb/test/src/config.test.ts
+++ b/modules/module-mongodb/test/src/config.test.ts
@@ -7,29 +7,23 @@ const BASE_CONFIG = {
 };
 
 describe('MongoDB connection config', () => {
-  test('defaults heartbeat_interval_seconds to 0 seconds', () => {
-    expect(normalizeConnectionConfig(BASE_CONFIG).heartbeat_interval_seconds).toBe(0);
+  test('defaults heartbeat_interval_seconds to 60 seconds', () => {
+    expect(normalizeConnectionConfig(BASE_CONFIG).heartbeat_interval_seconds).toBe(60);
   });
 
-  test('defaults a null heartbeat_interval_seconds to 0 seconds', () => {
+  test('defaults a null heartbeat_interval_seconds to 60 seconds', () => {
     expect(
       normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: null }).heartbeat_interval_seconds
-    ).toBe(0);
-  });
-
-  test('disables heartbeat_interval_seconds with 0', () => {
-    expect(
-      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: 0 }).heartbeat_interval_seconds
-    ).toBe(0);
+    ).toBe(60);
   });
 
   test('allows the MongoDB maximum heartbeat interval', () => {
     expect(
-      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: 300 }).heartbeat_interval_seconds
-    ).toBe(300);
+      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: 60 }).heartbeat_interval_seconds
+    ).toBe(60);
   });
 
-  test.each([4, 301, Number.NaN, Number.POSITIVE_INFINITY])(
+  test.each([0, 4, 61, Number.NaN, Number.POSITIVE_INFINITY])(
     'rejects invalid heartbeat_interval_seconds: %s',
     (heartbeat_interval_seconds) => {
       expect(() => normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds })).toThrow(

--- a/modules/module-mongodb/test/src/config.test.ts
+++ b/modules/module-mongodb/test/src/config.test.ts
@@ -1,0 +1,40 @@
+import { normalizeConnectionConfig } from '@module/types/types.js';
+import { describe, expect, test } from 'vitest';
+
+const BASE_CONFIG = {
+  type: 'mongodb' as const,
+  uri: 'mongodb://localhost:27017/powersync_test'
+};
+
+describe('MongoDB connection config', () => {
+  test('defaults heartbeat_interval_seconds to 0 seconds', () => {
+    expect(normalizeConnectionConfig(BASE_CONFIG).heartbeat_interval_seconds).toBe(0);
+  });
+
+  test('defaults a null heartbeat_interval_seconds to 0 seconds', () => {
+    expect(
+      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: null }).heartbeat_interval_seconds
+    ).toBe(0);
+  });
+
+  test('disables heartbeat_interval_seconds with 0', () => {
+    expect(
+      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: 0 }).heartbeat_interval_seconds
+    ).toBe(0);
+  });
+
+  test('allows the MongoDB maximum heartbeat interval', () => {
+    expect(
+      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: 300 }).heartbeat_interval_seconds
+    ).toBe(300);
+  });
+
+  test.each([4, 301, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid heartbeat_interval_seconds: %s',
+    (heartbeat_interval_seconds) => {
+      expect(() => normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds })).toThrow(
+        'heartbeat_interval_seconds'
+      );
+    }
+  );
+});

--- a/modules/module-mssql/src/module/MSSQLModule.ts
+++ b/modules/module-mssql/src/module/MSSQLModule.ts
@@ -41,7 +41,8 @@ export class MSSQLModule extends replication.ReplicationModule<types.MSSQLConnec
       metricsEngine: context.metricsEngine,
       connectionFactory: connectionFactory,
       rateLimiter: new MSSQLErrorRateLimiter(),
-      additionalConfig: normalisedConfig.additionalConfig
+      additionalConfig: normalisedConfig.additionalConfig,
+      heartbeatIntervalSeconds: normalisedConfig.heartbeat_interval_seconds
     });
   }
 

--- a/modules/module-mssql/src/types/types.ts
+++ b/modules/module-mssql/src/types/types.ts
@@ -8,6 +8,10 @@ export const DEFAULT_POLLING_BATCH_SIZE = 10;
 export const DEFAULT_POLLING_INTERVAL_MS = 1000;
 export const MSSQL_CONNECTION_TYPE = 'mssql' as const;
 
+const DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 60;
+const MIN_HEARTBEAT_INTERVAL_SECONDS = 5;
+const MAX_HEARTBEAT_INTERVAL_SECONDS = 60;
+
 export const AzureActiveDirectoryServicePrincipalSecret = t.object({
   type: t.literal('azure-active-directory-service-principal-secret'),
   options: t.object({
@@ -94,6 +98,8 @@ export interface NormalizedMSSQLConnectionConfig {
   lookup?: LookupFunction;
 
   additionalConfig: AdditionalConfig;
+
+  heartbeat_interval_seconds: number;
 }
 
 export const MSSQLConnectionConfig = service_types.configFile.DataSourceConfig.and(
@@ -110,7 +116,11 @@ export const MSSQLConnectionConfig = service_types.configFile.DataSourceConfig.a
     authentication: Authentication.optional(),
 
     reject_ip_ranges: t.array(t.string).optional(),
-    additionalConfig: AdditionalConfig.optional()
+    additionalConfig: AdditionalConfig.optional(),
+    /**
+     * Interval in seconds between source connection heartbeats. Null or omitted uses the default.
+     */
+    heartbeat_interval_seconds: t.number.or(t.Null).optional()
   })
 );
 
@@ -188,8 +198,22 @@ export function normalizeConnectionConfig(options: MSSQLConnectionConfig): Norma
       pollingIntervalMs: options.additionalConfig?.pollingIntervalMs ?? DEFAULT_POLLING_INTERVAL_MS,
       pollingBatchSize: options.additionalConfig?.pollingBatchSize ?? DEFAULT_POLLING_BATCH_SIZE,
       trustServerCertificate: options.additionalConfig?.trustServerCertificate ?? false
-    }
+    },
+    heartbeat_interval_seconds: normalizeHeartbeatInterval(options.heartbeat_interval_seconds)
   } satisfies NormalizedMSSQLConnectionConfig;
+}
+
+function normalizeHeartbeatInterval(value: number | null | undefined): number {
+  if (value == null) {
+    return DEFAULT_HEARTBEAT_INTERVAL_SECONDS;
+  }
+  if (!Number.isFinite(value) || value < MIN_HEARTBEAT_INTERVAL_SECONDS || value > MAX_HEARTBEAT_INTERVAL_SECONDS) {
+    throw new ServiceError(
+      ErrorCode.PSYNC_S1109,
+      `MSSQL connection: heartbeat_interval_seconds must be between ${MIN_HEARTBEAT_INTERVAL_SECONDS} and ${MAX_HEARTBEAT_INTERVAL_SECONDS} seconds`
+    );
+  }
+  return value;
 }
 
 export function baseUri(config: ResolvedMSSQLConnectionConfig) {

--- a/modules/module-mssql/test/src/config.test.ts
+++ b/modules/module-mssql/test/src/config.test.ts
@@ -1,0 +1,34 @@
+import { normalizeConnectionConfig } from '@module/types/types.js';
+import { describe, expect, test } from 'vitest';
+
+const BASE_CONFIG = {
+  type: 'mssql' as const,
+  uri: 'mssql://user:password@localhost:1433/powersync_test'
+};
+
+describe('SQL Server connection config', () => {
+  test('defaults heartbeat_interval_seconds to 60 seconds', () => {
+    expect(normalizeConnectionConfig(BASE_CONFIG).heartbeat_interval_seconds).toBe(60);
+  });
+
+  test('uses the default for a null heartbeat_interval_seconds', () => {
+    expect(
+      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: null }).heartbeat_interval_seconds
+    ).toBe(60);
+  });
+
+  test('allows the SQL Server maximum heartbeat interval', () => {
+    expect(
+      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: 60 }).heartbeat_interval_seconds
+    ).toBe(60);
+  });
+
+  test.each([0, 4, 61, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid heartbeat_interval_seconds: %s',
+    (heartbeat_interval_seconds) => {
+      expect(() => normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds })).toThrow(
+        'heartbeat_interval_seconds'
+      );
+    }
+  );
+});

--- a/modules/module-postgres/src/module/PostgresModule.ts
+++ b/modules/module-postgres/src/module/PostgresModule.ts
@@ -56,7 +56,8 @@ export class PostgresModule extends replication.ReplicationModule<types.Postgres
       storageEngine: context.storageEngine,
       metricsEngine: context.metricsEngine,
       connectionFactory: connectionFactory,
-      rateLimiter: new PostgresErrorRateLimiter()
+      rateLimiter: new PostgresErrorRateLimiter(),
+      heartbeatIntervalSeconds: normalisedConfig.heartbeat_interval_seconds
     });
   }
 

--- a/modules/module-postgres/src/types/types.ts
+++ b/modules/module-postgres/src/types/types.ts
@@ -1,4 +1,5 @@
 import * as lib_postgres from '@powersync/lib-service-postgres';
+import { ErrorCode, ServiceError } from '@powersync/lib-services-framework';
 import * as service_types from '@powersync/service-types';
 import * as t from 'ts-codec';
 
@@ -12,7 +13,10 @@ export const PostgresConnectionConfig = service_types.configFile.DataSourceConfi
   lib_postgres.BasePostgresConnectionConfig
 ).and(
   t.object({
-    // Add any replication connection specific config here in future
+    /**
+     * Interval in seconds between source connection heartbeats. Null or omitted uses the default.
+     */
+    heartbeat_interval_seconds: t.number.or(t.Null).optional()
   })
 );
 
@@ -24,7 +28,10 @@ export type PostgresConnectionConfig = t.Decoded<typeof PostgresConnectionConfig
 /**
  * Resolved version of {@link PostgresConnectionConfig}
  */
-export type ResolvedConnectionConfig = PostgresConnectionConfig & NormalizedPostgresConnectionConfig;
+export type ResolvedConnectionConfig = PostgresConnectionConfig &
+  NormalizedPostgresConnectionConfig & {
+    heartbeat_interval_seconds: number;
+  };
 
 export function isPostgresConfig(
   config: service_types.configFile.DataSourceConfig
@@ -39,6 +46,24 @@ export function isPostgresConfig(
  */
 export function normalizeConnectionConfig(options: PostgresConnectionConfig) {
   return {
-    ...lib_postgres.normalizeConnectionConfig(options)
-  } satisfies NormalizedPostgresConnectionConfig;
+    ...lib_postgres.normalizeConnectionConfig(options),
+    heartbeat_interval_seconds: normalizeHeartbeatInterval(options.heartbeat_interval_seconds)
+  } satisfies NormalizedPostgresConnectionConfig & { heartbeat_interval_seconds: number };
+}
+
+const DEFAULT_PING_INTERVAL_SECONDS = 60;
+const MIN_PING_INTERVAL_SECONDS = 5;
+const MAX_PING_INTERVAL_SECONDS = 60;
+
+function normalizeHeartbeatInterval(value: number | null | undefined): number {
+  if (value == null) {
+    return DEFAULT_PING_INTERVAL_SECONDS;
+  }
+  if (!Number.isFinite(value) || value < MIN_PING_INTERVAL_SECONDS || value > MAX_PING_INTERVAL_SECONDS) {
+    throw new ServiceError(
+      ErrorCode.PSYNC_S1109,
+      `Postgres connection: heartbeat_interval_seconds must be between ${MIN_PING_INTERVAL_SECONDS} and ${MAX_PING_INTERVAL_SECONDS} seconds`
+    );
+  }
+  return value;
 }

--- a/modules/module-postgres/test/src/config.test.ts
+++ b/modules/module-postgres/test/src/config.test.ts
@@ -1,0 +1,35 @@
+import { normalizeConnectionConfig } from '@module/types/types.js';
+import { describe, expect, test } from 'vitest';
+
+const BASE_CONFIG = {
+  type: 'postgresql' as const,
+  uri: 'postgresql://postgres:postgres@localhost:5432/powersync_test',
+  sslmode: 'disable' as const
+};
+
+describe('Postgres connection config', () => {
+  test('defaults heartbeat_interval_seconds to 60 seconds', () => {
+    expect(normalizeConnectionConfig(BASE_CONFIG).heartbeat_interval_seconds).toBe(60);
+  });
+
+  test('uses the default for a null heartbeat_interval_seconds', () => {
+    expect(
+      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: null }).heartbeat_interval_seconds
+    ).toBe(60);
+  });
+
+  test('allows the Postgres maximum heartbeat interval', () => {
+    expect(
+      normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds: 60 }).heartbeat_interval_seconds
+    ).toBe(60);
+  });
+
+  test.each([0, 4, 61, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid heartbeat_interval_seconds: %s',
+    (heartbeat_interval_seconds) => {
+      expect(() => normalizeConnectionConfig({ ...BASE_CONFIG, heartbeat_interval_seconds })).toThrow(
+        'heartbeat_interval_seconds'
+      );
+    }
+  );
+});

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -12,7 +12,7 @@ import { ErrorRateLimiter } from './ErrorRateLimiter.js';
 import { ConnectionTestResult } from './ReplicationModule.js';
 
 // Default to 1 minute when no source-specific interval is configured.
-const PING_INTERVAL = 1_000_000_000n * 60n;
+const DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 60;
 
 // In the initial startup period, we use a short refresh interval. This helps to take over replication quickly in the case
 // of rolling deploys. After the initial period, we switch to a longer refresh interval to reduce load.
@@ -35,7 +35,7 @@ export interface AbstractReplicatorOptions {
    */
   rateLimiter: ErrorRateLimiter;
   /**
-   * Interval in seconds between source connection pings. Null disables pings.
+   * Interval in seconds between source connection pings. Null or undefined uses the default; 0 disables pings.
    */
   heartbeatIntervalSeconds?: number | null;
 }
@@ -75,14 +75,9 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
 
   protected constructor(private options: AbstractReplicatorOptions) {
     this.logger = logger.child({ name: `Replicator:${options.id}` });
+    const heartbeatIntervalSeconds = options.heartbeatIntervalSeconds ?? DEFAULT_HEARTBEAT_INTERVAL_SECONDS;
     this.heartbeatIntervalNanos =
-      options.heartbeatIntervalSeconds == null
-        ? options.heartbeatIntervalSeconds === null
-          ? null
-          : PING_INTERVAL
-        : options.heartbeatIntervalSeconds <= 0
-          ? null
-          : BigInt(Math.round(options.heartbeatIntervalSeconds * 1_000_000_000));
+      heartbeatIntervalSeconds === 0 ? null : BigInt(Math.round(heartbeatIntervalSeconds * 1_000_000_000));
   }
 
   /**

--- a/packages/service-core/src/replication/AbstractReplicator.ts
+++ b/packages/service-core/src/replication/AbstractReplicator.ts
@@ -11,7 +11,7 @@ import { AbstractReplicationJob } from './AbstractReplicationJob.js';
 import { ErrorRateLimiter } from './ErrorRateLimiter.js';
 import { ConnectionTestResult } from './ReplicationModule.js';
 
-// 1 minute
+// Default to 1 minute when no source-specific interval is configured.
 const PING_INTERVAL = 1_000_000_000n * 60n;
 
 // In the initial startup period, we use a short refresh interval. This helps to take over replication quickly in the case
@@ -34,6 +34,10 @@ export interface AbstractReplicatorOptions {
    * This limits the effect of retries when there is a persistent issue.
    */
   rateLimiter: ErrorRateLimiter;
+  /**
+   * Interval in seconds between source connection pings. Null disables pings.
+   */
+  heartbeatIntervalSeconds?: number | null;
 }
 
 /**
@@ -62,13 +66,23 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
    */
   private activeReplicationJob: T | undefined = undefined;
 
-  // First ping is only after 5 minutes, not when starting
+  // The first ping is only after the configured interval, not when starting.
   private lastPing = hrtime.bigint();
+
+  private readonly heartbeatIntervalNanos: bigint | null;
 
   private abortController: AbortController | undefined;
 
   protected constructor(private options: AbstractReplicatorOptions) {
     this.logger = logger.child({ name: `Replicator:${options.id}` });
+    this.heartbeatIntervalNanos =
+      options.heartbeatIntervalSeconds == null
+        ? options.heartbeatIntervalSeconds === null
+          ? null
+          : PING_INTERVAL
+        : options.heartbeatIntervalSeconds <= 0
+          ? null
+          : BigInt(Math.round(options.heartbeatIntervalSeconds * 1_000_000_000));
   }
 
   /**
@@ -184,9 +198,9 @@ export abstract class AbstractReplicator<T extends AbstractReplicationJob = Abst
 
         // Ensure that the replication jobs' connections are kept alive.
         // We don't ping while in error retry back-off, to avoid having too failures.
-        if (this.rateLimiter.mayPing()) {
+        if (this.heartbeatIntervalNanos != null && this.rateLimiter.mayPing()) {
           const now = hrtime.bigint();
-          if (now - this.lastPing >= PING_INTERVAL) {
+          if (now - this.lastPing >= this.heartbeatIntervalNanos) {
             for (const activeJob of this.replicationJobs.values()) {
               await activeJob.keepAlive();
             }

--- a/packages/service-core/test/src/AbstractReplicator.test.ts
+++ b/packages/service-core/test/src/AbstractReplicator.test.ts
@@ -40,7 +40,39 @@ class TestReplicator extends AbstractReplicator {
   addClearingJob(replicationStreamId: number, promise: Promise<void>): void {
     this.clearingJobs.set(replicationStreamId, promise);
   }
+
+  get heartbeatIntervalNanosForTest(): bigint | null {
+    return (this as any).heartbeatIntervalNanos;
+  }
 }
+
+describe('AbstractReplicator heartbeat interval', () => {
+  const options: AbstractReplicatorOptions = {
+    id: 'test',
+    storageEngine: {} as AbstractReplicatorOptions['storageEngine'],
+    metricsEngine: {} as AbstractReplicatorOptions['metricsEngine'],
+    syncRuleProvider: {} as AbstractReplicatorOptions['syncRuleProvider'],
+    rateLimiter: {} as AbstractReplicatorOptions['rateLimiter']
+  };
+
+  it.each([undefined, null])('uses the default for %s', (heartbeatIntervalSeconds) => {
+    const replicator = new TestReplicator(async () => {}, { ...options, heartbeatIntervalSeconds });
+
+    expect(replicator.heartbeatIntervalNanosForTest).toBe(60_000_000_000n);
+  });
+
+  it('disables the heartbeat interval with 0', () => {
+    const replicator = new TestReplicator(async () => {}, { ...options, heartbeatIntervalSeconds: 0 });
+
+    expect(replicator.heartbeatIntervalNanosForTest).toBeNull();
+  });
+
+  it('converts a positive heartbeat interval to nanoseconds', () => {
+    const replicator = new TestReplicator(async () => {}, { ...options, heartbeatIntervalSeconds: 5 });
+
+    expect(replicator.heartbeatIntervalNanosForTest).toBe(5_000_000_000n);
+  });
+});
 
 describe('AbstractReplicator stopped stream cleanup', () => {
   it('holds the replication stream lock across source and storage cleanup', async () => {


### PR DESCRIPTION
This adds a configurable `heartbeat_interval_seconds` option for MongoDB, Postgres, SQL Server.

The exact default and behavior differs based on source db:
1. MongoDB: ~No heartbeat by default. Now configurable between 5s and 300s, to write to `_powersync_checkpoints`.~ Configurable heartbeat between 5s and 60s. Write to `_powersync_checkpoints` if there is no recent resume token - details below.
2. Postgres: Default writes to WAL using `pg_logical_emit_message` every 60s. Now configurable between 5s and 60s.
3. SQL Server: Default writes to `_powersync_checkpoints` every 60s. Now configurable between 5s and 60s.

The defaults above match the previous behavior except for MongoDB.

We can expand the configurable ranges over time, but needs more testing to ensure there are no side effects if it is increased above 60s.

The main goal of the PR is to avoid PSYNC_S1345 change stream timeout errors on MongoDB, if there are massive bulk writes to a different database (see test case in comments). While this is a rare case, the severity is significant when it is hit: It completely blocks replication, requiring re-replication from scratch to recover. It also happens more commonly on large clusters, where re-replication can take a long time.

Update: For MongoDB, we now use a hybrid approach:
1. If we persisted a recent resume token (within `heartbeat_interval_seconds`), we do nothing - same as before. Since this resume token is regularly updated, this allows us to mark progress despite the bulk writes in a different databases.
2. If there is no recent resume token, typically due to replication lag, we write to `_powersync_checkpoints`. When we do catch up, we'll have those operations distributed through the oplog, allowing the change stream to make progress.

Note that the changes here only help if the replication process is running. The PSYNC_S1345 condition can still be triggered if there are bulk writes in a different database while the replication process is stopped / crashing, but there is not much we can do in that case.

## Use case for custom `heartbeat_interval_seconds`

In most cases, the default should be fine. The interval can be reduced to help with:
1. Faster detection of replication issues using the diagnostics API, since last_keepalive_at is updated more often. See this issue for an example: https://github.com/powersync-ja/powersync-service/issues/700#issuecomment-4843213908
2. Further reducing the likelihood of getting stuck in PSYNC_S1345.

## AI Usage

Manually designed; implemented using Codex gpt-5.6; manually tweaked and commented.