### PR TITLE
feat(module-postgres): initial snapshot filters for Postgres sources

### DIFF
--- a/.changeset/initial-snapshot-filters-postgres.md
+++ b/.changeset/initial-snapshot-filters-postgres.md
@@ -1,0 +1,19 @@
+---
+'@powersync/service-sync-rules': minor
+'@powersync/service-core': minor
+'@powersync/service-module-postgres': minor
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+---
+
+Add `initial_snapshot_filters` support for Postgres sources.
+
+A global `initial_snapshot_filters` section in the sync config maps table patterns
+(including schema and table wildcards) to a SQL WHERE clause applied during the initial
+snapshot, so the source database skips rows outside the filter instead of the service
+reading and discarding them. The filter is applied in all snapshot query types, including
+the chunked resume path.
+
+Filters are also persisted alongside the compiled sync plan, so configs using
+`edition: 3` restore them correctly when replication rebuilds the config from the stored
+plan.

--- a/.changeset/initial-snapshot-filters-postgres.md
+++ b/.changeset/initial-snapshot-filters-postgres.md
@@ -12,7 +12,9 @@ A global `initial_snapshot_filters` section in the sync config maps table patter
 (including schema and table wildcards) to a SQL WHERE clause applied during the initial
 snapshot, so the source database skips rows outside the filter instead of the service
 reading and discarding them. The filter is applied in all snapshot query types, including
-the chunked resume path.
+the chunked resume path. The snapshot progress estimate (`replicated/~total`) is also computed
+with the filter applied, using the query planner's row estimate instead of the table's
+`reltuples`, so the logged total reflects the rows that will actually be replicated.
 
 Filters are also persisted alongside the compiled sync plan, so configs using
 `edition: 3` restore them correctly when replication rebuilds the config from the stored

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoBucketBatchV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoBucketBatchV1.ts
@@ -145,6 +145,7 @@ export class MongoBucketBatchV1 extends MongoBucketBatch {
         ) ?? [],
       snapshotComplete: doc.snapshot_done ?? true,
       sourceMetadata: doc.source_metadata ?? null,
+      initialSnapshotFilter: syncRules.getInitialSnapshotFilter(ref),
       ...syncRules.getMatchingSources(ref)
     });
     table.syncEvent = syncRules.tableTriggersEvent(ref);

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/source-table-utils.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/source-table-utils.ts
@@ -366,13 +366,14 @@ export function sourceTableFromDocument(
       mapping.parameterLookupId(source)
     )
   };
+  const ref = {
+    connectionTag,
+    schema: doc.schema_name,
+    name: doc.table_name
+  };
   const table = new storage.SourceTable({
     id: doc._id,
-    ref: {
-      connectionTag,
-      schema: doc.schema_name,
-      name: doc.table_name
-    },
+    ref,
     objectId: doc.relation_id,
     replicaIdColumns:
       doc.replica_id_columns?.map(
@@ -383,7 +384,8 @@ export function sourceTableFromDocument(
     parameterLookupSources: resolvedMemberships.parameterLookupSources,
     bucketDataSourceIds: new Set(resolvedMembershipIds.bucketDataSourceIds),
     parameterLookupSourceIds: new Set(resolvedMembershipIds.parameterLookupSourceIds),
-    sourceMetadata: doc.source_metadata ?? null
+    sourceMetadata: doc.source_metadata ?? null,
+    initialSnapshotFilter: syncConfig.getInitialSnapshotFilter(ref)
   });
   table.syncData = table.bucketDataSources.length > 0;
   table.syncParameters = table.parameterLookupSources.length > 0;

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -303,6 +303,7 @@ export class PostgresBucketBatch
         ) ?? [],
       snapshotComplete: row.snapshot_done ?? true,
       sourceMetadata: row.source_metadata,
+      initialSnapshotFilter: syncRules.getInitialSnapshotFilter(ref),
       ...syncRules.getMatchingSources(ref)
     });
 

--- a/modules/module-postgres-storage/src/types/models/SyncRules.ts
+++ b/modules/module-postgres-storage/src/types/models/SyncRules.ts
@@ -61,6 +61,18 @@ export const SyncRules = t.object({
           maxTimeValuePrecision: t.number.optional()
         }),
         eventDescriptors: t.record(t.array(t.string)),
+        // Ordered list (matching is first-match-wins; JSONB does not preserve object key order).
+        initialSnapshotFilters: t
+          .array(
+            t.object({
+              pattern: t.string,
+              filter: t.object({
+                sql: t.string.optional(),
+                mongo: t.any.optional()
+              })
+            })
+          )
+          .optional(),
         errors: t.array(ReplicationError).optional()
       })
     )

