### PR TITLE
Avoid ts-codec unions

### DIFF
--- a/.changeset/puny-nights-find.md
+++ b/.changeset/puny-nights-find.md
@@ -1,0 +1,13 @@
+---
+'@powersync/service-module-postgres-storage': patch
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-module-postgres': patch
+'@powersync/service-module-mongodb': patch
+'@powersync/service-module-convex': patch
+'@powersync/service-core': patch
+'@powersync/service-module-mssql': patch
+'@powersync/lib-service-postgres': patch
+'@powersync/service-types': patch
+---
+
+Optimize runtime type checks, closes https://github.com/powersync-ja/powersync-service/issues/771.

--- a/libs/lib-postgres/src/types/types.ts
+++ b/libs/lib-postgres/src/types/types.ts
@@ -24,7 +24,7 @@ export const BasePostgresConnectionConfig = t.object({
   database: t.string.optional(),
 
   /** Defaults to verify-full */
-  sslmode: t.literal('verify-full').or(t.literal('verify-ca')).or(t.literal('disable')).optional(),
+  sslmode: service_types.enumLiteral('verify-full', 'verify-ca', 'disable').optional(),
   /** Required for verify-ca, optional for verify-full */
   cacert: t.string.optional(),
 

--- a/modules/module-convex/src/client/ConvexAPITypes.ts
+++ b/modules/module-convex/src/client/ConvexAPITypes.ts
@@ -1,4 +1,5 @@
 import { schema } from '@powersync/lib-services-framework';
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 
 export const ConvexRawDocument = t
@@ -47,7 +48,7 @@ export type ConvexJsonSchemasResult = t.Encoded<typeof ConvexJsonSchemasResult>;
 
 export const ConvexListSnapshotResult = t.object({
   snapshot: bigint,
-  cursor: t.string.or(t.Null),
+  cursor: orNull(t.string),
   hasMore: t.boolean,
   values: t.array(ConvexRawDocument)
 });

--- a/modules/module-convex/src/replication/ConvexSnapshotProgressCursor.ts
+++ b/modules/module-convex/src/replication/ConvexSnapshotProgressCursor.ts
@@ -1,9 +1,10 @@
 import { ReplicationAssertionError } from '@powersync/lib-services-framework';
+import { orNull } from '@powersync/service-types';
 import * as bson from 'bson';
 import * as t from 'ts-codec';
 
 export const ConvexSnapshotProgressCursor = t.object({
-  cursor: t.string.or(t.Null),
+  cursor: orNull(t.string),
   finished: t.boolean
 });
 

--- a/modules/module-mongodb-storage/src/types/types.ts
+++ b/modules/module-mongodb-storage/src/types/types.ts
@@ -13,11 +13,7 @@ import * as t from 'ts-codec';
  * and `auto` makes the timeouts depend on where the process happens to be running. Both are still
  * handled when they come from the AWS environment, and are then treated as `standard`.
  */
-export const S3DefaultsMode = t
-  .literal('standard')
-  .or(t.literal('in-region'))
-  .or(t.literal('cross-region'))
-  .or(t.literal('mobile'));
+export const S3DefaultsMode = service_types.enumLiteral('standard', 'in-region', 'cross-region', 'mobile');
 
 export type S3DefaultsMode = t.Encoded<typeof S3DefaultsMode>;
 
@@ -38,12 +34,13 @@ const S3ObjectStorageConfig = t.object({
   inline_threshold_bytes: t.number.optional()
 });
 
-export const MongoStorageReadPreference = t
-  .literal('primary')
-  .or(t.literal('primaryPreferred'))
-  .or(t.literal('secondary'))
-  .or(t.literal('secondaryPreferred'))
-  .or(t.literal('nearest'));
+export const MongoStorageReadPreference = service_types.enumLiteral(
+  'primary',
+  'primaryPreferred',
+  'secondary',
+  'secondaryPreferred',
+  'nearest'
+);
 
 export type MongoStorageReadPreference = t.Encoded<typeof MongoStorageReadPreference>;
 

--- a/modules/module-mongodb/src/types/types.ts
+++ b/modules/module-mongodb/src/types/types.ts
@@ -67,11 +67,11 @@ export interface NormalizedMongoConnectionConfig {
 export const MongoConnectionConfig = service_types.configFile.DataSourceConfig.and(lib_mongo.BaseMongoConfig).and(
   t.object({
     // Replication specific settings
-    post_images: t.literal('off').or(t.literal('auto_configure')).or(t.literal('read_only')).optional(),
+    post_images: service_types.enumLiteral('off', 'auto_configure', 'read_only').optional(),
     /**
      * Interval in seconds between source connection heartbeats. Null or omitted defaults to 60 seconds.
      */
-    heartbeat_interval_seconds: t.number.or(t.Null).optional()
+    heartbeat_interval_seconds: service_types.orNull(t.number).optional()
   })
 );
 

--- a/modules/module-mssql/src/types/types.ts
+++ b/modules/module-mssql/src/types/types.ts
@@ -132,7 +132,7 @@ export const MSSQLConnectionConfig = service_types.configFile.DataSourceConfig.a
     /**
      * Interval in seconds between source connection heartbeats. Null or omitted uses the default.
      */
-    heartbeat_interval_seconds: t.number.or(t.Null).optional()
+    heartbeat_interval_seconds: service_types.orNull(t.number).optional()
   })
 );
 

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -19,6 +19,7 @@ import {
   utils
 } from '@powersync/service-core';
 import * as sync_rules from '@powersync/service-sync-rules';
