### PR TITLE
fix: use unordered equality in sync compiler

### DIFF
--- a/.changeset/tidy-filters-agree.md
+++ b/.changeset/tidy-filters-agree.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Correctly reuse equivalent Sync Streams query components when independent filters or attached table-valued functions appear in a different order.

--- a/packages/sync-rules/src/compiler/compatibility.ts
+++ b/packages/sync-rules/src/compiler/compatibility.ts
@@ -1,4 +1,4 @@
-import { Equality, listEquality, StableHasher } from './equality.js';
+import { Equality, listEquality, StableHasher, unorderedEquality } from './equality.js';
 
 /**
  * Interface for structures that can be compared for equality in a way that ignores referenced result set.
@@ -23,4 +23,4 @@ export const equalsIgnoringResultSet: Equality<EqualsIgnoringResultSet> = {
 };
 
 export const equalsIgnoringResultSetList = listEquality(equalsIgnoringResultSet);
-export const equalsIgnoringResultSetUnordered = listEquality(equalsIgnoringResultSet);
+export const equalsIgnoringResultSetUnordered = unorderedEquality(equalsIgnoringResultSet);

--- a/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
@@ -4,7 +4,7 @@ exports[`new sync stream features > IN operator with static left clause 1`] = `
 {
   "buckets": [
     {
-      "hash": 274764250,
+      "hash": 504882872,
       "sources": [
         0,
       ],
@@ -17,7 +17,7 @@ exports[`new sync stream features > IN operator with static left clause 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 466638588,
+      "hash": 252303259,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -56,7 +56,7 @@ exports[`new sync stream features > IN operator with static left clause 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 467461012,
+      "hash": 61622074,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -104,7 +104,7 @@ exports[`new sync stream features > IN operator with two static clauses 1`] = `
 {
   "buckets": [
     {
-      "hash": 274764250,
+      "hash": 504882872,
       "sources": [
         0,
       ],
@@ -117,7 +117,7 @@ exports[`new sync stream features > IN operator with two static clauses 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 466638588,
+      "hash": 252303259,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -196,7 +196,7 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
 {
   "buckets": [
     {
-      "hash": 2313189,
+      "hash": 215122439,
       "sources": [
         0,
       ],
@@ -209,7 +209,7 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 470455392,
+      "hash": 80560391,
       "outputTableName": "Scene",
       "partitionBy": [
         {
@@ -247,7 +247,7 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 469881182,
+      "hash": 331282873,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -287,7 +287,7 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 391349695,
+      "hash": 14791390,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -438,7 +438,7 @@ exports[`new sync stream features > circular references > at first level 1`] = `
 {
   "buckets": [
     {
-      "hash": 391555584,
+      "hash": 369605791,
       "sources": [
         0,
       ],
@@ -451,7 +451,7 @@ exports[`new sync stream features > circular references > at first level 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 322241169,
+      "hash": 258551590,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -482,7 +482,7 @@ exports[`new sync stream features > circular references > at first level 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 20765332,
+      "hash": 508315757,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -589,7 +589,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
 {
   "buckets": [
     {
-      "hash": 329617792,
+      "hash": 533534265,
       "sources": [
         0,
       ],
@@ -602,7 +602,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 215694379,
+      "hash": 501930921,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -633,7 +633,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 527378076,
+      "hash": 105317550,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -662,7 +662,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
     },
     {
       "filters": [],
-      "hash": 462853403,
+      "hash": 251179367,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -694,7 +694,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
     },
     {
       "filters": [],
-      "hash": 307161944,
+      "hash": 350988327,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "2",
@@ -807,7 +807,7 @@ exports[`new sync stream features > circular references > table-valued 1`] = `
 {
   "buckets": [
     {
-      "hash": 250014934,
+      "hash": 108933878,
       "sources": [
         0,
       ],
@@ -820,7 +820,7 @@ exports[`new sync stream features > circular references > table-valued 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 50729839,
+      "hash": 309686539,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -864,7 +864,7 @@ exports[`new sync stream features > circular references > table-valued 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 321622908,
+      "hash": 311271245,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -942,7 +942,7 @@ exports[`new sync stream features > in array 1`] = `
 {
   "buckets": [
     {
-      "hash": 64262756,
+      "hash": 307632867,
       "sources": [
         0,
       ],
@@ -975,7 +975,7 @@ exports[`new sync stream features > in array 1`] = `
           "type": "scalar_in",
         },
       ],
-      "hash": 209438134,
+      "hash": 366938535,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -1012,7 +1012,7 @@ exports[`new sync stream features > in array and additional filter in subquery 1
 {
   "buckets": [
     {
-      "hash": 322018032,
+      "hash": 371862092,
       "sources": [
         0,
       ],
@@ -1025,7 +1025,7 @@ exports[`new sync stream features > in array and additional filter in subquery 1
         "star",
       ],
       "filters": [],
-      "hash": 526524156,
+      "hash": 25953646,
       "outputTableName": "notes",
       "partitionBy": [
         {
@@ -1066,7 +1066,7 @@ exports[`new sync stream features > in array and additional filter in subquery 1
           "type": "binary",
         },
       ],
-      "hash": 372404644,
+      "hash": 450331817,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1169,7 +1169,7 @@ exports[`new sync stream features > in json array 1`] = `
 {
   "buckets": [
     {
-      "hash": 28125559,
+      "hash": 267897099,
       "sources": [
         0,
       ],
@@ -1200,7 +1200,7 @@ exports[`new sync stream features > in json array 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 475318095,
+      "hash": 484392710,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -1247,7 +1247,7 @@ exports[`new sync stream features > joins feedback > response 1 1`] = `
 {
   "buckets": [
     {
-      "hash": 87224296,
+      "hash": 221193482,
       "sources": [
         0,
       ],
@@ -1260,7 +1260,7 @@ exports[`new sync stream features > joins feedback > response 1 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 5951378,
+      "hash": 97057433,
       "outputTableName": "u",
       "partitionBy": [
         {
@@ -1283,7 +1283,7 @@ exports[`new sync stream features > joins feedback > response 1 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 323715566,
+      "hash": 7102946,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1315,7 +1315,7 @@ exports[`new sync stream features > joins feedback > response 1 1`] = `
     },
     {
       "filters": [],
-      "hash": 302276225,
+      "hash": 96230619,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -1424,7 +1424,7 @@ exports[`new sync stream features > joins feedback > response 4 1`] = `
 {
   "buckets": [
     {
-      "hash": 514655288,
+      "hash": 499713123,
       "sources": [
         0,
       ],
@@ -1437,7 +1437,7 @@ exports[`new sync stream features > joins feedback > response 4 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 445379715,
+      "hash": 313970881,
       "outputTableName": "m",
       "partitionBy": [
         {
@@ -1475,7 +1475,7 @@ exports[`new sync stream features > joins feedback > response 4 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 64213188,
+      "hash": 478900091,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1568,7 +1568,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
 {
   "buckets": [
     {
-      "hash": 260926888,
+      "hash": 372337345,
       "sources": [
         0,
         1,
@@ -1582,7 +1582,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 353156391,
+      "hash": 62299225,
       "outputTableName": "users",
       "partitionBy": [
         {
@@ -1606,7 +1606,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 41817212,
+      "hash": 521704692,
       "outputTableName": "families",
       "partitionBy": [
         {
@@ -1629,7 +1629,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 143919389,
+      "hash": 381188991,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1661,7 +1661,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
     },
     {
       "filters": [],
-      "hash": 32571796,
+      "hash": 440281250,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -1770,7 +1770,7 @@ exports[`new sync stream features > joins feedback > response 8 1`] = `
 {
   "buckets": [
     {
-      "hash": 415757919,
+      "hash": 184379202,
       "sources": [
         0,
       ],
@@ -1783,7 +1783,7 @@ exports[`new sync stream features > joins feedback > response 8 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 166151257,
+      "hash": 29364994,
       "outputTableName": "events",
       "partitionBy": [
         {
@@ -1806,7 +1806,7 @@ exports[`new sync stream features > joins feedback > response 8 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 29987209,
+      "hash": 418216473,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1899,7 +1899,7 @@ exports[`new sync stream features > joins feedback > response 9 1`] = `
 {
   "buckets": [
     {
-      "hash": 243129021,
+      "hash": 206255983,
       "sources": [
         0,
       ],
@@ -1912,7 +1912,7 @@ exports[`new sync stream features > joins feedback > response 9 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 105399988,
+      "hash": 333904209,
       "outputTableName": "u",
       "partitionBy": [
         {
@@ -1935,7 +1935,7 @@ exports[`new sync stream features > joins feedback > response 9 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 88350941,
+      "hash": 1436015,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1967,7 +1967,7 @@ exports[`new sync stream features > joins feedback > response 9 1`] = `
     },
     {
       "filters": [],
-      "hash": 343817501,
+      "hash": 469586132,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -2076,7 +2076,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
 {
   "buckets": [
     {
-      "hash": 437667704,
+      "hash": 417667471,
       "sources": [
         0,
       ],
@@ -2089,7 +2089,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 268156404,
+      "hash": 329182865,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -2112,7 +2112,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 88350941,
+      "hash": 1436015,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2144,7 +2144,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
     },
     {
       "filters": [],
-      "hash": 343817501,
+      "hash": 469586132,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -2176,7 +2176,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
     },
     {
       "filters": [],
-      "hash": 392582824,
+      "hash": 434154687,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "2",
@@ -2301,7 +2301,7 @@ exports[`new sync stream features > joins feedback > response 11 1`] = `
 {
   "buckets": [
     {
-      "hash": 327475413,
+      "hash": 15255881,
       "sources": [
         0,
       ],
@@ -2314,7 +2314,7 @@ exports[`new sync stream features > joins feedback > response 11 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 259562331,
+      "hash": 334678181,
       "outputTableName": "t",
       "partitionBy": [
         {
@@ -2337,7 +2337,7 @@ exports[`new sync stream features > joins feedback > response 11 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 97816743,
+      "hash": 277446621,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2430,7 +2430,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
 {
   "buckets": [
     {
-      "hash": 160259622,
+      "hash": 242995705,
       "sources": [
         0,
       ],
@@ -2443,7 +2443,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 394681392,
+      "hash": 350236831,
       "outputTableName": "p",
       "partitionBy": [
         {
@@ -2466,7 +2466,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 531268250,
+      "hash": 225571037,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2547,7 +2547,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 296491538,
+      "hash": 395043210,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -2656,7 +2656,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
 {
   "buckets": [
     {
-      "hash": 27478573,
+      "hash": 188573007,
       "sources": [
         0,
       ],
@@ -2669,7 +2669,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 97931753,
+      "hash": 252506179,
       "outputTableName": "c",
       "partitionBy": [
         {
@@ -2692,7 +2692,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 153371152,
+      "hash": 438214067,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2739,7 +2739,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 382068356,
+      "hash": 5166607,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -2771,7 +2771,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
     },
     {
       "filters": [],
-      "hash": 503875718,
+      "hash": 305606865,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "2",
@@ -2896,7 +2896,7 @@ exports[`new sync stream features > json-each of cte 1`] = `
 {
   "buckets": [
     {
-      "hash": 385826507,
+      "hash": 156964455,
       "sources": [
         0,
       ],
@@ -2952,7 +2952,7 @@ exports[`new sync stream features > json-each of cte 1`] = `
         },
       ],
       "filters": [],
-      "hash": 288003166,
+      "hash": 452187534,
       "outputTableName": "Scene",
       "partitionBy": [
         {
@@ -3012,7 +3012,7 @@ exports[`new sync stream features > json-each of cte 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 133462033,
+      "hash": 98845667,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3230,7 +3230,7 @@ exports[`new sync stream features > not in array 1`] = `
 {
   "buckets": [
     {
-      "hash": 185054388,
+      "hash": 207301670,
       "sources": [
         0,
       ],
@@ -3267,7 +3267,7 @@ exports[`new sync stream features > not in array 1`] = `
           "type": "unary",
         },
       ],
-      "hash": 2294649,
+      "hash": 159147029,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -3304,7 +3304,7 @@ exports[`new sync stream features > not in json array 1`] = `
 {
   "buckets": [
     {
-      "hash": 464039641,
+      "hash": 52312721,
       "sources": [
         0,
       ],
@@ -3338,7 +3338,7 @@ exports[`new sync stream features > not in json array 1`] = `
           "type": "unary",
         },
       ],
-      "hash": 354655507,
+      "hash": 133622965,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -3375,7 +3375,7 @@ exports[`new sync stream features > order-independent parameters 1`] = `
 {
   "buckets": [
     {
-      "hash": 67514874,
+      "hash": 13101728,
       "sources": [
         0,
         1,
@@ -3389,7 +3389,7 @@ exports[`new sync stream features > order-independent parameters 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 440482107,
+      "hash": 486948174,
       "outputTableName": "stores",
       "partitionBy": [
         {
@@ -3421,7 +3421,7 @@ exports[`new sync stream features > order-independent parameters 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 272980298,
+      "hash": 516218655,
       "outputTableName": "products",
       "partitionBy": [
         {
@@ -3514,7 +3514,7 @@ exports[`new sync stream features > row metadata 1`] = `
 {
   "buckets": [
     {
-      "hash": 524705252,
+      "hash": 13444962,
       "sources": [
         0,
       ],
@@ -3536,7 +3536,7 @@ exports[`new sync stream features > row metadata 1`] = `
         },
       ],
       "filters": [],
-      "hash": 352817177,
+      "hash": 418226136,
       "outputTableName": "source",
       "partitionBy": [
         {
@@ -3602,7 +3602,7 @@ exports[`new sync stream features > table-valued functions > partition on data 1
 {
   "buckets": [
     {
-      "hash": 71456886,
+      "hash": 28022504,
       "sources": [
         0,
       ],
@@ -3615,7 +3615,7 @@ exports[`new sync stream features > table-valued functions > partition on data 1
         "star",
       ],
       "filters": [],
-      "hash": 81981113,
+      "hash": 332279886,
       "outputTableName": "posts",
       "partitionBy": [
         {
@@ -3694,7 +3694,7 @@ exports[`new sync stream features > table-valued functions > partition on parame
 {
   "buckets": [
     {
-      "hash": 445777469,
+      "hash": 457862451,
       "sources": [
         0,
       ],
@@ -3707,7 +3707,7 @@ exports[`new sync stream features > table-valued functions > partition on parame
         "star",
       ],
       "filters": [],
-      "hash": 75754117,
+      "hash": 102194264,
       "outputTableName": "users",
       "partitionBy": [
         {
@@ -3730,7 +3730,7 @@ exports[`new sync stream features > table-valued functions > partition on parame
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 310310455,
+      "hash": 368987341,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3836,7 +3836,7 @@ exports[`new sync stream features > table-valued functions > static filter 1`] =
 {
   "buckets": [
     {
-      "hash": 144538386,
+      "hash": 378144963,
       "sources": [
         0,
       ],
@@ -3865,7 +3865,7 @@ exports[`new sync stream features > table-valued functions > static filter 1`] =
           "type": "binary",
         },
       ],
-      "hash": 297403199,
+      "hash": 219838904,
       "outputTableName": "posts",
       "partitionBy": [],
       "table": {

--- a/packages/sync-rules/test/src/compiler/__snapshots__/compatibility.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/compatibility.test.ts.snap
@@ -4,7 +4,7 @@ exports[`old streams test > OR in subquery 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -17,7 +17,7 @@ exports[`old streams test > OR in subquery 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -40,7 +40,7 @@ exports[`old streams test > OR in subquery 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -87,7 +87,7 @@ exports[`old streams test > OR in subquery 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 225195556,
+      "hash": 535568965,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -194,7 +194,7 @@ exports[`old streams test > in > on parameter data 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -207,7 +207,7 @@ exports[`old streams test > in > on parameter data 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -296,7 +296,7 @@ exports[`old streams test > in > on parameter data and table 1`] = `
 {
   "buckets": [
     {
-      "hash": 317489756,
+      "hash": 329503465,
       "sources": [
         0,
       ],
@@ -309,7 +309,7 @@ exports[`old streams test > in > on parameter data and table 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 19117565,
+      "hash": 24455521,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -340,7 +340,7 @@ exports[`old streams test > in > on parameter data and table 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -472,7 +472,7 @@ exports[`old streams test > in > parameter and auth match on same column 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -485,7 +485,7 @@ exports[`old streams test > in > parameter and auth match on same column 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -598,7 +598,7 @@ exports[`old streams test > in > parameter value in subquery 1`] = `
 {
   "buckets": [
     {
-      "hash": 274764250,
+      "hash": 504882872,
       "sources": [
         0,
       ],
@@ -611,7 +611,7 @@ exports[`old streams test > in > parameter value in subquery 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 466638588,
+      "hash": 252303259,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -632,7 +632,7 @@ exports[`old streams test > in > parameter value in subquery 1`] = `
           "type": "data",
         },
       ],
-      "hash": 195983547,
+      "hash": 417725376,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -709,7 +709,7 @@ exports[`old streams test > in > row value in subquery 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -722,7 +722,7 @@ exports[`old streams test > in > row value in subquery 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -745,7 +745,7 @@ exports[`old streams test > in > row value in subquery 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -838,7 +838,7 @@ exports[`old streams test > in > two subqueries 1`] = `
 {
   "buckets": [
     {
-      "hash": 445777469,
+      "hash": 457862451,
       "sources": [
         0,
       ],
@@ -851,7 +851,7 @@ exports[`old streams test > in > two subqueries 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 75754117,
+      "hash": 102194264,
       "outputTableName": "users",
       "partitionBy": [
         {
@@ -874,7 +874,7 @@ exports[`old streams test > in > two subqueries 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 199313316,
+      "hash": 504745499,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -906,7 +906,7 @@ exports[`old streams test > in > two subqueries 1`] = `
     },
     {
       "filters": [],
-      "hash": 73863455,
+      "hash": 231959447,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -1042,7 +1042,7 @@ exports[`old streams test > nested subqueries 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -1055,7 +1055,7 @@ exports[`old streams test > nested subqueries 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1085,7 +1085,7 @@ exports[`old streams test > nested subqueries 1`] = `
           "type": "data",
         },
       ],
-      "hash": 195983547,
+      "hash": 498096823,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1108,7 +1108,7 @@ exports[`old streams test > nested subqueries 1`] = `
     },
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -1197,14 +1197,14 @@ exports[`old streams test > normalization > distribute and 1`] = `
 {
   "buckets": [
     {
-      "hash": 493187891,
+      "hash": 61595621,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 323255266,
+      "hash": 207485264,
       "sources": [
         1,
       ],
@@ -1238,7 +1238,7 @@ exports[`old streams test > normalization > distribute and 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 238671398,
+      "hash": 166247159,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1283,7 +1283,7 @@ exports[`old streams test > normalization > distribute and 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 101128796,
+      "hash": 24294581,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -1297,7 +1297,7 @@ exports[`old streams test > normalization > distribute and 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1413,7 +1413,7 @@ exports[`old streams test > normalization > double negation 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -1426,7 +1426,7 @@ exports[`old streams test > normalization > double negation 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1449,7 +1449,7 @@ exports[`old streams test > normalization > double negation 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1542,14 +1542,14 @@ exports[`old streams test > normalization > negated and 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 33619584,
+      "hash": 26583447,
       "sources": [
         1,
       ],
@@ -1562,7 +1562,7 @@ exports[`old streams test > normalization > negated and 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1611,7 +1611,7 @@ exports[`old streams test > normalization > negated and 1`] = `
           "type": "unary",
         },
       ],
-      "hash": 198981493,
+      "hash": 348342576,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -1625,7 +1625,7 @@ exports[`old streams test > normalization > negated and 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1724,7 +1724,7 @@ exports[`old streams test > normalization > negated or 1`] = `
 {
   "buckets": [
     {
-      "hash": 184056576,
+      "hash": 479468891,
       "sources": [
         0,
       ],
@@ -1762,7 +1762,7 @@ exports[`old streams test > normalization > negated or 1`] = `
           "type": "unary",
         },
       ],
-      "hash": 86439904,
+      "hash": 272618088,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1785,7 +1785,7 @@ exports[`old streams test > normalization > negated or 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1878,14 +1878,14 @@ exports[`old streams test > or > parameter match or request condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 160843911,
+      "hash": 101052997,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 274764250,
+      "hash": 504882872,
       "sources": [
         1,
       ],
@@ -1898,7 +1898,7 @@ exports[`old streams test > or > parameter match or request condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 177858022,
+      "hash": 404544856,
       "outputTableName": "issues",
       "partitionBy": [
         {
@@ -1922,7 +1922,7 @@ exports[`old streams test > or > parameter match or request condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 466638588,
+      "hash": 252303259,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -2002,14 +2002,14 @@ exports[`old streams test > or > parameter match or row condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 160843911,
+      "hash": 101052997,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 302690008,
+      "hash": 50401802,
       "sources": [
         1,
       ],
@@ -2022,7 +2022,7 @@ exports[`old streams test > or > parameter match or row condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 177858022,
+      "hash": 404544856,
       "outputTableName": "issues",
       "partitionBy": [
         {
@@ -2067,7 +2067,7 @@ exports[`old streams test > or > parameter match or row condition 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 81581617,
+      "hash": 384031872,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -2130,7 +2130,7 @@ exports[`old streams test > or > request condition or request condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 177103915,
+      "hash": 221375721,
       "sources": [
         0,
       ],
@@ -2143,7 +2143,7 @@ exports[`old streams test > or > request condition or request condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 38682893,
+      "hash": 276881970,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2217,14 +2217,14 @@ exports[`old streams test > or > row condition or parameter condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 177103915,
+      "hash": 221375721,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 232094228,
+      "hash": 329713050,
       "sources": [
         1,
       ],
@@ -2237,7 +2237,7 @@ exports[`old streams test > or > row condition or parameter condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 38682893,
+      "hash": 276881970,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2273,7 +2273,7 @@ exports[`old streams test > or > row condition or parameter condition 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 25054764,
+      "hash": 409210892,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2333,7 +2333,7 @@ exports[`old streams test > or > row condition or row condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 70511047,
+      "hash": 337635011,
       "sources": [
         0,
       ],
@@ -2391,7 +2391,7 @@ exports[`old streams test > or > row condition or row condition 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 288509552,
+      "hash": 329744546,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2428,14 +2428,14 @@ exports[`old streams test > or > subquery or token parameter 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 177103915,
+      "hash": 221375721,
       "sources": [
         1,
       ],
@@ -2448,7 +2448,7 @@ exports[`old streams test > or > subquery or token parameter 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -2472,7 +2472,7 @@ exports[`old streams test > or > subquery or token parameter 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 38682893,
+      "hash": 276881970,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2486,7 +2486,7 @@ exports[`old streams test > or > subquery or token parameter 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2602,7 +2602,7 @@ exports[`old streams test > overlap 1`] = `
 {
   "buckets": [
     {
-      "hash": 443096475,
+      "hash": 148726195,
       "sources": [
         0,
       ],
@@ -2615,7 +2615,7 @@ exports[`old streams test > overlap 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 499645457,
+      "hash": 448514192,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -2651,7 +2651,7 @@ exports[`old streams test > overlap 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 199313316,
+      "hash": 504745499,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2744,7 +2744,7 @@ exports[`old streams test > row condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 232094228,
+      "hash": 329713050,
       "sources": [
         0,
       ],
@@ -2778,7 +2778,7 @@ exports[`old streams test > row condition 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 25054764,
+      "hash": 409210892,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2815,7 +2815,7 @@ exports[`old streams test > row filter and stream parameter 1`] = `
 {
   "buckets": [
     {
-      "hash": 512760912,
+      "hash": 344674728,
       "sources": [
         0,
       ],
@@ -2849,7 +2849,7 @@ exports[`old streams test > row filter and stream parameter 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 145057899,
+      "hash": 291356175,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -2915,7 +2915,7 @@ exports[`old streams test > stream parameter 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -2928,7 +2928,7 @@ exports[`old streams test > stream parameter 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -2994,7 +2994,7 @@ exports[`old streams test > table alias 1`] = `
 {
   "buckets": [
     {
-      "hash": 466037865,
+      "hash": 40253737,
       "sources": [
         0,
       ],
@@ -3007,7 +3007,7 @@ exports[`old streams test > table alias 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 265683697,
+      "hash": 215568770,
       "outputTableName": "outer",
       "partitionBy": [
         {
@@ -3030,7 +3030,7 @@ exports[`old streams test > table alias 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 84822844,
+      "hash": 105082585,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3123,7 +3123,7 @@ exports[`old streams test > without filter 1`] = `
 {
   "buckets": [
     {
-      "hash": 177103915,
+      "hash": 221375721,
       "sources": [
         0,
       ],
@@ -3136,7 +3136,7 @@ exports[`old streams test > without filter 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 38682893,
+      "hash": 276881970,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {

--- a/packages/sync-rules/test/src/compiler/__snapshots__/cte.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/cte.test.ts.snap
@@ -4,7 +4,7 @@ exports[`common table expressions > as data source 1`] = `
 {
   "buckets": [
     {
-      "hash": 68553592,
+      "hash": 175706552,
       "sources": [
         0,
       ],
@@ -34,7 +34,7 @@ exports[`common table expressions > as data source 1`] = `
         },
       ],
       "filters": [],
-      "hash": 472729660,
+      "hash": 210323829,
       "outputTableName": "organisations",
       "partitionBy": [
         {
@@ -57,7 +57,7 @@ exports[`common table expressions > as data source 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 283023369,
+      "hash": 505749374,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -150,7 +150,7 @@ exports[`common table expressions > as parameter query 1`] = `
 {
   "buckets": [
     {
-      "hash": 29476625,
+      "hash": 377732370,
       "sources": [
         0,
       ],
@@ -163,7 +163,7 @@ exports[`common table expressions > as parameter query 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 27460384,
+      "hash": 39898946,
       "outputTableName": "projects",
       "partitionBy": [
         {
@@ -186,7 +186,7 @@ exports[`common table expressions > as parameter query 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 283023369,
+      "hash": 505749374,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -218,7 +218,7 @@ exports[`common table expressions > as parameter query 1`] = `
     },
     {
       "filters": [],
-      "hash": 500582714,
+      "hash": 371913368,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -327,7 +327,7 @@ exports[`common table expressions > can reference CTE multiple times 1`] = `
 {
   "buckets": [
     {
-      "hash": 187425881,
+      "hash": 436886157,
       "sources": [
         0,
       ],
@@ -340,7 +340,7 @@ exports[`common table expressions > can reference CTE multiple times 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 6968780,
+      "hash": 365381597,
       "outputTableName": "tbl_a",
       "partitionBy": [
         {
@@ -371,7 +371,7 @@ exports[`common table expressions > can reference CTE multiple times 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 250920890,
+      "hash": 40997809,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -403,7 +403,7 @@ exports[`common table expressions > can reference CTE multiple times 1`] = `
     },
     {
       "filters": [],
-      "hash": 215867003,
+      "hash": 91539928,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -545,7 +545,7 @@ exports[`common table expressions > multiple output references 1`] = `
 {
   "buckets": [
     {
-      "hash": 498511015,
+      "hash": 326810458,
       "sources": [
         0,
       ],
@@ -558,7 +558,7 @@ exports[`common table expressions > multiple output references 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 28119074,
+      "hash": 337175667,
       "outputTableName": "workspace",
       "partitionBy": [
         {


### PR DESCRIPTION
When working on https://github.com/powersync-ja/powersync-service/pull/762, I noticed the `equalsIgnoringResultSetUnordered` should probably be using `unorderedEquality` instead of `listEquality`.

This allows the Sync Streams compiler to reuse equivalent query components when independent filters or attached table-valued functions are discovered in a different order.

Incremental reprocessing compares serialized JSON, with bucket data sources sorted, so this does not change how reordered queries are compared between deployments. The serialized JSON includes the compiler hashes though, so upgrading across this change will cause a one-time failure to reuse existing definitions.

AI usage: Manually implemented the change. Reviewed with Codex 5.6