### PR TITLE
Fix connection stall after data fetch errors

### DIFF
--- a/.changeset/curvy-masks-sniff.md
+++ b/.changeset/curvy-masks-sniff.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Fix connection stall after data fetch errors.

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -120,8 +120,9 @@ async function* streamResponseInner(
     logger: logger
   });
   // The checkpoint iterator can have a pending next() while a data batch fails.
-  // Abort it before returning so that async-generator return() is not queued behind
-  // that pending next() until another checkpoint arrives.
+  // Aborting this on cleanup makes that pending next() settle, so the watcher subscription
+  // is released instead of staying open until another checkpoint arrives. See the cleanup
+  // in the finally block below.
   const checkpointWatchController = new AbortController();
   const stream = bucketStorage.watchCheckpointChanges({
     user_id: checkpointUserId,
@@ -338,10 +339,17 @@ async function* streamResponseInner(
       }
     } while (!signal.aborted);
   } finally {
+    // The abort makes a pending next() settle as soon as the storage watcher observes it,
+    // releasing the subscription. return() is still needed for the case where there is no
+    // pending next(): the watcher is then suspended at a yield and never observes the abort.
+    // Neither is awaited: async generators queue return() behind a pending next(), so
+    // awaiting it here would keep the connection open until the next checkpoint arrives.
     checkpointWatchController.abort();
-    // Do not await return(): async generators queue it behind a pending next().
-    // The abort above makes that next() settle as soon as the storage watcher observes it.
-    newCheckpoints.return?.().catch(() => {});
+    newCheckpoints.return?.().catch((e) => {
+      if (!isAbortError(e)) {
+        logger.warn('Error while closing the checkpoint watcher', e);
+      }
+    });
   }
 }
 

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -119,9 +119,13 @@ async function* streamResponseInner(
     syncRequest: params,
     logger: logger
   });
+  // The checkpoint iterator can have a pending next() while a data batch fails.
+  // Abort it before returning so that async-generator return() is not queued behind
+  // that pending next() until another checkpoint arrives.
+  const checkpointWatchController = new AbortController();
   const stream = bucketStorage.watchCheckpointChanges({
     user_id: checkpointUserId,
-    signal
+    signal: AbortSignal.any([signal, checkpointWatchController.signal])
   });
   const newCheckpoints = stream[Symbol.asyncIterator]();
 
@@ -334,7 +338,10 @@ async function* streamResponseInner(
       }
     } while (!signal.aborted);
   } finally {
-    await newCheckpoints.return?.();
+    checkpointWatchController.abort();
+    // Do not await return(): async generators queue it behind a pending next().
+    // The abort above makes that next() settle as soon as the storage watcher observes it.
+    newCheckpoints.return?.().catch(() => {});
   }
 }
 

--- a/packages/service-core/test/src/routes/stream.test.ts
+++ b/packages/service-core/test/src/routes/stream.test.ts
@@ -242,7 +242,7 @@ bucket_definitions:
 
         yield {
           chunkData: {
-            bucket: '1#global[]',
+            bucket: 'global[]',
             data: Array.from({ length: 1000 }, () => ({ op: 'PUT' })),
             has_more: true,
             after: '0',
@@ -271,20 +271,27 @@ bucket_definitions:
       }
     })();
 
+    let timeout: NodeJS.Timeout | undefined;
     const outcome = await Promise.race([
       response.then(
         () => new Error('Sync stream unexpectedly completed'),
         (error) => error
       ),
-      new Promise((resolve) => setTimeout(() => resolve(new Error('Sync stream did not close')), 500))
+      new Promise((resolve) => {
+        timeout = setTimeout(() => resolve(new Error('Sync stream did not close')), 500);
+      })
     ]);
+    clearTimeout(timeout);
+
+    // Capture this before aborting below, which would set it regardless of the stream cleanup.
+    const abortedByCleanup = checkpointWatcherAborted;
 
     controller.abort();
     await response.catch(() => {});
 
     expect(outcome).toBeInstanceOf(Error);
     expect((outcome as Error).message).toContain('Simulated data fetch failure');
-    expect(checkpointWatcherAborted).toBe(true);
+    expect(abortedByCleanup).toBe(true);
   });
 });
 

--- a/packages/service-core/test/src/routes/stream.test.ts
+++ b/packages/service-core/test/src/routes/stream.test.ts
@@ -1,4 +1,12 @@
-import { BasicRouterRequest, Context, JwtPayload, SyncRulesBucketStorage } from '@/index.js';
+import {
+  BasicRouterRequest,
+  CHECKPOINT_INVALIDATE_ALL,
+  Context,
+  JwtPayload,
+  RequestTracker,
+  streamResponse,
+  SyncRulesBucketStorage
+} from '@/index.js';
 import { logger, RouterResponse, ServiceError } from '@powersync/lib-services-framework';
 import {
   DEFAULT_HYDRATION_STATE,
@@ -181,6 +189,102 @@ describe('Stream Route', () => {
         DEFAULT_PARAM_LOGGING_FORMAT_OPTIONS.maxStringLength
       );
     });