+import { orNull } from '@powersync/service-types';
 import * as timers from 'timers/promises';
 import * as t from 'ts-codec';
 import * as uuid from 'uuid';
@@ -64,10 +65,10 @@ const StatefulCheckpoint = models.ActiveCheckpoint.and(t.object({ state: t.Enum(
 const CheckpointWithStatus = StatefulCheckpoint.and(
   t.object({
     snapshot_done: t.boolean,
-    no_checkpoint_before: t.string.or(t.Null),
+    no_checkpoint_before: orNull(t.string),
     can_checkpoint: t.boolean,
-    keepalive_op: bigint.or(t.Null),
-    new_last_checkpoint: bigint.or(t.Null),
+    keepalive_op: orNull(bigint),
+    new_last_checkpoint: orNull(bigint),
     created_checkpoint: t.boolean
   })
 );

--- a/modules/module-postgres-storage/src/types/models/ActiveCheckpoint.ts
+++ b/modules/module-postgres-storage/src/types/models/ActiveCheckpoint.ts
@@ -1,3 +1,4 @@
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 import { bigint, pgwire_number } from '../codecs.js';
 
@@ -7,8 +8,8 @@ import { bigint, pgwire_number } from '../codecs.js';
  */
 export const ActiveCheckpoint = t.object({
   id: pgwire_number,
-  last_checkpoint: t.Null.or(bigint),
-  last_checkpoint_lsn: t.Null.or(t.string)
+  last_checkpoint: orNull(bigint),
+  last_checkpoint_lsn: orNull(t.string)
 });
 
 export type ActiveCheckpoint = t.Encoded<typeof ActiveCheckpoint>;

--- a/modules/module-postgres-storage/src/types/models/BucketData.ts
+++ b/modules/module-postgres-storage/src/types/models/BucketData.ts
@@ -1,3 +1,4 @@
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 import { bigint, hexBuffer, pgwire_number } from '../codecs.js';
 
@@ -13,13 +14,13 @@ export const BucketData = t.object({
   bucket_name: t.string,
   op_id: bigint,
   op: t.Enum(OpType),
-  source_table: t.Null.or(t.string),
-  source_key: t.Null.or(hexBuffer),
-  table_name: t.string.or(t.Null),
-  row_id: t.string.or(t.Null),
+  source_table: orNull(t.string),
+  source_key: orNull(hexBuffer),
+  table_name: orNull(t.string),
+  row_id: orNull(t.string),
   checksum: bigint,
-  data: t.Null.or(t.string),
-  target_op: t.Null.or(bigint)
+  data: orNull(t.string),
+  target_op: orNull(bigint)
 });
 
 export type BucketData = t.Encoded<typeof BucketData>;

--- a/modules/module-postgres-storage/src/types/models/CurrentData.ts
+++ b/modules/module-postgres-storage/src/types/models/CurrentData.ts
@@ -1,3 +1,4 @@
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 import { bigint, hexBuffer, jsonb, pgwire_number } from '../codecs.js';
 
@@ -26,7 +27,7 @@ export const V3CurrentData = t.object({
   lookups: t.array(hexBuffer),
   source_key: hexBuffer,
   source_table: t.string,
-  pending_delete: t.Null.or(bigint)
+  pending_delete: orNull(bigint)
 });
 
 export type V1CurrentData = t.Encoded<typeof V1CurrentData>;

--- a/modules/module-postgres-storage/src/types/models/SdkReporting.ts
+++ b/modules/module-postgres-storage/src/types/models/SdkReporting.ts
@@ -1,3 +1,4 @@
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 import { bigint, jsonb } from '../codecs.js';
 
@@ -11,12 +12,11 @@ export type Sdks = t.Encoded<typeof Sdks>;
 
 export const SdkReporting = t.object({
   users: bigint,
-  sdks: t
-    .object({
+  sdks: orNull(
+    t.object({
       data: jsonb<Sdks[]>(t.array(Sdks))
     })
-    .optional()
-    .or(t.Null)
+  ).optional()
 });
 
 export type SdkReporting = t.Encoded<typeof SdkReporting>;

--- a/modules/module-postgres-storage/src/types/models/SourceTable.ts
+++ b/modules/module-postgres-storage/src/types/models/SourceTable.ts
@@ -1,4 +1,5 @@
 import { JsonValue } from '@powersync/service-core';
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 import { bigint, hexBuffer, jsonb, jsonb_raw, pgwire_number } from '../codecs.js';
 
@@ -22,18 +23,18 @@ export const SourceTable = t.object({
   id: t.string,
   group_id: pgwire_number,
   connection_id: bigint,
-  relation_id: t.Null.or(jsonb_raw<StoredRelationId>()),
+  relation_id: orNull(jsonb_raw<StoredRelationId>()),
   schema_name: t.string,
   table_name: t.string,
-  replica_id_columns: t.Null.or(jsonb(t.array(ColumnDescriptor))),
+  replica_id_columns: orNull(jsonb(t.array(ColumnDescriptor))),
   snapshot_done: t.boolean,
-  snapshot_total_estimated_count: t.Null.or(bigint),
-  snapshot_replicated_count: t.Null.or(bigint),
-  snapshot_last_key: t.Null.or(hexBuffer),
+  snapshot_total_estimated_count: orNull(bigint),
+  snapshot_replicated_count: orNull(bigint),
+  snapshot_last_key: orNull(hexBuffer),
   /**
    * Source-specific metadata. Null for legacy records.
    */
-  source_metadata: t.Null.or(jsonb_raw<JsonValue>())
+  source_metadata: orNull(jsonb_raw<JsonValue>())
 });
 
 export type SourceTable = t.Encoded<typeof SourceTable>;

--- a/modules/module-postgres-storage/src/types/models/SyncRules.ts
+++ b/modules/module-postgres-storage/src/types/models/SyncRules.ts
@@ -1,5 +1,5 @@
 import { framework, storage } from '@powersync/service-core';
-import { ReplicationError } from '@powersync/service-types';
+import { orNull, ReplicationError } from '@powersync/service-types';
 import * as t from 'ts-codec';
 import { bigint, pgwire_number } from '../codecs.js';
 import { jsonContainerObject } from './json.js';
@@ -16,42 +16,42 @@ export const SyncRules = t.object({
   /**
    * May be set if snapshot_done = false, if the replication stream requires it.
    */
-  snapshot_lsn: t.Null.or(t.string),
+  snapshot_lsn: orNull(t.string),
   /**
    * The last consistent checkpoint.
    *
    * There may be higher OpIds used in the database if we're in the middle of replicating a large transaction.
    */
-  last_checkpoint: t.Null.or(bigint),
+  last_checkpoint: orNull(bigint),
   /**
    * The LSN associated with the last consistent checkpoint.
    */
-  last_checkpoint_lsn: t.Null.or(t.string),
+  last_checkpoint_lsn: orNull(t.string),
   /**
    * If set, no new checkpoints may be created < this value.
    */
-  no_checkpoint_before: t.Null.or(t.string),
+  no_checkpoint_before: orNull(t.string),
   slot_name: t.string,
   /**
    * Last time we persisted a checkpoint.
    *
    * This may be old if no data is incoming.
    */
-  last_checkpoint_ts: t.Null.or(framework.codecs.date),
+  last_checkpoint_ts: orNull(framework.codecs.date),
   /**
    * Last time we persisted a checkpoint or keepalive.
    *
    * This should stay fairly current while replicating.
    */
-  last_keepalive_ts: t.Null.or(framework.codecs.date),
+  last_keepalive_ts: orNull(framework.codecs.date),
   /**
    * If an error is stopping replication, it will be stored here.
    */
-  last_fatal_error: t.Null.or(t.string),
-  keepalive_op: t.Null.or(bigint),
-  storage_version: t.Null.or(pgwire_number).optional(),
+  last_fatal_error: orNull(t.string),
+  keepalive_op: orNull(bigint),
+  storage_version: orNull(pgwire_number).optional(),
   content: t.string,
-  sync_plan: t.Null.or(
+  sync_plan: orNull(
     jsonContainerObject(
       t.object({
         plan: t.any,

--- a/modules/module-postgres-storage/src/types/models/WriteCheckpoint.ts
+++ b/modules/module-postgres-storage/src/types/models/WriteCheckpoint.ts
@@ -1,4 +1,5 @@
 import { framework } from '@powersync/service-core';
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 import { bigint, jsonb } from '../codecs.js';
 
@@ -6,7 +7,7 @@ export const WriteCheckpoint = t.object({
   user_id: t.string,
   lsns: jsonb(t.record(t.string)),
   write_checkpoint: bigint,
-  checkpoint_requested_at: t.Null.or(framework.codecs.date)
+  checkpoint_requested_at: orNull(framework.codecs.date)
 });
 
 export type WriteCheckpoint = t.Encoded<typeof WriteCheckpoint>;
@@ -16,7 +17,7 @@ export const CustomWriteCheckpoint = t.object({
   user_id: t.string,
   write_checkpoint: bigint,
   sync_rules_id: bigint,
-  checkpoint_requested_at: t.Null.or(framework.codecs.date)
+  checkpoint_requested_at: orNull(framework.codecs.date)
 });
 
 export type CustomWriteCheckpoint = t.Encoded<typeof CustomWriteCheckpoint>;

--- a/modules/module-postgres-storage/test/src/storage.test.ts
+++ b/modules/module-postgres-storage/test/src/storage.test.ts
@@ -1,12 +1,13 @@
 import { framework, storage, updateSyncRulesFromYaml } from '@powersync/service-core';
 import { bucketRequest, compactActive, register, test_utils } from '@powersync/service-core-tests';
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 import { describe, expect, test } from 'vitest';
 import { CLEAR_BATCH_LIMIT } from '../../src/storage/PostgresSyncRulesStorage.js';
 import { POSTGRES_STORAGE_FACTORY, TEST_STORAGE_VERSIONS } from './util.js';
 
 const CheckpointRequestedAtRow = t.object({
-  checkpoint_requested_at: t.Null.or(framework.codecs.date)
+  checkpoint_requested_at: orNull(framework.codecs.date)
 });
 
 describe('Sync Bucket Validation', register.registerBucketValidationTests);

--- a/modules/module-postgres/src/types/types.ts
+++ b/modules/module-postgres/src/types/types.ts
@@ -27,7 +27,7 @@ export const PostgresConnectionConfig = service_types.configFile.DataSourceConfi
     /**
      * Interval in seconds between source connection heartbeats. Null or omitted uses the default.
      */
-    heartbeat_interval_seconds: t.number.or(t.Null).optional()
+    heartbeat_interval_seconds: service_types.orNull(t.number).optional()
   })
 );
 

--- a/packages/service-core/src/util/protocol-types.ts
+++ b/packages/service-core/src/util/protocol-types.ts
@@ -1,5 +1,6 @@
 import { JsonContainer } from '@powersync/service-jsonbig';
 import { BucketPriority, SqliteJsonRow } from '@powersync/service-sync-rules';
+import { orNull } from '@powersync/service-types';
 import * as t from 'ts-codec';
 
 export const BucketRequest = t.object({
@@ -24,14 +25,14 @@ export const RequestedStreamSubscription = t.object({
   /**
    * An optional dictionary of parameters to pass to this specific stream.
    */
-  parameters: t.union(t.record(t.any), t.Null),
+  parameters: orNull(t.record(t.any)),
   /**
    * Set when the client wishes to re-assign a different priority to this stream.
    *
    * Streams and sync rules can also assign a default priority, but clients are allowed to override those. This can be
    * useful when the priority for partial syncs depends on e.g. the current page opened in a client.
    */
-  override_priority: t.union(t.number, t.Null)
+  override_priority: orNull(t.number)
 });
 
 export type RequestedStreamSubscription = t.Decoded<typeof RequestedStreamSubscription>;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,11 +10,15 @@
   "repository": "https://github.com/powersync-ja/powersync-service",
   "scripts": {
     "clean": "rm -r ./dist && tsc -b --clean",
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "test": "vitest"
   },
   "dependencies": {
     "dedent": "^1.6.0",
     "ts-codec": "^1.3.0",
     "uri-js": "^4.4.1"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
   }
 }

--- a/packages/types/src/codecs.ts
+++ b/packages/types/src/codecs.ts
@@ -1,0 +1,95 @@
+import { AnyCodec, Codec, codec, CodecType, Ix, Ox, TransformError } from 'ts-codec';
+
+/**
+ * An optimized codec equivalent to `type.or(Null)`.
+ */
+export function orNull<T extends AnyCodec>(type: T): Codec<Ix<T> | null, Ox<T> | null> {
+  return codec(
+    CodecType.Union,
+    (data) => {
+      if (data === null) {
+        return null;
+      }
+      return type.encode(data);
+    },
+    (data) => {
+      if (data === null) {
+        return null;
+      }
+      return type.decode(data);
+    },
+    type.props
+  );
+}
+
+/**
+ * A codec parsing a static enumeration of literals.
+ *
+ * `enumLiteral('foo', 'bar')` is an equivalent but more efficient implementation of
+ * `literal('foo').or(literal('bar'))`
+ */
+export function enumLiteral<T extends string>(...values: T[]): Codec<T, T> {
+  function validate(source: unknown): T {
+    function invalid(): never {
+      const allowed = values.join(', ');
+      throw new TransformError(`Expected one of ${allowed}, but got ${source}`);
+    }
+
+    if (typeof source !== 'string') invalid();
+    if (!values.includes(source as T)) invalid();
+
+    return source as T;
+  }
+
+  return codec(CodecType.Enum, validate, validate);
+}
+
+type NamedPrimitiveTypes = {
+  string: string;
+  number: number;
+  boolean: boolean;
+  null: null;
+  undefined: undefined;
+};
+
+type EnabledKeys<T> = {
+  [K in keyof T]: T[K] extends true ? K : never;
+}[keyof T];
+
+type PrimitiveUnion<T extends Partial<Record<keyof NamedPrimitiveTypes, boolean>>> = NamedPrimitiveTypes[Extract<
+  EnabledKeys<T>,
+  keyof NamedPrimitiveTypes
+>];
+
+/**
+ * Parses multiple primitive types.
+ *
+ * `anyPrimitive({ boolean: true, string: true })` behaves identical to `boolean.or(string)`, but is more efficient.
+ */
+export function anyPrimitive<const T extends Partial<Record<keyof NamedPrimitiveTypes, boolean>>>(
+  allowedPrimitives: T
+): Codec<PrimitiveUnion<T>, PrimitiveUnion<T>> {
+  function validate(source: unknown): PrimitiveUnion<T> {
+    switch (typeof source) {
+      case 'string':
+        if (allowedPrimitives.string) return source as PrimitiveUnion<T>;
+        break;
+      case 'number':
+        if (allowedPrimitives.number) return source as PrimitiveUnion<T>;
+        break;
+      case 'boolean':
+        if (allowedPrimitives.boolean) return source as PrimitiveUnion<T>;
+        break;
+      case 'undefined':
+        if (allowedPrimitives.undefined) return source as PrimitiveUnion<T>;
+        break;
+      case 'object':
+        if (allowedPrimitives.null && source === null) return source as PrimitiveUnion<T>;
+        break;
+    }
+
+    throw new TransformError(`Primitive value ${source} is not allowed.`);
+  }
+
+  return codec(CodecType.Literal, validate, validate);
+}

--- a/packages/types/src/codecs.ts
+++ b/packages/types/src/codecs.ts
@@ -1,11 +1,12 @@
-import { AnyCodec, Codec, codec, CodecType, Ix, Ox, TransformError } from 'ts-codec';
+import type { AnyCodec, Codec, Ix, Ox, Union } from 'ts-codec';
+import * as t from 'ts-codec';
 
 /**
  * An optimized codec equivalent to `type.or(Null)`.
  */
 export function orNull<T extends AnyCodec>(type: T): Codec<Ix<T> | null, Ox<T> | null> {
-  return codec(
-    CodecType.Union,
+  return t.codec(
+    t.CodecType.Union,
     (data) => {
       if (data === null) {
         return null;
@@ -18,7 +19,9 @@ export function orNull<T extends AnyCodec>(type: T): Codec<Ix<T> | null, Ox<T> |
       }
       return type.decode(data);
     },
-    type.props
+    {
+      codecs: [type, t.Null]
+    } satisfies Union<T, typeof t.Null>['props']
   );
 }
 
@@ -32,7 +35,7 @@ export function enumLiteral<T extends string>(...values: T[]): Codec<T, T> {
   function validate(source: unknown): T {
     function invalid(): never {
       const allowed = values.join(', ');
-      throw new TransformError(`Expected one of ${allowed}, but got ${source}`);
+      throw new t.TransformError(`Expected one of ${allowed}, but got ${source}`);
     }
 
     if (typeof source !== 'string') invalid();
@@ -41,7 +44,9 @@ export function enumLiteral<T extends string>(...values: T[]): Codec<T, T> {
     return source as T;
   }
 
-  return codec(CodecType.Enum, validate, validate);
+  return t.codec(t.CodecType.Enum, validate, validate, {
+    enum: values
+  });
 }
 
 type NamedPrimitiveTypes = {
@@ -49,7 +54,13 @@ type NamedPrimitiveTypes = {
   number: number;
   boolean: boolean;
   null: null;
-  undefined: undefined;
+};
+
+const primitiveCodecs: Record<keyof NamedPrimitiveTypes, AnyCodec> = {
+  string: t.string,
+  number: t.number,
+  boolean: t.boolean,
+  null: t.Null
 };
 
 type EnabledKeys<T> = {
@@ -80,16 +91,22 @@ export function anyPrimitive<const T extends Partial<Record<keyof NamedPrimitive
       case 'boolean':
         if (allowedPrimitives.boolean) return source as PrimitiveUnion<T>;
         break;
-      case 'undefined':
-        if (allowedPrimitives.undefined) return source as PrimitiveUnion<T>;
-        break;
       case 'object':
         if (allowedPrimitives.null && source === null) return source as PrimitiveUnion<T>;
         break;
     }
 
-    throw new TransformError(`Primitive value ${source} is not allowed.`);
+    throw new t.TransformError(`Primitive value ${source} is not allowed.`);
   }
 
-  return codec(CodecType.Literal, validate, validate);
+  const codecsForSchema: AnyCodec[] = [];
+  for (const [key, value] of Object.entries(allowedPrimitives)) {
+    if (value) {
+      codecsForSchema.push(primitiveCodecs[key as keyof NamedPrimitiveTypes]);
+    }
+  }
+
+  return t.codec(t.CodecType.Union, validate, validate, {
+    codecs: codecsForSchema
+  } satisfies Union<AnyCodec, AnyCodec>['props']);
 }

--- a/packages/types/src/config/PowerSyncConfig.ts
+++ b/packages/types/src/config/PowerSyncConfig.ts
@@ -1,5 +1,6 @@
 import dedent from 'dedent';
 import * as t from 'ts-codec';
+import { anyPrimitive, enumLiteral } from '../codecs.js';
 
 /**
  * The meta tags here are used in the generated JSON schema.
@@ -96,10 +97,7 @@ export const jwkRSA = t
     e: t.string.meta({
       description: 'RSA exponent, Base64 URL encoded.'
     }),
-    alg: t
-      .literal('RS256')
-      .or(t.literal('RS384'))
-      .or(t.literal('RS512'))
+    alg: enumLiteral('RS256', 'RS384', 'RS512')
       .meta({
         description: 'The algorithm intended for use with this key (RS256, RS384, or RS512).'
       })
@@ -128,7 +126,7 @@ export const jwkHmac = t
     k: t.string.meta({
       description: 'The HMAC key value, Base64 URL encoded.'
     }),
-    alg: t.literal('HS256').or(t.literal('HS384')).or(t.literal('HS512')).meta({
+    alg: enumLiteral('HS256', 'HS384', 'HS512').meta({
       description: 'The algorithm intended for use with this key (HS256, HS384, or HS512).'
     }),
     use: t.string
@@ -152,7 +150,7 @@ export const jwkOKP = t
       })
       .optional(),
     /** Other curves have security issues so only these two are supported. */
-    crv: t.literal('Ed25519').or(t.literal('Ed448')).meta({
+    crv: enumLiteral('Ed25519', 'Ed448').meta({
       description: 'The cryptographic curve used with this key. Only Ed25519 and Ed448 are supported.'
     }),
     x: t.string.meta({
@@ -182,7 +180,7 @@ export const jwkEC = t
         description: 'Key ID, a unique identifier for the key.'
       })
       .optional(),
-    crv: t.literal('P-256').or(t.literal('P-384')).or(t.literal('P-521')).meta({
+    crv: enumLiteral('P-256', 'P-384', 'P-521').meta({
       description: 'The cryptographic curve used with this key (P-256, P-384, or P-521).'
     }),
     x: t.string.meta({
@@ -191,7 +189,7 @@ export const jwkEC = t
     y: t.string.meta({
       description: 'The y coordinate for the Elliptic Curve point, Base64 URL encoded.'
     }),
-    alg: t.literal('ES256').or(t.literal('ES384')).or(t.literal('ES512')).meta({
+    alg: enumLiteral('ES256', 'ES384', 'ES512').meta({
       description: 'The algorithm intended for use with this key (ES256, ES384, or ES512).'
     }),
     use: t.string
@@ -204,7 +202,7 @@ export const jwkEC = t
     description: 'JSON Web Key (JWK) representation of an Elliptic Curve key.'
   });
 
-const jwk = t.union(t.union(t.union(jwkRSA, jwkHmac), jwkOKP), jwkEC).meta({
+const jwk = jwkRSA.or(jwkHmac).or(jwkOKP).or(jwkEC).meta({
   description: 'A JSON Web Key (JWK) representing a cryptographic key. Can be RSA, HMAC, OKP, or EC key types.'
 });
 
@@ -222,21 +220,12 @@ export type StrictJwk = t.Decoded<typeof jwk>;
 
 export const LoggingConfig = t
   .object({
-    level: t
-      .literal('silly')
-      .or(t.literal('debug'))
-      .or(t.literal('verbose'))
-      .or(t.literal('http'))
-      .or(t.literal('info'))
-      .or(t.literal('warn'))
-      .or(t.literal('error'))
+    level: enumLiteral('silly', 'debug', 'verbose', 'http', 'info', 'warn', 'error')
       .meta({
         description: 'Log level for the service logs.'
       })
       .optional(),
-    format: t
-      .literal('json')
-      .or(t.literal('text'))
+    format: enumLiteral('json', 'text')
       .meta({
         description: 'Log output format.'
       })
@@ -544,7 +533,7 @@ export const powerSyncConfig = t
       .optional(),
 
     parameters: t
-      .record(t.number.or(t.string).or(t.boolean).or(t.Null))
+      .record(anyPrimitive({ null: true, number: true, string: true, boolean: true }))
       .meta({
         description: 'Global parameters that can be referenced in sync config and other configurations.'
       })

--- a/packages/types/src/definitions.ts
+++ b/packages/types/src/definitions.ts
@@ -1,4 +1,5 @@
 import * as t from 'ts-codec';
+import { enumLiteral } from './codecs.js';
 
 export const SourceSpan = t.object({
   start_offset: t.number,
@@ -8,7 +9,7 @@ export type SourceSpan = t.Encoded<typeof SourceSpan>;
 
 export const ReplicationError = t.object({
   /** Warning: Could indicate an issue. Fatal: Prevents replicating. */
-  level: t.literal('warning').or(t.literal('fatal')),
+  level: enumLiteral('warning', 'fatal'),
   message: t.string,
   location: SourceSpan.optional(),
   ts: t.string.optional()

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export * as configFile from './config/PowerSyncConfig.js';
 
+export * from './codecs.js';
 export * from './definitions.js';
 export * from './metrics.js';
 export * as metric_types from './metrics.js';

--- a/packages/types/src/routes.ts
+++ b/packages/types/src/routes.ts
@@ -1,4 +1,5 @@
 import * as t from 'ts-codec';
+import { anyPrimitive } from './codecs.js';
 import { ConnectionStatus, InstanceSchema, SyncRulesStatus } from './definitions.js';
 
 export const GetSchemaRequest = t.object({});
@@ -11,7 +12,7 @@ export const ExecuteSqlRequest = t.object({
   connection_id: t.string.optional(),
   sql: t.object({
     query: t.string,
-    args: t.array(t.string.or(t.number).or(t.boolean))
+    args: t.array(anyPrimitive({ string: true, number: true, boolean: true }))
   })
 });
 export type ExecuteSqlRequest = t.Encoded<typeof ExecuteSqlRequest>;
@@ -20,7 +21,7 @@ export const ExecuteSqlResponse = t.object({
   success: t.boolean,
   results: t.object({
     columns: t.array(t.string),
-    rows: t.array(t.array(t.string.or(t.number).or(t.boolean).or(t.Null)))
+    rows: t.array(t.array(anyPrimitive({ string: true, number: true, boolean: true, null: true })))
   }),
   /** Set if success = false */
   error: t.string.optional()

--- a/packages/types/test/codecs.test.ts
+++ b/packages/types/test/codecs.test.ts
@@ -1,0 +1,87 @@
+import * as t from 'ts-codec';
+import { describe, expect, test } from 'vitest';
+
+import { anyPrimitive, enumLiteral, orNull } from '../src/codecs.js';
+
+test('orNull', () => {
+  const codec = orNull(t.literal('allowed'));
+
+  expect(codec.encode('allowed')).toStrictEqual('allowed');
+  expect(codec.decode('allowed')).toStrictEqual('allowed');
+  expect(codec.encode(null)).toStrictEqual(null);
+  expect(codec.decode(null)).toStrictEqual(null);
+
+  expect(() => codec.encode('invalid' as any)).throws();
+  expect(() => codec.decode('invalid' as any)).throws();
+});
+
+test('enumLiteral', () => {
+  const codec = enumLiteral('foo', 'bar', 'baz');
+
+  for (const value of ['foo', 'bar', 'baz'] as const) {
+    expect(codec.encode(value)).toStrictEqual(value);
+    expect(codec.decode(value)).toStrictEqual(value);
+  }
+
+  expect(() => codec.encode('invalid' as any)).throws();
+  expect(() => codec.decode('invalid' as any)).throws();
+});
+
+describe('anyPrimitive', () => {
+  test('allows only the configured types', () => {
+    const codec = anyPrimitive({ string: true, number: true }) as t.AnyCodec;
+
+    expect(codec.decode('foo')).toStrictEqual('foo');
+    expect(codec.decode(42)).toStrictEqual(42);
+    expect(codec.encode('foo')).toStrictEqual('foo');
+    expect(codec.encode(42)).toStrictEqual(42);
+
+    expect(() => codec.decode(true)).throws();
+    expect(() => codec.decode(null)).throws();
+    expect(() => codec.decode(undefined)).throws();
+    expect(() => codec.decode({})).throws();
+  });
+
+  test('allows null', () => {
+    const codec = anyPrimitive({ null: true }) as t.AnyCodec;
+
+    expect(codec.decode(null)).toStrictEqual(null);
+    expect(codec.encode(null)).toStrictEqual(null);
+
+    expect(() => codec.decode('foo')).throws();
+    expect(() => codec.decode(undefined)).throws();
+    expect(() => codec.decode({})).throws();
+  });
+
+  test('allows undefined', () => {
+    const codec = anyPrimitive({ undefined: true }) as t.AnyCodec;
+
+    expect(codec.decode(undefined)).toStrictEqual(undefined);
+    expect(codec.encode(undefined)).toStrictEqual(undefined);
+
+    expect(() => codec.decode(null)).throws();
+    expect(() => codec.decode('foo')).throws();
+  });
+
+  test('rejects types not in the configuration, even when other types are allowed', () => {
+    const codec = anyPrimitive({ boolean: true }) as t.AnyCodec;
+
+    expect(codec.decode(true)).toStrictEqual(true);
+    expect(codec.decode(false)).toStrictEqual(false);
+
+    expect(() => codec.decode('foo')).throws();
+    expect(() => codec.decode(1)).throws();
+    expect(() => codec.decode(null)).throws();
+    expect(() => codec.decode(undefined)).throws();
+  });
+
+  test('with no allowed types rejects everything', () => {
+    const codec = anyPrimitive({}) as any as t.AnyCodec;
+
+    expect(() => codec.decode('foo')).throws();
+    expect(() => codec.decode(1)).throws();
+    expect(() => codec.decode(true)).throws();
+    expect(() => codec.decode(null)).throws();
+    expect(() => codec.decode(undefined)).throws();
+  });
+});

--- a/packages/types/test/codecs.test.ts
+++ b/packages/types/test/codecs.test.ts
@@ -53,16 +53,6 @@ describe('anyPrimitive', () => {
     expect(() => codec.decode({})).throws();
   });
 
-  test('allows undefined', () => {
-    const codec = anyPrimitive({ undefined: true }) as t.AnyCodec;
-
-    expect(codec.decode(undefined)).toStrictEqual(undefined);
-    expect(codec.encode(undefined)).toStrictEqual(undefined);
-
-    expect(() => codec.decode(null)).throws();
-    expect(() => codec.decode('foo')).throws();
-  });
-
   test('rejects types not in the configuration, even when other types are allowed', () => {
     const codec = anyPrimitive({ boolean: true }) as t.AnyCodec;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -824,6 +824,10 @@ importers:
       uri-js:
         specifier: ^4.4.1
         version: 4.4.1
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(vite@8.0.9(@types/node@25.5.0)(esbuild@0.27.0)(yaml@2.8.3))
 
   service:
     dependencies:


### PR DESCRIPTION
The `ts-codec` package implements `union()` and `.or()` combinators by trying options in sequence, catching errors when an option throws to continue with the next option. While elegant, it's not particularly efficient as V8 needs to collect a stack trace on every failed option.

The postgres bucket storage uses `ts-codec` to decode rows from postgres, an operation we want to be fast. Us using an union combinator results in us taking 60% of JavaScript execution time for a null check, something that should be very cheap (https://github.com/powersync-ja/powersync-service/issues/771).

This introduces a few specialized codecs for these issues:

1. `orNull()` as a replacement for `$codec.or(t.Null)` which short-circuits null values instead.
2. `enumLiteral('a', 'b', 'c')` as a replacement for `t.literal('a').or(t.literal('b')).or(t.literal('c'))`. Inspired by `t.Enum` but based on string literal unions for compactness.
3. `anyPrimitive()` as a replacement for `t.boolean.or(t.number)...` with configurable primitive types.

After this PR, the following unions remain:

- `TableSchema.sqlite_type`: This is only used as a type or as a codec in the `/api/admin/v1/schema` endpoint, not critical for performance.
- `Authentication` in `MSSQLConnectionConfig`; `jwk` and `powerSyncConfig.client_auth` in `PowerSyncConfig.ts`: Only used for configuration, not critical for performance.
- A few in `compile-json-schema.ts`: Development script, not relevant for performance.

AI use: I used Claude Code to write tests, the signature of `anyPrimitive`, and to review this.