### PR TITLE
Add storage.default_storage_version option

### DIFF
--- a/.changeset/thick-shrimps-thank.md
+++ b/.changeset/thick-shrimps-thank.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+'@powersync/service-types': patch
+---
+
+Add storage.default_storage_version config option.

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -42,6 +42,7 @@ export interface MongoBucketStorageOptions {
   readPreference?: mongo.ReadPreference;
   checksumCacheTtlMs?: number;
   clearBatchThrottleRate?: number;
+  defaultStorageVersion?: number;
   /**
    * Reuse a compatible active replication stream by appending a new sync config.
    *
@@ -478,7 +479,10 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
 
   async updateSyncRules(options: storage.UpdateSyncRulesOptions): Promise<MongoPersistedReplicationStream> {
     const storageVersion =
-      options.storageVersion ?? options.config.parsed.config.storageVersion ?? storage.CURRENT_STORAGE_VERSION;
+      options.storageVersion ??
+      options.config.parsed.config.storageVersion ??
+      this.options.defaultStorageVersion ??
+      storage.CURRENT_STORAGE_VERSION;
 
     const storageConfig = getMongoStorageConfig(storageVersion);
     if (storageConfig.incrementalReprocessing) {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoStorageProvider.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoStorageProvider.ts
@@ -69,6 +69,7 @@ export class MongoStorageProvider implements storage.StorageProvider {
       readPreference,
       clearBatchThrottleRate: normalizeClearBatchThrottleRate(decodedConfig.clear_batch_throttle_rate),
       checksumCacheTtlMs: resolvedConfig.api_parameters.bucket_count_cache_ttl_minutes * 60_000,
+      defaultStorageVersion: decodedConfig.default_storage_version,
       // Right now, only MongoDB source databases supports incremental reprocessing.
       // Remove this filter when we support it for other source databases.
       // This assumes a single source connection - revisit if we ever support multiple connections.

--- a/modules/module-mongodb-storage/src/types/types.ts
+++ b/modules/module-mongodb-storage/src/types/types.ts
@@ -27,7 +27,7 @@ export const MongoStorageReadPreference = t
 
 export type MongoStorageReadPreference = t.Encoded<typeof MongoStorageReadPreference>;
 
-export const MongoStorageConfig = lib_mongo.BaseMongoConfig.and(
+export const MongoStorageConfig = service_types.configFile.BaseStorageConfig.and(lib_mongo.BaseMongoConfig).and(
   t.object({
     /**
      * Read preference for bulk checksum and bucket data reads.

--- a/modules/module-postgres-storage/src/storage/PostgresBucketStorageFactory.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresBucketStorageFactory.ts
@@ -15,6 +15,7 @@ export type PostgresBucketStorageOptions = {
   config: NormalizedPostgresStorageConfig;
   replicationStreamNamePrefix: string;
   checksumCacheTtlMs?: number;
+  defaultStorageVersion?: number;
 };
 
 export class PostgresBucketStorageFactory extends storage.BucketStorageFactory {
@@ -156,7 +157,10 @@ export class PostgresBucketStorageFactory extends storage.BucketStorageFactory {
 
   async updateSyncRules(options: storage.UpdateSyncRulesOptions): Promise<PostgresPersistedReplicationStream> {
     const storageVersion =
-      options.storageVersion ?? options.config.parsed.config.storageVersion ?? storage.CURRENT_STORAGE_VERSION;
+      options.storageVersion ??
+      options.config.parsed.config.storageVersion ??
+      this.options.defaultStorageVersion ??
+      storage.CURRENT_STORAGE_VERSION;
     const storageConfig = storage.STORAGE_VERSION_CONFIG[storageVersion];
     if (storageConfig == null) {
       throw new framework.ServiceError(

--- a/modules/module-postgres-storage/src/storage/PostgresStorageProvider.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresStorageProvider.ts
@@ -28,7 +28,8 @@ export class PostgresStorageProvider implements storage.StorageProvider {
     const storageFactory = new PostgresBucketStorageFactory({
       config: normalizedConfig,
       replicationStreamNamePrefix: options.resolvedConfig.slot_name_prefix,
-      checksumCacheTtlMs: options.resolvedConfig.api_parameters.bucket_count_cache_ttl_minutes * 60_000
+      checksumCacheTtlMs: options.resolvedConfig.api_parameters.bucket_count_cache_ttl_minutes * 60_000,
+      defaultStorageVersion: decodedConfig.default_storage_version
     });
 
     const reportStorageFactory = new PostgresReportStorage({

--- a/packages/service-core/src/util/config/compound-config-collector.ts
+++ b/packages/service-core/src/util/config/compound-config-collector.ts
@@ -1,4 +1,5 @@
 import { logger, LookupOptions } from '@powersync/lib-services-framework';
+import { validateStorageVersion } from '@powersync/service-sync-rules';
 import { configFile } from '@powersync/service-types';
 import * as auth from '../../auth/auth-index.js';
 import { ConfigCollector } from './collectors/config-collector.js';
@@ -61,6 +62,11 @@ export class CompoundConfigCollector {
    */
   async collectConfig(runnerConfig: RunnerConfig = {}): Promise<ResolvedPowerSyncConfig> {
     const baseConfig = await this.collectBaseConfig(runnerConfig);
+
+    const defaultStorageVersion = baseConfig.storage?.default_storage_version;
+    if (defaultStorageVersion != null && validateStorageVersion(defaultStorageVersion) == null) {
+      throw new Error(`Storage version ${defaultStorageVersion} is not supported`);
+    }
 
     const dataSources = baseConfig.replication?.connections ?? [];
     if (dataSources.length > 1) {

--- a/packages/service-core/test/src/config.test.ts
+++ b/packages/service-core/test/src/config.test.ts
@@ -70,6 +70,44 @@ describe('Config', () => {
     expect(config.api_parameters.max_buckets_per_connection).toBe(1);
   });
 
+  it('should resolve the storage default version', {}, async () => {
+    const yamlConfig = /* yaml */ `
+      # PowerSync config
+      replication:
+        connections: []
+      storage:
+        type: mongodb
+        default_storage_version: 3
+    `;
+
+    const collector = new CompoundConfigCollector();
+
+    const config = await collector.collectConfig({
+      config_base64: Buffer.from(yamlConfig, 'utf-8').toString('base64')
+    });
+
+    expect(config.storage.default_storage_version).toBe(3);
+  });
+
+  it.each([1, 1.5, 4])('should reject unsupported storage default version %s', async (defaultStorageVersion) => {
+    const yamlConfig = /* yaml */ `
+      # PowerSync config
+      replication:
+        connections: []
+      storage:
+        type: mongodb
+        default_storage_version: ${defaultStorageVersion}
+    `;
+
+    const collector = new CompoundConfigCollector();
+
+    await expect(
+      collector.collectConfig({
+        config_base64: Buffer.from(yamlConfig, 'utf-8').toString('base64')
+      })
+    ).rejects.toThrow(`Storage version ${defaultStorageVersion} is not supported`);
+  });
+
   it('should resolve checkpoint request retention config', {}, async () => {
     const yamlConfig = /* yaml */ `
       # PowerSync config

--- a/packages/types/src/config/PowerSyncConfig.ts
+++ b/packages/types/src/config/PowerSyncConfig.ts
@@ -257,6 +257,12 @@ export const BaseStorageConfig = t
       .meta({
         description: 'Maximum number of connections to the storage database, per process. Defaults to 8.'
       })
+      .optional(),
+    default_storage_version: t.number
+      .meta({
+        description:
+          'Storage version to use when deploying a sync config that does not specify storage_version. Defaults to 2.'
+      })
       .optional()
   })
   .meta({


### PR DESCRIPTION
Add `storage.default_storage_version` option, to override the current default storage version 2.

This is used only for sync config updates, only when `config.storage_version` is not defined in the sync config. Changing this value does not trigger sync config updates by itself, unlike `config.storage_version` in the sync config.

The main use case for this is for PowerSync Cloud: This allows us to opt-in specific instances to newer storage versions, before rolling it out as the default for everyone, and without having to modify the sync config.

For self-hosting, the recommended path remains to configure `config.storage_version` directly in the sync config.

## AI Usage

Used Codex gpt-5.6 to implement.