### PR TITLE
Log checkpoint_interrupted for errors while fetching data

### DIFF
--- a/.changeset/shaggy-humans-make.md
+++ b/.changeset/shaggy-humans-make.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-core': patch
+---
+
+Log checkpoint_interrupted when a stream errors while fetching data.

--- a/packages/service-core/src/sync/sync.ts
+++ b/packages/service-core/src/sync/sync.ts
@@ -175,6 +175,16 @@ async function* streamResponseInner(
     }
   }
 
+  function checkpointLogDetails(cp: storage.ReplicationCheckpoint) {
+    return {
+      checkpoint: cp.checkpoint,
+      user_id: tokenPayload.userIdJson,
+      ...tracker.getIncrementalCheckpointStats()
+    };
+  }
+
+  let activeCheckpoint: { checkpoint: storage.ReplicationCheckpoint; trace: ActiveCheckpointTrace } | null = null;
+
   try {
     let nextCheckpointPromise: Promise<PromiseSettledResult<IteratorResult<CheckpointAndLine>>> | undefined;
 
@@ -200,6 +210,7 @@ async function* streamResponseInner(
       const trace = next.value.value.trace!;
       const checkpoint = next.value.value.checkpoint;
       const tracer = trace.tracer;
+      activeCheckpoint = { checkpoint, trace };
 
       const { checkpointLine, bucketsToFetch, bucketDataRequestHint } = line;
 
@@ -271,14 +282,6 @@ async function* streamResponseInner(
         maybeRaceForNewCheckpoint();
       }
 
-      function checkpointLogDetails(cp: storage.ReplicationCheckpoint) {
-        return {
-          checkpoint: cp.checkpoint,
-          user_id: tokenPayload.userIdJson,
-          ...tracker.getIncrementalCheckpointStats()
-        };
-      }
-
       // This incrementally updates dataBuckets with each individual bucket position.
       // At the end of this, we can be sure that all buckets have data up to the checkpoint.
       for (const [priority, buckets] of priorityBatches) {
@@ -333,12 +336,23 @@ async function* streamResponseInner(
           ms: getCheckpointTraceTimings(trace.span)
         });
       }
+      if (checkpointResult != null) {
+        activeCheckpoint = null;
+      }
 
       if (!abortCheckpointSignal.aborted) {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
     } while (!signal.aborted);
   } finally {
+    if (activeCheckpoint != null) {
+      const { checkpoint, trace } = activeCheckpoint;
+      logger.info(`checkpoint_interrupted: ${checkpoint.checkpoint}`, {
+        ...checkpointLogDetails(checkpoint),
+        ms: getCheckpointTraceTimings(trace.span)
+      });
+    }
+
     // The abort makes a pending next() settle as soon as the storage watcher observes it,
     // releasing the subscription. return() is still needed for the case where there is no
     // pending next(): the watcher is then suspended at a yield and never observes the abort.

--- a/packages/service-core/test/src/routes/stream.test.ts
+++ b/packages/service-core/test/src/routes/stream.test.ts
@@ -17,7 +17,7 @@ import {
 import * as sqlite from 'node:sqlite';
 import { Readable, Writable } from 'stream';
 import { pipeline } from 'stream/promises';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import winston from 'winston';
 import { syncStreamed } from '../../../src/routes/endpoints/sync-stream.js';
 import { DEFAULT_PARAM_LOGGING_FORMAT_OPTIONS, limitParamsForLogging } from '../../../src/util/param-logging.js';
@@ -255,6 +255,8 @@ bucket_definitions:
     } as Partial<SyncRulesBucketStorage>;
     const serviceContext = mockServiceContext(storage);
     const controller = new AbortController();
+    const checkpointLogger = logger.child({});
+    const checkpointLogSpy = vi.spyOn(checkpointLogger, 'info');
 
     const response = (async () => {
       for await (const _line of streamResponse({
@@ -265,7 +267,8 @@ bucket_definitions:
         token: new JwtPayload({ sub: 'test-user', exp: Date.now() / 1000 + 10_000 }),
         tracker: new RequestTracker(serviceContext.metricsEngine),
         isEncodingAsBson: false,
-        signal: controller.signal
+        signal: controller.signal,
+        logger: checkpointLogger
       })) {
         // Consume the response until the simulated data fetch error is propagated.
       }
@@ -292,6 +295,13 @@ bucket_definitions:
     expect(outcome).toBeInstanceOf(Error);
     expect((outcome as Error).message).toContain('Simulated data fetch failure');
     expect(abortedByCleanup).toBe(true);
+    expect(checkpointLogSpy).toHaveBeenCalledWith('checkpoint_interrupted: 1', {
+      checkpoint: 1n,
+      user_id: 'test-user',
+      operations_synced: 1000,
+      data_synced_bytes: 0,
+      ms: expect.any(Object)
+    });
   });
 });
 


### PR DESCRIPTION
We currently log `checkpoint_complete` and `checkpoint_invalidated` with timing data, helping to diagnose performance issues. However, we had a big missing case: If we stream is interrupted when fetching data, for example due to a `Timeout while waiting for data` error, we did not log the timing data. Cases with high sync load can often run into these errors, leading to removing a lot of useful timing info.

This adds a `checkpoint_interrupted` message in a finally block, making sure that we log before exiting the stream.

There are still some remaining cases this does not cover:
1. Error while fetching the checkpoint.
2. Error while computing the checksum.

But this does now cover the cases where fetching and/or sending the _data_ is slow, which are the ones we're focusing on for now.

## AI Usage

Implemented using Codex gpt-5.6; manually reviewed.