--- a/modules/module-postgres/src/replication/SnapshotQuery.ts
+++ b/modules/module-postgres/src/replication/SnapshotQuery.ts
@@ -37,7 +37,11 @@ export class SimpleSnapshotQuery implements SnapshotQuery {
   ) {}
 
   public async initialize(): Promise<void> {
-    await rquery(this.connection, `DECLARE snapshot_cursor CURSOR FOR SELECT * FROM ${this.table.qualifiedName}`);
+    let query = `SELECT * FROM ${this.table.qualifiedName}`;
+    if (this.table.initialSnapshotFilter?.sql) {
+      query += ` WHERE (${this.table.initialSnapshotFilter.sql})`;
+    }
+    await rquery(this.connection, `DECLARE snapshot_cursor CURSOR FOR ${query}`);
   }
 
   public nextChunk(): AsyncIterableIterator<PgChunk> {
@@ -120,18 +124,26 @@ export class ChunkedSnapshotQuery implements SnapshotQuery {
   public async *nextChunk(): AsyncIterableIterator<PgChunk> {
     let stream: AsyncIterableIterator<PgChunk>;
     const escapedKeyName = escapeIdentifier(this.key.name);
+    const snapshotFilter = this.table.initialSnapshotFilter?.sql;
     if (this.lastKey == null) {
-      stream = rstream(
-        this.connection,
-        `SELECT * FROM ${this.table.qualifiedName} ORDER BY ${escapedKeyName} LIMIT ${this.chunkSize}`
-      );
+      let query = `SELECT * FROM ${this.table.qualifiedName}`;
+      if (snapshotFilter) {
+        query += ` WHERE (${snapshotFilter})`;
+      }
+      query += ` ORDER BY ${escapedKeyName} LIMIT ${this.chunkSize}`;
+      stream = rstream(this.connection, query);
     } else {
       if (this.key.typeId == null) {
         throw new Error(`typeId required for primary key ${this.key.name}`);
       }
       const type = Number(this.key.typeId);
+      let query = `SELECT * FROM ${this.table.qualifiedName} WHERE ${escapedKeyName} > $1`;
+      if (snapshotFilter) {
+        query += ` AND (${snapshotFilter})`;
+      }
+      query += ` ORDER BY ${escapedKeyName} LIMIT ${this.chunkSize}`;
       stream = rstream(this.connection, {
-        statement: `SELECT * FROM ${this.table.qualifiedName} WHERE ${escapedKeyName} > $1 ORDER BY ${escapedKeyName} LIMIT ${this.chunkSize}`,
+        statement: query,
         params: [{ value: this.lastKey, type }]
       });
     }
@@ -202,8 +214,12 @@ export class IdSnapshotQuery implements SnapshotQuery {
     if (type == null) {
       throw new Error(`Cannot determine primary key array type for ${JSON.stringify(keyDefinition)}`);
     }
+    let query = `SELECT * FROM ${this.table.qualifiedName} WHERE ${escapeIdentifier(keyDefinition.name)} = ANY($1)`;
+    if (this.table.initialSnapshotFilter?.sql) {
+      query += ` AND (${this.table.initialSnapshotFilter.sql})`;
+    }
     yield* rstream(this.connection, {
-      statement: `SELECT * FROM ${this.table.qualifiedName} WHERE ${escapeIdentifier(keyDefinition.name)} = ANY($1)`,
+      statement: query,
       params: [
         {
           type: type,

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -737,6 +737,13 @@ WHERE  oid = $1::regclass`,
       q = new SimpleSnapshotQuery(db, table, this.snapshotChunkLength);
       at = 0;
     }
+
+    if (table.initialSnapshotFilter?.sql) {
+      this.logger.info(
+        `Applying initial snapshot filter on ${table.qualifiedName}: ${table.initialSnapshotFilter.sql}`
+      );
+    }
+
     await q.initialize();
 
     let hasRemainingData = true;

--- a/modules/module-postgres/src/replication/WalStream.ts
+++ b/modules/module-postgres/src/replication/WalStream.ts
@@ -534,7 +534,36 @@ WHERE  oid = $1::regclass`,
       params: [{ value: table.qualifiedName, type: 'varchar' }]
     });
     const row = results.rows[0];
-    return Number(row?.decodeWithoutCustomTypes(0) ?? -1n);
+    const tableEstimate = Number(row?.decodeWithoutCustomTypes(0) ?? -1n);
+    const filter = table.initialSnapshotFilter?.sql;
+    if (filter == null || tableEstimate < 0) {
+      // No filter, or no statistics yet (reltuples = -1), so a filtered estimate would be a guess too.
+      return tableEstimate;
+    }
+    return await this.estimatedFilteredCountNumber(db, table, filter);
+  }
+
+  /**
+   * Estimate the number of rows matching the initial snapshot filter.
+   *
+   * `reltuples` covers the whole table, which with a selective filter is far more than the
+   * snapshot will read. The planner's row estimate for the filtered query uses the same
+   * statistics without reading the table, while a `count(*)` would scan every table before
+   * the snapshot starts and again on each re-estimate.
+   */
+  private async estimatedFilteredCountNumber(
+    db: pgwire.PgConnection,
+    table: storage.SourceTable,
+    filter: string
+  ): Promise<number> {
+    const results = await rquery(db, `EXPLAIN (FORMAT JSON) SELECT * FROM ${table.qualifiedName} WHERE (${filter})`);
+    const row = results.rows[0];
+    if (row == null) {
+      return -1;
+    }
+    const plan = JSON.parse(String(row.decodeWithoutCustomTypes(0)));
+    const estimate = Number(plan?.[0]?.Plan?.['Plan Rows']);
+    return Number.isFinite(estimate) ? estimate : -1;
   }
 
   /**

--- a/modules/module-postgres/test/src/snapshot_filters.test.ts
+++ b/modules/module-postgres/test/src/snapshot_filters.test.ts
@@ -1,0 +1,77 @@
+import { reduceBucket } from '@powersync/service-core';
+import { describe, expect, test } from 'vitest';
+import { describeWithStorage, StorageVersionTestContext } from './util.js';
+import { WalStreamTestContext } from './wal_stream_utils.js';
+
+describe('initial snapshot filters', () => {
+  describeWithStorage({ timeout: 120_000 }, defineSnapshotFilterTests);
+});
+
+function defineSnapshotFilterTests({ factory, storageVersion }: StorageVersionTestContext) {
+  test('applies filter during initial snapshot', async () => {
+    // A small chunk length so the filter is also exercised on the resume path
+    // (WHERE key > $1 AND (filter)) of the chunked snapshot query.
+    await using context = await WalStreamTestContext.open(factory, {
+      storageVersion,
+      walStreamOptions: { snapshotChunkLength: 100 }
+    });
+
+    await context.updateSyncRules(`
+initial_snapshot_filters:
+  test_data:
+    sql: "archived = false"
+
+bucket_definitions:
+  global:
+    data:
+      - SELECT id, description FROM test_data WHERE archived = false`);
+    const { pool } = context;
+
+    await pool.query(`
+      CREATE TABLE test_data(
+        id int4 primary key,
+        description text,
+        archived boolean not null default false
+      )`);
+    // 1000 rows, of which only 150 match the filter.
+    await pool.query(`
+      INSERT INTO test_data(id, description, archived)
+      SELECT i, 'row ' || i, i % 10 >= 5 OR i > 300 FROM generate_series(1, 1000) i`);
+
+    await context.replicateSnapshot();
+
+    const data = await context.getBucketData('global[]', undefined, {});
+    const reduced = reduceBucket(data).filter((row) => row.object_type == 'test_data');
+    expect(reduced.length).toEqual(150);
+  });
+
+  test('filter with a plain table name matches the table in any schema', async () => {
+    await using context = await WalStreamTestContext.open(factory, { storageVersion });
+
+    await context.updateSyncRules(`
+initial_snapshot_filters:
+  test_data:
+    sql: "amount > 10"
+
+bucket_definitions:
+  global:
+    data:
+      - SELECT id, amount FROM "%".test_data WHERE amount > 10`);
+    const { pool } = context;
+
+    for (const schema of ['tenant_a', 'tenant_b']) {
+      await pool.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
+      await pool.query(`CREATE SCHEMA ${schema}`);
+      await pool.query(`CREATE TABLE ${schema}.test_data(id int4 primary key, amount int4)`);
+    }
+    await pool.query(`INSERT INTO tenant_a.test_data SELECT i, i FROM generate_series(1, 20) i`);
+    await pool.query(`INSERT INTO tenant_b.test_data SELECT 100 + i, i FROM generate_series(1, 30) i`);
+
+    await context.replicateSnapshot();
+
+    const data = await context.getBucketData('global[]', undefined, {});
+    const reduced = reduceBucket(data).filter((row) => row.object_type == 'test_data');
+    // tenant_a: amounts 11-20 (10 rows), tenant_b: amounts 11-30 (20 rows).
+    expect(reduced.length).toEqual(30);
+  });
+}

--- a/modules/module-postgres/test/src/snapshot_filters.test.ts
+++ b/modules/module-postgres/test/src/snapshot_filters.test.ts
@@ -45,6 +45,50 @@ bucket_definitions:
     expect(reduced.length).toEqual(150);
   });
 
+  test('applies filter when restored from a compiled sync plan (edition 3)', async () => {
+    // With edition 3, sync configs are persisted with a compiled sync plan, and replication restores the
+    // config from the stored plan instead of re-parsing the YAML. The filters must survive that round-trip.
+    await using context = await WalStreamTestContext.open(factory, {
+      storageVersion,
+      walStreamOptions: { snapshotChunkLength: 100 }
+    });
+
+    // The stream deliberately selects ALL rows: the row count in the bucket then directly measures whether
+    // the snapshot filter was pushed down to the snapshot query (150 rows) or ignored (1000 rows).
+    await context.updateSyncRules(`
+initial_snapshot_filters:
+  test_data:
+    sql: "archived = false"
+
+streams:
+  global:
+    query: SELECT id, description FROM test_data
+
+config:
+  edition: 3`);
+    // Reload the config from storage, like the replicator does on startup — replication must not depend on
+    // the in-memory config from the deploy.
+    await context.loadNextSyncRules();
+    const { pool } = context;
+
+    await pool.query(`
+      CREATE TABLE test_data(
+        id int4 primary key,
+        description text,
+        archived boolean not null default false
+      )`);
+    // 1000 rows, of which only 150 match the filter.
+    await pool.query(`
+      INSERT INTO test_data(id, description, archived)
+      SELECT i, 'row ' || i, i % 10 >= 5 OR i > 300 FROM generate_series(1, 1000) i`);
+
+    await context.replicateSnapshot();
+
+    const data = await context.getBucketData('global|0[]', undefined, {});
+    const reduced = reduceBucket(data).filter((row) => row.object_type == 'test_data');
+    expect(reduced.length).toEqual(150);
+  });
+
   test('filter with a plain table name matches the table in any schema', async () => {
     await using context = await WalStreamTestContext.open(factory, { storageVersion });
 

--- a/modules/module-postgres/test/src/snapshot_filters.test.ts
+++ b/modules/module-postgres/test/src/snapshot_filters.test.ts
@@ -89,6 +89,49 @@ config:
     expect(reduced.length).toEqual(150);
   });
 
+  test('estimates the snapshot row count with the filter applied', async () => {
+    await using context = await WalStreamTestContext.open(factory, { storageVersion });
+
+    await context.updateSyncRules(`
+initial_snapshot_filters:
+  test_data:
+    sql: "archived = false"
+
+bucket_definitions:
+  global:
+    data:
+      - SELECT id, description FROM test_data WHERE archived = false`);
+    const { pool } = context;
+
+    await pool.query(`
+      CREATE TABLE test_data(
+        id int4 primary key,
+        description text,
+        archived boolean not null default false
+      )`);
+    // 1000 rows, of which only 150 match the filter.
+    await pool.query(`
+      INSERT INTO test_data(id, description, archived)
+      SELECT i, 'row ' || i, i % 10 >= 5 OR i > 300 FROM generate_series(1, 1000) i`);
+    // Both the table estimate (reltuples) and the filtered estimate come from planner statistics.
+    await pool.query(`ANALYZE test_data`);
+
+    const tables = await context.getResolvedTables();
+    expect(tables.length).toEqual(1);
+    expect(tables[0].initialSnapshotFilter?.sql).toEqual('archived = false');
+
+    const db = await context.connectionManager.snapshotConnection();
+    try {
+      const estimate = await context.walStream.estimatedCountNumber(db, tables[0]);
+      // Without the filter this would be ~1000. With fresh statistics on a boolean column the
+      // planner gets close to the exact 150; the range leaves room for sampling.
+      expect(estimate).toBeGreaterThanOrEqual(100);
+      expect(estimate).toBeLessThanOrEqual(200);
+    } finally {
+      await db.end();
+    }
+  });
+
   test('filter with a plain table name matches the table in any schema', async () => {
     await using context = await WalStreamTestContext.open(factory, { storageVersion });
 

--- a/packages/service-core/src/storage/BucketStorageFactory.ts
+++ b/packages/service-core/src/storage/BucketStorageFactory.ts
@@ -1,5 +1,6 @@
 import { BaseObserver, logger } from '@powersync/lib-services-framework';
 import {
+  InitialSnapshotFilter,
   PrecompiledSyncConfig,
   SerializedSyncPlan as RawSerializedSyncPlan,
   SerializedCompatibilityContext,
@@ -167,6 +168,11 @@ export interface UpdateSyncRulesOptions {
   defaultSchema?: string;
 }
 
+export interface SerializedInitialSnapshotFilter {
+  pattern: string;
+  filter: InitialSnapshotFilter;
+}
+
 export interface SerializedSyncPlan {
   /**
    * The serialized plan, from {@link serializeSyncPlan}.
@@ -181,6 +187,16 @@ export interface SerializedSyncPlan {
    * them.
    */
   eventDescriptors: Record<string, string[]>;
+  /**
+   * Initial snapshot filters are not represented in the sync plan either — like event descriptors, they are persisted
+   * here so they survive the round-trip through the stored plan.
+   *
+   * Stored as an ordered list rather than a map: filter matching is first-match-wins, and JSONB storage does not
+   * preserve object key order.
+   *
+   * Absent on plans serialized before this field existed; those are treated as having no filters.
+   */
+  initialSnapshotFilters?: SerializedInitialSnapshotFilter[];
   errors?: ReplicationError[];
 }
 
@@ -214,6 +230,7 @@ export function updateSyncRulesFromConfig(
       compatibility: config.compatibility.serialize(),
       plan: serializeSyncPlan(config.plan),
       eventDescriptors,
+      initialSnapshotFilters: [...config.initialSnapshotFilters].map(([pattern, filter]) => ({ pattern, filter })),
       errors: errors.map((e) => syncConfigYamlErrorToReplicationError(e))
     };
   }

--- a/packages/service-core/src/storage/PersistedSyncConfigContent.ts
+++ b/packages/service-core/src/storage/PersistedSyncConfigContent.ts
@@ -59,6 +59,12 @@ export function parsePersistedSyncConfigContent(options: ParsePersistedSyncConfi
   // This means asUpdateOptions will not change the storage version, even if the default changes.
   precompiled.storageVersion = storageVersion;
 
+  // Initial snapshot filters are not part of the compiled plan and must be restored separately, preserving
+  // their order (matching is first-match-wins).
+  precompiled.initialSnapshotFilters = new Map(
+    (compiledPlan.initialSnapshotFilters ?? []).map(({ pattern, filter }) => [pattern, filter])
+  );
+
   const errors: YamlError[] = [];
   if (compiledPlan.errors) {
     for (const error of compiledPlan.errors) {

--- a/packages/service-core/src/storage/SourceTable.ts
+++ b/packages/service-core/src/storage/SourceTable.ts
@@ -2,6 +2,7 @@ import {
   BucketDataSource,
   BucketDefinitionId,
   DEFAULT_TAG,
+  InitialSnapshotFilter,
   ParameterIndexId,
   ParameterIndexLookupCreator,
   SourceTableRef
@@ -39,6 +40,12 @@ export interface SourceTableOptions {
    * Source-specific metadata. Null when no metadata has been recorded.
    */
   sourceMetadata?: JsonValue;
+  /**
+   * Optional filter applied to this table during the initial snapshot.
+   *
+   * Resolved from the sync config's global `initial_snapshot_filters`.
+   */
+  initialSnapshotFilter?: InitialSnapshotFilter;
 }
 
 export interface TableSnapshotStatus {
@@ -154,6 +161,10 @@ export class SourceTable {
     return this.options.sourceMetadata ?? null;
   }
 
+  get initialSnapshotFilter() {
+    return this.options.initialSnapshotFilter;
+  }
+
   /**
    * Sanitized name of the entity in the format of "{schema}.{entity name}".
    * Suitable for safe use in Postgres queries.
@@ -192,7 +203,8 @@ export class SourceTable {
       bucketDataSourceIds: this.bucketDataSourceIds == null ? undefined : new Set(this.bucketDataSourceIds),
       parameterLookupSourceIds:
         this.parameterLookupSourceIds == null ? undefined : new Set(this.parameterLookupSourceIds),
-      sourceMetadata: structuredClone(sourceMetadata)
+      sourceMetadata: structuredClone(sourceMetadata),
+      initialSnapshotFilter: this.initialSnapshotFilter
     });
     copy.syncData = this.syncData;
     copy.syncParameters = this.syncParameters;

--- a/packages/service-core/test/src/storage/sync_plan_persistence.test.ts
+++ b/packages/service-core/test/src/storage/sync_plan_persistence.test.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_TAG, PrecompiledSyncConfig } from '@powersync/service-sync-rules';
+import { describe, expect, test } from 'vitest';
+import * as storage from '../../../src/storage/storage-index.js';
+
+// With `edition: 3`, sync configs are persisted together with a compiled sync plan, and replication restores
+// the config from the stored plan instead of re-parsing the YAML (see parsePersistedSyncConfigContent).
+// Everything that lives outside the plan itself — like initial snapshot filters — must survive that round-trip.
+const SYNC_RULES_YAML = `
+initial_snapshot_filters:
+  lists:
+    sql: "archived = false"
+  "%":
+    sql: "deleted_at IS NULL"
+
+streams:
+  global:
+    query: SELECT * FROM lists
+
+config:
+  edition: 3
+`;
+
+function roundTrip(mutate?: (stored: any) => void) {
+  const update = storage.updateSyncRulesFromYaml(SYNC_RULES_YAML, { validate: true });
+  expect(update.config.plan).not.toBeNull();
+
+  // Simulate persistence of the serialized plan (JSONB for the Postgres storage module).
+  const stored = JSON.parse(JSON.stringify(update.config.plan));
+  mutate?.(stored);
+
+  return storage.parsePersistedSyncConfigContent({
+    content: update.config.yaml,
+    compiledPlan: stored,
+    storageVersion: update.config.parsed.config.storageVersion ?? 1,
+    parseOptions: { defaultSchema: 'public' }
+  });
+}
+
+describe('sync plan persistence', () => {
+  test('initial snapshot filters survive the compiled plan round-trip', () => {
+    const { config } = roundTrip();
+    expect(config).toBeInstanceOf(PrecompiledSyncConfig);
+
+    expect(config.getInitialSnapshotFilter(DEFAULT_TAG, 'public', 'lists')).toEqual({ sql: 'archived = false' });
+    // The specific entry must keep winning over the wildcard after the round-trip (first match wins).
+    expect(config.getInitialSnapshotFilter(DEFAULT_TAG, 'public', 'other_table')).toEqual({
+      sql: 'deleted_at IS NULL'
+    });
+  });
+
+  test('plans stored before filters were serialized are treated as having no filters', () => {
+    const { config } = roundTrip((stored) => {
+      delete stored.initialSnapshotFilters;
+    });
+    expect(config).toBeInstanceOf(PrecompiledSyncConfig);
+    expect(config.getInitialSnapshotFilter(DEFAULT_TAG, 'public', 'lists')).toBeUndefined();
+  });
+});

--- a/packages/sync-rules/src/HydratedSyncConfig.ts
+++ b/packages/sync-rules/src/HydratedSyncConfig.ts
@@ -10,6 +10,7 @@ import {
   GetQuerierOptions,
   HydrateSyncConfigParams,
   HydrationInput,
+  InitialSnapshotFilter,
   isEvaluatedParameters,
   isEvaluatedRow,
   isEvaluationError,
@@ -156,6 +157,16 @@ export class HydratedSyncConfig {
 
   tableSyncsParameters(table: SourceTableRef): boolean {
     return this.sourceDefinitions.some((definition) => definition.tableSyncsParameters(table));
+  }
+
+  getInitialSnapshotFilter(table: SourceTableRef): InitialSnapshotFilter | undefined {
+    for (const definition of this.sourceDefinitions) {
+      const filter = definition.getInitialSnapshotFilter(table.connectionTag, table.schema, table.name);
+      if (filter != null) {
+        return filter;
+      }
+    }
+    return undefined;
   }
 
   getMatchingSources(source: SourceTableRef): MatchingSources {

--- a/packages/sync-rules/src/SyncConfig.ts
+++ b/packages/sync-rules/src/SyncConfig.ts
@@ -14,6 +14,19 @@ import { SqliteInputValue, SqliteRow, SqliteValue } from './types.js';
 import { applyRowContext } from './utils.js';
 
 /**
+ * Filter definition for initial snapshot replication.
+ * Object with database-specific filters:
+ *   - sql: MySQL, PostgreSQL, SQL Server syntax
+ *   - mongo: MongoDB query syntax (BSON/EJSON format)
+ */
+export type InitialSnapshotFilter = {
+  sql?: string;
+  mongo?: any;
+};
+
+export type DatabaseType = 'sql' | 'mongo';
+
+/**
  * A class describing how the sync process has been configured (i.e. which buckets and parameters to create and how to
  * resolve buckets for connections).
  */
@@ -22,6 +35,13 @@ export abstract class SyncConfig {
   bucketParameterLookupSources: ParameterIndexLookupCreator[] = [];
   bucketSources: BucketSource[] = [];
   compatibility: CompatibilityContext = CompatibilityContext.FULL_BACKWARDS_COMPATIBILITY;
+
+  /**
+   * Global initial snapshot filters for source tables.
+   * Map structure: tableName -> initialSnapshotFilter
+   * Filters are applied globally during initial snapshot, regardless of bucket definitions.
+   */
+  initialSnapshotFilters: Map<string, InitialSnapshotFilter> = new Map();
   /**
    * If not defined, the storage module picks the latest stable version.
    *
@@ -120,6 +140,56 @@ export abstract class SyncConfig {
 
   debugRepresentation() {
     return this.bucketSources.map((rules) => rules.debugRepresentation());
+  }
+
+  /**
+   * Get the initial snapshot filter for a given table.
+   * Filters are applied globally and support wildcard matching.
+   *
+   * When called without `dbType`, returns the full filter object.
+   * When called with `dbType`, returns only the filter value for that database type.
+   *
+   * @param connectionTag Connection tag for the active source connection
+   * @param schema Schema name
+   * @param tableName Concrete table name (wildcards are allowed in the filter patterns, not here)
+   * @param dbType Optional database type ('sql' or 'mongo'). When provided, extracts the specific filter value.
+   */
+  getInitialSnapshotFilter(connectionTag: string, schema: string, tableName: string): InitialSnapshotFilter | undefined;
+  getInitialSnapshotFilter(connectionTag: string, schema: string, tableName: string, dbType: DatabaseType): any;
+  getInitialSnapshotFilter(
+    connectionTag: string,
+    schema: string,
+    tableName: string,
+    dbType?: DatabaseType
+  ): InitialSnapshotFilter | any | undefined {
+    for (const [pattern, filterDef] of this.initialSnapshotFilters) {
+      const tablePattern = this.parseTablePattern(connectionTag, schema, pattern);
+      if (tablePattern.matches({ connectionTag, schema, name: tableName })) {
+        if (dbType !== undefined) {
+          return filterDef[dbType];
+        }
+        return filterDef;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Helper to parse a table pattern string into a TablePattern object
+   */
+  private parseTablePattern(connectionTag: string, defaultSchema: string, pattern: string): TablePattern {
+    const parts = pattern.split('.');
+    if (parts.length === 1) {
+      return new TablePattern(`${connectionTag}.${defaultSchema}`, parts[0]);
+    }
+    if (parts.length === 2) {
+      return new TablePattern(`${connectionTag}.${parts[0]}`, parts[1]);
+    }
+    const tag = parts[0];
+    const schema = parts[1];
+    const tableName = parts.slice(2).join('.');
+    return new TablePattern(`${tag}.${schema}`, tableName);
   }
 }
 export interface SyncConfigWithErrors {

--- a/packages/sync-rules/src/from_yaml.ts
+++ b/packages/sync-rules/src/from_yaml.ts
@@ -16,7 +16,7 @@ import { syncStreamFromSql } from './legacy/streams/from_sql.js';
 import { SqlSyncRules } from './SqlSyncRules.js';
 import { validateStorageVersion } from './StorageVersion.js';
 import { PrecompiledSyncConfig } from './sync_plan/evaluator/index.js';
-import { SyncConfig, SyncConfigWithErrors } from './SyncConfig.js';
+import { InitialSnapshotFilter, SyncConfig, SyncConfigWithErrors } from './SyncConfig.js';
 import { TablePattern } from './TablePattern.js';
 import { QueryParseOptions, SourceSchema, StreamParseOptions } from './types.js';
 import { buildParsedToSourceValueMap, isBlockScalar, isQuotedScalar } from './yaml_scalar_map.js';
@@ -132,10 +132,51 @@ export class SyncConfigFromYaml {
 
     result.storageVersion = storageVersion;
 
+    const filtersMap = rootState.get('initial_snapshot_filters')?.requireMap();
+    if (filtersMap != null) {
+      this.#parseInitialSnapshotFilters(filtersMap, result);
+    }
+
     const eventDefinitions = this.#parseEventDefinitions(rootState, compatibility);
     result.eventDescriptors.push(...eventDefinitions);
 
     return result;
+  }
+
+  /**
+   * Parses the global `initial_snapshot_filters` configuration.
+   *
+   * Filters are applied per source table during the initial snapshot, regardless of
+   * bucket definitions. Table keys support the same patterns as bucket queries,
+   * including schema and table wildcards.
+   */
+  #parseInitialSnapshotFilters(filtersMap: YamlMapState, result: SyncConfig) {
+    for (const entry of filtersMap.stringKeyedItems()) {
+      using filterState = entry.value.requireMap(
+        `Initial snapshot filter for table '${entry.key}' must be an object with 'sql' and/or 'mongo' properties`
+      );
+      if (filterState == null) {
+        continue;
+      }
+
+      const filter: InitialSnapshotFilter = {};
+      const sql = filterState.get('sql')?.requireScalar()?.requireString();
+      if (sql != null) {
+        filter.sql = sql;
+      }
+      const mongoState = filterState.get('mongo');
+      if (mongoState != null) {
+        filter.mongo = mongoState.node.toJSON();
+      }
+
+      if (filter.sql === undefined && filter.mongo === undefined) {
+        filterState.reportError(
+          `Initial snapshot filter for table '${entry.key}' must have at least a 'sql' or 'mongo' property`
+        );
+        continue;
+      }
+      result.initialSnapshotFilters.set(entry.key, filter);
+    }
   }
 
   get #hasFatalError(): boolean {

--- a/packages/sync-rules/src/index.ts
+++ b/packages/sync-rules/src/index.ts
@@ -19,7 +19,7 @@ export * from './sqliteBool.js';
 export * from './SqlSyncRules.js';
 export * from './StaticSchema.js';
 export * from './StorageVersion.js';
-export { SyncConfig, SyncConfigWithErrors } from './SyncConfig.js';
+export { DatabaseType, InitialSnapshotFilter, SyncConfig, SyncConfigWithErrors } from './SyncConfig.js';
 export * from './TablePattern.js';
 export * from './types.js';
 export * from './types/custom_sqlite_value.js';

--- a/packages/sync-rules/src/json_schema.ts
+++ b/packages/sync-rules/src/json_schema.ts
@@ -8,6 +8,38 @@ const ajv = new Ajv({ allErrors: true, verbose: true });
 export const syncRulesSchema: ajvModule.Schema = {
   type: 'object',
   properties: {
+    initial_snapshot_filters: {
+      type: 'object',
+      description: 'Global filters applied during initial snapshot replication for specific tables',
+      examples: [
+        {
+          users: {
+            sql: "status = 'active'",
+            mongo: { status: 'active' }
+          },
+          orders: {
+            sql: "created_at > now() - interval '90 days'"
+          }
+        }
+      ],
+      patternProperties: {
+        '.*': {
+          type: 'object',
+          description: 'Database-specific filter syntax for a table',
+          properties: {
+            sql: {
+              type: 'string',
+              description: 'SQL WHERE clause for MySQL, PostgreSQL, SQL Server'
+            },
+            mongo: {
+              description: 'MongoDB query filter (BSON/EJSON format) - can be any valid MongoDB query object'
+            }
+          },
+          additionalProperties: false,
+          minProperties: 1
+        }
+      }
+    },
     bucket_definitions: {
       type: 'object',
       description: 'List of bucket definitions',


### PR DESCRIPTION
## Background

This is the Postgres subset of the prefiltering work in #502, which we've been running in our staging environment (schema-per-tenant, 4 tenant schemas, largest table 13.6M rows). It follows the direction from that discussion: filters are global rather than per-definition, keyed by table patterns with the same wildcard support as bucket queries, and `sql` as the database-specific key so other syntaxes can be added later.

## What this does

Adds a global `initial_snapshot_filters` section to the sync config, mapping table patterns (including schema and table wildcards) to a SQL WHERE clause applied during the initial snapshot:

```yaml
initial_snapshot_filters:
  maint_order_activities:
    sql: "ps_metadata IS NOT NULL AND deleted_at IS NULL"
  "%":
    sql: "deleted_at IS NULL"
```

Matching is first-match-wins, so specific tables go before wildcard patterns. The filter is applied in all snapshot query types, including the chunked resume path and row re-fetches during streaming. Rows excluded by the filter are skipped by the source database instead of being read, evaluated and discarded by the service, and never enter `current_data`.

The second commit fixes an interaction with compiled sync plans: with `config.edition: 3` the deploy persists a compiled plan, and replication rebuilds the config from the stored plan (`parsePersistedSyncConfigContent`), which did not restore `initialSnapshotFilters`. The filters parsed and validated fine but never reached the snapshot. They are now persisted alongside the plan (the same treatment `eventDescriptors` already get) as an ordered list of `{pattern, filter}` pairs, since matching is first-match-wins and JSONB storage does not preserve object key order. Plans stored before this field existed are treated as having no filters.

The third commit fixes the snapshot progress reported in the logs. `estimatedCountNumber` reads `reltuples` from `pg_class`, which covers the whole table, so with a selective filter the `To replicate` and `Replicating N/~total` lines (and the persisted `total_estimated_count`) kept showing the full table size, 13.6M for a snapshot of ~282k rows. When the table has a filter, the estimate now comes from the planner's row estimate for the filtered query (`EXPLAIN (FORMAT JSON)`), which uses the same statistics as `reltuples` without reading the table. A `count(*)` would be exact, but would scan every table before the snapshot starts and again on each 10 minute re-estimate. Tables without a filter, or without statistics yet, behave as before.

## Results

On our largest tenant the initial snapshot of a 13.6M row table went from reading all rows to only the ~282k matching the filter (~2% working set), and the full multi-tenant snapshot completes in minutes instead of hours.

One operational note that may be worth a line in the docs: a selective filter on a big table needs an index matching the predicate, since the chunked snapshot query is `WHERE <filter> ORDER BY pk LIMIT n`. Without one, our first chunk on that table took 8m38s, which blows the snapshot socket timeout and leaves the table retrying. With a partial index on `(id)` using the same predicate, 2.6s.

## Tests

- module-postgres: filtered chunked snapshot with resume, a bare table name pattern matching the same table across multiple schemas, and an edition-3 test that reloads the config from storage before replicating, covering the persisted-plan path. That last test is also what caught the filters not being applied with MongoDB bucket storage: the other test queries filter the same rows as the snapshot filter, so they pass either way, while the edition-3 test selects all rows and lets the row count measure the filter.
- module-postgres (progress estimate): resolves a filtered table, runs `ANALYZE` and checks that the estimate lands near the 150 matching rows rather than the ~1000 row table estimate.
- service-core: round-trip test for filters through compiled plan persistence, including pattern ordering and plans persisted before the field existed.

