### PR TITLE
Add S3 timing info for sync checkpoints

### DIFF
--- a/.changeset/breezy-tables-beam.md
+++ b/.changeset/breezy-tables-beam.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+---
+
+Add S3 timing info for sync checkpoints.

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -670,7 +670,7 @@ export async function* getBucketDataBatchV3(
     // Hydrate any operations from object storage.
     // In the future we can do this in a more pipelined fashion, but for now we hydrate
     // the entire batch at once.
-    await hydrateBucketDataDocuments(docs, ctx.objectStorage, { signal: options?.signal });
+    await hydrateBucketDataDocuments(docs, ctx.objectStorage, { signal: options?.signal, tracer: options?.tracer });
 
     let currentChunkSizeBytes = 0;
     let currentChunk: utils.SyncBucketData | null = null;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/BucketDataObjectStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/BucketDataObjectStorage.ts
@@ -1,4 +1,4 @@
-import { storage } from '@powersync/service-core';
+import { PerformanceTracer, storage } from '@powersync/service-core';
 import * as bson from 'bson';
 import { BucketDataDocumentV3, BucketOperation } from '../models.js';
 import { ObjectStorage, ObjectStorageOperationOptions } from './ObjectStorage.js';
@@ -41,7 +41,7 @@ export class BucketDataObjectStorage {
 export async function hydrateBucketDataDocuments(
   documents: BucketDataDocumentV3[],
   objectStorage: ObjectStorage | undefined,
-  options: ObjectStorageOperationOptions
+  options: ObjectStorageOperationOptions & { tracer?: PerformanceTracer<string> }
 ): Promise<void> {
   if (!objectStorage) {
     return;
@@ -50,6 +50,10 @@ export async function hydrateBucketDataDocuments(
   options.signal?.throwIfAborted();
   const store = new BucketDataObjectStorage(objectStorage);
   const storedDocuments = documents.filter((document) => document.storage_ref);
+  if (storedDocuments.length == 0) {
+    return;
+  }
+  using _ = options?.tracer?.span('s3', 'read');
   await Promise.all(
     storedDocuments.map(async (document) => {
       document.ops = await store.retrieve(document.storage_ref!.path, { signal: options.signal });

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -456,6 +456,9 @@ export interface BucketDataBatchOptions {
   /** Abort any in-progress work for this batch, including object-storage downloads. */
   signal?: AbortSignal;
 
+  /** Traces data reads performed by the storage implementation. */
+  tracer?: PerformanceTracer<string>;
+
   /** Limit number of documents returned. Defaults to 1000. */
   limit?: number;
 

--- a/packages/service-core/src/sync/BucketChecksumState.ts
+++ b/packages/service-core/src/sync/BucketChecksumState.ts
@@ -39,7 +39,9 @@ export type SyncCheckpointTraceCategory =
   // Data fetches. Holds one data lock for this period.
   | 'bucket_data'
   // Sending data to client, may include serialization overhead. Holds one data lock for this period in most cases.
-  | 'sending';
+  | 'sending'
+  // Time spent reading concurrent S3 requests, counted once per batch.
+  | 's3';
 
 export interface BucketChecksumStateOptions {
   syncContext: SyncContext;

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -437,7 +437,6 @@ async function* bucketDataBatch(
   } = request;
 
   const tracer = request.tracer;
-
   let checkpointInvalidated = false;
 
   const acquired = await tracer.span('acquiring_lock').with(async () => {
@@ -456,6 +455,7 @@ async function* bucketDataBatch(
     const filteredBuckets = checkpointLine.getFilteredBucketPositions(bucketsToFetch);
     const dataBatches = storage.getBucketDataBatch(checkpoint, filteredBuckets, {
       requestHint,
+      tracer,
       // Checkpoint supersession is a cooperative batch handoff. Only abort
       // in-flight storage work when the connection itself is closed.
       signal: abort_connection


### PR DESCRIPTION
This adds separate `s3` timing info for `checkpoint_complete` logs:

```
info: checkpoint_complete: 40201382 {"bson":false,"checkpoint":40201382,"client_id":"load-test-64","data_synced_bytes":50,"ms":{"acquiring_lock":24349,"bucket_data":348,"checksum":2,"other":2,"s3":1423,"sending":651,"total":26775},"operations_synced":0,"rid":"h/01a033c4-b6b5-715f-9668-b19721c2cfc5","route":"/sync/stream","user_id":"user-0002"}
```

Before, that was lumped under `bucket_data`. This now splits out the time waiting for S3 from the time waiting for MongoDB.

The current implementation executes all S3 reads for a single batch concurrently, with no database operation for that batch running at the same time. That makes these timings simple to implement and reason about. If we ever change to a pipeline-style approach where S3 reads can execute concurrently with database operations for the same batch, we'll have to tweak this.

S3 timings for replication would be a separate project, and is unfortunately a little more complex.

## AI Usage

Implemented using Codex gpt-5.6; manually tweaked and simplified.