### PR TITLE
S3 storage stats

### DIFF
--- a/.changeset/frank-teams-shout.md
+++ b/.changeset/frank-teams-shout.md
@@ -1,0 +1,8 @@
+---
+'@powersync/service-module-mongodb-storage': minor
+'@powersync/service-core': minor
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-types': patch
+---
+
+Add object storage metrics, split by replication stream.

--- a/.changeset/frank-teams-shout.md
+++ b/.changeset/frank-teams-shout.md
@@ -5,4 +5,4 @@
 '@powersync/service-types': patch
 ---
 
-Add object storage metrics, split by replication stream.
+Add object storage metrics, and storage metrics split by sync config.

--- a/libs/lib-mongodb/src/db/mongo.ts
+++ b/libs/lib-mongodb/src/db/mongo.ts
@@ -111,6 +111,10 @@ export const isMongoServerError = (error: any): error is mongo.MongoServerError 
   return error instanceof mongo.MongoServerError || error?.name == 'MongoServerError';
 };
 
+export const isMongoNamespaceNotFoundError = (error: unknown): error is mongo.MongoServerError => {
+  return isMongoServerError(error) && error.codeName === 'NamespaceNotFound';
+};
+
 export const isMongoNetworkTimeoutError = (error: any): error is mongo.MongoNetworkTimeoutError => {
   return error instanceof mongo.MongoNetworkTimeoutError || error?.name == 'MongoNetworkTimeoutError';
 };

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -783,7 +783,7 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
 
   async getStorageMetrics(): Promise<storage.StorageMetrics> {
     const ignoreNotExisting = (e: unknown) => {
-      if (lib_mongo.isMongoServerError(e) && e.codeName == 'NamespaceNotFound') {
+      if (lib_mongo.isMongoNamespaceNotFoundError(e)) {
         // Collection doesn't exist - return 0
         return [{ storageStats: { size: 0 } }];
       } else {

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -794,9 +794,6 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
       }
     };
 
-    // For now, we get storage metrics over all v1 and v3 collections.
-    // In the future, we may split these metrics to report separately for active replication streams versus processing streams.
-
     const aggregateStaticCollection = async <T extends mongo.Document>(collection: mongo.Collection<T>) => {
       // We check whether the collection exists before getting the statistics. This avoids repeated
       // errors in the MongoDB logs if the collection hasn't been created yet.
@@ -820,8 +817,9 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
     };
 
     const operations_aggregate = await aggregateStaticCollection(this.db.bucket_data);
+    const v3OperationCollections = await this.db.listBucketDataCollectionsV3();
     const v3_operation_aggregates = await Promise.all(
-      (await this.db.listBucketDataCollectionsV3()).map((collection) =>
+      v3OperationCollections.map((collection) =>
         collection
           .aggregate([
             {
@@ -837,8 +835,9 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
 
     const parameters_aggregate = await aggregateStaticCollection(this.db.bucket_parameters);
 
+    const v3ParameterCollections = await this.db.listAllParameterIndexCollectionsV3();
     const v3_parameter_aggregates = await Promise.all(
-      (await this.db.listAllParameterIndexCollectionsV3()).map((collection) =>
+      v3ParameterCollections.map((collection) =>
         collection
           .aggregate([
             {
@@ -854,8 +853,9 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
 
     const v1_source_record_aggregate = await aggregateStaticCollection(this.db.current_data);
 
+    const v3SourceRecordCollections = await this.db.listAllSourceRecordCollectionsV3();
     const source_record_aggregates = await Promise.all(
-      (await this.db.listAllSourceRecordCollectionsV3()).map((collection) =>
+      v3SourceRecordCollections.map((collection) =>
         collection
           .aggregate([
             {
@@ -868,6 +868,62 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
           .catch(ignoreNotExisting)
       )
     );
+
+    const v3StorageConfig = getMongoStorageConfig(storage.STORAGE_VERSION_3) as StorageConfig & {
+      incrementalReprocessing: true;
+    };
+    const v3Db = this.db.versioned(v3StorageConfig) as VersionedPowerSyncMongoV3;
+    const objectStorageUsage = await ObjectStorageUsage.readAllStreamUsage(v3Db);
+    const objectStorageUsageByStream = new Map(
+      objectStorageUsage.map((usage) => [usage.replication_stream_id, usage.active_bytes])
+    );
+
+    const v3StreamDocs = await this.db.sync_rules
+      .find(
+        { storage_version: { $gte: storage.STORAGE_VERSION_3 } },
+        { projection: { _id: 1, state: 1, storage_version: 1 } }
+      )
+      .toArray();
+    const streamMetrics = new Map<number, storage.StorageStreamMetrics>();
+    for (const stream of v3StreamDocs) {
+      streamMetrics.set(stream._id, {
+        replication_stream_id: stream._id,
+        stream_state: String(stream.state),
+        operations_size_bytes: 0,
+        parameters_size_bytes: 0,
+        replication_size_bytes: 0,
+        object_storage_size_bytes: Number(objectStorageUsageByStream.get(stream._id) ?? 0n)
+      });
+    }
+
+    const addStreamCollectionSize = (
+      collection: { collectionName: string },
+      aggregate: { storageStats?: { size?: number | bigint } }[],
+      prefix: string,
+      key: 'operations_size_bytes' | 'parameters_size_bytes' | 'replication_size_bytes'
+    ) => {
+      const match = collection.collectionName.match(new RegExp(`^${prefix}(\\d+)_`));
+      if (match == null) {
+        return;
+      }
+      const stream = streamMetrics.get(Number(match[1]));
+      if (stream == null) {
+        return;
+      }
+      stream[key] += Number(aggregate[0]?.storageStats?.size ?? 0);
+    };
+
+    v3OperationCollections.forEach((collection, index) =>
+      addStreamCollectionSize(collection, v3_operation_aggregates[index], 'bucket_data_', 'operations_size_bytes')
+    );
+    v3ParameterCollections.forEach((collection, index) =>
+      addStreamCollectionSize(collection, v3_parameter_aggregates[index], 'parameter_index_', 'parameters_size_bytes')
+    );
+    v3SourceRecordCollections.forEach((collection, index) =>
+      addStreamCollectionSize(collection, source_record_aggregates[index], 'source_records_', 'replication_size_bytes')
+    );
+
+    const totalObjectStorageSize = objectStorageUsage.reduce((total, usage) => total + usage.active_bytes, 0n);
     return {
       operations_size_bytes:
         Number(operations_aggregate[0].storageStats.size) +
@@ -877,7 +933,9 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
         v3_parameter_aggregates.reduce((total, aggregate) => total + Number(aggregate[0].storageStats.size), 0),
       replication_size_bytes:
         Number(v1_source_record_aggregate[0]?.storageStats?.size ?? 0) +
-        source_record_aggregates.reduce((total, aggregate) => total + Number(aggregate[0]?.storageStats?.size ?? 0), 0)
+        source_record_aggregates.reduce((total, aggregate) => total + Number(aggregate[0]?.storageStats?.size ?? 0), 0),
+      object_storage_size_bytes: Number(totalObjectStorageSize),
+      stream_metrics: [...streamMetrics.values()]
     };
   }
 

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -900,9 +900,13 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
       addCollectionSize(collection, source_record_aggregates[index], 'source_records_', collectionSizes)
     );
 
-    const syncConfigIds = v3StreamDocs.flatMap((stream) => stream.sync_configs.map((config) => config._id));
+    const syncConfigIds = v3StreamDocs.flatMap((stream) => (stream.sync_configs ?? []).map((config) => config._id));
     const syncConfigDefinitions =
-      syncConfigIds.length == 0 ? [] : await v3Db.syncConfigDefinitions.find({ _id: { $in: syncConfigIds } }).toArray();
+      syncConfigIds.length == 0
+        ? []
+        : await v3Db.syncConfigDefinitions
+            .find({ _id: { $in: syncConfigIds } }, { projection: { _id: 1, rule_mapping: 1 } })
+            .toArray();
     const syncConfigDefinitionsById = new Map(
       syncConfigDefinitions.map((definition) => [definition._id.toHexString(), definition])
     );
@@ -929,13 +933,13 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
       );
     }
 
-    const sumCollectionSizes = (prefix: string, streamId: number, ids: string[]) =>
-      ids.reduce((total, id) => total + (collectionSizes.get(`${prefix}${streamId}:${id}`) ?? 0), 0);
+    const sumCollectionSizes = (prefix: string, streamId: number, ids: ReadonlySet<string>) =>
+      [...ids].reduce((total, id) => total + (collectionSizes.get(`${prefix}${streamId}:${id}`) ?? 0), 0);
 
     const syncConfigMetrics: storage.StorageSyncConfigMetrics[] = [];
     for (const stream of v3StreamDocs) {
       const sourceTables = sourceTablesByStream.get(stream._id) ?? [];
-      for (const syncConfig of stream.sync_configs) {
+      for (const syncConfig of stream.sync_configs ?? []) {
         const definition = syncConfigDefinitionsById.get(syncConfig._id.toHexString());
         if (definition == null) {
           continue;
@@ -959,10 +963,10 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
         syncConfigMetrics.push({
           sync_config_id: syncConfig._id.toHexString(),
           sync_config_state: String(syncConfig.state),
-          operations_size_bytes: sumCollectionSizes('bucket_data_', stream._id, bucketDefinitionIds),
-          parameters_size_bytes: sumCollectionSizes('parameter_index_', stream._id, parameterIndexIds),
+          operations_size_bytes: sumCollectionSizes('bucket_data_', stream._id, bucketDefinitionIdSet),
+          parameters_size_bytes: sumCollectionSizes('parameter_index_', stream._id, parameterIndexIdSet),
           replication_size_bytes: replicationSize,
-          object_storage_size_bytes: bucketDefinitionIds.reduce(
+          object_storage_size_bytes: [...bucketDefinitionIdSet].reduce(
             (total, definitionId) => total + (objectStorageSizeByDefinition.get(`${stream._id}:${definitionId}`) ?? 0),
             0
           )

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -34,10 +34,7 @@ import { MongoPersistedReplicationStream } from './implementation/MongoPersisted
 import { stopReplicationStreamPipeline } from './implementation/SyncRuleStateUpdate.js';
 import { SyncRuleDocumentV1 } from './implementation/v1/models.js';
 import { ObjectStorage } from './implementation/v3/object-storage/ObjectStorage.js';
-import {
-  ObjectStorageUsage,
-  ReplicationStreamObjectStorageUsageResult
-} from './implementation/v3/object-storage/ObjectStorageUsage.js';
+import { ObjectStorageUsage } from './implementation/v3/object-storage/ObjectStorageUsage.js';
 import { VersionedPowerSyncMongoV3 } from './implementation/v3/VersionedPowerSyncMongoV3.js';
 import { ReplicationStreamDocumentV3, SyncConfigDefinition, SyncRuleConfigStateV3 } from './storage-index.js';
 
@@ -937,17 +934,6 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
       object_storage_size_bytes: Number(totalObjectStorageSize),
       stream_metrics: [...streamMetrics.values()]
     };
-  }
-
-  /**
-   * Read active object-storage usage for a v3 replication stream without scanning bucket data
-   * or the object store. Streams without usage documents are reported as zero.
-   */
-  async getObjectStorageUsage(replicationStreamId: number): Promise<ReplicationStreamObjectStorageUsageResult> {
-    const db = this.db.versioned(
-      getMongoStorageConfig(storage.STORAGE_VERSION_3) as StorageConfig & { incrementalReprocessing: true }
-    );
-    return new ObjectStorageUsage(db, replicationStreamId).readStreamUsage();
   }
 
   async getPowerSyncInstanceId(): Promise<string> {

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -963,10 +963,10 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
         syncConfigMetrics.push({
           sync_config_id: syncConfig._id.toHexString(),
           sync_config_state: String(syncConfig.state),
-          operations_size_bytes: sumCollectionSizes('bucket_data_', stream._id, bucketDefinitionIdSet),
-          parameters_size_bytes: sumCollectionSizes('parameter_index_', stream._id, parameterIndexIdSet),
-          replication_size_bytes: replicationSize,
-          object_storage_size_bytes: [...bucketDefinitionIdSet].reduce(
+          attributed_bucket_data_bytes: sumCollectionSizes('bucket_data_', stream._id, bucketDefinitionIdSet),
+          attributed_parameter_indexes_bytes: sumCollectionSizes('parameter_index_', stream._id, parameterIndexIdSet),
+          attributed_source_records_bytes: replicationSize,
+          attributed_object_storage_bytes: [...bucketDefinitionIdSet].reduce(
             (total, definitionId) => total + (objectStorageSizeByDefinition.get(`${stream._id}:${definitionId}`) ?? 0),
             0
           )

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -870,57 +870,110 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
       incrementalReprocessing: true;
     };
     const v3Db = this.db.versioned(v3StorageConfig) as VersionedPowerSyncMongoV3;
-    const objectStorageUsage = await ObjectStorageUsage.readAllStreamUsage(v3Db);
-    const objectStorageUsageByStream = new Map(
-      objectStorageUsage.map((usage) => [usage.replication_stream_id, usage.active_bytes])
-    );
+    const objectStorageDefinitionUsage = await ObjectStorageUsage.readAllDefinitionUsage(v3Db);
 
-    const v3StreamDocs = await this.db.sync_rules
-      .find(
-        { storage_version: { $gte: storage.STORAGE_VERSION_3 } },
-        { projection: { _id: 1, state: 1, storage_version: 1 } }
-      )
-      .toArray();
-    const streamMetrics = new Map<number, storage.StorageStreamMetrics>();
-    for (const stream of v3StreamDocs) {
-      streamMetrics.set(stream._id, {
-        replication_stream_id: stream._id,
-        stream_state: String(stream.state),
-        operations_size_bytes: 0,
-        parameters_size_bytes: 0,
-        replication_size_bytes: 0,
-        object_storage_size_bytes: Number(objectStorageUsageByStream.get(stream._id) ?? 0n)
-      });
-    }
+    const v3StreamDocs = (await this.db.sync_rules
+      .find({ storage_version: { $gte: storage.STORAGE_VERSION_3 } }, { projection: { _id: 1, sync_configs: 1 } })
+      .toArray()) as unknown as Pick<ReplicationStreamDocumentV3, '_id' | 'sync_configs'>[];
 
-    const addStreamCollectionSize = (
+    const collectionSizes = new Map<string, number>();
+    const addCollectionSize = (
       collection: { collectionName: string },
       aggregate: { storageStats?: { size?: number | bigint } }[],
       prefix: string,
-      key: 'operations_size_bytes' | 'parameters_size_bytes' | 'replication_size_bytes'
+      sizes: Map<string, number>
     ) => {
-      const match = collection.collectionName.match(new RegExp(`^${prefix}(\\d+)_`));
+      const match = collection.collectionName.match(new RegExp(`^${prefix}(\\d+)_(.+)$`));
       if (match == null) {
         return;
       }
-      const stream = streamMetrics.get(Number(match[1]));
-      if (stream == null) {
-        return;
-      }
-      stream[key] += Number(aggregate[0]?.storageStats?.size ?? 0);
+      sizes.set(`${prefix}${match[1]}:${match[2]}`, Number(aggregate[0]?.storageStats?.size ?? 0));
     };
 
     v3OperationCollections.forEach((collection, index) =>
-      addStreamCollectionSize(collection, v3_operation_aggregates[index], 'bucket_data_', 'operations_size_bytes')
+      addCollectionSize(collection, v3_operation_aggregates[index], 'bucket_data_', collectionSizes)
     );
     v3ParameterCollections.forEach((collection, index) =>
-      addStreamCollectionSize(collection, v3_parameter_aggregates[index], 'parameter_index_', 'parameters_size_bytes')
+      addCollectionSize(collection, v3_parameter_aggregates[index], 'parameter_index_', collectionSizes)
     );
     v3SourceRecordCollections.forEach((collection, index) =>
-      addStreamCollectionSize(collection, source_record_aggregates[index], 'source_records_', 'replication_size_bytes')
+      addCollectionSize(collection, source_record_aggregates[index], 'source_records_', collectionSizes)
     );
 
-    const totalObjectStorageSize = objectStorageUsage.reduce((total, usage) => total + usage.active_bytes, 0n);
+    const syncConfigIds = v3StreamDocs.flatMap((stream) => stream.sync_configs.map((config) => config._id));
+    const syncConfigDefinitions =
+      syncConfigIds.length == 0 ? [] : await v3Db.syncConfigDefinitions.find({ _id: { $in: syncConfigIds } }).toArray();
+    const syncConfigDefinitionsById = new Map(
+      syncConfigDefinitions.map((definition) => [definition._id.toHexString(), definition])
+    );
+
+    const sourceTablesByStream = new Map<
+      number,
+      { _id: ObjectId; bucket_data_source_ids: string[]; parameter_lookup_source_ids: string[] }[]
+    >();
+    await Promise.all(
+      v3StreamDocs.map(async (stream) => {
+        const sourceTables = await v3Db
+          .sourceTables(stream._id)
+          .find({}, { projection: { _id: 1, bucket_data_source_ids: 1, parameter_lookup_source_ids: 1 } })
+          .toArray();
+        sourceTablesByStream.set(stream._id, sourceTables);
+      })
+    );
+
+    const objectStorageSizeByDefinition = new Map<string, number>();
+    for (const usage of objectStorageDefinitionUsage) {
+      objectStorageSizeByDefinition.set(
+        `${usage.replication_stream_id}:${usage.definition_id}`,
+        Number(usage.active_bytes)
+      );
+    }
+
+    const sumCollectionSizes = (prefix: string, streamId: number, ids: string[]) =>
+      ids.reduce((total, id) => total + (collectionSizes.get(`${prefix}${streamId}:${id}`) ?? 0), 0);
+
+    const syncConfigMetrics: storage.StorageSyncConfigMetrics[] = [];
+    for (const stream of v3StreamDocs) {
+      const sourceTables = sourceTablesByStream.get(stream._id) ?? [];
+      for (const syncConfig of stream.sync_configs) {
+        const definition = syncConfigDefinitionsById.get(syncConfig._id.toHexString());
+        if (definition == null) {
+          continue;
+        }
+
+        const mapping = SingleSyncConfigBucketDefinitionMapping.fromPersistedMapping(definition.rule_mapping);
+        const bucketDefinitionIds = mapping.allBucketDefinitionIds();
+        const parameterIndexIds = mapping.allParameterIndexIds();
+        const bucketDefinitionIdSet = new Set(bucketDefinitionIds);
+        const parameterIndexIdSet = new Set(parameterIndexIds);
+        const replicationSize = sourceTables.reduce((total, sourceTable) => {
+          if (
+            !(sourceTable.bucket_data_source_ids ?? []).some((id) => bucketDefinitionIdSet.has(id)) &&
+            !(sourceTable.parameter_lookup_source_ids ?? []).some((id) => parameterIndexIdSet.has(id))
+          ) {
+            return total;
+          }
+          return total + (collectionSizes.get(`source_records_${stream._id}:${sourceTable._id.toHexString()}`) ?? 0);
+        }, 0);
+
+        syncConfigMetrics.push({
+          sync_config_id: syncConfig._id.toHexString(),
+          sync_config_state: String(syncConfig.state),
+          operations_size_bytes: sumCollectionSizes('bucket_data_', stream._id, bucketDefinitionIds),
+          parameters_size_bytes: sumCollectionSizes('parameter_index_', stream._id, parameterIndexIds),
+          replication_size_bytes: replicationSize,
+          object_storage_size_bytes: bucketDefinitionIds.reduce(
+            (total, definitionId) => total + (objectStorageSizeByDefinition.get(`${stream._id}:${definitionId}`) ?? 0),
+            0
+          )
+        });
+      }
+    }
+
+    const totalObjectStorageSize = objectStorageDefinitionUsage.reduce(
+      (total, usage) => total + usage.active_bytes,
+      0n
+    );
     return {
       operations_size_bytes:
         Number(operations_aggregate[0].storageStats.size) +
@@ -932,7 +985,7 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
         Number(v1_source_record_aggregate[0]?.storageStats?.size ?? 0) +
         source_record_aggregates.reduce((total, aggregate) => total + Number(aggregate[0]?.storageStats?.size ?? 0), 0),
       object_storage_size_bytes: Number(totalObjectStorageSize),
-      stream_metrics: [...streamMetrics.values()]
+      sync_config_metrics: syncConfigMetrics
     };
   }
 

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -34,6 +34,10 @@ import { MongoPersistedReplicationStream } from './implementation/MongoPersisted
 import { stopReplicationStreamPipeline } from './implementation/SyncRuleStateUpdate.js';
 import { SyncRuleDocumentV1 } from './implementation/v1/models.js';
 import { ObjectStorage } from './implementation/v3/object-storage/ObjectStorage.js';
+import {
+  ObjectStorageUsage,
+  ReplicationStreamObjectStorageUsageResult
+} from './implementation/v3/object-storage/ObjectStorageUsage.js';
 import { VersionedPowerSyncMongoV3 } from './implementation/v3/VersionedPowerSyncMongoV3.js';
 import { ReplicationStreamDocumentV3, SyncConfigDefinition, SyncRuleConfigStateV3 } from './storage-index.js';
 
@@ -875,6 +879,17 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
         Number(v1_source_record_aggregate[0]?.storageStats?.size ?? 0) +
         source_record_aggregates.reduce((total, aggregate) => total + Number(aggregate[0]?.storageStats?.size ?? 0), 0)
     };
+  }
+
+  /**
+   * Read active object-storage usage for a v3 replication stream without scanning bucket data
+   * or the object store. Streams without usage documents are reported as zero.
+   */
+  async getObjectStorageUsage(replicationStreamId: number): Promise<ReplicationStreamObjectStorageUsageResult> {
+    const db = this.db.versioned(
+      getMongoStorageConfig(storage.STORAGE_VERSION_3) as StorageConfig & { incrementalReprocessing: true }
+    );
+    return new ObjectStorageUsage(db, replicationStreamId).readStreamUsage();
   }
 
   async getPowerSyncInstanceId(): Promise<string> {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -22,7 +22,6 @@ import {
   storage,
   utils
 } from '@powersync/service-core';
-import { randomUUID } from 'node:crypto';
 import * as timers from 'node:timers/promises';
 import { mongoTableId } from '../../utils/util.js';
 import { PersistedBatch } from './common/PersistedBatch.js';
@@ -34,6 +33,7 @@ import { MongoParsedSyncConfigSet } from './MongoParsedSyncConfigSet.js';
 import { batchCreateCustomWriteCheckpoints } from './MongoWriteCheckpointAPI.js';
 import { OperationBatch, RecordOperation } from './OperationBatch.js';
 import { ObjectStorage } from './v3/object-storage/ObjectStorage.js';
+import { createObjectStorageUsageWriterId } from './v3/object-storage/ObjectStorageUsage.js';
 
 // Currently, we can only have a single flush() at a time, since it locks the op_id sequence.
 // While the MongoDB transaction retry mechanism handles this okay, using an in-process Mutex
@@ -109,7 +109,7 @@ export abstract class MongoBucketBatch
   private readonly storeCurrentData: boolean;
   public readonly skipExistingRows: boolean;
   protected readonly mapping: BucketDefinitionMapping;
-  protected readonly objectStorageUsageWriterId = randomUUID();
+  protected readonly objectStorageUsageWriterId = createObjectStorageUsageWriterId();
 
   private batch: OperationBatch | null = null;
   private write_checkpoint_batch: storage.CustomWriteCheckpointOptions[] = [];

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -22,6 +22,7 @@ import {
   storage,
   utils
 } from '@powersync/service-core';
+import { randomUUID } from 'node:crypto';
 import * as timers from 'node:timers/promises';
 import { mongoTableId } from '../../utils/util.js';
 import { PersistedBatch } from './common/PersistedBatch.js';
@@ -108,6 +109,7 @@ export abstract class MongoBucketBatch
   private readonly storeCurrentData: boolean;
   public readonly skipExistingRows: boolean;
   protected readonly mapping: BucketDefinitionMapping;
+  protected readonly objectStorageUsageWriterId = randomUUID();
 
   private batch: OperationBatch | null = null;
   private write_checkpoint_batch: storage.CustomWriteCheckpointOptions[] = [];

--- a/modules/module-mongodb-storage/src/storage/implementation/common/PersistedBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/common/PersistedBatch.ts
@@ -69,6 +69,7 @@ export interface PersistedBatchOptions {
    * Aborts in-flight object storage uploads when replication stops.
    */
   signal?: AbortSignal;
+  objectStorageUsageWriterId?: string;
 }
 
 /**
@@ -86,6 +87,7 @@ export abstract class PersistedBatch {
   protected readonly objectStorage?: ObjectStorage;
   protected readonly inlineThresholdBytes: number = DEFAULT_INLINE_THRESHOLD_BYTES;
   protected readonly signal?: AbortSignal;
+  protected readonly objectStorageUsageWriterId?: string;
 
   /**
    * For debug logging only.
@@ -108,6 +110,7 @@ export abstract class PersistedBatch {
     this.logger = options?.logger ?? defaultLogger;
     this.objectStorage = options?.objectStorage;
     this.signal = options?.signal;
+    this.objectStorageUsageWriterId = options?.objectStorageUsageWriterId;
     if (options?.inlineThresholdBytes != null) {
       this.inlineThresholdBytes = options.inlineThresholdBytes;
     }

--- a/modules/module-mongodb-storage/src/storage/implementation/db.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/db.ts
@@ -25,7 +25,7 @@ import {
 } from './v1/models.js';
 import { VersionedPowerSyncMongoV1 } from './v1/VersionedPowerSyncMongoV1.js';
 import { BucketDataDocumentV3 } from './v3/models.js';
-import { VersionedPowerSyncMongoV3 } from './v3/VersionedPowerSyncMongoV3.js';
+import { OBJECT_STORAGE_USAGE_COLLECTION, VersionedPowerSyncMongoV3 } from './v3/VersionedPowerSyncMongoV3.js';
 
 export interface PowerSyncMongoOptions {
   /**
@@ -178,7 +178,7 @@ export class PowerSyncMongo {
     await this.locks.deleteMany({});
     await this.bucket_state.deleteMany({});
     await this.custom_write_checkpoints.deleteMany({});
-    await this.db.collection('object_storage_usage').deleteMany({});
+    await this.db.collection(OBJECT_STORAGE_USAGE_COLLECTION).deleteMany({});
   }
 
   /**

--- a/modules/module-mongodb-storage/src/storage/implementation/db.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/db.ts
@@ -178,6 +178,7 @@ export class PowerSyncMongo {
     await this.locks.deleteMany({});
     await this.bucket_state.deleteMany({});
     await this.custom_write_checkpoints.deleteMany({});
+    await this.db.collection('object_storage_usage').deleteMany({});
   }
 
   /**

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
@@ -134,7 +134,7 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
         .sourceRecords(this.replicationStreamId, mongoTableId(table.id))
         .drop()
         .catch((error) => {
-          if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+          if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
             return;
           }
           throw error;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
@@ -46,7 +46,8 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
       logger: this.logger,
       objectStorage: this.options.objectStorage,
       inlineThresholdBytes: this.options.inlineThresholdBytes,
-      signal: this.options.signal
+      signal: this.options.signal,
+      objectStorageUsageWriterId: this.objectStorageUsageWriterId
     });
   }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
@@ -38,6 +38,7 @@ import { BucketDataDocumentV3, BucketStateDocumentV3 } from './models.js';
 import type { MongoSyncBucketStorageV3 } from './MongoSyncBucketStorageV3.js';
 import { BucketDataObjectStorage, hydrateBucketDataDocuments } from './object-storage/BucketDataObjectStorage.js';
 import { ObjectStorageLifecycle, PreparedObjectStorageUpload } from './object-storage/ObjectStorageLifecycle.js';
+import { createObjectStorageUsageWriterId, ObjectStorageUsage } from './object-storage/ObjectStorageUsage.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
 
 const DEFAULT_MIN_COMPACT_FULL_INTERVAL_MS = 2 * 60 * 60 * 1000;
@@ -68,6 +69,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
   readonly maxCompactFullIntervalMs: number;
   readonly compactLeaseDurationMs: number;
   readonly maxOpIdCap: InternalOpId | undefined;
+  private readonly objectStorageUsage: ObjectStorageUsage;
 
   constructor(bucketStorage: MongoSyncBucketStorageV3, db: VersionedPowerSyncMongoV3, options: storage.CompactOptions) {
     super(bucketStorage, db, options);
@@ -76,6 +78,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
     this.maxCompactFullIntervalMs = options.maxCompactFullIntervalMs ?? DEFAULT_MAX_COMPACT_FULL_INTERVAL_MS;
     this.compactLeaseDurationMs = options.compactLeaseDurationMs ?? DEFAULT_COMPACT_LEASE_DURATION_MS;
     this.maxOpIdCap = options.maxOpId;
+    this.objectStorageUsage = new ObjectStorageUsage(this.db, this.group_id, createObjectStorageUsageWriterId());
   }
 
   override async compact(): Promise<number> {
@@ -111,6 +114,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
       // Note that markers only expire after a delay, so this may skip many produced during this compact
       // run. However, during long compact runs, this may also have many ones it can clean up.
       await this.objectStorageLifecycle.cleanup(this.logger, { signal: this.signal });
+      await this.objectStorageUsage.foldStaleWriterDeltas();
     }
     return this.compactedBucketCount;
   }
@@ -972,6 +976,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
           await bucketContext.collection.deleteMany({ _id: { $in: idsToDelete } }, { session });
           await bucketContext.collection.insertMany(documents, { session });
           await this.finishObjectStorageReplacement(oldStoragePaths, newStoragePaths, uploads, session);
+          await this.recordObjectStorageReplacement(inputs, documents, context.definitionId, session);
         },
         {
           writeConcern: { w: 'majority' },
@@ -1069,6 +1074,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
         before = emptyBucketStats();
         after = emptyBucketStats();
         const oldStoragePaths: string[] = [];
+        let oldStorageBytes = 0n;
         const query = collection.find(
           {
             _id: {
@@ -1117,6 +1123,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
           if (doc.storage_ref) {
             oldStoragePaths.push(doc.storage_ref.path);
           }
+          oldStorageBytes += ObjectStorageUsage.bytes(doc);
 
           // The compaction scan established that every operation before the
           // boundary is MOVE/REMOVE/CLEAR. Root metadata is sufficient to fold
@@ -1166,6 +1173,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
         });
         await collection.insertOne(persisted.documents[0], { session });
         await this.finishObjectStorageReplacement(oldStoragePaths, persisted.storagePaths, persisted.uploads, session);
+        await this.recordObjectStorageReplacement(oldStorageBytes, persisted.documents, context.definitionId, session);
 
         opCountDiff = -clearedOpCount + 1;
         before = inputStats;
@@ -1201,6 +1209,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
         before = emptyBucketStats();
         after = emptyBucketStats();
         const oldStoragePaths: string[] = [];
+        let oldStorageBytes = 0n;
         const query = collection.find(
           {
             // This is a range query, but should only ever return two documents:
@@ -1251,6 +1260,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
           if (doc.storage_ref) {
             oldStoragePaths.push(doc.storage_ref.path);
           }
+          oldStorageBytes += ObjectStorageUsage.bytes(doc);
           await hydrateBucketDataDocuments([doc], this.storage.objectStorage, { signal: this.signal });
           maxTargetOp = maxOpId(maxTargetOp, doc.target_op);
           for (const op of loadBucketDataDocument(context, doc)) {
@@ -1311,6 +1321,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
         });
         await collection.insertMany(persisted.documents, { session });
         await this.finishObjectStorageReplacement(oldStoragePaths, persisted.storagePaths, persisted.uploads, session);
+        await this.recordObjectStorageReplacement(oldStorageBytes, persisted.documents, context.definitionId, session);
 
         opCountDiff = -clearedOpCount + 1;
         before = inputStats;
@@ -1363,6 +1374,23 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
       Array.from(oldStoragePaths).filter((path) => !newStoragePaths.has(path)),
       session
     );
+  }
+
+  private async recordObjectStorageReplacement(
+    oldDocumentsOrBytes: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>> | bigint,
+    newDocuments: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>>,
+    definitionId: BucketDefinitionId,
+    session: mongo.ClientSession
+  ): Promise<void> {
+    if (!this.storage.objectStorage) {
+      return;
+    }
+    const oldBytes =
+      typeof oldDocumentsOrBytes === 'bigint'
+        ? oldDocumentsOrBytes
+        : Array.from(oldDocumentsOrBytes).reduce((sum, document) => sum + ObjectStorageUsage.bytes(document), 0n);
+    const newBytes = Array.from(newDocuments).reduce((sum, document) => sum + ObjectStorageUsage.bytes(document), 0n);
+    await this.objectStorageUsage.applyDelta(definitionId, newBytes - oldBytes, session);
   }
 
   private async persistBucketData(

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
@@ -936,6 +936,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
     const expectedChecksum = inputs.reduce((sum, doc) => sum + doc.checksum, 0n);
     const expectedOpCount = inputs.reduce((sum, doc) => sum + doc.count, 0);
     const oldStoragePaths = inputs.flatMap((doc) => (doc.storage_ref ? [doc.storage_ref.path] : []));
+    const oldStorageBytes = inputs.reduce((sum, document) => sum + ObjectStorageUsage.bytes(document), 0n);
     const {
       documents,
       storagePaths: newStoragePaths,
@@ -976,7 +977,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
           await bucketContext.collection.deleteMany({ _id: { $in: idsToDelete } }, { session });
           await bucketContext.collection.insertMany(documents, { session });
           await this.finishObjectStorageReplacement(oldStoragePaths, newStoragePaths, uploads, session);
-          await this.recordObjectStorageReplacement(inputs, documents, context.definitionId, session);
+          await this.recordObjectStorageReplacement(oldStorageBytes, documents, context.definitionId, session);
         },
         {
           writeConcern: { w: 'majority' },
@@ -1377,7 +1378,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
   }
 
   private async recordObjectStorageReplacement(
-    oldDocumentsOrBytes: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>> | bigint,
+    oldBytes: bigint,
     newDocuments: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>>,
     definitionId: BucketDefinitionId,
     session: mongo.ClientSession
@@ -1385,11 +1386,10 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
     if (!this.storage.objectStorage) {
       return;
     }
-    const oldBytes =
-      typeof oldDocumentsOrBytes === 'bigint'
-        ? oldDocumentsOrBytes
-        : Array.from(oldDocumentsOrBytes).reduce((sum, document) => sum + ObjectStorageUsage.bytes(document), 0n);
-    const newBytes = Array.from(newDocuments).reduce((sum, document) => sum + ObjectStorageUsage.bytes(document), 0n);
+    let newBytes = 0n;
+    for (const document of newDocuments) {
+      newBytes += ObjectStorageUsage.bytes(document);
+    }
     await this.objectStorageUsage.applyDelta(definitionId, newBytes - oldBytes, session);
   }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -13,6 +13,7 @@ import {
 } from './models.js';
 import { ObjectStorage } from './object-storage/ObjectStorage.js';
 import { ObjectStorageLifecycle } from './object-storage/ObjectStorageLifecycle.js';
+import { ObjectStorageUsage } from './object-storage/ObjectStorageUsage.js';
 
 type SyncConfigState = ReplicationStreamDocumentV3['sync_configs'][number];
 
@@ -385,6 +386,19 @@ export class MongoStoppedSyncConfigCleanup {
     for (const definitionId of definitionIds) {
       this.throwIfAborted();
       await this.dropCollection(this.db.bucketData(this.replicationStreamId, definitionId));
+    }
+    if (definitionIds.length > 0) {
+      const usage = new ObjectStorageUsage(this.db, this.replicationStreamId);
+      await this.db.client.withSession((session) =>
+        session.withTransaction(async () => {
+          for (const definitionId of definitionIds) {
+            await usage.removeDefinition(definitionId, session);
+          }
+        })
+      );
+    }
+    for (const definitionId of definitionIds) {
+      this.throwIfAborted();
       await lifecycle?.deletePrefix(lifecycle.definitionPrefix(definitionId), { signal: this.signal });
     }
     return definitionIds.length;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -445,7 +445,7 @@ export class MongoStoppedSyncConfigCleanup {
     collection: lib_mongo.mongo.Collection<T>
   ): Promise<void> {
     await collection.drop({ maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS }).catch((error) => {
-      if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+      if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
         return;
       }
       throw error;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoStoppedSyncConfigCleanup.ts
@@ -387,7 +387,7 @@ export class MongoStoppedSyncConfigCleanup {
       this.throwIfAborted();
       await this.dropCollection(this.db.bucketData(this.replicationStreamId, definitionId));
     }
-    if (definitionIds.length > 0) {
+    if (definitionIds.length > 0 && this.objectStorage != null) {
       const usage = new ObjectStorageUsage(this.db, this.replicationStreamId);
       await this.db.client.withSession((session) =>
         session.withTransaction(async () => {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -50,7 +50,7 @@ import { MongoStoppedSyncConfigCleanup } from './MongoStoppedSyncConfigCleanup.j
 import { hydrateBucketDataDocuments } from './object-storage/BucketDataObjectStorage.js';
 import { ObjectStorage } from './object-storage/ObjectStorage.js';
 import { ObjectStorageLifecycle } from './object-storage/ObjectStorageLifecycle.js';
-import { ObjectStorageUsage, ReplicationStreamObjectStorageUsageResult } from './object-storage/ObjectStorageUsage.js';
+import { ObjectStorageUsage } from './object-storage/ObjectStorageUsage.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
 
 export interface MongoSyncBucketStorageContextV3 {
@@ -415,10 +415,6 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         }
         throw error;
       });
-  }
-
-  async getObjectStorageUsage(): Promise<ReplicationStreamObjectStorageUsageResult> {
-    return new ObjectStorageUsage(this.db, this.replicationStreamId).readStreamUsage();
   }
 
   protected async clearParameterIndexes(_signal?: AbortSignal): Promise<void> {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -50,6 +50,7 @@ import { MongoStoppedSyncConfigCleanup } from './MongoStoppedSyncConfigCleanup.j
 import { hydrateBucketDataDocuments } from './object-storage/BucketDataObjectStorage.js';
 import { ObjectStorage } from './object-storage/ObjectStorage.js';
 import { ObjectStorageLifecycle } from './object-storage/ObjectStorageLifecycle.js';
+import { ObjectStorageUsage, ReplicationStreamObjectStorageUsageResult } from './object-storage/ObjectStorageUsage.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
 
 export interface MongoSyncBucketStorageContextV3 {
@@ -399,6 +400,8 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
     for (const collection of await this.db.listBucketDataCollections(this.replicationStreamId)) {
       await collection.drop();
     }
+    const usage = new ObjectStorageUsage(this.db, this.replicationStreamId);
+    await this.db.client.withSession((session) => session.withTransaction(() => usage.removeStream(session)));
     if (this.objectStorage) {
       const lifecycle = new ObjectStorageLifecycle(this.db, this.replicationStreamId, this.objectStorage);
       await lifecycle.deletePrefix(lifecycle.streamPrefix(), { signal });
@@ -412,6 +415,10 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
         }
         throw error;
       });
+  }
+
+  async getObjectStorageUsage(): Promise<ReplicationStreamObjectStorageUsageResult> {
+    return new ObjectStorageUsage(this.db, this.replicationStreamId).readStreamUsage();
   }
 
   protected async clearParameterIndexes(_signal?: AbortSignal): Promise<void> {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoSyncBucketStorageV3.ts
@@ -410,7 +410,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       .pendingObjectStorageDeletes(this.replicationStreamId)
       .drop({ maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS })
       .catch((error) => {
-        if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+        if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
           return;
         }
         throw error;
@@ -438,7 +438,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       .bucketState(this.replicationStreamId)
       .drop({ maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS })
       .catch((error) => {
-        if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+        if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
           return;
         }
         throw error;
@@ -450,7 +450,7 @@ export class MongoSyncBucketStorageV3 extends MongoSyncBucketStorage {
       .sourceTables(this.replicationStreamId)
       .drop({ maxTimeMS: lib_mongo.db.MONGO_CLEAR_OPERATION_TIMEOUT_MS })
       .catch((error) => {
-        if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+        if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
           return;
         }
         throw error;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/PersistedBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/PersistedBatchV3.ts
@@ -25,12 +25,14 @@ import {
   taggedBucketParameterDocumentToTagged
 } from './models.js';
 import { ObjectStorageLifecycle } from './object-storage/ObjectStorageLifecycle.js';
+import { ObjectStorageUsage } from './object-storage/ObjectStorageUsage.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
 
 export class PersistedBatchV3 extends PersistedBatch {
   currentData: { sourceTableId: bson.ObjectId; operation: mongo.AnyBulkWriteOperation<CurrentDataDocumentV3> }[] = [];
   sourceTablePendingDeletes = new Map<string, InternalOpId>();
   protected readonly objectStorageLifecycle?: ObjectStorageLifecycle;
+  protected readonly objectStorageUsage?: ObjectStorageUsage;
 
   declare protected readonly db: VersionedPowerSyncMongoV3;
 
@@ -44,6 +46,7 @@ export class PersistedBatchV3 extends PersistedBatch {
     super(db, group_id, mapping, writtenSize, options);
     if (this.objectStorage) {
       this.objectStorageLifecycle = new ObjectStorageLifecycle(this.db, this.group_id, this.objectStorage);
+      this.objectStorageUsage = new ObjectStorageUsage(this.db, this.group_id, this.objectStorageUsageWriterId);
     }
   }
 
@@ -226,7 +229,6 @@ export class PersistedBatchV3 extends PersistedBatch {
       operationsByDefinition.set(document.bucketKey.definitionId, existing);
     }
 
-    let uploadCount = 0;
     const plans = Array.from(operationsByDefinition, ([definitionId, documents]) => {
       const operationsByBucket = Map.groupBy(documents, (document) => document.bucketKey.bucket);
       const lifecycle = this.objectStorageLifecycle;
@@ -246,7 +248,6 @@ export class PersistedBatchV3 extends PersistedBatch {
             continue;
           }
 
-          uploadCount += 1;
           createInserts.push(async () => {
             const minOp = chunk[0].o;
             const maxOp = chunk[chunk.length - 1].o;
@@ -284,7 +285,17 @@ export class PersistedBatchV3 extends PersistedBatch {
     // separate limiter here.
     const writes = await createAllInserts();
 
+    const usageDeltas = new Map<BucketDefinitionId, bigint>();
     for (const { definitionId, inserts } of writes) {
+      const delta = inserts.reduce((sum, operation) => {
+        if (!('insertOne' in operation)) {
+          throw new ReplicationAssertionError('Expected only bucket-data inserts when accounting object storage usage');
+        }
+        return sum + ObjectStorageUsage.bytes(operation.insertOne.document);
+      }, 0n);
+      if (delta !== 0n) {
+        usageDeltas.set(definitionId, delta);
+      }
       if (inserts.length > 0) {
         await this.db.bucketData(this.group_id, definitionId).bulkWrite(inserts, {
           session,
@@ -292,6 +303,7 @@ export class PersistedBatchV3 extends PersistedBatch {
         });
       }
     }
+    await this.objectStorageUsage?.applyDeltas(usageDeltas, session);
   }
 
   protected async flushBucketParameters(session: mongo.ClientSession) {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/PersistedBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/PersistedBatchV3.ts
@@ -232,7 +232,8 @@ export class PersistedBatchV3 extends PersistedBatch {
     const plans = Array.from(operationsByDefinition, ([definitionId, documents]) => {
       const operationsByBucket = Map.groupBy(documents, (document) => document.bucketKey.bucket);
       const lifecycle = this.objectStorageLifecycle;
-      const createInserts: (() => Promise<mongo.AnyBulkWriteOperation<BucketDataDocumentV3>>)[] = [];
+      type BucketDataInsert = { insertOne: { document: BucketDataDocumentV3 } };
+      const createInserts: (() => Promise<BucketDataInsert>)[] = [];
 
       for (const [bucket, ops] of operationsByBucket) {
         this.resetBucketPersistedBytes(definitionId, bucket);
@@ -285,16 +286,16 @@ export class PersistedBatchV3 extends PersistedBatch {
     // separate limiter here.
     const writes = await createAllInserts();
 
-    const usageDeltas = new Map<BucketDefinitionId, bigint>();
+    const usageDeltas = this.objectStorageUsage == null ? undefined : new Map<BucketDefinitionId, bigint>();
     for (const { definitionId, inserts } of writes) {
-      const delta = inserts.reduce((sum, operation) => {
-        if (!('insertOne' in operation)) {
-          throw new ReplicationAssertionError('Expected only bucket-data inserts when accounting object storage usage');
+      if (usageDeltas != null) {
+        const delta = inserts.reduce(
+          (sum, operation) => sum + ObjectStorageUsage.bytes(operation.insertOne.document),
+          0n
+        );
+        if (delta !== 0n) {
+          usageDeltas.set(definitionId, delta);
         }
-        return sum + ObjectStorageUsage.bytes(operation.insertOne.document);
-      }, 0n);
-      if (delta !== 0n) {
-        usageDeltas.set(definitionId, delta);
       }
       if (inserts.length > 0) {
         await this.db.bucketData(this.group_id, definitionId).bulkWrite(inserts, {
@@ -303,7 +304,9 @@ export class PersistedBatchV3 extends PersistedBatch {
         });
       }
     }
-    await this.objectStorageUsage?.applyDeltas(usageDeltas, session);
+    if (usageDeltas != null) {
+      await this.objectStorageUsage!.applyDeltas(usageDeltas, session);
+    }
   }
 
   protected async flushBucketParameters(session: mongo.ClientSession) {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/VersionedPowerSyncMongoV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/VersionedPowerSyncMongoV3.ts
@@ -8,6 +8,7 @@ import {
   BucketStateDocumentV3,
   CurrentDataDocumentV3,
   ObjectStorageDeletionMarker,
+  ObjectStorageUsageDocument,
   SourceTableDocumentV3,
   SyncConfigDefinition
 } from './models.js';
@@ -74,6 +75,10 @@ export class VersionedPowerSyncMongoV3 extends BaseVersionedPowerSyncMongo {
     return this.db.collection<ObjectStorageDeletionMarker>(`pending_object_storage_deletes_${replicationStreamId}`);
   }
 
+  get objectStorageUsage(): mongo.Collection<ObjectStorageUsageDocument> {
+    return this.db.collection<ObjectStorageUsageDocument>('object_storage_usage');
+  }
+
   listBucketDataCollections(replicationStreamId: number) {
     return this.listCollectionsByPrefix(`bucket_data_${replicationStreamId}_`);
   }
@@ -124,6 +129,16 @@ export class VersionedPowerSyncMongoV3 extends BaseVersionedPowerSyncMongo {
       {
         name: 'next_compact_check',
         partialFilterExpression: { next_compact_check: { $exists: true } }
+      }
+    );
+    await this.objectStorageUsage.createIndex(
+      {
+        replication_stream_id: 1,
+        writer_id: 1
+      },
+      {
+        name: 'replication_stream_writer',
+        unique: true
       }
     );
   }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/VersionedPowerSyncMongoV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/VersionedPowerSyncMongoV3.ts
@@ -13,6 +13,8 @@ import {
   SyncConfigDefinition
 } from './models.js';
 
+export const OBJECT_STORAGE_USAGE_COLLECTION = 'object_storage_usage';
+
 export class VersionedPowerSyncMongoV3 extends BaseVersionedPowerSyncMongo {
   constructor(
     upstream: ConstructorParameters<typeof BaseVersionedPowerSyncMongo>[0],
@@ -76,7 +78,7 @@ export class VersionedPowerSyncMongoV3 extends BaseVersionedPowerSyncMongo {
   }
 
   get objectStorageUsage(): mongo.Collection<ObjectStorageUsageDocument> {
-    return this.db.collection<ObjectStorageUsageDocument>('object_storage_usage');
+    return this.db.collection<ObjectStorageUsageDocument>(OBJECT_STORAGE_USAGE_COLLECTION);
   }
 
   listBucketDataCollections(replicationStreamId: number) {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/VersionedPowerSyncMongoV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/VersionedPowerSyncMongoV3.ts
@@ -131,15 +131,5 @@ export class VersionedPowerSyncMongoV3 extends BaseVersionedPowerSyncMongo {
         partialFilterExpression: { next_compact_check: { $exists: true } }
       }
     );
-    await this.objectStorageUsage.createIndex(
-      {
-        replication_stream_id: 1,
-        writer_id: 1
-      },
-      {
-        name: 'replication_stream_writer',
-        unique: true
-      }
-    );
   }
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
@@ -233,6 +233,14 @@ export interface StorageRef {
   file_size: number;
 }
 
+export interface ObjectStorageUsageDocument {
+  _id: bson.ObjectId;
+  replication_stream_id: number;
+  writer_id: string;
+  updated_at: Date;
+  definitions: Record<BucketDefinitionId, bigint>;
+}
+
 /** An S3 object that may be deleted once its grace period has elapsed. */
 export interface ObjectStorageDeletionMarker {
   _id: bson.ObjectId;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/models.ts
@@ -234,9 +234,10 @@ export interface StorageRef {
 }
 
 export interface ObjectStorageUsageDocument {
-  _id: bson.ObjectId;
-  replication_stream_id: number;
-  writer_id: string;
+  _id: {
+    g: number;
+    w: string;
+  };
   updated_at: Date;
   definitions: Record<BucketDefinitionId, bigint>;
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -44,29 +44,8 @@ export class ObjectStorageUsage {
     return BigInt(document.storage_ref?.file_size ?? 0);
   }
 
-  static replacementDelta(
-    oldDocuments: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>>,
-    newDocuments: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>>
-  ): bigint {
-    let delta = 0n;
-    for (const document of oldDocuments) {
-      delta -= ObjectStorageUsage.bytes(document);
-    }
-    for (const document of newDocuments) {
-      delta += ObjectStorageUsage.bytes(document);
-    }
-    return delta;
-  }
-
   static async readAllStreamUsage(db: VersionedPowerSyncMongoV3): Promise<ReplicationStreamObjectStorageUsageResult[]> {
     return db.client.withSession({ snapshot: true }, async (session) => {
-      const exists =
-        (await db.db.listCollections({ name: db.objectStorageUsage.collectionName }, { nameOnly: true }).toArray())
-          .length > 0;
-      if (!exists) {
-        return [];
-      }
-
       const entries = await db.objectStorageUsage
         .aggregate<{
           _id: { replication_stream_id: number; definition_id: BucketDefinitionId };

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -1,9 +1,8 @@
-import * as lib_mongo from '@powersync/lib-service-mongodb';
 import { mongo } from '@powersync/lib-service-mongodb';
 import { ReplicationAssertionError } from '@powersync/lib-services-framework';
 import { BucketDefinitionId } from '@powersync/service-sync-rules';
 import { randomUUID } from 'node:crypto';
-import { BucketDataDocumentV3 } from '../models.js';
+import { BucketDataDocumentV3, ObjectStorageUsageDocument } from '../models.js';
 import { VersionedPowerSyncMongoV3 } from '../VersionedPowerSyncMongoV3.js';
 
 export const OBJECT_STORAGE_USAGE_BASE_WRITER_ID = '__base__';
@@ -79,17 +78,10 @@ export class ObjectStorageUsage {
     }
 
     await this.db.objectStorageUsage.updateOne(
-      {
-        replication_stream_id: this.replicationStreamId,
-        writer_id: this.writerId
-      },
+      { _id: this.documentId() },
       {
         $inc: increments,
-        $currentDate: { updated_at: true },
-        $setOnInsert: {
-          replication_stream_id: this.replicationStreamId,
-          writer_id: this.writerId
-        }
+        $currentDate: { updated_at: true }
       },
       { upsert: true, session }
     );
@@ -113,7 +105,7 @@ export class ObjectStorageUsage {
     const entries = await this.db.objectStorageUsage
       .aggregate<{ _id: BucketDefinitionId; active_bytes: bigint }>(
         [
-          { $match: { replication_stream_id: this.replicationStreamId } },
+          { $match: { '_id.g': this.replicationStreamId } },
           { $project: { definitions: { $objectToArray: '$definitions' } } },
           { $unwind: '$definitions' },
           {
@@ -136,14 +128,14 @@ export class ObjectStorageUsage {
 
   async removeDefinition(definitionId: BucketDefinitionId, session: mongo.ClientSession): Promise<void> {
     await this.db.objectStorageUsage.updateMany(
-      { replication_stream_id: this.replicationStreamId },
+      { '_id.g': this.replicationStreamId },
       { $unset: { [this.definitionPath(definitionId)]: 1 } },
       { session }
     );
   }
 
   async removeStream(session: mongo.ClientSession): Promise<void> {
-    await this.db.objectStorageUsage.deleteMany({ replication_stream_id: this.replicationStreamId }, { session });
+    await this.db.objectStorageUsage.deleteMany({ '_id.g': this.replicationStreamId }, { session });
   }
 
   async foldStaleWriterDeltas(
@@ -158,75 +150,62 @@ export class ObjectStorageUsage {
       return;
     }
 
-    const folderLock = new lib_mongo.locks.MongoLockManager({
-      collection: this.db.locks,
-      name: `object-storage-usage-fold-${this.replicationStreamId}`
-    });
-    await folderLock.lock(() =>
-      this.db.client.withSession((session) =>
-        session.withTransaction(
-          async () => {
-            const staleDocuments = await this.db.objectStorageUsage
-              .find(
-                {
-                  replication_stream_id: this.replicationStreamId,
-                  writer_id: { $ne: OBJECT_STORAGE_USAGE_BASE_WRITER_ID },
-                  $expr: {
-                    $lt: [
-                      '$updated_at',
-                      { $dateSubtract: { startDate: '$$NOW', unit: 'millisecond', amount: staleWriterMs } }
-                    ]
-                  }
-                },
-                { session, sort: { updated_at: 1 }, limit }
-              )
-              .toArray();
-            if (staleDocuments.length === 0) {
-              return;
-            }
-
-            const deltas = new Map<BucketDefinitionId, bigint>();
-            for (const document of staleDocuments) {
-              for (const [definitionId, delta] of Object.entries(document.definitions ?? {})) {
-                this.validateDefinitionId(definitionId);
-                deltas.set(definitionId, (deltas.get(definitionId) ?? 0n) + BigInt(delta));
-              }
-            }
-
-            const increments: Record<string, bigint> = {};
-            for (const [definitionId, delta] of deltas) {
-              if (delta !== 0n) {
-                increments[this.definitionPath(definitionId)] = delta;
-              }
-            }
-            if (Object.keys(increments).length > 0) {
-              await this.db.objectStorageUsage.updateOne(
-                {
-                  replication_stream_id: this.replicationStreamId,
-                  writer_id: OBJECT_STORAGE_USAGE_BASE_WRITER_ID
-                },
-                {
-                  $inc: increments,
-                  $currentDate: { updated_at: true },
-                  $setOnInsert: {
-                    replication_stream_id: this.replicationStreamId,
-                    writer_id: OBJECT_STORAGE_USAGE_BASE_WRITER_ID
-                  }
-                },
-                { upsert: true, session }
-              );
-            }
-
-            await this.db.objectStorageUsage.deleteMany(
+    await this.db.client.withSession((session) =>
+      session.withTransaction(
+        async () => {
+          const staleDocuments = await this.db.objectStorageUsage
+            .find(
               {
-                replication_stream_id: this.replicationStreamId,
-                _id: { $in: staleDocuments.map((document) => document._id) }
+                '_id.g': this.replicationStreamId,
+                '_id.w': { $ne: OBJECT_STORAGE_USAGE_BASE_WRITER_ID },
+                $expr: {
+                  $lt: [
+                    '$updated_at',
+                    { $dateSubtract: { startDate: '$$NOW', unit: 'millisecond', amount: staleWriterMs } }
+                  ]
+                }
               },
-              { session }
+              { session, sort: { updated_at: 1 }, limit }
+            )
+            .toArray();
+          if (staleDocuments.length === 0) {
+            return;
+          }
+
+          const deltas = new Map<BucketDefinitionId, bigint>();
+          for (const document of staleDocuments) {
+            for (const [definitionId, delta] of Object.entries(document.definitions ?? {})) {
+              this.validateDefinitionId(definitionId);
+              deltas.set(definitionId, (deltas.get(definitionId) ?? 0n) + BigInt(delta));
+            }
+          }
+
+          const increments: Record<string, bigint> = {};
+          for (const [definitionId, delta] of deltas) {
+            if (delta !== 0n) {
+              increments[this.definitionPath(definitionId)] = delta;
+            }
+          }
+          if (Object.keys(increments).length > 0) {
+            await this.db.objectStorageUsage.updateOne(
+              { _id: this.documentId(OBJECT_STORAGE_USAGE_BASE_WRITER_ID) },
+              {
+                $inc: increments,
+                $currentDate: { updated_at: true }
+              },
+              { upsert: true, session }
             );
-          },
-          { readConcern: { level: 'snapshot' }, writeConcern: { w: 'majority' } }
-        )
+          }
+
+          await this.db.objectStorageUsage.deleteMany(
+            {
+              '_id.g': this.replicationStreamId,
+              _id: { $in: staleDocuments.map((document) => document._id) }
+            },
+            { session }
+          );
+        },
+        { readConcern: { level: 'snapshot' }, writeConcern: { w: 'majority' } }
       )
     );
   }
@@ -234,6 +213,16 @@ export class ObjectStorageUsage {
   private definitionPath(definitionId: BucketDefinitionId): string {
     this.validateDefinitionId(definitionId);
     return `definitions.${definitionId}`;
+  }
+
+  private documentId(writerId = this.writerId): ObjectStorageUsageDocument['_id'] {
+    if (writerId == null) {
+      throw new ReplicationAssertionError('A writer id is required to identify object-storage usage');
+    }
+    return {
+      g: this.replicationStreamId,
+      w: writerId
+    };
   }
 
   private validateDefinitionId(definitionId: BucketDefinitionId): void {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -103,19 +103,6 @@ export class ObjectStorageUsage {
     });
   }
 
-  static async readAllStreamUsage(db: VersionedPowerSyncMongoV3): Promise<ReplicationStreamObjectStorageUsageResult[]> {
-    const definitionUsage = await this.readAllDefinitionUsage(db);
-    const totals = new Map<number, bigint>();
-    for (const entry of definitionUsage) {
-      totals.set(entry.replication_stream_id, (totals.get(entry.replication_stream_id) ?? 0n) + entry.active_bytes);
-    }
-
-    return [...totals].map(([replicationStreamId, activeBytes]) => ({
-      replication_stream_id: replicationStreamId,
-      active_bytes: activeBytes
-    }));
-  }
-
   async applyDelta(definitionId: BucketDefinitionId, delta: bigint, session: mongo.ClientSession): Promise<void> {
     await this.applyDeltas(new Map([[definitionId, delta]]), session);
   }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -79,7 +79,7 @@ export class ObjectStorageUsage {
         )
         .toArray()
         .catch((error) => {
-          if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+          if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
             return [];
           }
           throw error;
@@ -178,7 +178,7 @@ export class ObjectStorageUsage {
       )
       .toArray()
       .catch((error) => {
-        if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+        if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
           return [];
         }
         throw error;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -16,11 +16,6 @@ export interface ReplicationStreamObjectStorageDefinitionUsageResult {
   active_bytes: bigint;
 }
 
-export interface ObjectStorageUsageEntry {
-  definition_id: BucketDefinitionId;
-  active_bytes: bigint;
-}
-
 export function createObjectStorageUsageWriterId(): string {
   return randomUUID();
 }
@@ -128,41 +123,6 @@ export class ObjectStorageUsage {
     );
   }
 
-  async readEntries(): Promise<ObjectStorageUsageEntry[]> {
-    return this.db.client.withSession({ snapshot: true }, (session) => this.readEntriesInSession(session));
-  }
-
-  async readEntriesInSession(session: mongo.ClientSession): Promise<ObjectStorageUsageEntry[]> {
-    const entries = await this.db.objectStorageUsage
-      .aggregate<{ _id: BucketDefinitionId; active_bytes: bigint }>(
-        [
-          { $match: { '_id.g': this.replicationStreamId } },
-          { $project: { definitions: { $objectToArray: '$definitions' } } },
-          { $unwind: '$definitions' },
-          {
-            $group: {
-              _id: '$definitions.k',
-              active_bytes: { $sum: '$definitions.v' }
-            }
-          }
-        ],
-        { session, readConcern: 'snapshot' }
-      )
-      .toArray()
-      .catch((error) => {
-        if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
-          return [];
-        }
-        throw error;
-      });
-
-    return entries.map((entry) => {
-      const activeBytes = BigInt(entry.active_bytes ?? 0);
-      this.assertNonNegative(activeBytes, `definition ${entry._id}`);
-      return { definition_id: entry._id, active_bytes: activeBytes };
-    });
-  }
-
   async removeDefinition(definitionId: BucketDefinitionId, session: mongo.ClientSession): Promise<void> {
     await this.db.objectStorageUsage.updateMany(
       { '_id.g': this.replicationStreamId },
@@ -265,12 +225,6 @@ export class ObjectStorageUsage {
   private validateDefinitionId(definitionId: BucketDefinitionId): void {
     if (definitionId.length === 0 || definitionId.includes('.') || definitionId.includes('$')) {
       throw new ReplicationAssertionError(`Invalid bucket definition id for object-storage usage: ${definitionId}`);
-    }
-  }
-
-  private assertNonNegative(value: bigint, target: string): void {
-    if (value < 0n) {
-      throw new ReplicationAssertionError(`Negative active object-storage usage for ${target}: ${value}`);
     }
   }
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -1,0 +1,250 @@
+import * as lib_mongo from '@powersync/lib-service-mongodb';
+import { mongo } from '@powersync/lib-service-mongodb';
+import { ReplicationAssertionError } from '@powersync/lib-services-framework';
+import { BucketDefinitionId } from '@powersync/service-sync-rules';
+import { randomUUID } from 'node:crypto';
+import { BucketDataDocumentV3 } from '../models.js';
+import { VersionedPowerSyncMongoV3 } from '../VersionedPowerSyncMongoV3.js';
+
+export const OBJECT_STORAGE_USAGE_BASE_WRITER_ID = '__base__';
+export const DEFAULT_OBJECT_STORAGE_USAGE_STALE_WRITER_MS = 30 * 60 * 1000;
+export const DEFAULT_OBJECT_STORAGE_USAGE_FOLD_LIMIT = 100;
+
+export interface ReplicationStreamObjectStorageUsageResult {
+  replication_stream_id: number;
+  active_bytes: bigint;
+}
+
+export interface ObjectStorageUsageEntry {
+  definition_id: BucketDefinitionId;
+  active_bytes: bigint;
+}
+
+export function createObjectStorageUsageWriterId(): string {
+  return randomUUID();
+}
+
+/**
+ * Tracks active S3 references. Values are signed writer-local deltas, so reference changes and
+ * accounting updates can be committed together without making replication and compaction share a
+ * hot counter document.
+ */
+export class ObjectStorageUsage {
+  constructor(
+    private readonly db: VersionedPowerSyncMongoV3,
+    private readonly replicationStreamId: number,
+    readonly writerId?: string
+  ) {
+    if (writerId === OBJECT_STORAGE_USAGE_BASE_WRITER_ID) {
+      throw new ReplicationAssertionError('The reserved object-storage usage writer id cannot be used by a writer');
+    }
+  }
+
+  static bytes(document: Pick<BucketDataDocumentV3, 'storage_ref'>): bigint {
+    return BigInt(document.storage_ref?.file_size ?? 0);
+  }
+
+  static replacementDelta(
+    oldDocuments: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>>,
+    newDocuments: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>>
+  ): bigint {
+    let delta = 0n;
+    for (const document of oldDocuments) {
+      delta -= ObjectStorageUsage.bytes(document);
+    }
+    for (const document of newDocuments) {
+      delta += ObjectStorageUsage.bytes(document);
+    }
+    return delta;
+  }
+
+  async applyDelta(definitionId: BucketDefinitionId, delta: bigint, session: mongo.ClientSession): Promise<void> {
+    await this.applyDeltas(new Map([[definitionId, delta]]), session);
+  }
+
+  async applyDeltas(deltas: ReadonlyMap<BucketDefinitionId, bigint>, session: mongo.ClientSession): Promise<void> {
+    if (this.writerId == null) {
+      throw new ReplicationAssertionError('A writer id is required to apply object-storage usage');
+    }
+
+    const increments: Record<string, bigint> = {};
+    for (const [definitionId, delta] of deltas) {
+      if (delta === 0n) {
+        continue;
+      }
+      increments[this.definitionPath(definitionId)] = delta;
+    }
+    if (Object.keys(increments).length === 0) {
+      return;
+    }
+
+    await this.db.objectStorageUsage.updateOne(
+      {
+        replication_stream_id: this.replicationStreamId,
+        writer_id: this.writerId
+      },
+      {
+        $inc: increments,
+        $currentDate: { updated_at: true },
+        $setOnInsert: {
+          replication_stream_id: this.replicationStreamId,
+          writer_id: this.writerId
+        }
+      },
+      { upsert: true, session }
+    );
+  }
+
+  async readEntries(): Promise<ObjectStorageUsageEntry[]> {
+    return this.db.client.withSession({ snapshot: true }, (session) => this.readEntriesInSession(session));
+  }
+
+  async readStreamUsage(): Promise<ReplicationStreamObjectStorageUsageResult> {
+    const entries = await this.readEntries();
+    const activeBytes = entries.reduce((sum, entry) => sum + entry.active_bytes, 0n);
+    this.assertNonNegative(activeBytes, 'stream');
+    return {
+      replication_stream_id: this.replicationStreamId,
+      active_bytes: activeBytes
+    };
+  }
+
+  async readEntriesInSession(session: mongo.ClientSession): Promise<ObjectStorageUsageEntry[]> {
+    const entries = await this.db.objectStorageUsage
+      .aggregate<{ _id: BucketDefinitionId; active_bytes: bigint }>(
+        [
+          { $match: { replication_stream_id: this.replicationStreamId } },
+          { $project: { definitions: { $objectToArray: '$definitions' } } },
+          { $unwind: '$definitions' },
+          {
+            $group: {
+              _id: '$definitions.k',
+              active_bytes: { $sum: '$definitions.v' }
+            }
+          }
+        ],
+        { session, readConcern: 'snapshot' }
+      )
+      .toArray();
+
+    return entries.map((entry) => {
+      const activeBytes = BigInt(entry.active_bytes ?? 0);
+      this.assertNonNegative(activeBytes, `definition ${entry._id}`);
+      return { definition_id: entry._id, active_bytes: activeBytes };
+    });
+  }
+
+  async removeDefinition(definitionId: BucketDefinitionId, session: mongo.ClientSession): Promise<void> {
+    await this.db.objectStorageUsage.updateMany(
+      { replication_stream_id: this.replicationStreamId },
+      { $unset: { [this.definitionPath(definitionId)]: 1 } },
+      { session }
+    );
+  }
+
+  async removeStream(session: mongo.ClientSession): Promise<void> {
+    await this.db.objectStorageUsage.deleteMany({ replication_stream_id: this.replicationStreamId }, { session });
+  }
+
+  async foldStaleWriterDeltas(
+    options: {
+      staleWriterMs?: number;
+      limit?: number;
+    } = {}
+  ): Promise<void> {
+    const staleWriterMs = options.staleWriterMs ?? DEFAULT_OBJECT_STORAGE_USAGE_STALE_WRITER_MS;
+    const limit = options.limit ?? DEFAULT_OBJECT_STORAGE_USAGE_FOLD_LIMIT;
+    if (limit <= 0) {
+      return;
+    }
+
+    const folderLock = new lib_mongo.locks.MongoLockManager({
+      collection: this.db.locks,
+      name: `object-storage-usage-fold-${this.replicationStreamId}`
+    });
+    await folderLock.lock(() =>
+      this.db.client.withSession((session) =>
+        session.withTransaction(
+          async () => {
+            const staleDocuments = await this.db.objectStorageUsage
+              .find(
+                {
+                  replication_stream_id: this.replicationStreamId,
+                  writer_id: { $ne: OBJECT_STORAGE_USAGE_BASE_WRITER_ID },
+                  $expr: {
+                    $lt: [
+                      '$updated_at',
+                      { $dateSubtract: { startDate: '$$NOW', unit: 'millisecond', amount: staleWriterMs } }
+                    ]
+                  }
+                },
+                { session, sort: { updated_at: 1 }, limit }
+              )
+              .toArray();
+            if (staleDocuments.length === 0) {
+              return;
+            }
+
+            const deltas = new Map<BucketDefinitionId, bigint>();
+            for (const document of staleDocuments) {
+              for (const [definitionId, delta] of Object.entries(document.definitions ?? {})) {
+                this.validateDefinitionId(definitionId);
+                deltas.set(definitionId, (deltas.get(definitionId) ?? 0n) + BigInt(delta));
+              }
+            }
+
+            const increments: Record<string, bigint> = {};
+            for (const [definitionId, delta] of deltas) {
+              if (delta !== 0n) {
+                increments[this.definitionPath(definitionId)] = delta;
+              }
+            }
+            if (Object.keys(increments).length > 0) {
+              await this.db.objectStorageUsage.updateOne(
+                {
+                  replication_stream_id: this.replicationStreamId,
+                  writer_id: OBJECT_STORAGE_USAGE_BASE_WRITER_ID
+                },
+                {
+                  $inc: increments,
+                  $currentDate: { updated_at: true },
+                  $setOnInsert: {
+                    replication_stream_id: this.replicationStreamId,
+                    writer_id: OBJECT_STORAGE_USAGE_BASE_WRITER_ID
+                  }
+                },
+                { upsert: true, session }
+              );
+            }
+
+            await this.db.objectStorageUsage.deleteMany(
+              {
+                replication_stream_id: this.replicationStreamId,
+                _id: { $in: staleDocuments.map((document) => document._id) }
+              },
+              { session }
+            );
+          },
+          { readConcern: { level: 'snapshot' }, writeConcern: { w: 'majority' } }
+        )
+      )
+    );
+  }
+
+  private definitionPath(definitionId: BucketDefinitionId): string {
+    this.validateDefinitionId(definitionId);
+    return `definitions.${definitionId}`;
+  }
+
+  private validateDefinitionId(definitionId: BucketDefinitionId): void {
+    if (definitionId.length === 0 || definitionId.includes('.') || definitionId.includes('$')) {
+      throw new ReplicationAssertionError(`Invalid bucket definition id for object-storage usage: ${definitionId}`);
+    }
+  }
+
+  private assertNonNegative(value: bigint, target: string): void {
+    if (value < 0n) {
+      throw new ReplicationAssertionError(`Negative active object-storage usage for ${target}: ${value}`);
+    }
+  }
+}

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -85,10 +85,11 @@ export class ObjectStorageUsage {
       return entries.map((entry) => {
         const activeBytes = BigInt(entry.active_bytes ?? 0);
         if (activeBytes < 0n) {
-          throw new ReplicationAssertionError(
-            `Negative active object-storage usage for definition ${entry._id.definition_id} ` +
-              `in stream ${entry._id.replication_stream_id}: ${activeBytes}`
-          );
+          return {
+            replication_stream_id: entry._id.replication_stream_id,
+            definition_id: entry._id.definition_id,
+            active_bytes: 0n
+          };
         }
         return {
           replication_stream_id: entry._id.replication_stream_id,

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -54,6 +54,9 @@ export class ObjectStorageUsage {
     db: VersionedPowerSyncMongoV3
   ): Promise<ReplicationStreamObjectStorageDefinitionUsageResult[]> {
     return db.client.withSession({ snapshot: true }, async (session) => {
+      // Deliberately read the whole usage collection. The number of replication streams is
+      // expected to stay low, so a collection scan is cheaper than issuing one _id range query
+      // per stream (and the usage collection is bounded by streams and writers, not buckets).
       const entries = await db.objectStorageUsage
         .aggregate<{
           _id: { replication_stream_id: number; definition_id: BucketDefinitionId };

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -1,3 +1,4 @@
+import * as lib_mongo from '@powersync/lib-service-mongodb';
 import { mongo } from '@powersync/lib-service-mongodb';
 import { ReplicationAssertionError } from '@powersync/lib-services-framework';
 import { BucketDefinitionId } from '@powersync/service-sync-rules';
@@ -55,6 +56,69 @@ export class ObjectStorageUsage {
       delta += ObjectStorageUsage.bytes(document);
     }
     return delta;
+  }
+
+  static async readAllStreamUsage(db: VersionedPowerSyncMongoV3): Promise<ReplicationStreamObjectStorageUsageResult[]> {
+    return db.client.withSession({ snapshot: true }, async (session) => {
+      const exists =
+        (await db.db.listCollections({ name: db.objectStorageUsage.collectionName }, { nameOnly: true }).toArray())
+          .length > 0;
+      if (!exists) {
+        return [];
+      }
+
+      const entries = await db.objectStorageUsage
+        .aggregate<{
+          _id: { replication_stream_id: number; definition_id: BucketDefinitionId };
+          active_bytes: bigint;
+        }>(
+          [
+            { $project: { replication_stream_id: '$_id.g', definitions: { $objectToArray: '$definitions' } } },
+            { $unwind: '$definitions' },
+            {
+              $group: {
+                _id: {
+                  replication_stream_id: '$replication_stream_id',
+                  definition_id: '$definitions.k'
+                },
+                active_bytes: { $sum: '$definitions.v' }
+              }
+            }
+          ],
+          { session, readConcern: 'snapshot' }
+        )
+        .toArray()
+        .catch((error) => {
+          if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+            return [];
+          }
+          throw error;
+        });
+
+      const totals = new Map<number, bigint>();
+      for (const entry of entries) {
+        const activeBytes = BigInt(entry.active_bytes ?? 0);
+        if (activeBytes < 0n) {
+          throw new ReplicationAssertionError(
+            `Negative active object-storage usage for definition ${entry._id.definition_id} ` +
+              `in stream ${entry._id.replication_stream_id}: ${activeBytes}`
+          );
+        }
+        totals.set(entry._id.replication_stream_id, (totals.get(entry._id.replication_stream_id) ?? 0n) + activeBytes);
+      }
+
+      return [...totals].map(([replicationStreamId, activeBytes]) => {
+        if (activeBytes < 0n) {
+          throw new ReplicationAssertionError(
+            `Negative active object-storage usage for stream ${replicationStreamId}: ${activeBytes}`
+          );
+        }
+        return {
+          replication_stream_id: replicationStreamId,
+          active_bytes: activeBytes
+        };
+      });
+    });
   }
 
   async applyDelta(definitionId: BucketDefinitionId, delta: bigint, session: mongo.ClientSession): Promise<void> {
@@ -117,7 +181,13 @@ export class ObjectStorageUsage {
         ],
         { session, readConcern: 'snapshot' }
       )
-      .toArray();
+      .toArray()
+      .catch((error) => {
+        if (lib_mongo.isMongoServerError(error) && error.codeName === 'NamespaceNotFound') {
+          return [];
+        }
+        throw error;
+      });
 
     return entries.map((entry) => {
       const activeBytes = BigInt(entry.active_bytes ?? 0);

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -10,11 +10,6 @@ export const OBJECT_STORAGE_USAGE_BASE_WRITER_ID = '__base__';
 export const DEFAULT_OBJECT_STORAGE_USAGE_STALE_WRITER_MS = 30 * 60 * 1000;
 export const DEFAULT_OBJECT_STORAGE_USAGE_FOLD_LIMIT = 100;
 
-export interface ReplicationStreamObjectStorageUsageResult {
-  replication_stream_id: number;
-  active_bytes: bigint;
-}
-
 export interface ReplicationStreamObjectStorageDefinitionUsageResult {
   replication_stream_id: number;
   definition_id: BucketDefinitionId;
@@ -135,16 +130,6 @@ export class ObjectStorageUsage {
 
   async readEntries(): Promise<ObjectStorageUsageEntry[]> {
     return this.db.client.withSession({ snapshot: true }, (session) => this.readEntriesInSession(session));
-  }
-
-  async readStreamUsage(): Promise<ReplicationStreamObjectStorageUsageResult> {
-    const entries = await this.readEntries();
-    const activeBytes = entries.reduce((sum, entry) => sum + entry.active_bytes, 0n);
-    this.assertNonNegative(activeBytes, 'stream');
-    return {
-      replication_stream_id: this.replicationStreamId,
-      active_bytes: activeBytes
-    };
   }
 
   async readEntriesInSession(session: mongo.ClientSession): Promise<ObjectStorageUsageEntry[]> {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -15,6 +15,12 @@ export interface ReplicationStreamObjectStorageUsageResult {
   active_bytes: bigint;
 }
 
+export interface ReplicationStreamObjectStorageDefinitionUsageResult {
+  replication_stream_id: number;
+  definition_id: BucketDefinitionId;
+  active_bytes: bigint;
+}
+
 export interface ObjectStorageUsageEntry {
   definition_id: BucketDefinitionId;
   active_bytes: bigint;
@@ -44,7 +50,9 @@ export class ObjectStorageUsage {
     return BigInt(document.storage_ref?.file_size ?? 0);
   }
 
-  static async readAllStreamUsage(db: VersionedPowerSyncMongoV3): Promise<ReplicationStreamObjectStorageUsageResult[]> {
+  static async readAllDefinitionUsage(
+    db: VersionedPowerSyncMongoV3
+  ): Promise<ReplicationStreamObjectStorageDefinitionUsageResult[]> {
     return db.client.withSession({ snapshot: true }, async (session) => {
       const entries = await db.objectStorageUsage
         .aggregate<{
@@ -74,8 +82,7 @@ export class ObjectStorageUsage {
           throw error;
         });
 
-      const totals = new Map<number, bigint>();
-      for (const entry of entries) {
+      return entries.map((entry) => {
         const activeBytes = BigInt(entry.active_bytes ?? 0);
         if (activeBytes < 0n) {
           throw new ReplicationAssertionError(
@@ -83,21 +90,26 @@ export class ObjectStorageUsage {
               `in stream ${entry._id.replication_stream_id}: ${activeBytes}`
           );
         }
-        totals.set(entry._id.replication_stream_id, (totals.get(entry._id.replication_stream_id) ?? 0n) + activeBytes);
-      }
-
-      return [...totals].map(([replicationStreamId, activeBytes]) => {
-        if (activeBytes < 0n) {
-          throw new ReplicationAssertionError(
-            `Negative active object-storage usage for stream ${replicationStreamId}: ${activeBytes}`
-          );
-        }
         return {
-          replication_stream_id: replicationStreamId,
+          replication_stream_id: entry._id.replication_stream_id,
+          definition_id: entry._id.definition_id,
           active_bytes: activeBytes
         };
       });
     });
+  }
+
+  static async readAllStreamUsage(db: VersionedPowerSyncMongoV3): Promise<ReplicationStreamObjectStorageUsageResult[]> {
+    const definitionUsage = await this.readAllDefinitionUsage(db);
+    const totals = new Map<number, bigint>();
+    for (const entry of definitionUsage) {
+      totals.set(entry.replication_stream_id, (totals.get(entry.replication_stream_id) ?? 0n) + entry.active_bytes);
+    }
+
+    return [...totals].map(([replicationStreamId, activeBytes]) => ({
+      replication_stream_id: replicationStreamId,
+      active_bytes: activeBytes
+    }));
   }
 
   async applyDelta(definitionId: BucketDefinitionId, delta: bigint, session: mongo.ClientSession): Promise<void> {

--- a/modules/module-mongodb-storage/src/storage/storage-index.ts
+++ b/modules/module-mongodb-storage/src/storage/storage-index.ts
@@ -15,11 +15,13 @@ export { loadBucketDataDocument, serializeBucketData } from './implementation/v3
 export {
   BucketDataDocumentV3,
   BucketOperation,
+  ObjectStorageUsageDocument,
   RecordedLookupV3,
   ReplicationStreamDocumentV3,
   SyncConfigDefinition,
   SyncRuleConfigStateV3,
   taggedBucketParameterDocumentToTagged
 } from './implementation/v3/models.js';
+export * from './implementation/v3/object-storage/ObjectStorageUsage.js';
 export * from './MongoBucketStorage.js';
 export * from './MongoReportStorage.js';

--- a/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
+++ b/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
@@ -5,6 +5,7 @@ import {
   ObjectStorageUsage
 } from '@module/storage/implementation/v3/object-storage/ObjectStorageUsage.js';
 import { VersionedPowerSyncMongoV3 } from '@module/storage/implementation/v3/VersionedPowerSyncMongoV3.js';
+import * as lib_mongo from '@powersync/lib-service-mongodb';
 import { mongo } from '@powersync/lib-service-mongodb';
 import { updateSyncRulesFromYaml } from '@powersync/service-core';
 import { BucketDefinitionId } from '@powersync/service-sync-rules';
@@ -22,6 +23,11 @@ type UsageContext = {
   db: VersionedPowerSyncMongoV3;
   bucketStorage: MongoSyncBucketStorage;
   definitionId: BucketDefinitionId;
+};
+
+type UsageEntry = {
+  definition_id: BucketDefinitionId;
+  active_bytes: bigint;
 };
 
 async function withUsageContext<T>(callback: (context: UsageContext) => Promise<T>): Promise<T> {
@@ -43,6 +49,35 @@ async function withTransaction<T>(
   } finally {
     await session.endSession();
   }
+}
+
+async function readUsageEntries(
+  db: VersionedPowerSyncMongoV3,
+  replicationStreamId: number,
+  session?: mongo.ClientSession
+): Promise<UsageEntry[]> {
+  const entries = await db.objectStorageUsage
+    .aggregate<{ _id: BucketDefinitionId; active_bytes: bigint }>(
+      [
+        { $match: { '_id.g': replicationStreamId } },
+        { $project: { definitions: { $objectToArray: '$definitions' } } },
+        { $unwind: '$definitions' },
+        { $group: { _id: '$definitions.k', active_bytes: { $sum: '$definitions.v' } } }
+      ],
+      { session, readConcern: 'snapshot' }
+    )
+    .toArray()
+    .catch((error) => {
+      if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
+        return [];
+      }
+      throw error;
+    });
+
+  return entries.map((entry) => ({
+    definition_id: entry._id,
+    active_bytes: BigInt(entry.active_bytes ?? 0)
+  }));
 }
 
 function usageDocument(
@@ -99,7 +134,9 @@ describe('ObjectStorageUsage', () => {
       });
 
       expect(await bucketData.countDocuments({ storage_ref: { $exists: true } })).toBe(1);
-      await expect(usage.readEntries()).resolves.toEqual([{ definition_id: definitionId, active_bytes: 123n }]);
+      await expect(readUsageEntries(db, replicationStreamId)).resolves.toEqual([
+        { definition_id: definitionId, active_bytes: 123n }
+      ]);
     });
   });
 
@@ -122,7 +159,7 @@ describe('ObjectStorageUsage', () => {
         );
 
         await usage.foldStaleWriterDeltas({ staleWriterMs: 0 });
-        const entries = await usage.readEntriesInSession(readSession);
+        const entries = await readUsageEntries(db, replicationStreamId, readSession);
 
         await readSession.commitTransaction();
         expect(entries).toEqual([{ definition_id: definitionId, active_bytes: 115n }]);
@@ -133,7 +170,9 @@ describe('ObjectStorageUsage', () => {
         await readSession.endSession();
       }
 
-      await expect(usage.readEntries()).resolves.toEqual([{ definition_id: definitionId, active_bytes: 115n }]);
+      await expect(readUsageEntries(db, replicationStreamId)).resolves.toEqual([
+        { definition_id: definitionId, active_bytes: 115n }
+      ]);
     });
   });
 
@@ -153,7 +192,7 @@ describe('ObjectStorageUsage', () => {
       // The folder committed first and deleted the writer shard. The writer's
       // next transaction must recreate it through the upsert.
       await withTransaction(db, (session) => usage.applyDelta(definitionId, 4n, session));
-      expect((await usage.readEntries())[0].active_bytes).toBe(14n);
+      expect((await readUsageEntries(db, replicationStreamId))[0].active_bytes).toBe(14n);
 
       await db.objectStorageUsage.updateOne(
         { _id: { g: replicationStreamId, w: writerId } },
@@ -163,7 +202,7 @@ describe('ObjectStorageUsage', () => {
 
       // The writer committed before the folder. Folding the recreated shard
       // must preserve the same visible total.
-      expect((await usage.readEntries())[0].active_bytes).toBe(14n);
+      expect((await readUsageEntries(db, replicationStreamId))[0].active_bytes).toBe(14n);
     });
   });
 
@@ -188,7 +227,9 @@ describe('ObjectStorageUsage', () => {
         withTransaction(db, (session) => usage.removeDefinition(definitionId, session))
       ]);
 
-      await expect(usage.readEntries()).resolves.toEqual([{ definition_id: otherDefinitionId, active_bytes: 18n }]);
+      await expect(readUsageEntries(db, replicationStreamId)).resolves.toEqual([
+        { definition_id: otherDefinitionId, active_bytes: 18n }
+      ]);
 
       await withTransaction(db, async (session) => {
         await new ObjectStorageUsage(db, otherStreamId).removeStream(session);
@@ -208,7 +249,7 @@ describe('ObjectStorageUsage', () => {
   test('returns no entries for an absent usage collection', async () => {
     await withUsageContext(async ({ db, bucketStorage }) => {
       await db.objectStorageUsage.drop().catch(() => undefined);
-      await expect(new ObjectStorageUsage(db, bucketStorage.replicationStreamId).readEntries()).resolves.toEqual([]);
+      await expect(readUsageEntries(db, bucketStorage.replicationStreamId)).resolves.toEqual([]);
     });
   });
 });

--- a/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
+++ b/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
@@ -1,0 +1,255 @@
+import { MongoSyncBucketStorage } from '@module/storage/implementation/createMongoSyncBucketStorage.js';
+import { BucketDataDocumentV3, ObjectStorageUsageDocument } from '@module/storage/implementation/v3/models.js';
+import {
+  OBJECT_STORAGE_USAGE_BASE_WRITER_ID,
+  ObjectStorageUsage
+} from '@module/storage/implementation/v3/object-storage/ObjectStorageUsage.js';
+import { VersionedPowerSyncMongoV3 } from '@module/storage/implementation/v3/VersionedPowerSyncMongoV3.js';
+import { mongo } from '@powersync/lib-service-mongodb';
+import { updateSyncRulesFromYaml } from '@powersync/service-core';
+import { BucketDefinitionId } from '@powersync/service-sync-rules';
+import { describe, expect, test } from 'vitest';
+import { INITIALIZED_MONGO_STORAGE_FACTORY } from './util.js';
+
+const SYNC_RULES_YAML = `
+bucket_definitions:
+  global:
+    data:
+      - SELECT id FROM items
+`;
+
+type UsageContext = {
+  db: VersionedPowerSyncMongoV3;
+  bucketStorage: MongoSyncBucketStorage;
+  definitionId: BucketDefinitionId;
+};
+
+async function withUsageContext<T>(callback: (context: UsageContext) => Promise<T>): Promise<T> {
+  await using factory = await INITIALIZED_MONGO_STORAGE_FACTORY.factory();
+  const syncRules = await factory.updateSyncRules(updateSyncRulesFromYaml(SYNC_RULES_YAML, { storageVersion: 3 }));
+  const bucketStorage = factory.getInstance(syncRules) as MongoSyncBucketStorage;
+  const db = bucketStorage.db as VersionedPowerSyncMongoV3;
+  const definitionId = syncRules.syncConfigContent[0].mapping.allBucketDefinitionIds()[0];
+  return callback({ db, bucketStorage, definitionId });
+}
+
+async function withTransaction<T>(
+  db: VersionedPowerSyncMongoV3,
+  callback: (session: mongo.ClientSession) => Promise<T>
+): Promise<T> {
+  const session = db.client.startSession();
+  try {
+    return await session.withTransaction(() => callback(session));
+  } finally {
+    await session.endSession();
+  }
+}
+
+function usageDocument(
+  replicationStreamId: number,
+  writerId: string,
+  definitions: Record<string, bigint>,
+  updatedAt = new Date(0)
+): ObjectStorageUsageDocument {
+  return {
+    _id: { g: replicationStreamId, w: writerId },
+    updated_at: updatedAt,
+    definitions
+  };
+}
+
+function bucketDataDocument(
+  replicationStreamId: number,
+  definitionId: BucketDefinitionId,
+  fileSize: number
+): BucketDataDocumentV3 {
+  return {
+    _id: { b: `${replicationStreamId}-${definitionId}`, o: 1n },
+    min_op: 1n,
+    checksum: 1n,
+    count: 1,
+    size: fileSize,
+    storage_ref: {
+      path: `bucket-data/${replicationStreamId}/${definitionId}/1.bson`,
+      file_size: fileSize
+    }
+  };
+}
+
+describe('ObjectStorageUsage', () => {
+  test('counts a committed reference exactly once after an aborted transaction is retried', async () => {
+    await withUsageContext(async ({ db, bucketStorage, definitionId }) => {
+      const replicationStreamId = bucketStorage.replicationStreamId;
+      const writerId = 'replication-writer';
+      const usage = new ObjectStorageUsage(db, replicationStreamId, writerId);
+      const bucketData = db.bucketData(replicationStreamId, definitionId);
+      const document = bucketDataDocument(replicationStreamId, definitionId, 123);
+
+      await expect(
+        withTransaction(db, async (session) => {
+          await bucketData.insertOne(document, { session });
+          await usage.applyDelta(definitionId, 123n, session);
+          throw new Error('abort this attempt');
+        })
+      ).rejects.toThrow('abort this attempt');
+
+      await withTransaction(db, async (session) => {
+        await bucketData.insertOne(document, { session });
+        await usage.applyDelta(definitionId, 123n, session);
+      });
+
+      expect(await bucketData.countDocuments({ storage_ref: { $exists: true } })).toBe(1);
+      await expect(usage.readStreamUsage()).resolves.toEqual({
+        replication_stream_id: replicationStreamId,
+        active_bytes: 123n
+      });
+    });
+  });
+
+  test.each([
+    {
+      name: 'S3-to-S3',
+      oldDocuments: [{ storage_ref: { path: 'old', file_size: 10 } }],
+      newDocuments: [{ storage_ref: { path: 'new', file_size: 25 } }],
+      expected: 15n
+    },
+    {
+      name: 'S3-to-inline',
+      oldDocuments: [{ storage_ref: { path: 'old', file_size: 10 } }],
+      newDocuments: [{}],
+      expected: -10n
+    },
+    {
+      name: 'inline-to-S3',
+      oldDocuments: [{}],
+      newDocuments: [{ storage_ref: { path: 'new', file_size: 25 } }],
+      expected: 25n
+    },
+    {
+      name: 'multiple-input-to-one-output',
+      oldDocuments: [
+        { storage_ref: { path: 'old-1', file_size: 10 } },
+        { storage_ref: { path: 'old-2', file_size: 20 } }
+      ],
+      newDocuments: [{ storage_ref: { path: 'new', file_size: 25 } }],
+      expected: -5n
+    }
+  ])('$name replacement records the signed byte delta', ({ oldDocuments, newDocuments, expected }) => {
+    expect(ObjectStorageUsage.replacementDelta(oldDocuments, newDocuments)).toBe(expected);
+  });
+
+  test('snapshot usage reads observe a complete pre-fold view', async () => {
+    await withUsageContext(async ({ db, bucketStorage, definitionId }) => {
+      const replicationStreamId = bucketStorage.replicationStreamId;
+      const usage = new ObjectStorageUsage(db, replicationStreamId);
+      await db.objectStorageUsage.insertMany([
+        usageDocument(replicationStreamId, OBJECT_STORAGE_USAGE_BASE_WRITER_ID, { [definitionId]: 100n }),
+        usageDocument(replicationStreamId, 'replication', { [definitionId]: 20n }),
+        usageDocument(replicationStreamId, 'compactor', { [definitionId]: -5n })
+      ]);
+
+      const readSession = db.client.startSession();
+      try {
+        readSession.startTransaction({ readConcern: { level: 'snapshot' } });
+        await db.objectStorageUsage.findOne(
+          { _id: { g: replicationStreamId, w: OBJECT_STORAGE_USAGE_BASE_WRITER_ID } },
+          { session: readSession }
+        );
+
+        await usage.foldStaleWriterDeltas({ staleWriterMs: 0 });
+        const entries = await usage.readEntriesInSession(readSession);
+
+        await readSession.commitTransaction();
+        expect(entries).toEqual([{ definition_id: definitionId, active_bytes: 115n }]);
+      } catch (error) {
+        await readSession.abortTransaction().catch(() => undefined);
+        throw error;
+      } finally {
+        await readSession.endSession();
+      }
+
+      await expect(usage.readStreamUsage()).resolves.toEqual({
+        replication_stream_id: replicationStreamId,
+        active_bytes: 115n
+      });
+    });
+  });
+
+  test('folding preserves totals across both writer/folder commit orders', async () => {
+    await withUsageContext(async ({ db, bucketStorage, definitionId }) => {
+      const replicationStreamId = bucketStorage.replicationStreamId;
+      const writerId = 'reused-writer';
+      const usage = new ObjectStorageUsage(db, replicationStreamId, writerId);
+
+      await withTransaction(db, (session) => usage.applyDelta(definitionId, 10n, session));
+      await db.objectStorageUsage.updateOne(
+        { _id: { g: replicationStreamId, w: writerId } },
+        { $set: { updated_at: new Date(0) } }
+      );
+      await usage.foldStaleWriterDeltas({ staleWriterMs: 0 });
+
+      // The folder committed first and deleted the writer shard. The writer's
+      // next transaction must recreate it through the upsert.
+      await withTransaction(db, (session) => usage.applyDelta(definitionId, 4n, session));
+      expect((await usage.readStreamUsage()).active_bytes).toBe(14n);
+
+      await db.objectStorageUsage.updateOne(
+        { _id: { g: replicationStreamId, w: writerId } },
+        { $set: { updated_at: new Date(0) } }
+      );
+      await usage.foldStaleWriterDeltas({ staleWriterMs: 0 });
+
+      // The writer committed before the folder. Folding the recreated shard
+      // must preserve the same visible total.
+      expect((await usage.readStreamUsage()).active_bytes).toBe(14n);
+    });
+  });
+
+  test('definition cleanup racing a fold removes only that definition, and stream clear is isolated', async () => {
+    await withUsageContext(async ({ db, bucketStorage, definitionId }) => {
+      const replicationStreamId = bucketStorage.replicationStreamId;
+      const otherStreamId = replicationStreamId + 1;
+      const otherDefinitionId = 'other_definition';
+      const usage = new ObjectStorageUsage(db, replicationStreamId);
+
+      await db.objectStorageUsage.insertMany([
+        usageDocument(replicationStreamId, OBJECT_STORAGE_USAGE_BASE_WRITER_ID, {
+          [definitionId]: 3n,
+          [otherDefinitionId]: 7n
+        }),
+        usageDocument(replicationStreamId, 'writer', { [definitionId]: 20n, [otherDefinitionId]: 11n }),
+        usageDocument(otherStreamId, 'other-writer', { [definitionId]: 50n })
+      ]);
+
+      await Promise.all([
+        usage.foldStaleWriterDeltas({ staleWriterMs: 0 }),
+        withTransaction(db, (session) => usage.removeDefinition(definitionId, session))
+      ]);
+
+      await expect(usage.readEntries()).resolves.toEqual([{ definition_id: otherDefinitionId, active_bytes: 18n }]);
+
+      await withTransaction(db, async (session) => {
+        await new ObjectStorageUsage(db, otherStreamId).removeStream(session);
+      });
+      await db.objectStorageUsage.insertOne(usageDocument(otherStreamId, 'other-writer', { [definitionId]: 50n }));
+
+      await withTransaction(db, async (session) => {
+        await usage.removeStream(session);
+      });
+
+      await expect(ObjectStorageUsage.readAllStreamUsage(db)).resolves.toEqual([
+        { replication_stream_id: otherStreamId, active_bytes: 50n }
+      ]);
+    });
+  });
+
+  test('returns zero for an absent usage collection', async () => {
+    await withUsageContext(async ({ db, bucketStorage }) => {
+      await db.objectStorageUsage.drop().catch(() => undefined);
+      await expect(new ObjectStorageUsage(db, bucketStorage.replicationStreamId).readStreamUsage()).resolves.toEqual({
+        replication_stream_id: bucketStorage.replicationStreamId,
+        active_bytes: 0n
+      });
+    });
+  });
+});

--- a/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
+++ b/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
@@ -205,8 +205,8 @@ describe('ObjectStorageUsage', () => {
         await usage.removeStream(session);
       });
 
-      await expect(ObjectStorageUsage.readAllStreamUsage(db)).resolves.toEqual([
-        { replication_stream_id: otherStreamId, active_bytes: 50n }
+      await expect(ObjectStorageUsage.readAllDefinitionUsage(db)).resolves.toEqual([
+        { replication_stream_id: otherStreamId, definition_id: definitionId, active_bytes: 50n }
       ]);
     });
   });

--- a/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
+++ b/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
@@ -106,38 +106,6 @@ describe('ObjectStorageUsage', () => {
     });
   });
 
-  test.each([
-    {
-      name: 'S3-to-S3',
-      oldDocuments: [{ storage_ref: { path: 'old', file_size: 10 } }],
-      newDocuments: [{ storage_ref: { path: 'new', file_size: 25 } }],
-      expected: 15n
-    },
-    {
-      name: 'S3-to-inline',
-      oldDocuments: [{ storage_ref: { path: 'old', file_size: 10 } }],
-      newDocuments: [{}],
-      expected: -10n
-    },
-    {
-      name: 'inline-to-S3',
-      oldDocuments: [{}],
-      newDocuments: [{ storage_ref: { path: 'new', file_size: 25 } }],
-      expected: 25n
-    },
-    {
-      name: 'multiple-input-to-one-output',
-      oldDocuments: [
-        { storage_ref: { path: 'old-1', file_size: 10 } },
-        { storage_ref: { path: 'old-2', file_size: 20 } }
-      ],
-      newDocuments: [{ storage_ref: { path: 'new', file_size: 25 } }],
-      expected: -5n
-    }
-  ])('$name replacement records the signed byte delta', ({ oldDocuments, newDocuments, expected }) => {
-    expect(ObjectStorageUsage.replacementDelta(oldDocuments, newDocuments)).toBe(expected);
-  });
-
   test('snapshot usage reads observe a complete pre-fold view', async () => {
     await withUsageContext(async ({ db, bucketStorage, definitionId }) => {
       const replicationStreamId = bucketStorage.replicationStreamId;

--- a/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
+++ b/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
@@ -99,10 +99,7 @@ describe('ObjectStorageUsage', () => {
       });
 
       expect(await bucketData.countDocuments({ storage_ref: { $exists: true } })).toBe(1);
-      await expect(usage.readStreamUsage()).resolves.toEqual({
-        replication_stream_id: replicationStreamId,
-        active_bytes: 123n
-      });
+      await expect(usage.readEntries()).resolves.toEqual([{ definition_id: definitionId, active_bytes: 123n }]);
     });
   });
 
@@ -136,10 +133,7 @@ describe('ObjectStorageUsage', () => {
         await readSession.endSession();
       }
 
-      await expect(usage.readStreamUsage()).resolves.toEqual({
-        replication_stream_id: replicationStreamId,
-        active_bytes: 115n
-      });
+      await expect(usage.readEntries()).resolves.toEqual([{ definition_id: definitionId, active_bytes: 115n }]);
     });
   });
 
@@ -159,7 +153,7 @@ describe('ObjectStorageUsage', () => {
       // The folder committed first and deleted the writer shard. The writer's
       // next transaction must recreate it through the upsert.
       await withTransaction(db, (session) => usage.applyDelta(definitionId, 4n, session));
-      expect((await usage.readStreamUsage()).active_bytes).toBe(14n);
+      expect((await usage.readEntries())[0].active_bytes).toBe(14n);
 
       await db.objectStorageUsage.updateOne(
         { _id: { g: replicationStreamId, w: writerId } },
@@ -169,7 +163,7 @@ describe('ObjectStorageUsage', () => {
 
       // The writer committed before the folder. Folding the recreated shard
       // must preserve the same visible total.
-      expect((await usage.readStreamUsage()).active_bytes).toBe(14n);
+      expect((await usage.readEntries())[0].active_bytes).toBe(14n);
     });
   });
 
@@ -211,13 +205,10 @@ describe('ObjectStorageUsage', () => {
     });
   });
 
-  test('returns zero for an absent usage collection', async () => {
+  test('returns no entries for an absent usage collection', async () => {
     await withUsageContext(async ({ db, bucketStorage }) => {
       await db.objectStorageUsage.drop().catch(() => undefined);
-      await expect(new ObjectStorageUsage(db, bucketStorage.replicationStreamId).readStreamUsage()).resolves.toEqual({
-        replication_stream_id: bucketStorage.replicationStreamId,
-        active_bytes: 0n
-      });
+      await expect(new ObjectStorageUsage(db, bucketStorage.replicationStreamId).readEntries()).resolves.toEqual([]);
     });
   });
 });

--- a/modules/module-mongodb-storage/test/src/storage_s3_compaction_lifecycle.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_s3_compaction_lifecycle.test.ts
@@ -1,3 +1,4 @@
+import * as lib_mongo from '@powersync/lib-service-mongodb';
 import { storage, updateSyncRulesFromYaml } from '@powersync/service-core';
 import { bucketRequest, compactActive, test_utils } from '@powersync/service-core-tests';
 import { describe, expect, test } from 'vitest';
@@ -5,7 +6,6 @@ import { MongoSyncBucketStorage } from '../../src/storage/implementation/createM
 import { MongoSyncBucketStorageV3 } from '../../src/storage/implementation/v3/MongoSyncBucketStorageV3.js';
 import { VersionedPowerSyncMongoV3 } from '../../src/storage/implementation/v3/VersionedPowerSyncMongoV3.js';
 import { ObjectStorageError } from '../../src/storage/implementation/v3/object-storage/ObjectStorage.js';
-import { ObjectStorageUsage } from '../../src/storage/implementation/v3/object-storage/ObjectStorageUsage.js';
 import { env } from './env.js';
 import { createMemoryS3TestStorageSuite, createS3TestStorageSuite } from './helpers/s3TestFactory.js';
 
@@ -35,8 +35,21 @@ async function expectUsageMatchesBucketData(bucketStorage: MongoSyncBucketStorag
   const db = v3BucketStorage.db as VersionedPowerSyncMongoV3;
   const documents = await db.bucketData(v3BucketStorage.replicationStreamId, definitionId).find({}).toArray();
   const expectedBytes = documents.reduce((sum, document) => sum + BigInt(document.storage_ref?.file_size ?? 0), 0n);
-  const entries = await new ObjectStorageUsage(db, v3BucketStorage.replicationStreamId).readEntries();
-  expect(entries.reduce((sum, entry) => sum + entry.active_bytes, 0n)).toBe(expectedBytes);
+  const entries = await db.objectStorageUsage
+    .aggregate<{ active_bytes: bigint }>([
+      { $match: { '_id.g': v3BucketStorage.replicationStreamId } },
+      { $project: { definitions: { $objectToArray: '$definitions' } } },
+      { $unwind: '$definitions' },
+      { $group: { _id: null, active_bytes: { $sum: '$definitions.v' } } }
+    ])
+    .toArray()
+    .catch((error) => {
+      if (lib_mongo.isMongoNamespaceNotFoundError(error)) {
+        return [];
+      }
+      throw error;
+    });
+  expect(BigInt(entries[0]?.active_bytes ?? 0)).toBe(expectedBytes);
 }
 
 describe('S3 compaction storage lifecycle', () => {

--- a/modules/module-mongodb-storage/test/src/storage_s3_compaction_lifecycle.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_s3_compaction_lifecycle.test.ts
@@ -2,6 +2,7 @@ import { storage, updateSyncRulesFromYaml } from '@powersync/service-core';
 import { bucketRequest, compactActive, test_utils } from '@powersync/service-core-tests';
 import { describe, expect, test } from 'vitest';
 import { MongoSyncBucketStorage } from '../../src/storage/implementation/createMongoSyncBucketStorage.js';
+import { MongoSyncBucketStorageV3 } from '../../src/storage/implementation/v3/MongoSyncBucketStorageV3.js';
 import { VersionedPowerSyncMongoV3 } from '../../src/storage/implementation/v3/VersionedPowerSyncMongoV3.js';
 import { ObjectStorageError } from '../../src/storage/implementation/v3/object-storage/ObjectStorage.js';
 import { env } from './env.js';
@@ -26,6 +27,17 @@ function memoryS3Factory(options: { inlineThresholdBytes?: number } = {}) {
     inlineThresholdBytes: options.inlineThresholdBytes ?? 0
   });
   return { memoryStorage: objectStorage, factory: factoryGen };
+}
+
+async function expectUsageMatchesBucketData(bucketStorage: MongoSyncBucketStorage, definitionId: string) {
+  const v3BucketStorage = bucketStorage as MongoSyncBucketStorageV3;
+  const db = v3BucketStorage.db as VersionedPowerSyncMongoV3;
+  const documents = await db.bucketData(v3BucketStorage.replicationStreamId, definitionId).find({}).toArray();
+  const expectedBytes = documents.reduce((sum, document) => sum + BigInt(document.storage_ref?.file_size ?? 0), 0n);
+  await expect(v3BucketStorage.getObjectStorageUsage()).resolves.toEqual({
+    replication_stream_id: v3BucketStorage.replicationStreamId,
+    active_bytes: expectedBytes
+  });
 }
 
 describe('S3 compaction storage lifecycle', () => {
@@ -121,6 +133,103 @@ describe('S3 compaction storage lifecycle', () => {
     expect(docs[0].storage_ref).toBeUndefined();
     expect(docs[0].ops).toBeDefined();
     expect(memoryStorage.store.size).toBe(0);
+    await expectUsageMatchesBucketData(bucketStorage, definitionId);
+  });
+
+  test('boundary CLEAR replacement updates active object-storage usage', async () => {
+    const { factory: factoryGen } = memoryS3Factory();
+    await using factory = await factoryGen.factory();
+    const syncRules = await factory.updateSyncRules(updateSyncRulesFromYaml(SYNC_RULES_YAML, { storageVersion: 3 }));
+    const bucketStorage = factory.getInstance(syncRules) as MongoSyncBucketStorage;
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const sourceTable = await test_utils.resolveTestTable(writer, 'items', ['id'], factoryGen, 11);
+    await writer.markAllSnapshotDone('1/1');
+    for (const [index, description] of ['first', 'second', 'latest'].entries()) {
+      await writer.save({
+        sourceTable,
+        tag: index === 0 ? storage.SaveOperationTag.INSERT : storage.SaveOperationTag.UPDATE,
+        after: { id: 'A', description: description.repeat(100) },
+        afterReplicaId: test_utils.rid('A')
+      });
+    }
+    await writer.commit('1/1');
+
+    const definitionId = syncRules.syncConfigContent[0].mapping.allBucketDefinitionIds()[0];
+    const request = bucketRequest(syncRules.syncConfigContent[0], 'global[]', 0n);
+    const checkpoint = await bucketStorage.getCheckpoint();
+    await compactActive(factory, {
+      maxOpId: checkpoint.checkpoint,
+      compactBuckets: [request.bucket],
+      minBucketChanges: 1,
+      minChangeRatio: 0
+    });
+
+    const batch = await test_utils.getBatchArray(bucketStorage.getBucketDataBatch(checkpoint, [request]));
+    const data = batch.flatMap((chunk) => chunk.chunkData.data);
+    expect(data.some((op: any) => op.op === 'CLEAR')).toBe(true);
+    await expectUsageMatchesBucketData(bucketStorage, definitionId);
+  });
+
+  test('leading and boundary CLEAR replacements update active object-storage usage', async () => {
+    const { factory: factoryGen } = memoryS3Factory();
+    await using factory = await factoryGen.factory();
+    const syncRules = await factory.updateSyncRules(updateSyncRulesFromYaml(SYNC_RULES_YAML, { storageVersion: 3 }));
+    const bucketStorage = factory.getInstance(syncRules) as MongoSyncBucketStorage;
+
+    await using writer = await bucketStorage.createWriter(test_utils.BATCH_OPTIONS);
+    const sourceTable = await test_utils.resolveTestTable(writer, 'items', ['id'], factoryGen, 12);
+    await writer.markAllSnapshotDone('1/1');
+
+    // The first and last A versions force a leading MOVE document. The
+    // middle document also contains a large surviving PUT, keeping it as the
+    // CLEAR boundary document rather than merging it with the leading group.
+    await writer.save({
+      sourceTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: { id: 'A', description: 'old' },
+      afterReplicaId: test_utils.rid('A')
+    });
+    await writer.commit('1/1');
+
+    await writer.save({
+      sourceTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      after: { id: 'A', description: 'middle' },
+      afterReplicaId: test_utils.rid('A')
+    });
+    await writer.save({
+      sourceTable,
+      tag: storage.SaveOperationTag.INSERT,
+      after: { id: 'B', description: 'b'.repeat(990_000) },
+      afterReplicaId: test_utils.rid('B')
+    });
+    await writer.commit('2/1');
+
+    await writer.save({
+      sourceTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      after: { id: 'A', description: 'latest'.repeat(10_000) },
+      afterReplicaId: test_utils.rid('A')
+    });
+    await writer.commit('3/1');
+
+    const definitionId = syncRules.syncConfigContent[0].mapping.allBucketDefinitionIds()[0];
+    const request = bucketRequest(syncRules.syncConfigContent[0], 'global[]', 0n);
+    const checkpoint = await bucketStorage.getCheckpoint();
+    await compactActive(factory, {
+      maxOpId: checkpoint.checkpoint,
+      compactBuckets: [request.bucket],
+      clearBatchLimit: 2,
+      moveBatchQueryLimit: 1,
+      minBucketChanges: 1,
+      minChangeRatio: 0
+    });
+
+    const batch = await test_utils.getBatchArray(bucketStorage.getBucketDataBatch(checkpoint, [request]));
+    const data = batch.flatMap((chunk) => chunk.chunkData.data);
+    expect(data.some((op: any) => op.op === 'CLEAR')).toBe(true);
+    await expectUsageMatchesBucketData(bucketStorage, definitionId);
   });
 
   test('MOVE compaction merges adjacent objects using their compacted size in one write', async () => {
@@ -195,6 +304,7 @@ describe('S3 compaction storage lifecycle', () => {
     // final replacement was uploaded. There was no intermediate MOVE-only
     // object before the merge.
     expect(objectStore.size).toBe(4);
+    await expectUsageMatchesBucketData(bucketStorage, definitionId);
   });
 
   test('compaction only retires S3 objects at or below the maxOpId horizon', async () => {
@@ -259,6 +369,7 @@ describe('S3 compaction storage lifecycle', () => {
 
     // Retired objects remain readable during the reference grace period.
     expect([...lowerPaths].every((path) => memoryStorage.store.has(path))).toBe(true);
+    await expectUsageMatchesBucketData(bucketStorage, definitionId);
 
     const batch = await test_utils.getBatchArray(bucketStorage.getBucketDataBatch(readCheckpoint, [request]));
     const data = batch.flatMap((chunk) => chunk.chunkData.data);
@@ -404,6 +515,7 @@ describe('S3 compaction storage lifecycle', () => {
     for (const path of afterS3Paths) {
       expect(storedPaths.has(path)).toBe(true);
     }
+    await expectUsageMatchesBucketData(bucketStorage, definitionId);
 
     // The replacement object is readable and contains the expected compacted
     // operation sequence.

--- a/modules/module-mongodb-storage/test/src/storage_s3_compaction_lifecycle.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_s3_compaction_lifecycle.test.ts
@@ -5,6 +5,7 @@ import { MongoSyncBucketStorage } from '../../src/storage/implementation/createM
 import { MongoSyncBucketStorageV3 } from '../../src/storage/implementation/v3/MongoSyncBucketStorageV3.js';
 import { VersionedPowerSyncMongoV3 } from '../../src/storage/implementation/v3/VersionedPowerSyncMongoV3.js';
 import { ObjectStorageError } from '../../src/storage/implementation/v3/object-storage/ObjectStorage.js';
+import { ObjectStorageUsage } from '../../src/storage/implementation/v3/object-storage/ObjectStorageUsage.js';
 import { env } from './env.js';
 import { createMemoryS3TestStorageSuite, createS3TestStorageSuite } from './helpers/s3TestFactory.js';
 
@@ -34,10 +35,8 @@ async function expectUsageMatchesBucketData(bucketStorage: MongoSyncBucketStorag
   const db = v3BucketStorage.db as VersionedPowerSyncMongoV3;
   const documents = await db.bucketData(v3BucketStorage.replicationStreamId, definitionId).find({}).toArray();
   const expectedBytes = documents.reduce((sum, document) => sum + BigInt(document.storage_ref?.file_size ?? 0), 0n);
-  await expect(v3BucketStorage.getObjectStorageUsage()).resolves.toEqual({
-    replication_stream_id: v3BucketStorage.replicationStreamId,
-    active_bytes: expectedBytes
-  });
+  const entries = await new ObjectStorageUsage(db, v3BucketStorage.replicationStreamId).readEntries();
+  expect(entries.reduce((sum, entry) => sum + entry.active_bytes, 0n)).toBe(expectedBytes);
 }
 
 describe('S3 compaction storage lifecycle', () => {

--- a/modules/module-postgres-storage/src/storage/PostgresBucketStorageFactory.ts
+++ b/modules/module-postgres-storage/src/storage/PostgresBucketStorageFactory.ts
@@ -79,7 +79,8 @@ export class PostgresBucketStorageFactory extends storage.BucketStorageFactory {
       return {
         operations_size_bytes: 0,
         parameters_size_bytes: 0,
-        replication_size_bytes: 0
+        replication_size_bytes: 0,
+        object_storage_size_bytes: 0
       };
     }
 
@@ -105,7 +106,8 @@ export class PostgresBucketStorageFactory extends storage.BucketStorageFactory {
     return {
       operations_size_bytes: Number(sizes!.operations_size_bytes),
       parameters_size_bytes: Number(sizes!.parameter_size_bytes),
-      replication_size_bytes: Number(sizes!.v1_current_size_bytes) + Number(sizes!.v3_current_size_bytes)
+      replication_size_bytes: Number(sizes!.v1_current_size_bytes) + Number(sizes!.v3_current_size_bytes),
+      object_storage_size_bytes: 0
     };
   }
 

--- a/packages/service-core-tests/src/tests/register-data-storage-data-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-data-tests.ts
@@ -1458,7 +1458,7 @@ bucket_definitions:
   test('empty storage metrics', async () => {
     await using f = await generateStorageFactory({ dropAll: true });
     const metrics = await f.getStorageMetrics();
-    expect(metrics).toEqual({
+    expect(metrics).toMatchObject({
       operations_size_bytes: 0,
       parameters_size_bytes: 0,
       replication_size_bytes: 0,

--- a/packages/service-core-tests/src/tests/register-data-storage-data-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-data-tests.ts
@@ -1461,7 +1461,8 @@ bucket_definitions:
     expect(metrics).toEqual({
       operations_size_bytes: 0,
       parameters_size_bytes: 0,
-      replication_size_bytes: 0
+      replication_size_bytes: 0,
+      object_storage_size_bytes: 0
     });
 
     const r = await f.configureSyncRules(updateSyncRulesFromYaml('bucket_definitions: {}'));

--- a/packages/service-core/src/metrics/metrics-interfaces.ts
+++ b/packages/service-core/src/metrics/metrics-interfaces.ts
@@ -19,7 +19,12 @@ export interface ObservableGauge {
    *  Set a value provider that provides the value for the gauge at the time of observation.
    *  @param valueProvider
    */
-  setValueProvider(valueProvider: () => Promise<number | undefined>): void;
+  setValueProvider(valueProvider: () => Promise<number | ObservableGaugeObservation[] | undefined>): void;
+}
+
+export interface ObservableGaugeObservation {
+  value: number;
+  attributes?: Record<string, string>;
 }
 
 export enum Precision {

--- a/packages/service-core/src/metrics/open-telemetry/OpenTelemetryMetricsFactory.ts
+++ b/packages/service-core/src/metrics/open-telemetry/OpenTelemetryMetricsFactory.ts
@@ -4,6 +4,7 @@ import {
   MetricMetadata,
   MetricsFactory,
   ObservableGauge,
+  ObservableGaugeObservation,
   Precision,
   UpDownCounter
 } from '../metrics-interfaces.js';
@@ -31,12 +32,16 @@ export class OpenTelemetryMetricsFactory implements MetricsFactory {
     });
 
     return {
-      setValueProvider(valueProvider: () => Promise<number | undefined>) {
+      setValueProvider(valueProvider: () => Promise<number | ObservableGaugeObservation[] | undefined>) {
         gauge.addCallback(async (result) => {
           const value = await valueProvider();
 
-          if (value != undefined) {
+          if (typeof value === 'number') {
             result.observe(value);
+          } else if (value != undefined) {
+            for (const observation of value) {
+              result.observe(observation.value, observation.attributes);
+            }
           }
         });
       }

--- a/packages/service-core/src/storage/BucketStorageFactory.ts
+++ b/packages/service-core/src/storage/BucketStorageFactory.ts
@@ -156,10 +156,10 @@ export interface StorageMetrics {
 export interface StorageSyncConfigMetrics {
   sync_config_id: string;
   sync_config_state: string;
-  operations_size_bytes: number;
-  parameters_size_bytes: number;
-  replication_size_bytes: number;
-  object_storage_size_bytes: number;
+  attributed_bucket_data_bytes: number;
+  attributed_parameter_indexes_bytes: number;
+  attributed_source_records_bytes: number;
+  attributed_object_storage_bytes: number;
 }
 
 export interface UpdateSyncRulesOptions {

--- a/packages/service-core/src/storage/BucketStorageFactory.ts
+++ b/packages/service-core/src/storage/BucketStorageFactory.ts
@@ -141,6 +141,25 @@ export interface StorageMetrics {
    * Size of current_data.
    */
   replication_size_bytes: number;
+
+  /**
+   * Size of active object-storage references, such as S3 bucket-data objects.
+   */
+  object_storage_size_bytes?: number;
+
+  /**
+   * Per-replication-stream storage sizes, when the storage backend can provide them.
+   */
+  stream_metrics?: StorageStreamMetrics[];
+}
+
+export interface StorageStreamMetrics {
+  replication_stream_id: number;
+  stream_state: string;
+  operations_size_bytes: number;
+  parameters_size_bytes: number;
+  replication_size_bytes: number;
+  object_storage_size_bytes: number;
 }
 
 export interface UpdateSyncRulesOptions {

--- a/packages/service-core/src/storage/BucketStorageFactory.ts
+++ b/packages/service-core/src/storage/BucketStorageFactory.ts
@@ -148,14 +148,14 @@ export interface StorageMetrics {
   object_storage_size_bytes?: number;
 
   /**
-   * Per-replication-stream storage sizes, when the storage backend can provide them.
+   * Per-sync-config storage sizes, when the storage backend can provide them.
    */
-  stream_metrics?: StorageStreamMetrics[];
+  sync_config_metrics?: StorageSyncConfigMetrics[];
 }
 
-export interface StorageStreamMetrics {
-  replication_stream_id: number;
-  stream_state: string;
+export interface StorageSyncConfigMetrics {
+  sync_config_id: string;
+  sync_config_state: string;
   operations_size_bytes: number;
   parameters_size_bytes: number;
   replication_size_bytes: number;

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -10,7 +10,7 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     unit: 'bytes'
   });
   engine.createObservableGauge({
-    name: StorageMetric.REPLICATION_SIZE_BYTES_BY_SYNC_CONFIG,
+    name: StorageMetric.ATTRIBUTED_SOURCE_RECORDS_BYTES,
     description: 'Size of current data stored in PowerSync by sync config',
     unit: 'bytes'
   });
@@ -21,7 +21,7 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     unit: 'bytes'
   });
   engine.createObservableGauge({
-    name: StorageMetric.OPERATION_SIZE_BYTES_BY_SYNC_CONFIG,
+    name: StorageMetric.ATTRIBUTED_BUCKET_DATA_BYTES,
     description: 'Size of operations stored in PowerSync by sync config',
     unit: 'bytes'
   });
@@ -32,7 +32,7 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     unit: 'bytes'
   });
   engine.createObservableGauge({
-    name: StorageMetric.PARAMETER_SIZE_BYTES_BY_SYNC_CONFIG,
+    name: StorageMetric.ATTRIBUTED_PARAMETER_INDEXES_BYTES,
     description: 'Size of parameter data stored in PowerSync by sync config',
     unit: 'bytes'
   });
@@ -43,7 +43,7 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     unit: 'bytes'
   });
   engine.createObservableGauge({
-    name: StorageMetric.OBJECT_STORAGE_SIZE_BYTES_BY_SYNC_CONFIG,
+    name: StorageMetric.ATTRIBUTED_OBJECT_STORAGE_BYTES,
     description: 'Size of active object-storage references by sync config',
     unit: 'bytes'
   });
@@ -51,21 +51,15 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
 
 export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: BucketStorageFactory): void {
   const replication_storage_size_bytes = engine.getObservableGauge(StorageMetric.REPLICATION_SIZE_BYTES);
-  const replication_storage_size_bytes_by_sync_config = engine.getObservableGauge(
-    StorageMetric.REPLICATION_SIZE_BYTES_BY_SYNC_CONFIG
-  );
+  const attributed_source_records_bytes = engine.getObservableGauge(StorageMetric.ATTRIBUTED_SOURCE_RECORDS_BYTES);
   const operation_storage_size_bytes = engine.getObservableGauge(StorageMetric.OPERATION_SIZE_BYTES);
-  const operation_storage_size_bytes_by_sync_config = engine.getObservableGauge(
-    StorageMetric.OPERATION_SIZE_BYTES_BY_SYNC_CONFIG
-  );
+  const attributed_bucket_data_bytes = engine.getObservableGauge(StorageMetric.ATTRIBUTED_BUCKET_DATA_BYTES);
   const parameter_storage_size_bytes = engine.getObservableGauge(StorageMetric.PARAMETER_SIZE_BYTES);
-  const parameter_storage_size_bytes_by_sync_config = engine.getObservableGauge(
-    StorageMetric.PARAMETER_SIZE_BYTES_BY_SYNC_CONFIG
+  const attributed_parameter_indexes_bytes = engine.getObservableGauge(
+    StorageMetric.ATTRIBUTED_PARAMETER_INDEXES_BYTES
   );
   const object_storage_size_bytes = engine.getObservableGauge(StorageMetric.OBJECT_STORAGE_SIZE_BYTES);
-  const object_storage_size_bytes_by_sync_config = engine.getObservableGauge(
-    StorageMetric.OBJECT_STORAGE_SIZE_BYTES_BY_SYNC_CONFIG
-  );
+  const attributed_object_storage_bytes = engine.getObservableGauge(StorageMetric.ATTRIBUTED_OBJECT_STORAGE_BYTES);
 
   const MINIMUM_INTERVAL = 60_000;
 
@@ -84,10 +78,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
   };
 
   type StorageSizeMetricKey =
-    | 'operations_size_bytes'
-    | 'parameters_size_bytes'
-    | 'replication_size_bytes'
-    | 'object_storage_size_bytes';
+    | 'attributed_bucket_data_bytes'
+    | 'attributed_parameter_indexes_bytes'
+    | 'attributed_source_records_bytes'
+    | 'attributed_object_storage_bytes';
 
   function nonNegative(value: number): number;
   function nonNegative(value: number | undefined): number | undefined;
@@ -114,10 +108,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return nonNegative(metrics?.replication_size_bytes);
   });
 
-  replication_storage_size_bytes_by_sync_config.setValueProvider(async () => {
+  attributed_source_records_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return observationsForSyncConfigs(metrics, 'replication_size_bytes');
+      return observationsForSyncConfigs(metrics, 'attributed_source_records_bytes');
     }
   });
 
@@ -126,10 +120,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return nonNegative(metrics?.operations_size_bytes);
   });
 
-  operation_storage_size_bytes_by_sync_config.setValueProvider(async () => {
+  attributed_bucket_data_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return observationsForSyncConfigs(metrics, 'operations_size_bytes');
+      return observationsForSyncConfigs(metrics, 'attributed_bucket_data_bytes');
     }
   });
 
@@ -138,10 +132,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return nonNegative(metrics?.parameters_size_bytes);
   });
 
-  parameter_storage_size_bytes_by_sync_config.setValueProvider(async () => {
+  attributed_parameter_indexes_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return observationsForSyncConfigs(metrics, 'parameters_size_bytes');
+      return observationsForSyncConfigs(metrics, 'attributed_parameter_indexes_bytes');
     }
   });
 
@@ -150,10 +144,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return nonNegative(metrics?.object_storage_size_bytes);
   });
 
-  object_storage_size_bytes_by_sync_config.setValueProvider(async () => {
+  attributed_object_storage_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return observationsForSyncConfigs(metrics, 'object_storage_size_bytes');
+      return observationsForSyncConfigs(metrics, 'attributed_object_storage_bytes');
     }
   });
 }

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -9,10 +9,20 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     description: 'Size of current data stored in PowerSync',
     unit: 'bytes'
   });
+  engine.createObservableGauge({
+    name: StorageMetric.REPLICATION_SIZE_BYTES_BY_STREAM,
+    description: 'Size of current data stored in PowerSync by replication stream',
+    unit: 'bytes'
+  });
 
   engine.createObservableGauge({
     name: StorageMetric.OPERATION_SIZE_BYTES,
     description: 'Size of operations stored in PowerSync',
+    unit: 'bytes'
+  });
+  engine.createObservableGauge({
+    name: StorageMetric.OPERATION_SIZE_BYTES_BY_STREAM,
+    description: 'Size of operations stored in PowerSync by replication stream',
     unit: 'bytes'
   });
 
@@ -21,12 +31,41 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     description: 'Size of parameter data stored in PowerSync',
     unit: 'bytes'
   });
+  engine.createObservableGauge({
+    name: StorageMetric.PARAMETER_SIZE_BYTES_BY_STREAM,
+    description: 'Size of parameter data stored in PowerSync by replication stream',
+    unit: 'bytes'
+  });
+
+  engine.createObservableGauge({
+    name: StorageMetric.OBJECT_STORAGE_SIZE_BYTES,
+    description: 'Size of active object-storage references stored in PowerSync',
+    unit: 'bytes'
+  });
+  engine.createObservableGauge({
+    name: StorageMetric.OBJECT_STORAGE_SIZE_BYTES_BY_STREAM,
+    description: 'Size of active object-storage references by replication stream',
+    unit: 'bytes'
+  });
 }
 
 export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: BucketStorageFactory): void {
   const replication_storage_size_bytes = engine.getObservableGauge(StorageMetric.REPLICATION_SIZE_BYTES);
+  const replication_storage_size_bytes_by_stream = engine.getObservableGauge(
+    StorageMetric.REPLICATION_SIZE_BYTES_BY_STREAM
+  );
   const operation_storage_size_bytes = engine.getObservableGauge(StorageMetric.OPERATION_SIZE_BYTES);
+  const operation_storage_size_bytes_by_stream = engine.getObservableGauge(
+    StorageMetric.OPERATION_SIZE_BYTES_BY_STREAM
+  );
   const parameter_storage_size_bytes = engine.getObservableGauge(StorageMetric.PARAMETER_SIZE_BYTES);
+  const parameter_storage_size_bytes_by_stream = engine.getObservableGauge(
+    StorageMetric.PARAMETER_SIZE_BYTES_BY_STREAM
+  );
+  const object_storage_size_bytes = engine.getObservableGauge(StorageMetric.OBJECT_STORAGE_SIZE_BYTES);
+  const object_storage_size_bytes_by_stream = engine.getObservableGauge(
+    StorageMetric.OBJECT_STORAGE_SIZE_BYTES_BY_STREAM
+  );
 
   const MINIMUM_INTERVAL = 60_000;
 
@@ -44,24 +83,71 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return cachedRequest;
   };
 
+  type StorageSizeMetricKey =
+    | 'operations_size_bytes'
+    | 'parameters_size_bytes'
+    | 'replication_size_bytes'
+    | 'object_storage_size_bytes';
+
+  const observationsForStreams = (metrics: StorageMetrics, key: StorageSizeMetricKey) => {
+    const observations: { value: number; attributes?: Record<string, string> }[] = [];
+    for (const stream of metrics.stream_metrics ?? []) {
+      observations.push({
+        value: stream[key],
+        attributes: {
+          replication_stream_id: String(stream.replication_stream_id),
+          stream_state: stream.stream_state
+        }
+      });
+    }
+    return observations;
+  };
+
   replication_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
+    return metrics?.replication_size_bytes;
+  });
+
+  replication_storage_size_bytes_by_stream.setValueProvider(async () => {
+    const metrics = await getMetrics();
     if (metrics) {
-      return metrics.replication_size_bytes;
+      return observationsForStreams(metrics, 'replication_size_bytes');
     }
   });
 
   operation_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
+    return metrics?.operations_size_bytes;
+  });
+
+  operation_storage_size_bytes_by_stream.setValueProvider(async () => {
+    const metrics = await getMetrics();
     if (metrics) {
-      return metrics.operations_size_bytes;
+      return observationsForStreams(metrics, 'operations_size_bytes');
     }
   });
 
   parameter_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
+    return metrics?.parameters_size_bytes;
+  });
+
+  parameter_storage_size_bytes_by_stream.setValueProvider(async () => {
+    const metrics = await getMetrics();
     if (metrics) {
-      return metrics.parameters_size_bytes;
+      return observationsForStreams(metrics, 'parameters_size_bytes');
+    }
+  });
+
+  object_storage_size_bytes.setValueProvider(async () => {
+    const metrics = await getMetrics();
+    return metrics?.object_storage_size_bytes;
+  });
+
+  object_storage_size_bytes_by_stream.setValueProvider(async () => {
+    const metrics = await getMetrics();
+    if (metrics) {
+      return observationsForStreams(metrics, 'object_storage_size_bytes');
     }
   });
 }

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -63,15 +63,69 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
 
   const MINIMUM_INTERVAL = 60_000;
 
+  /**
+   * How long a sync config that is no longer present keeps being reported as zero.
+   *
+   * This must comfortably exceed the longest metric export interval, so that every configured
+   * reader observes the zero at least once. The OTLP reader exports every 5 minutes.
+   */
+  const RETIRED_SYNC_CONFIG_INTERVAL = 15 * 60_000;
+
+  type SyncConfigAttributes = {
+    sync_config_id: string;
+    sync_config_state: string;
+  };
+
+  /**
+   * Attribute sets reported at least once, along with the last time each was present in the
+   * storage metrics.
+   *
+   * These gauges are exported with cumulative temporality, which means the metrics SDK keeps
+   * re-exporting the last reported value for every attribute set it has seen, also after we stop
+   * reporting that set. Without this, a sync config that has since been pruned would keep
+   * reporting its last non-zero size indefinitely, so sums over these gauges would drift upwards
+   * permanently. Reporting zero for a while instead leaves the SDK carrying a zero forward.
+   */
+  const reportedSyncConfigs = new Map<string, { attributes: SyncConfigAttributes; lastSeen: number }>();
+
+  const syncConfigKey = (attributes: SyncConfigAttributes) =>
+    `${attributes.sync_config_id}|${attributes.sync_config_state}`;
+
+  const trackSyncConfigs = (metrics: StorageMetrics | null) => {
+    if (metrics == null) {
+      // Failed to read the metrics - this says nothing about which sync configs still exist.
+      return;
+    }
+    const now = Date.now();
+    for (const syncConfig of metrics.sync_config_metrics ?? []) {
+      const attributes = {
+        sync_config_id: syncConfig.sync_config_id,
+        sync_config_state: syncConfig.sync_config_state
+      };
+      reportedSyncConfigs.set(syncConfigKey(attributes), { attributes, lastSeen: now });
+    }
+    for (const [key, entry] of reportedSyncConfigs) {
+      if (now - entry.lastSeen > RETIRED_SYNC_CONFIG_INTERVAL) {
+        reportedSyncConfigs.delete(key);
+      }
+    }
+  };
+
   let cachedRequest: Promise<StorageMetrics | null> | undefined = undefined;
   let cacheTimestamp = 0;
 
   const getMetrics = () => {
     if (!cachedRequest || Date.now() - cacheTimestamp > MINIMUM_INTERVAL) {
-      cachedRequest = storage.getStorageMetrics().catch((e) => {
-        logger.error(`Failed to get storage metrics`, e);
-        return null;
-      });
+      cachedRequest = storage
+        .getStorageMetrics()
+        .catch((e) => {
+          logger.error(`Failed to get storage metrics`, e);
+          return null;
+        })
+        .then((metrics) => {
+          trackSyncConfigs(metrics);
+          return metrics;
+        });
       cacheTimestamp = Date.now();
     }
     return cachedRequest;
@@ -91,14 +145,19 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
 
   const observationsForSyncConfigs = (metrics: StorageMetrics, key: StorageSizeMetricKey) => {
     const observations: { value: number; attributes?: Record<string, string> }[] = [];
+    const present = new Set<string>();
     for (const syncConfig of metrics.sync_config_metrics ?? []) {
-      observations.push({
-        value: nonNegative(syncConfig[key]),
-        attributes: {
-          sync_config_id: syncConfig.sync_config_id,
-          sync_config_state: syncConfig.sync_config_state
-        }
-      });
+      const attributes = {
+        sync_config_id: syncConfig.sync_config_id,
+        sync_config_state: syncConfig.sync_config_state
+      };
+      present.add(syncConfigKey(attributes));
+      observations.push({ value: nonNegative(syncConfig[key]), attributes });
+    }
+    for (const entry of reportedSyncConfigs.values()) {
+      if (!present.has(syncConfigKey(entry.attributes))) {
+        observations.push({ value: 0, attributes: entry.attributes });
+      }
     }
     return observations;
   };

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -89,13 +89,17 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     | 'replication_size_bytes'
     | 'object_storage_size_bytes';
 
-  const nonNegative = (value: number | undefined) => (value == null ? value : Math.max(0, value));
+  function nonNegative(value: number): number;
+  function nonNegative(value: number | undefined): number | undefined;
+  function nonNegative(value: number | undefined) {
+    return value == null ? value : Math.max(0, value);
+  }
 
   const observationsForSyncConfigs = (metrics: StorageMetrics, key: StorageSizeMetricKey) => {
     const observations: { value: number; attributes?: Record<string, string> }[] = [];
     for (const syncConfig of metrics.sync_config_metrics ?? []) {
       observations.push({
-        value: nonNegative(syncConfig[key])!,
+        value: nonNegative(syncConfig[key]),
         attributes: {
           sync_config_id: syncConfig.sync_config_id,
           sync_config_state: syncConfig.sync_config_state

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -10,8 +10,8 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     unit: 'bytes'
   });
   engine.createObservableGauge({
-    name: StorageMetric.REPLICATION_SIZE_BYTES_BY_STREAM,
-    description: 'Size of current data stored in PowerSync by replication stream',
+    name: StorageMetric.REPLICATION_SIZE_BYTES_BY_SYNC_CONFIG,
+    description: 'Size of current data stored in PowerSync by sync config',
     unit: 'bytes'
   });
 
@@ -21,8 +21,8 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     unit: 'bytes'
   });
   engine.createObservableGauge({
-    name: StorageMetric.OPERATION_SIZE_BYTES_BY_STREAM,
-    description: 'Size of operations stored in PowerSync by replication stream',
+    name: StorageMetric.OPERATION_SIZE_BYTES_BY_SYNC_CONFIG,
+    description: 'Size of operations stored in PowerSync by sync config',
     unit: 'bytes'
   });
 
@@ -32,8 +32,8 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     unit: 'bytes'
   });
   engine.createObservableGauge({
-    name: StorageMetric.PARAMETER_SIZE_BYTES_BY_STREAM,
-    description: 'Size of parameter data stored in PowerSync by replication stream',
+    name: StorageMetric.PARAMETER_SIZE_BYTES_BY_SYNC_CONFIG,
+    description: 'Size of parameter data stored in PowerSync by sync config',
     unit: 'bytes'
   });
 
@@ -43,28 +43,28 @@ export function createCoreStorageMetrics(engine: MetricsEngine): void {
     unit: 'bytes'
   });
   engine.createObservableGauge({
-    name: StorageMetric.OBJECT_STORAGE_SIZE_BYTES_BY_STREAM,
-    description: 'Size of active object-storage references by replication stream',
+    name: StorageMetric.OBJECT_STORAGE_SIZE_BYTES_BY_SYNC_CONFIG,
+    description: 'Size of active object-storage references by sync config',
     unit: 'bytes'
   });
 }
 
 export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: BucketStorageFactory): void {
   const replication_storage_size_bytes = engine.getObservableGauge(StorageMetric.REPLICATION_SIZE_BYTES);
-  const replication_storage_size_bytes_by_stream = engine.getObservableGauge(
-    StorageMetric.REPLICATION_SIZE_BYTES_BY_STREAM
+  const replication_storage_size_bytes_by_sync_config = engine.getObservableGauge(
+    StorageMetric.REPLICATION_SIZE_BYTES_BY_SYNC_CONFIG
   );
   const operation_storage_size_bytes = engine.getObservableGauge(StorageMetric.OPERATION_SIZE_BYTES);
-  const operation_storage_size_bytes_by_stream = engine.getObservableGauge(
-    StorageMetric.OPERATION_SIZE_BYTES_BY_STREAM
+  const operation_storage_size_bytes_by_sync_config = engine.getObservableGauge(
+    StorageMetric.OPERATION_SIZE_BYTES_BY_SYNC_CONFIG
   );
   const parameter_storage_size_bytes = engine.getObservableGauge(StorageMetric.PARAMETER_SIZE_BYTES);
-  const parameter_storage_size_bytes_by_stream = engine.getObservableGauge(
-    StorageMetric.PARAMETER_SIZE_BYTES_BY_STREAM
+  const parameter_storage_size_bytes_by_sync_config = engine.getObservableGauge(
+    StorageMetric.PARAMETER_SIZE_BYTES_BY_SYNC_CONFIG
   );
   const object_storage_size_bytes = engine.getObservableGauge(StorageMetric.OBJECT_STORAGE_SIZE_BYTES);
-  const object_storage_size_bytes_by_stream = engine.getObservableGauge(
-    StorageMetric.OBJECT_STORAGE_SIZE_BYTES_BY_STREAM
+  const object_storage_size_bytes_by_sync_config = engine.getObservableGauge(
+    StorageMetric.OBJECT_STORAGE_SIZE_BYTES_BY_SYNC_CONFIG
   );
 
   const MINIMUM_INTERVAL = 60_000;
@@ -89,14 +89,14 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     | 'replication_size_bytes'
     | 'object_storage_size_bytes';
 
-  const observationsForStreams = (metrics: StorageMetrics, key: StorageSizeMetricKey) => {
+  const observationsForSyncConfigs = (metrics: StorageMetrics, key: StorageSizeMetricKey) => {
     const observations: { value: number; attributes?: Record<string, string> }[] = [];
-    for (const stream of metrics.stream_metrics ?? []) {
+    for (const syncConfig of metrics.sync_config_metrics ?? []) {
       observations.push({
-        value: stream[key],
+        value: syncConfig[key],
         attributes: {
-          replication_stream_id: String(stream.replication_stream_id),
-          stream_state: stream.stream_state
+          sync_config_id: syncConfig.sync_config_id,
+          sync_config_state: syncConfig.sync_config_state
         }
       });
     }
@@ -108,10 +108,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return metrics?.replication_size_bytes;
   });
 
-  replication_storage_size_bytes_by_stream.setValueProvider(async () => {
+  replication_storage_size_bytes_by_sync_config.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return observationsForStreams(metrics, 'replication_size_bytes');
+      return observationsForSyncConfigs(metrics, 'replication_size_bytes');
     }
   });
 
@@ -120,10 +120,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return metrics?.operations_size_bytes;
   });
 
-  operation_storage_size_bytes_by_stream.setValueProvider(async () => {
+  operation_storage_size_bytes_by_sync_config.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return observationsForStreams(metrics, 'operations_size_bytes');
+      return observationsForSyncConfigs(metrics, 'operations_size_bytes');
     }
   });
 
@@ -132,10 +132,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return metrics?.parameters_size_bytes;
   });
 
-  parameter_storage_size_bytes_by_stream.setValueProvider(async () => {
+  parameter_storage_size_bytes_by_sync_config.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return observationsForStreams(metrics, 'parameters_size_bytes');
+      return observationsForSyncConfigs(metrics, 'parameters_size_bytes');
     }
   });
 
@@ -144,10 +144,10 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     return metrics?.object_storage_size_bytes;
   });
 
-  object_storage_size_bytes_by_stream.setValueProvider(async () => {
+  object_storage_size_bytes_by_sync_config.setValueProvider(async () => {
     const metrics = await getMetrics();
     if (metrics) {
-      return observationsForStreams(metrics, 'object_storage_size_bytes');
+      return observationsForSyncConfigs(metrics, 'object_storage_size_bytes');
     }
   });
 }

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -89,11 +89,13 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     | 'replication_size_bytes'
     | 'object_storage_size_bytes';
 
+  const nonNegative = (value: number | undefined) => (value == null ? value : Math.max(0, value));
+
   const observationsForSyncConfigs = (metrics: StorageMetrics, key: StorageSizeMetricKey) => {
     const observations: { value: number; attributes?: Record<string, string> }[] = [];
     for (const syncConfig of metrics.sync_config_metrics ?? []) {
       observations.push({
-        value: syncConfig[key],
+        value: nonNegative(syncConfig[key])!,
         attributes: {
           sync_config_id: syncConfig.sync_config_id,
           sync_config_state: syncConfig.sync_config_state
@@ -105,7 +107,7 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
 
   replication_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
-    return metrics?.replication_size_bytes;
+    return nonNegative(metrics?.replication_size_bytes);
   });
 
   replication_storage_size_bytes_by_sync_config.setValueProvider(async () => {
@@ -117,7 +119,7 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
 
   operation_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
-    return metrics?.operations_size_bytes;
+    return nonNegative(metrics?.operations_size_bytes);
   });
 
   operation_storage_size_bytes_by_sync_config.setValueProvider(async () => {
@@ -129,7 +131,7 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
 
   parameter_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
-    return metrics?.parameters_size_bytes;
+    return nonNegative(metrics?.parameters_size_bytes);
   });
 
   parameter_storage_size_bytes_by_sync_config.setValueProvider(async () => {
@@ -141,7 +143,7 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
 
   object_storage_size_bytes.setValueProvider(async () => {
     const metrics = await getMetrics();
-    return metrics?.object_storage_size_bytes;
+    return nonNegative(metrics?.object_storage_size_bytes);
   });
 
   object_storage_size_bytes_by_sync_config.setValueProvider(async () => {

--- a/packages/service-core/test/src/storage-metrics.test.ts
+++ b/packages/service-core/test/src/storage-metrics.test.ts
@@ -1,0 +1,141 @@
+import { MetricsEngine } from '@/metrics/MetricsEngine.js';
+import {
+  MetricMetadata,
+  MetricsFactory,
+  ObservableGauge,
+  ObservableGaugeObservation
+} from '@/metrics/metrics-interfaces.js';
+import { BucketStorageFactory, StorageMetrics, StorageSyncConfigMetrics } from '@/storage/BucketStorageFactory.js';
+import { createCoreStorageMetrics, initializeCoreStorageMetrics } from '@/storage/storage-metrics.js';
+import { StorageMetric } from '@powersync/service-types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ValueProvider = () => Promise<number | ObservableGaugeObservation[] | undefined>;
+
+function testEngine() {
+  const providers = new Map<string, ValueProvider>();
+  const factory: MetricsFactory = {
+    createCounter: () => ({ add: () => {} }),
+    createUpDownCounter: () => ({ add: () => {} }),
+    createObservableGauge: (metadata: MetricMetadata): ObservableGauge => ({
+      setValueProvider: (valueProvider) => providers.set(metadata.name, valueProvider)
+    })
+  };
+  const engine = new MetricsEngine({ factory, disable_telemetry_sharing: true });
+  createCoreStorageMetrics(engine);
+  return { engine, providers };
+}
+
+function syncConfigMetrics(id: string, state: string, bytes: number): StorageSyncConfigMetrics {
+  return {
+    sync_config_id: id,
+    sync_config_state: state,
+    attributed_bucket_data_bytes: bytes,
+    attributed_parameter_indexes_bytes: bytes,
+    attributed_source_records_bytes: bytes,
+    attributed_object_storage_bytes: bytes
+  };
+}
+
+function storageMetrics(sync_config_metrics: StorageSyncConfigMetrics[]): StorageMetrics {
+  return {
+    operations_size_bytes: 0,
+    parameters_size_bytes: 0,
+    replication_size_bytes: 0,
+    object_storage_size_bytes: 0,
+    sync_config_metrics
+  };
+}
+
+describe('storage metrics', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports retired sync configs as zero, then stops reporting them', async () => {
+    let current = storageMetrics([syncConfigMetrics('config-a', 'ACTIVE', 100)]);
+    const storage = {
+      getStorageMetrics: async () => current
+    } as unknown as BucketStorageFactory;
+
+    const { engine, providers } = testEngine();
+    initializeCoreStorageMetrics(engine, storage);
+    const provider = providers.get(StorageMetric.ATTRIBUTED_BUCKET_DATA_BYTES)!;
+
+    expect(await provider()).toEqual([
+      { value: 100, attributes: { sync_config_id: 'config-a', sync_config_state: 'ACTIVE' } }
+    ]);
+
+    // The sync config is pruned. Its series must go to zero rather than keep its last value,
+    // since the SDK carries the last reported value forward under cumulative temporality.
+    current = storageMetrics([syncConfigMetrics('config-b', 'ACTIVE', 50)]);
+    vi.setSystemTime(61_000);
+
+    expect(await provider()).toEqual([
+      { value: 50, attributes: { sync_config_id: 'config-b', sync_config_state: 'ACTIVE' } },
+      { value: 0, attributes: { sync_config_id: 'config-a', sync_config_state: 'ACTIVE' } }
+    ]);
+
+    // Once every reader has had a chance to observe the zero, stop reporting it entirely.
+    vi.setSystemTime(61_000 + 16 * 60_000);
+
+    expect(await provider()).toEqual([
+      { value: 50, attributes: { sync_config_id: 'config-b', sync_config_state: 'ACTIVE' } }
+    ]);
+  });
+
+  it('treats a state transition as a retired attribute set', async () => {
+    let current = storageMetrics([syncConfigMetrics('config-a', 'PROCESSING', 100)]);
+    const storage = {
+      getStorageMetrics: async () => current
+    } as unknown as BucketStorageFactory;
+
+    const { engine, providers } = testEngine();
+    initializeCoreStorageMetrics(engine, storage);
+    const provider = providers.get(StorageMetric.ATTRIBUTED_SOURCE_RECORDS_BYTES)!;
+
+    await provider();
+
+    current = storageMetrics([syncConfigMetrics('config-a', 'ACTIVE', 120)]);
+    vi.setSystemTime(61_000);
+
+    expect(await provider()).toEqual([
+      { value: 120, attributes: { sync_config_id: 'config-a', sync_config_state: 'ACTIVE' } },
+      { value: 0, attributes: { sync_config_id: 'config-a', sync_config_state: 'PROCESSING' } }
+    ]);
+  });
+
+  it('does not report anything as retired when reading the metrics fails', async () => {
+    let fail = false;
+    const storage = {
+      getStorageMetrics: async () => {
+        if (fail) {
+          throw new Error('storage unavailable');
+        }
+        return storageMetrics([syncConfigMetrics('config-a', 'ACTIVE', 100)]);
+      }
+    } as unknown as BucketStorageFactory;
+
+    const { engine, providers } = testEngine();
+    initializeCoreStorageMetrics(engine, storage);
+    const provider = providers.get(StorageMetric.ATTRIBUTED_OBJECT_STORAGE_BYTES)!;
+
+    await provider();
+
+    fail = true;
+    vi.setSystemTime(61_000);
+    expect(await provider()).toBeUndefined();
+
+    // The failure must not be interpreted as the sync config having been pruned.
+    fail = false;
+    vi.setSystemTime(122_000);
+    expect(await provider()).toEqual([
+      { value: 100, attributes: { sync_config_id: 'config-a', sync_config_state: 'ACTIVE' } }
+    ]);
+  });
+});

--- a/packages/types/src/metrics.ts
+++ b/packages/types/src/metrics.ts
@@ -26,14 +26,14 @@ export enum ReplicationMetric {
 export enum StorageMetric {
   // Size of current replication data stored in PowerSync
   REPLICATION_SIZE_BYTES = 'powersync_replication_storage_size_bytes',
-  REPLICATION_SIZE_BYTES_BY_SYNC_CONFIG = 'powersync_replication_storage_size_bytes_by_sync_config',
+  ATTRIBUTED_SOURCE_RECORDS_BYTES = 'powersync_attributed_source_records_bytes',
   // Size of operations data stored in PowerSync
   OPERATION_SIZE_BYTES = 'powersync_operation_storage_size_bytes',
-  OPERATION_SIZE_BYTES_BY_SYNC_CONFIG = 'powersync_operation_storage_size_bytes_by_sync_config',
+  ATTRIBUTED_BUCKET_DATA_BYTES = 'powersync_attributed_bucket_data_bytes',
   // Size of parameter data stored in PowerSync
   PARAMETER_SIZE_BYTES = 'powersync_parameter_storage_size_bytes',
-  PARAMETER_SIZE_BYTES_BY_SYNC_CONFIG = 'powersync_parameter_storage_size_bytes_by_sync_config',
+  ATTRIBUTED_PARAMETER_INDEXES_BYTES = 'powersync_attributed_parameter_indexes_bytes',
   // Size of active S3 object-storage references stored in PowerSync
   OBJECT_STORAGE_SIZE_BYTES = 'powersync_object_storage_size_bytes',
-  OBJECT_STORAGE_SIZE_BYTES_BY_SYNC_CONFIG = 'powersync_object_storage_size_bytes_by_sync_config'
+  ATTRIBUTED_OBJECT_STORAGE_BYTES = 'powersync_attributed_object_storage_bytes'
 }

--- a/packages/types/src/metrics.ts
+++ b/packages/types/src/metrics.ts
@@ -26,8 +26,14 @@ export enum ReplicationMetric {
 export enum StorageMetric {
   // Size of current replication data stored in PowerSync
   REPLICATION_SIZE_BYTES = 'powersync_replication_storage_size_bytes',
+  REPLICATION_SIZE_BYTES_BY_STREAM = 'powersync_replication_storage_size_bytes_by_stream',
   // Size of operations data stored in PowerSync
   OPERATION_SIZE_BYTES = 'powersync_operation_storage_size_bytes',
+  OPERATION_SIZE_BYTES_BY_STREAM = 'powersync_operation_storage_size_bytes_by_stream',
   // Size of parameter data stored in PowerSync
-  PARAMETER_SIZE_BYTES = 'powersync_parameter_storage_size_bytes'
+  PARAMETER_SIZE_BYTES = 'powersync_parameter_storage_size_bytes',
+  PARAMETER_SIZE_BYTES_BY_STREAM = 'powersync_parameter_storage_size_bytes_by_stream',
+  // Size of active S3 object-storage references stored in PowerSync
+  OBJECT_STORAGE_SIZE_BYTES = 'powersync_object_storage_size_bytes',
+  OBJECT_STORAGE_SIZE_BYTES_BY_STREAM = 'powersync_object_storage_size_bytes_by_stream'
 }

--- a/packages/types/src/metrics.ts
+++ b/packages/types/src/metrics.ts
@@ -26,14 +26,14 @@ export enum ReplicationMetric {
 export enum StorageMetric {
   // Size of current replication data stored in PowerSync
   REPLICATION_SIZE_BYTES = 'powersync_replication_storage_size_bytes',
-  REPLICATION_SIZE_BYTES_BY_STREAM = 'powersync_replication_storage_size_bytes_by_stream',
+  REPLICATION_SIZE_BYTES_BY_SYNC_CONFIG = 'powersync_replication_storage_size_bytes_by_sync_config',
   // Size of operations data stored in PowerSync
   OPERATION_SIZE_BYTES = 'powersync_operation_storage_size_bytes',
-  OPERATION_SIZE_BYTES_BY_STREAM = 'powersync_operation_storage_size_bytes_by_stream',
+  OPERATION_SIZE_BYTES_BY_SYNC_CONFIG = 'powersync_operation_storage_size_bytes_by_sync_config',
   // Size of parameter data stored in PowerSync
   PARAMETER_SIZE_BYTES = 'powersync_parameter_storage_size_bytes',
-  PARAMETER_SIZE_BYTES_BY_STREAM = 'powersync_parameter_storage_size_bytes_by_stream',
+  PARAMETER_SIZE_BYTES_BY_SYNC_CONFIG = 'powersync_parameter_storage_size_bytes_by_sync_config',
   // Size of active S3 object-storage references stored in PowerSync
   OBJECT_STORAGE_SIZE_BYTES = 'powersync_object_storage_size_bytes',
-  OBJECT_STORAGE_SIZE_BYTES_BY_STREAM = 'powersync_object_storage_size_bytes_by_stream'
+  OBJECT_STORAGE_SIZE_BYTES_BY_SYNC_CONFIG = 'powersync_object_storage_size_bytes_by_sync_config'
 }


### PR DESCRIPTION
This records storage stats for S3.

With MongoDB and Postgres, we can cheaply get stats by querying the collection/table, getting metrics with the same granularity as the collection/table. This now exploits it for MongoDB v3 storage: This now reports storage sizes per sync config, in addition to the global metrics. This makes it easy to view metrics for configs that are active, replicating, or deleting.

For S3, it's more tricky. There is no native S3 API that gives aggregated storage size. AWS does provide:
1. ListObject: Iterate through all S3 entries. Does not scale well.
2. CloudWatch metrics for total object size and count per bucket, updated daily. No way to split based on prefix; no way to get more recent data; no way to limit access to specific CloudWatch metrics via policies.
3. S3 Storage Lens: Can give aggregated metrics per bucket or per prefix. Requires extra work to configure.
4. S3 Inventory: Provides a summary of metadata over all S3 files in a bucket, updated daily or hourly. Slightly easier and faster than ListObject calls, but still does not scale well, and requires extra work to configure.

We could also iterate through bucket_data documents, or bucket_state documents, but neither scales well to hundreds of millions of buckets.

This instead updates aggregate counters when writing. By using the same transaction that performs the write, we ensure the numbers stay accurate. As a core requirement, we split the numbers by replication stream and by bucket definition id.

We could store the numbers on the existing `sync_rules` document, or an equivalent document per replication stream or bucket definition. The core issue that has is write contention between the replication process and compact workers. Since both would update the same document, it can easily lead to high write contention, completely stalling replication in the worst case.

This implementation works around it by "sharding" the counters based on the writer: Each writer generates a random writer id, and scopes all writes to that, completely avoiding write contention. As long as the number of writers stay small, the number of documents stay small, and reads stay cheap. But since every process restart or compact run can generate a new id, we do fold up these stats after each compact job.

## Metrics

Example Prometheus metrics below. We now produce metrics for each individual sync config. Note that if they share storage (shared definitions; shared source tables), the storage will be double-counted. The goal here for these metrics is to get a stable value per sync config, not to track overall usage.

```
# Old storage metrics: unchanged
powersync_replication_storage_size_bytes 7340032
powersync_operation_storage_size_bytes 2097152
powersync_parameter_storage_size_bytes 524288

# Added: total object storage size
powersync_object_storage_size_bytes 1048576

# Added: Metrics attributed to sync configs
# Note that these may add up to less than the totals if V1 storage is still used, and more than the totals where sync configs share storage. This is intentional.
powersync_attributed_source_records_bytes{sync_config_id="65f...",sync_config_state="ACTIVE"} 5242880
powersync_attributed_source_records_bytes{sync_config_id="65a...",sync_config_state="PROCESSING"}
4194304

powersync_attributed_bucket_data_bytes{sync_config_id="65f...",sync_config_state="ACTIVE"} 1572864
powersync_attributed_bucket_data_bytes{sync_config_id="65a...",sync_config_state="PROCESSING"} 1310720

powersync_attributed_parameter_indexes_bytes{sync_config_id="65f...",sync_config_state="ACTIVE"} 262144
powersync_attributed_parameter_indexes_bytes{sync_config_id="65a...",sync_config_state="PROCESSING"}
131072

powersync_attributed_object_storage_bytes{sync_config_id="65f...",sync_config_state="ACTIVE"} 786432
powersync_attributed_object_storage_bytes{sync_config_id="65a...",sync_config_state="PROCESSING"} 524288
```

## AI Usage

Planned and implemented using Codex gpt-5.6. Manually reviewed and tweaked.

