### PR TITLE
[MSSQL] Add custom CA certificate support for MSSQL connections

### DIFF
--- a/.changeset/mssql-add-cacert-support.md
+++ b/.changeset/mssql-add-cacert-support.md
@@ -1,0 +1,9 @@
+---
+'@powersync/service-module-mssql': minor
+---
+
+Add custom CA certificate support for MSSQL connections.
+
+The new `cacert` option allows PowerSync to validate SQL Server certificates issued by a private CA
+without enabling `trustServerCertificate`. An optional `tls_servername` can be specified when the connection
+hostname differs from the name in the server certificate.

--- a/modules/module-mssql/src/replication/MSSQLConnectionManager.ts
+++ b/modules/module-mssql/src/replication/MSSQLConnectionManager.ts
@@ -11,6 +11,28 @@ export interface MSSQLConnectionManagerListener {
   onEnded(): void;
 }
 
+export function createConnectionPoolConfig(
+  options: NormalizedMSSQLConnectionConfig,
+  poolOptions: sql.PoolOpts<sql.Connection>
+): sql.config {
+  return {
+    authentication: options.authentication,
+    user: options.username,
+    password: options.password,
+    server: options.hostname,
+    port: options.port,
+    database: options.database,
+    pool: poolOptions,
+    options: {
+      appName: `powersync/${POWERSYNC_VERSION}`,
+      encrypt: true, // Required for Azure
+      trustServerCertificate: options.additionalConfig.trustServerCertificate,
+      ...(options.tls_servername ? { serverName: options.tls_servername } : {}),
+      ...(options.cacert ? { cryptoCredentialsDetails: { ca: options.cacert } } : {})
+    }
+  };
+}
+
 export class MSSQLConnectionManager extends BaseObserver<MSSQLConnectionManagerListener> {
   private readonly pool: sql.ConnectionPool;
 
@@ -20,20 +42,7 @@ export class MSSQLConnectionManager extends BaseObserver<MSSQLConnectionManagerL
   ) {
     super();
     // The pool is lazy - no connections are opened until a query is performed.
-    this.pool = new sql.ConnectionPool({
-      authentication: options.authentication,
-      user: options.username,
-      password: options.password,
-      server: options.hostname,
-      port: options.port,
-      database: options.database,
-      pool: poolOptions,
-      options: {
-        appName: `powersync/${POWERSYNC_VERSION}`,
-        encrypt: true, // Required for Azure
-        trustServerCertificate: options.additionalConfig.trustServerCertificate
-      }
-    });
+    this.pool = new sql.ConnectionPool(createConnectionPoolConfig(options, poolOptions));
   }
 
   public get connectionTag() {

--- a/modules/module-mssql/src/types/types.ts
+++ b/modules/module-mssql/src/types/types.ts
@@ -93,6 +93,12 @@ export interface NormalizedMSSQLConnectionConfig {
   database: string;
   schema?: string;
 
+  /** PEM-encoded certificate authority used to validate the SQL Server certificate. */
+  cacert?: string;
+
+  /** Server name to use when validating the SQL Server certificate. */
+  tls_servername?: string;
+
   authentication?: Authentication;
 
   lookup?: LookupFunction;
@@ -112,6 +118,12 @@ export const MSSQLConnectionConfig = service_types.configFile.DataSourceConfig.a
     schema: t.string.optional(),
     hostname: t.string.optional(),
     port: service_types.configFile.portCodec.optional(),
+
+    /** PEM-encoded certificate authority used to validate the SQL Server certificate. */
+    cacert: t.string.optional(),
+
+    /** Server name to use when validating the SQL Server certificate. */
+    tls_servername: t.string.optional(),
 
     authentication: Authentication.optional(),
 
@@ -179,6 +191,13 @@ export function normalizeConnectionConfig(options: MSSQLConnectionConfig): Norma
     throw new ServiceError(ErrorCode.PSYNC_S1105, `MSSQL connection: database required`);
   }
 
+  if (options.cacert && options.additionalConfig?.trustServerCertificate) {
+    throw new ServiceError(
+      ErrorCode.PSYNC_S1604,
+      'MSSQL connection: cacert cannot be used with trustServerCertificate because certificate validation would be disabled'
+    );
+  }
+
   const lookup = makeHostnameLookupFunction(hostname, { reject_ip_ranges: options.reject_ip_ranges ?? [] });
 
   return {
@@ -190,6 +209,8 @@ export function normalizeConnectionConfig(options: MSSQLConnectionConfig): Norma
     hostname,
     port,
     database,
+    cacert: options.cacert,
+    tls_servername: options.tls_servername,
 
     lookup,
     authentication: options.authentication,

--- a/modules/module-mssql/test/src/config.test.ts
+++ b/modules/module-mssql/test/src/config.test.ts
@@ -1,3 +1,4 @@
+import { createConnectionPoolConfig } from '@module/replication/MSSQLConnectionManager.js';
 import { normalizeConnectionConfig } from '@module/types/types.js';
 import { describe, expect, test } from 'vitest';
 
@@ -7,6 +8,42 @@ const BASE_CONFIG = {
 };
 
 describe('SQL Server connection config', () => {
+  test('passes a custom CA to the SQL Server TLS configuration', () => {
+    const cacert = `-----BEGIN CERTIFICATE-----
+test certificate
+-----END CERTIFICATE-----`;
+    const normalized = normalizeConnectionConfig({ ...BASE_CONFIG, cacert });
+
+    expect(normalized.cacert).toBe(cacert);
+    expect(createConnectionPoolConfig(normalized, {}).options).toMatchObject({
+      encrypt: true,
+      trustServerCertificate: false,
+      cryptoCredentialsDetails: { ca: cacert }
+    });
+  });
+
+  test('passes a custom TLS server name to the SQL Server TLS configuration', () => {
+    const normalized = normalizeConnectionConfig({ ...BASE_CONFIG, tls_servername: 'sql.internal.example' });
+
+    expect(createConnectionPoolConfig(normalized, {}).options?.serverName).toBe('sql.internal.example');
+  });
+
+  test('rejects a custom CA when server certificate validation is disabled', () => {
+    expect(() =>
+      normalizeConnectionConfig({
+        ...BASE_CONFIG,
+        cacert: 'certificate',
+        additionalConfig: { trustServerCertificate: true }
+      })
+    ).toThrow(/cacert cannot be used with trustServerCertificate/);
+  });
+
+  test('does not configure a custom TLS context without a custom CA', () => {
+    const normalized = normalizeConnectionConfig(BASE_CONFIG);
+
+    expect(createConnectionPoolConfig(normalized, {}).options?.cryptoCredentialsDetails).toBeUndefined();
+  });
+
   test('defaults heartbeat_interval_seconds to 60 seconds', () => {
     expect(normalizeConnectionConfig(BASE_CONFIG).heartbeat_interval_seconds).toBe(60);
   });

--- a/packages/service-errors/src/codes.ts
+++ b/packages/service-errors/src/codes.ts
@@ -382,6 +382,11 @@ export enum ErrorCode {
    */
   PSYNC_S1603 = 'PSYNC_S1603',
 
+  /**
+   *  MSSQL connection configuration error.
+   */
+  PSYNC_S1604 = 'PSYNC_S1604',
+
   // ## PSYNC_S2xxx: Service API
 
   /**


### PR DESCRIPTION
### Summary

This allows users to specify a CA certificate in the connection config, to be used when opening connections to the SQL Server source DB. Encryption on the connection was always enabled, but for non Azure SQL Server DBs this required the `trustServerCertificate` flag to be set to true, which accepts self signed certificates.

#### Changes

Added the `cacert` and `tls_servername` fields to the MSSQLConnectionConfig. If present those values are then used when opening connections to the SQL server database.
`tls_servername` need only be specified when the DB hostname PowerSync connects to differs from the DNS name in the SQL Server certificate.  For example with the connection config:
```
hostname: 10.0.1.25
tls_servername: sql-prod.internal.example
```
PowerSync connects to 10.0.1.25, but validates that the certificate is valid for sql-prod.internal.example.

#### AI Disclaimer

Used GPT 5.6 to investigate feasibility and then add the required cacert support. 
Manually verified functionality by connecting the PowerSync service to a SQL Server with a specified cacert.