### PR TITLE
Optimize subkey UUID performance

### DIFF
--- a/.changeset/ripe-items-hang.md
+++ b/.changeset/ripe-items-hang.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Optimization for generating subkey UUIDs.

--- a/packages/service-core/src/util/utils.ts
+++ b/packages/service-core/src/util/utils.ts
@@ -33,7 +33,7 @@ export interface PartialChecksum {
  */
 export type InternalOpId = bigint;
 
-export const ID_NAMESPACE = 'a396dd91-09fc-4017-a28d-3df722f651e9';
+export const ID_NAMESPACE = uuid.parse('a396dd91-09fc-4017-a28d-3df722f651e9');
 
 export function escapeIdentifier(identifier: string) {
   return `"${identifier.replace(/"/g, '""').replace(/\./g, '"."')}"`;


### PR DESCRIPTION
For `subkey` in the protocol (unique id by source replica identity), we currently create a uuidv5 from a combination of the source table id and source replica identity. It turns out this is quite an expensive operation, and can account for 20-30% for API process CPU usage for syncing small operations in some cases.

This implements a very simple optimization to increase throughput for generating these ids: Pre-parse the UUIDnamespace, instead of parsing from string -> Buffer for every id that we generate.

## Future optimizations

The optimization here is limited, but fully backwards-compatible. We can get further gains if we do consider more substantial changes:

1. Pre-compute and persist these values when replicating, instead of calculating on-demand when syncing. Requires storage changes.
2. Change the uuid input to not start with bson serialization. Needs care to preserve backwards-compatibility for existing rows.
3. Omit the subkey in cases where we can guarantee unique rows by id. This will further reduce overhead for syncing, storage on the client, and can improve performance on the client. Needs care to preserve backwards-compatibility for existing rows.

## Benchmarks

All these tests use 30x concurrency clients with one process, syncing 166MB of data over 148k operations (1.12KB/operation). The table here shows the average throughput in the process for each case.

test | ops/s | MB/s (uncompressed size)
| --- | --- | --- |
main branch, gzip | 57.7k/s | 64.7MB/s
this PR, gzip | 60.8k/s | 68.2MB/s
main branch, identity | 83.8k/s | 94.0MB/s
this PR, identity | 88.9k/s | 99.6MB/s

So this gives a 5-6% increase in throughput when CPU bound, or 5-6% reduction in CPU usage for the same throughput. Case with smaller operations will see bigger gains; larger operations will see smaller gains.

## Testing

Existing tests confirm that the generated UUIDs remain the same.

## AI Usage

Optimization identified by Codex, manually implemented.