+  });
+
+  it('closes after a data fetch error while waiting for a new checkpoint', async () => {
+    // After 1,000 operations, the sync stream concurrently calls next() on the
+    // checkpoint watcher. This test then fails the next data fetch without
+    // producing another checkpoint. Before the fix, awaiting watcher.return()
+    // during cleanup queued it behind that pending next(), leaving the response
+    // open until an unrelated checkpoint was written.
+    const syncRules = SqlSyncRules.fromYaml(
+      `
+bucket_definitions:
+  global:
+    data: []
+      `,
+      { defaultSchema: 'public' }
+    ).config.hydrate(defaultHydrationOptions);
+
+    let checkpointWatcherAborted = false;
+    let dataFetches = 0;
+    const storage = {
+      watchCheckpointChanges: async function* ({ signal }) {
+        yield {
+          base: {
+            checkpoint: 1n,
+            lsn: '1',
+            getParameterSets: async () => []
+          },
+          writeCheckpoint: null,
+          update: CHECKPOINT_INVALIDATE_ALL
+        };
+
+        await new Promise<void>((_resolve, reject) => {
+          // There is intentionally no next checkpoint: cleanup must abort this
+          // pending wait rather than wait for it to complete naturally.
+          signal.addEventListener(
+            'abort',
+            () => {
+              checkpointWatcherAborted = true;
+              reject(new Error('Checkpoint watcher aborted'));
+            },
+            { once: true }
+          );
+        });
+      },
+      getChecksums: async (_checkpoint, buckets) =>
+        new Map(buckets.map(({ bucket }) => [bucket, { bucket, checksum: 1, count: 1000 }])),
+      getBucketDataBatch: async function* () {
+        if (dataFetches++ > 0) {
+          throw new Error('Simulated data fetch failure');
+        }
+
+        yield {
+          chunkData: {
+            bucket: '1#global[]',
+            data: Array.from({ length: 1000 }, () => ({ op: 'PUT' })),
+            has_more: true,
+            after: '0',
+            next_after: '1000'
+          },
+          targetOp: null
+        };
+        yield { hasMore: true };
+      }
+    } as Partial<SyncRulesBucketStorage>;
+    const serviceContext = mockServiceContext(storage);
+    const controller = new AbortController();
+
+    const response = (async () => {
+      for await (const _line of streamResponse({
+        syncContext: serviceContext.syncContext,
+        bucketStorage: storage as SyncRulesBucketStorage,
+        syncRules,
+        params: { client_id: 'test-client', raw_data: true },
+        token: new JwtPayload({ sub: 'test-user', exp: Date.now() / 1000 + 10_000 }),
+        tracker: new RequestTracker(serviceContext.metricsEngine),
+        isEncodingAsBson: false,
+        signal: controller.signal
+      })) {
+        // Consume the response until the simulated data fetch error is propagated.
+      }
+    })();
+
+    const outcome = await Promise.race([
+      response.then(
+        () => new Error('Sync stream unexpectedly completed'),
+        (error) => error
+      ),
+      new Promise((resolve) => setTimeout(() => resolve(new Error('Sync stream did not close')), 500))
+    ]);
+
+    controller.abort();
+    await response.catch(() => {});
+
+    expect(outcome).toBeInstanceOf(Error);
+    expect((outcome as Error).message).toContain('Simulated data fetch failure');
+    expect(checkpointWatcherAborted).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes #772 - see the issue for details.

The issue affects both MongoDB and Postgres storage. It is commonly triggered when:
1. Many clients sync large volumes of data concurrently, triggering both the "sync multiple batches of data" and "Timeout while waiting for data" conditions.
2. No new checkpoints are created in this period.

This may have a disproportionate effect on load tests, since new checkpoints "resolve" the issue, which is typical in production for high load use cases, but not always in load tests. But it's not exclusive: This can happen in real production scenarios.

Confirmed that the issue is isolated to affected connections: The connection that received the error stalls, but it does not hold a lock, so does not directly affect other connections in the same process. So unlike #769, the issue does not persist on the process, and is resolved when the client reconnects or a new checkpoint is created.

## AI Usage

Issue confirmed and fix implemented using Codex gpt-5.6. Manually verified the issue and fix, and further reviewed and cleaned up using Claude Opus 5.

