### PR TITLE
Fix equality for table-valued functions

### DIFF
--- a/.changeset/tidy-filters-agree.md
+++ b/.changeset/tidy-filters-agree.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-sync-rules': patch
+---
+
+Correctly reuse equivalent Sync Streams query components when independent filters or attached table-valued functions appear in a different order.

--- a/packages/sync-rules/src/compiler/bucket_resolver.ts
+++ b/packages/sync-rules/src/compiler/bucket_resolver.ts
@@ -1,9 +1,11 @@
 import { StreamOptions } from '../sync_plan/plan.js';
-import { equalsIgnoringResultSetList, equalsIgnoringResultSetUnordered } from './compatibility.js';
+import { resultSetIgnoringEquality, TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
 import { Equality, Equatable, HashSet, StableHasher, unorderedEquality } from './equality.js';
 import { RequestExpression, RowExpression } from './filter.js';
 import { PointLookup, RowEvaluator, SourceRowProcessor } from './rows.js';
 import { TableValuedResultSet } from './table.js';
+
+const equalsIgnoringNoResultSets = resultSetIgnoringEquality(TableValuedHashCodes.empty, TableValuedIdentities.empty);
 
 /**
  * Describes how to resolve a subscription to buckets.
@@ -18,7 +20,7 @@ export class StreamResolver {
   ) {}
 
   buildInstantiationHash(hasher: StableHasher) {
-    equalsIgnoringResultSetUnordered.hash(hasher, this.requestFilters);
+    equalsIgnoringNoResultSets.unorderedEquality.hash(hasher, this.requestFilters);
     StreamResolver.lookupStageEquality.hash(hasher, this.lookupStages);
     this.resolvedBucket.buildInstantiationHash(hasher);
   }
@@ -28,7 +30,7 @@ export class StreamResolver {
       return false;
     }
 
-    if (!equalsIgnoringResultSetUnordered.equals(other.requestFilters, this.requestFilters)) {
+    if (!equalsIgnoringNoResultSets.unorderedEquality.equals(other.requestFilters, this.requestFilters)) {
       return false;
     }
 
@@ -87,24 +89,36 @@ export class ParameterLookup implements Equatable {
 }
 
 export class EvaluateTableValuedFunction implements Equatable {
+  readonly #equalities: ReturnType<typeof resultSetIgnoringEquality>;
+
   constructor(
     readonly tableValuedFunction: TableValuedResultSet,
     readonly outputs: RowExpression[],
     readonly filters: RowExpression[]
-  ) {}
+  ) {
+    const hashCodeMap = new Map<TableValuedResultSet, number>();
+    hashCodeMap.set(tableValuedFunction, 0);
+    const symbolMap = new Map<TableValuedResultSet, symbol>();
+    symbolMap.set(tableValuedFunction, Symbol());
+
+    this.#equalities = resultSetIgnoringEquality(
+      new TableValuedHashCodes(hashCodeMap),
+      new TableValuedIdentities(symbolMap)
+    );
+  }
 
   buildHash(hasher: StableHasher): void {
-    this.tableValuedFunction.buildBehaviorHashCode(hasher);
-    equalsIgnoringResultSetList.hash(hasher, this.outputs);
-    equalsIgnoringResultSetList.hash(hasher, this.filters);
+    this.tableValuedFunction.buildBehaviorHashCode(TableValuedHashCodes.empty, hasher);
+    this.#equalities.listEquality.hash(hasher, this.outputs);
+    this.#equalities.unorderedEquality.hash(hasher, this.filters);
   }
 
   equals(other: unknown): boolean {
     return (
       other instanceof EvaluateTableValuedFunction &&
-      other.tableValuedFunction.behavesIdenticalTo(this.tableValuedFunction) &&
-      equalsIgnoringResultSetList.equals(other.outputs, this.outputs) &&
-      equalsIgnoringResultSetList.equals(other.filters, this.filters)
+      other.tableValuedFunction.behavesIdenticalTo(this.tableValuedFunction, TableValuedIdentities.empty) &&
+      this.#equalities.listEquality.equals(this.outputs, other.outputs) &&
+      this.#equalities.unorderedEquality.equals(this.filters, other.filters)
     );
   }
 }
@@ -143,11 +157,14 @@ export class RequestParameterValue implements Equatable {
   constructor(readonly expression: RequestExpression) {}
 
   buildHash(hasher: StableHasher): void {
-    this.expression.assumingSameResultSetEqualityHashCode(hasher);
+    this.expression.assumingSamePrimaryResultSetEqualityHashCode(TableValuedHashCodes.empty, hasher);
   }
 
   equals(other: unknown): boolean {
-    return other instanceof RequestParameterValue && other.expression.equalsAssumingSameResultSet(this.expression);
+    return (
+      other instanceof RequestParameterValue &&
+      this.expression.equalsAssumingSamePrimaryResultSet(other.expression, TableValuedIdentities.empty)
+    );
   }
 }
 

--- a/packages/sync-rules/src/compiler/bucket_resolver.ts
+++ b/packages/sync-rules/src/compiler/bucket_resolver.ts
@@ -1,15 +1,9 @@
 import { StreamOptions } from '../sync_plan/plan.js';
-import { resultSetIgnoringEquality, TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
+import { TableValuedFunctionEquality } from './compatibility.js';
 import { Equality, Equatable, HashSet, StableHasher, unorderedEquality } from './equality.js';
 import { RequestExpression, RowExpression } from './filter.js';
 import { PointLookup, RowEvaluator, SourceRowProcessor } from './rows.js';
 import { TableValuedResultSet } from './table.js';
-
-/**
- * Most expressions we compare here are only derived from request data without any table-valued functions that would be
- * in scope implicitly. So we can use an empty identity mapping for table-valued functions to compare them.
- */
-const equalsIgnoringNoResultSets = resultSetIgnoringEquality(TableValuedHashCodes.empty, TableValuedIdentities.empty);
 
 /**
  * Describes how to resolve a subscription to buckets.
@@ -24,7 +18,7 @@ export class StreamResolver {
   ) {}
 
   buildInstantiationHash(hasher: StableHasher) {
-    equalsIgnoringNoResultSets.unorderedEquality.hash(hasher, this.requestFilters);
+    TableValuedFunctionEquality.empty.unorderedEquality.hash(hasher, this.requestFilters);
     StreamResolver.lookupStageEquality.hash(hasher, this.lookupStages);
     this.resolvedBucket.buildInstantiationHash(hasher);
   }
@@ -34,7 +28,7 @@ export class StreamResolver {
       return false;
     }
 
-    if (!equalsIgnoringNoResultSets.unorderedEquality.equals(other.requestFilters, this.requestFilters)) {
+    if (!TableValuedFunctionEquality.empty.unorderedEquality.equals(other.requestFilters, this.requestFilters)) {
       return false;
     }
 
@@ -93,36 +87,40 @@ export class ParameterLookup implements Equatable {
 }
 
 export class EvaluateTableValuedFunction implements Equatable {
-  readonly #equalities: ReturnType<typeof resultSetIgnoringEquality>;
+  readonly #hashes: TableValuedFunctionEquality;
 
   constructor(
     readonly tableValuedFunction: TableValuedResultSet,
     readonly outputs: RowExpression[],
     readonly filters: RowExpression[]
   ) {
-    const hashCodeMap = new Map<TableValuedResultSet, number>();
-    hashCodeMap.set(tableValuedFunction, 0);
-    const symbolMap = new Map<TableValuedResultSet, symbol>();
-    symbolMap.set(tableValuedFunction, Symbol());
-
-    this.#equalities = resultSetIgnoringEquality(
-      new TableValuedHashCodes(hashCodeMap),
-      new TableValuedIdentities(symbolMap)
-    );
+    this.#hashes = TableValuedFunctionEquality.forSingleTableValuedFunction(tableValuedFunction);
   }
 
   buildHash(hasher: StableHasher): void {
-    this.tableValuedFunction.buildBehaviorHashCode(TableValuedHashCodes.empty, hasher);
-    this.#equalities.listEquality.hash(hasher, this.outputs);
-    this.#equalities.unorderedEquality.hash(hasher, this.filters);
+    this.tableValuedFunction.buildBehaviorHashCode(TableValuedFunctionEquality.empty, hasher);
+    this.#hashes.listEquality.hash(hasher, this.outputs);
+    this.#hashes.unorderedEquality.hash(hasher, this.filters);
   }
 
   equals(other: unknown): boolean {
+    if (
+      !(other instanceof EvaluateTableValuedFunction) ||
+      !other.tableValuedFunction.behavesIdenticalTo(this.tableValuedFunction, TableValuedFunctionEquality.empty)
+    ) {
+      return false;
+    }
+
+    const symbolMap = new Map<TableValuedResultSet, symbol>();
+    const symbol = Symbol();
+    symbolMap.set(this.tableValuedFunction, symbol);
+    symbolMap.set(other.tableValuedFunction, symbol);
+
+    const equality = TableValuedFunctionEquality.mergeForEquality(this.#hashes, other.#hashes, symbolMap);
+
     return (
-      other instanceof EvaluateTableValuedFunction &&
-      other.tableValuedFunction.behavesIdenticalTo(this.tableValuedFunction, TableValuedIdentities.empty) &&
-      this.#equalities.listEquality.equals(this.outputs, other.outputs) &&
-      this.#equalities.unorderedEquality.equals(this.filters, other.filters)
+      equality.listEquality.equals(this.outputs, other.outputs) &&
+      equality.unorderedEquality.equals(this.filters, other.filters)
     );
   }
 }
@@ -161,13 +159,13 @@ export class RequestParameterValue implements Equatable {
   constructor(readonly expression: RequestExpression) {}
 
   buildHash(hasher: StableHasher): void {
-    this.expression.assumingSamePrimaryResultSetEqualityHashCode(TableValuedHashCodes.empty, hasher);
+    this.expression.assumingSamePrimaryResultSetEqualityHashCode(TableValuedFunctionEquality.empty, hasher);
   }
 
   equals(other: unknown): boolean {
     return (
       other instanceof RequestParameterValue &&
-      this.expression.equalsAssumingSamePrimaryResultSet(other.expression, TableValuedIdentities.empty)
+      this.expression.equalsAssumingSamePrimaryResultSet(other.expression, TableValuedFunctionEquality.empty)
     );
   }
 }

--- a/packages/sync-rules/src/compiler/bucket_resolver.ts
+++ b/packages/sync-rules/src/compiler/bucket_resolver.ts
@@ -5,6 +5,10 @@ import { RequestExpression, RowExpression } from './filter.js';
 import { PointLookup, RowEvaluator, SourceRowProcessor } from './rows.js';
 import { TableValuedResultSet } from './table.js';
 
+/**
+ * Most expressions we compare here are only derived from request data without any table-valued functions that would be
+ * in scope implicitly. So we can use an empty identity mapping for table-valued functions to compare them.
+ */
 const equalsIgnoringNoResultSets = resultSetIgnoringEquality(TableValuedHashCodes.empty, TableValuedIdentities.empty);
 
 /**

--- a/packages/sync-rules/src/compiler/compatibility.ts
+++ b/packages/sync-rules/src/compiler/compatibility.ts
@@ -1,13 +1,19 @@
-import { Equality, listEquality, StableHasher, unorderedEquality } from './equality.js';
+import { Equality, listEquality, orderedEquals, StableHasher, unorderedEquality } from './equality.js';
 import { PhysicalSourceResultSet, SourceResultSet, TableValuedResultSet } from './table.js';
 
 /**
- * Interface for structures that can be compared for equality in a way that ignores referenced result sets.
+ * A semantic equality operator for syntactic structures.
  *
  * This is primarily used to compare expressions across streams. If we have two streams defined as
  * `SELECT * FROM users WHERE id = ...` , the `id` column would not be equal between those since it references a the
  * syntactical `users` table added to each individual statement. But if we are in a context where we know the resolved
  * physical table is the same, this allows comparing expressions for equality.
+ *
+ * It is the responsibility of the caller to also check the primary result set (like `users` in this example) for
+ * equality before invoking these methods. Additionally, streams are allowed to join table-valued functions derived from
+ * the primary result set. Those must also be equal, which is why {@link TableValuedHashCodes} is used to generate
+ * stable hash codes for them and {@link TableValuedIdentities} guarantees that available table-valued functions have a
+ * 1:1 correspondence between compared structures.
  */
 export interface EqualsIgnoringPrimaryResultSet {
   equalsAssumingSamePrimaryResultSet(other: EqualsIgnoringPrimaryResultSet, identities: TableValuedIdentities): boolean;
@@ -15,6 +21,11 @@ export interface EqualsIgnoringPrimaryResultSet {
   assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void;
 }
 
+/**
+ * Pre-computed hash codes for table-valued functions available to a {@link EqualsIgnoringPrimaryResultSet}.
+ *
+ * This is used to embed hashes for table-valued functions when their columns are referenced.
+ */
 export class TableValuedHashCodes {
   readonly #tableValued: Map<TableValuedResultSet, number>;
 
@@ -43,6 +54,15 @@ export class TableValuedHashCodes {
   static readonly empty = new TableValuedHashCodes(new Map());
 }
 
+/**
+ * When comparing two bucket data or parameter processors that can both have table-valued functions on them, an identity
+ * for those functions that is valid for both processors.
+ *
+ * This allows testing expressions referencing table-valued functions for equality across different queries: A caller
+ * first verifies that added table-valued functions are equal on the given queries by constructing an identity mapping
+ * so that `identityOf(tableValuedFunctionInA) == identityOf(tableValuedFunctionInB)` iff `tableValuedFunctionInA` and
+ * `tableValuedFunctionInB` are equivalent.
+ */
 export class TableValuedIdentities {
   readonly #identities: Map<TableValuedResultSet, symbol>;
 
@@ -64,28 +84,7 @@ export class TableValuedIdentities {
   }
 
   orderedEquals(a: Iterable<EqualsIgnoringPrimaryResultSet>, b: Iterable<EqualsIgnoringPrimaryResultSet>): boolean {
-    // TODO: Reuse
-    if (a === b) return true;
-
-    const iteratorA = a[Symbol.iterator]();
-    const iteratorB = b[Symbol.iterator]();
-
-    while (true) {
-      let nextA = iteratorA.next();
-      let nextB = iteratorB.next();
-
-      if (nextA.done != nextB.done) {
-        return false; // Different lengths
-      } else if (nextA.done) {
-        return true; // Both done
-      } else {
-        const elementA = nextA.value;
-        const elementB = nextB.value;
-        if (!elementA.equalsAssumingSamePrimaryResultSet(elementB, this)) {
-          return false;
-        }
-      }
-    }
+    return orderedEquals(a, b, (elementA, elementB) => elementA.equalsAssumingSamePrimaryResultSet(elementB, this));
   }
 
   static readonly empty = new TableValuedIdentities(new Map());
@@ -93,6 +92,10 @@ export class TableValuedIdentities {
   private static readonly primarySymbol = Symbol.for('primary');
 }
 
+/**
+ * An equals and hash code operator for {@link EqualsIgnoringPrimaryResultSet} by binding hash codes and identities for
+ * table-valued functions.
+ */
 export function resultSetIgnoringEquality(hashes: TableValuedHashCodes, identities: TableValuedIdentities) {
   const equality: Equality<EqualsIgnoringPrimaryResultSet> = {
     hash(hasher: StableHasher, value: EqualsIgnoringPrimaryResultSet): void {

--- a/packages/sync-rules/src/compiler/compatibility.ts
+++ b/packages/sync-rules/src/compiler/compatibility.ts
@@ -1,26 +1,111 @@
 import { Equality, listEquality, StableHasher, unorderedEquality } from './equality.js';
+import { PhysicalSourceResultSet, SourceResultSet, TableValuedResultSet } from './table.js';
 
 /**
- * Interface for structures that can be compared for equality in a way that ignores referenced result set.
+ * Interface for structures that can be compared for equality in a way that ignores referenced result sets.
  *
  * This is primarily used to compare expressions across streams. If we have two streams defined as
  * `SELECT * FROM users WHERE id = ...` , the `id` column would not be equal between those since it references a the
- * logical `users` table added to each individual statement. But if we are in a context where we know the physical table
- * is the same, this allows comparing expressions for equality.
+ * syntactical `users` table added to each individual statement. But if we are in a context where we know the resolved
+ * physical table is the same, this allows comparing expressions for equality.
  */
-export interface EqualsIgnoringResultSet {
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean;
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void;
+export interface EqualsIgnoringPrimaryResultSet {
+  equalsAssumingSamePrimaryResultSet(other: EqualsIgnoringPrimaryResultSet, identities: TableValuedIdentities): boolean;
+
+  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void;
 }
 
-export const equalsIgnoringResultSet: Equality<EqualsIgnoringResultSet> = {
-  equals: function (a: EqualsIgnoringResultSet, b: EqualsIgnoringResultSet): boolean {
-    return a.equalsAssumingSameResultSet(b);
-  },
-  hash: function (hasher: StableHasher, value: EqualsIgnoringResultSet): void {
-    return value.assumingSameResultSetEqualityHashCode(hasher);
-  }
-};
+export class TableValuedHashCodes {
+  readonly #tableValued: Map<TableValuedResultSet, number>;
 
-export const equalsIgnoringResultSetList = listEquality(equalsIgnoringResultSet);
-export const equalsIgnoringResultSetUnordered = unorderedEquality(equalsIgnoringResultSet);
+  constructor(tableValued: Map<TableValuedResultSet, number>) {
+    this.#tableValued = tableValued;
+  }
+
+  hashTableValued(resultSet: SourceResultSet, hasher: StableHasher) {
+    // There's only one primary result set which we ignore by design.
+    if (resultSet instanceof PhysicalSourceResultSet) return;
+
+    const hash = this.#tableValued.get(resultSet);
+    if (hash == null) {
+      throw new Error('Hashing unknown table-valued result set');
+    }
+
+    hasher.addHash(hash);
+  }
+
+  hashOrdered(inner: Iterable<EqualsIgnoringPrimaryResultSet>, hasher: StableHasher) {
+    for (const element of inner) {
+      element.assumingSamePrimaryResultSetEqualityHashCode(this, hasher);
+    }
+  }
+
+  static readonly empty = new TableValuedHashCodes(new Map());
+}
+
+export class TableValuedIdentities {
+  readonly #identities: Map<TableValuedResultSet, symbol>;
+
+  constructor(identities: Map<TableValuedResultSet, symbol>) {
+    this.#identities = identities;
+  }
+
+  identityOf(resultSet: SourceResultSet): symbol {
+    if (resultSet instanceof PhysicalSourceResultSet) {
+      return TableValuedIdentities.primarySymbol;
+    }
+
+    const symbol = this.#identities.get(resultSet);
+    if (symbol == null) {
+      throw new Error('Unknown table-valued result set for equals');
+    }
+
+    return symbol;
+  }
+
+  orderedEquals(a: Iterable<EqualsIgnoringPrimaryResultSet>, b: Iterable<EqualsIgnoringPrimaryResultSet>): boolean {
+    // TODO: Reuse
+    if (a === b) return true;
+
+    const iteratorA = a[Symbol.iterator]();
+    const iteratorB = b[Symbol.iterator]();
+
+    while (true) {
+      let nextA = iteratorA.next();
+      let nextB = iteratorB.next();
+
+      if (nextA.done != nextB.done) {
+        return false; // Different lengths
+      } else if (nextA.done) {
+        return true; // Both done
+      } else {
+        const elementA = nextA.value;
+        const elementB = nextB.value;
+        if (!elementA.equalsAssumingSamePrimaryResultSet(elementB, this)) {
+          return false;
+        }
+      }
+    }
+  }
+
+  static readonly empty = new TableValuedIdentities(new Map());
+
+  private static readonly primarySymbol = Symbol.for('primary');
+}
+
+export function resultSetIgnoringEquality(hashes: TableValuedHashCodes, identities: TableValuedIdentities) {
+  const equality: Equality<EqualsIgnoringPrimaryResultSet> = {
+    hash(hasher: StableHasher, value: EqualsIgnoringPrimaryResultSet): void {
+      value.assumingSamePrimaryResultSetEqualityHashCode(hashes, hasher);
+    },
+    equals(a: EqualsIgnoringPrimaryResultSet, b: EqualsIgnoringPrimaryResultSet): boolean {
+      return a.equalsAssumingSamePrimaryResultSet(b, identities);
+    }
+  };
+
+  return {
+    equality,
+    listEquality: listEquality(equality),
+    unorderedEquality: unorderedEquality(equality)
+  };
+}

--- a/packages/sync-rules/src/compiler/compatibility.ts
+++ b/packages/sync-rules/src/compiler/compatibility.ts
@@ -1,4 +1,4 @@
-import { Equality, listEquality, StableHasher } from './equality.js';
+import { Equality, listEquality, StableHasher, unorderedEquality } from './equality.js';
 
 /**
  * Interface for structures that can be compared for equality in a way that ignores referenced result set.
@@ -23,4 +23,4 @@ export const equalsIgnoringResultSet: Equality<EqualsIgnoringResultSet> = {
 };
 
 export const equalsIgnoringResultSetList = listEquality(equalsIgnoringResultSet);
-export const equalsIgnoringResultSetUnordered = listEquality(equalsIgnoringResultSet);
+export const equalsIgnoringResultSetUnordered = unorderedEquality(equalsIgnoringResultSet);

--- a/packages/sync-rules/src/compiler/compatibility.ts
+++ b/packages/sync-rules/src/compiler/compatibility.ts
@@ -1,4 +1,4 @@
-import { Equality, listEquality, orderedEquals, StableHasher, unorderedEquality } from './equality.js';
+import { Equality, listEquality, StableHasher, unorderedEquality } from './equality.js';
 import { PhysicalSourceResultSet, SourceResultSet, TableValuedResultSet } from './table.js';
 
 /**
@@ -16,65 +16,42 @@ import { PhysicalSourceResultSet, SourceResultSet, TableValuedResultSet } from '
  * 1:1 correspondence between compared structures.
  */
 export interface EqualsIgnoringPrimaryResultSet {
-  equalsAssumingSamePrimaryResultSet(other: EqualsIgnoringPrimaryResultSet, identities: TableValuedIdentities): boolean;
+  equalsAssumingSamePrimaryResultSet(
+    other: EqualsIgnoringPrimaryResultSet,
+    tableValued: TableValuedFunctionEquality
+  ): boolean;
 
-  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void;
+  assumingSamePrimaryResultSetEqualityHashCode(tableValued: TableValuedFunctionEquality, hasher: StableHasher): void;
 }
 
-/**
- * Pre-computed hash codes for table-valued functions available to a {@link EqualsIgnoringPrimaryResultSet}.
- *
- * This is used to embed hashes for table-valued functions when their columns are referenced.
- */
-export class TableValuedHashCodes {
-  readonly #tableValued: Map<TableValuedResultSet, number>;
-
-  constructor(tableValued: Map<TableValuedResultSet, number>) {
-    this.#tableValued = tableValued;
-  }
-
-  hashTableValued(resultSet: SourceResultSet, hasher: StableHasher) {
-    // There's only one primary result set which we ignore by design.
-    if (resultSet instanceof PhysicalSourceResultSet) return;
-
-    const hash = this.#tableValued.get(resultSet);
-    if (hash == null) {
-      throw new Error('Hashing unknown table-valued result set');
-    }
-
-    hasher.addHash(hash);
-  }
-
-  hashOrdered(inner: Iterable<EqualsIgnoringPrimaryResultSet>, hasher: StableHasher) {
-    for (const element of inner) {
-      element.assumingSamePrimaryResultSetEqualityHashCode(this, hasher);
-    }
-  }
-
-  static readonly empty = new TableValuedHashCodes(new Map());
+interface ReadOnlyMap<K, V> {
+  get(key: K): V | undefined;
 }
 
-/**
- * When comparing two bucket data or parameter processors that can both have table-valued functions on them, an identity
- * for those functions that is valid for both processors.
- *
- * This allows testing expressions referencing table-valued functions for equality across different queries: A caller
- * first verifies that added table-valued functions are equal on the given queries by constructing an identity mapping
- * so that `identityOf(tableValuedFunctionInA) == identityOf(tableValuedFunctionInB)` iff `tableValuedFunctionInA` and
- * `tableValuedFunctionInB` are equivalent.
- */
-export class TableValuedIdentities {
-  readonly #identities: Map<TableValuedResultSet, symbol>;
+export class TableValuedFunctionEquality implements Equality<EqualsIgnoringPrimaryResultSet> {
+  readonly #hashes: ReadOnlyMap<TableValuedResultSet, number>;
+  readonly #identities: ReadOnlyMap<TableValuedResultSet, unknown>;
 
-  constructor(identities: Map<TableValuedResultSet, symbol>) {
+  #ordered: Equality<Iterable<EqualsIgnoringPrimaryResultSet>> | undefined;
+  #unordered: Equality<Iterable<EqualsIgnoringPrimaryResultSet>> | undefined;
+
+  private constructor(
+    hashes: ReadOnlyMap<TableValuedResultSet, number>,
+    identities: ReadOnlyMap<TableValuedResultSet, unknown>
+  ) {
+    this.#hashes = hashes;
     this.#identities = identities;
   }
 
-  identityOf(resultSet: SourceResultSet): symbol {
-    if (resultSet instanceof PhysicalSourceResultSet) {
-      return TableValuedIdentities.primarySymbol;
-    }
+  get listEquality() {
+    return (this.#ordered ??= listEquality(this));
+  }
 
+  get unorderedEquality() {
+    return (this.#unordered ??= unorderedEquality(this));
+  }
+
+  #lookupIdentity(resultSet: TableValuedResultSet) {
     const symbol = this.#identities.get(resultSet);
     if (symbol == null) {
       throw new Error('Unknown table-valued result set for equals');
@@ -83,32 +60,80 @@ export class TableValuedIdentities {
     return symbol;
   }
 
-  orderedEquals(a: Iterable<EqualsIgnoringPrimaryResultSet>, b: Iterable<EqualsIgnoringPrimaryResultSet>): boolean {
-    return orderedEquals(a, b, (elementA, elementB) => elementA.equalsAssumingSamePrimaryResultSet(elementB, this));
+  equals(a: EqualsIgnoringPrimaryResultSet, b: EqualsIgnoringPrimaryResultSet): boolean {
+    return a.equalsAssumingSamePrimaryResultSet(b, this);
   }
 
-  static readonly empty = new TableValuedIdentities(new Map());
-
-  private static readonly primarySymbol = Symbol.for('primary');
-}
-
-/**
- * An equals and hash code operator for {@link EqualsIgnoringPrimaryResultSet} by binding hash codes and identities for
- * table-valued functions.
- */
-export function resultSetIgnoringEquality(hashes: TableValuedHashCodes, identities: TableValuedIdentities) {
-  const equality: Equality<EqualsIgnoringPrimaryResultSet> = {
-    hash(hasher: StableHasher, value: EqualsIgnoringPrimaryResultSet): void {
-      value.assumingSamePrimaryResultSetEqualityHashCode(hashes, hasher);
-    },
-    equals(a: EqualsIgnoringPrimaryResultSet, b: EqualsIgnoringPrimaryResultSet): boolean {
-      return a.equalsAssumingSamePrimaryResultSet(b, identities);
+  resultSetEquals(a: SourceResultSet, b: SourceResultSet): boolean {
+    // We don't need to compare primary result sets, those are assumed to be equal.
+    if (a instanceof PhysicalSourceResultSet) {
+      return b instanceof PhysicalSourceResultSet;
+    } else if (b instanceof PhysicalSourceResultSet) {
+      return a instanceof PhysicalSourceResultSet;
     }
-  };
 
-  return {
-    equality,
-    listEquality: listEquality(equality),
-    unorderedEquality: unorderedEquality(equality)
-  };
+    return this.#lookupIdentity(a) === this.#lookupIdentity(b);
+  }
+
+  hashResultSet(hasher: StableHasher, resultSet: SourceResultSet): void {
+    // There's only one primary result set which we ignore by design.
+    if (resultSet instanceof PhysicalSourceResultSet) return;
+
+    const hash = this.#hashes.get(resultSet);
+    if (hash == null) {
+      throw new Error('Hashing unknown table-valued result set');
+    }
+
+    hasher.addHash(hash);
+  }
+
+  hash(hasher: StableHasher, value: EqualsIgnoringPrimaryResultSet): void {
+    return value.assumingSamePrimaryResultSetEqualityHashCode(this, hasher);
+  }
+
+  /**
+   * An equality operator for table-valued functions, suitable only for generating hash codes within a single structure
+   * owning table-valued functions.
+   *
+   * This can't be used to compare functions across streams or to test for equality.
+   */
+  static forHashCode(innerHashes: ReadOnlyMap<TableValuedResultSet, number>) {
+    return this.forSingleOwner(innerHashes, {
+      // Compare by identity within the single owner.
+      get: (tableValued) => tableValued
+    });
+  }
+
+  static forSingleTableValuedFunction(resultSet: TableValuedResultSet) {
+    const hashCodeMap = new Map<TableValuedResultSet, number>();
+    // Hash codes are only used to ensure column references to different table-valued functions generate different
+    // codes. Since there's just one, it can be an arbitrary value.
+    hashCodeMap.set(resultSet, 0);
+
+    return this.forHashCode(hashCodeMap);
+  }
+
+  static forSingleOwner(
+    innerHashes: ReadOnlyMap<TableValuedResultSet, number>,
+    equality: ReadOnlyMap<TableValuedResultSet, unknown>
+  ) {
+    return new TableValuedFunctionEquality(innerHashes, equality);
+  }
+
+  static mergeForEquality(
+    localHashes: TableValuedFunctionEquality,
+    otherHashes: TableValuedFunctionEquality,
+    equality: ReadOnlyMap<TableValuedResultSet, symbol>
+  ) {
+    return new TableValuedFunctionEquality(
+      {
+        get(key) {
+          return localHashes.#hashes.get(key) ?? otherHashes.#hashes.get(key);
+        }
+      },
+      equality
+    );
+  }
+
+  static readonly empty = new TableValuedFunctionEquality(new Map(), new Map());
 }

--- a/packages/sync-rules/src/compiler/equality.ts
+++ b/packages/sync-rules/src/compiler/equality.ts
@@ -149,27 +149,7 @@ export interface Equatable {
 export function listEquality<E>(equality: Equality<E>): Equality<Iterable<E>> {
   return {
     equals: (a, b) => {
-      if (a === b) return true;
-
-      const iteratorA = a[Symbol.iterator]();
-      const iteratorB = b[Symbol.iterator]();
-
-      while (true) {
-        let nextA = iteratorA.next();
-        let nextB = iteratorB.next();
-
-        if (nextA.done != nextB.done) {
-          return false; // Different lengths
-        } else if (nextA.done) {
-          return true; // Both done
-        } else {
-          const elementA = nextA.value;
-          const elementB = nextB.value;
-          if (!equality.equals(elementA, elementB)) {
-            return false;
-          }
-        }
-      }
+      return orderedEquals(a, b, equality.equals.bind(equality));
     },
     hash: (hasher, value) => {
       for (const e of value) {
@@ -177,6 +157,30 @@ export function listEquality<E>(equality: Equality<E>): Equality<Iterable<E>> {
       }
     }
   };
+}
+
+export function orderedEquals<T>(a: Iterable<T>, b: Iterable<T>, comparator: (a: T, b: T) => boolean) {
+  if (a === b) return true;
+
+  const iteratorA = a[Symbol.iterator]();
+  const iteratorB = b[Symbol.iterator]();
+
+  while (true) {
+    let nextA = iteratorA.next();
+    let nextB = iteratorB.next();
+
+    if (nextA.done != nextB.done) {
+      return false; // Different lengths
+    } else if (nextA.done) {
+      return true; // Both done
+    } else {
+      const elementA = nextA.value;
+      const elementB = nextB.value;
+      if (!comparator(elementA, elementB)) {
+        return false;
+      }
+    }
+  }
 }
 
 /**

--- a/packages/sync-rules/src/compiler/equality.ts
+++ b/packages/sync-rules/src/compiler/equality.ts
@@ -149,7 +149,27 @@ export interface Equatable {
 export function listEquality<E>(equality: Equality<E>): Equality<Iterable<E>> {
   return {
     equals: (a, b) => {
-      return orderedEquals(a, b, equality.equals.bind(equality));
+      if (a === b) return true;
+
+      const iteratorA = a[Symbol.iterator]();
+      const iteratorB = b[Symbol.iterator]();
+
+      while (true) {
+        let nextA = iteratorA.next();
+        let nextB = iteratorB.next();
+
+        if (nextA.done != nextB.done) {
+          return false; // Different lengths
+        } else if (nextA.done) {
+          return true; // Both done
+        } else {
+          const elementA = nextA.value;
+          const elementB = nextB.value;
+          if (!equality.equals(elementA, elementB)) {
+            return false;
+          }
+        }
+      }
     },
     hash: (hasher, value) => {
       for (const e of value) {
@@ -157,30 +177,6 @@ export function listEquality<E>(equality: Equality<E>): Equality<Iterable<E>> {
       }
     }
   };
-}
-
-export function orderedEquals<T>(a: Iterable<T>, b: Iterable<T>, comparator: (a: T, b: T) => boolean) {
-  if (a === b) return true;
-
-  const iteratorA = a[Symbol.iterator]();
-  const iteratorB = b[Symbol.iterator]();
-
-  while (true) {
-    let nextA = iteratorA.next();
-    let nextB = iteratorB.next();
-
-    if (nextA.done != nextB.done) {
-      return false; // Different lengths
-    } else if (nextA.done) {
-      return true; // Both done
-    } else {
-      const elementA = nextA.value;
-      const elementB = nextB.value;
-      if (!comparator(elementA, elementB)) {
-        return false;
-      }
-    }
-  }
 }
 
 /**

--- a/packages/sync-rules/src/compiler/expression.ts
+++ b/packages/sync-rules/src/compiler/expression.ts
@@ -4,9 +4,9 @@ import { ExternalData, SqlExpression } from '../sync_plan/expression.js';
 import { ExpressionToSqlite } from '../sync_plan/expression_to_sql.js';
 import { RecursiveExpressionVisitor } from '../sync_plan/expression_visitor.js';
 import { ConnectionParameterSource } from '../sync_plan/plan.js';
-import { EqualsIgnoringResultSet, equalsIgnoringResultSetList } from './compatibility.js';
+import { EqualsIgnoringPrimaryResultSet, TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
 import { ParsingErrorListener } from './compiler.js';
-import { StableHasher } from './equality.js';
+import { Equatable, StableHasher } from './equality.js';
 import { SourceResultSet } from './table.js';
 
 /**
@@ -20,7 +20,7 @@ import { SourceResultSet } from './table.js';
  * Once in this form, it's easy to reason about dependencies in expressions (used to later generate parameter match
  * clauses) and to evaluate expressions at runtime (by preparing them as a statement and binding external values).
  */
-export class SyncExpression implements EqualsIgnoringResultSet {
+export class SyncExpression implements EqualsIgnoringPrimaryResultSet {
   #sql?: string;
   #instantiation?: readonly ExpressionInput[];
 
@@ -63,17 +63,20 @@ export class SyncExpression implements EqualsIgnoringResultSet {
     readonly locations: NodeLocations
   ) {}
 
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
+  equalsAssumingSamePrimaryResultSet(
+    other: EqualsIgnoringPrimaryResultSet,
+    identities: TableValuedIdentities
+  ): boolean {
     return (
       other instanceof SyncExpression &&
       other.sql == this.sql &&
-      equalsIgnoringResultSetList.equals(other.instantiation, this.instantiation)
+      identities.orderedEquals(other.instantiation, this.instantiation)
     );
   }
 
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
+  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
     hasher.addString(this.sql);
-    equalsIgnoringResultSetList.hash(hasher, this.instantiation);
+    codes.hashOrdered(this.instantiation, hasher);
   }
 }
 
@@ -95,14 +98,17 @@ export type ExpressionInput = ColumnInRow | RowMetadata | ConnectionParameter;
  * An expression input resolved against a row of a result set: either a column value or metadata about the row's
  * source table.
  */
-export abstract class RowReference implements EqualsIgnoringResultSet {
+export abstract class RowReference implements EqualsIgnoringPrimaryResultSet {
   constructor(
     readonly syntacticOrigin: Expr,
     readonly resultSet: SourceResultSet
   ) {}
 
-  abstract equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean;
-  abstract assumingSameResultSetEqualityHashCode(hasher: StableHasher): void;
+  abstract equalsAssumingSamePrimaryResultSet(
+    other: EqualsIgnoringPrimaryResultSet,
+    identities: TableValuedIdentities
+  ): boolean;
+  abstract assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void;
 }
 
 export class ColumnInRow extends RowReference {
@@ -114,12 +120,20 @@ export class ColumnInRow extends RowReference {
     super(syntacticOrigin, resultSet);
   }
 
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
-    return other instanceof ColumnInRow && other.column == this.column;
+  override equalsAssumingSamePrimaryResultSet(
+    other: EqualsIgnoringPrimaryResultSet,
+    identities: TableValuedIdentities
+  ): boolean {
+    return (
+      other instanceof ColumnInRow &&
+      other.column == this.column &&
+      identities.identityOf(other.resultSet) === identities.identityOf(this.resultSet)
+    );
   }
 
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
+  override assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
     hasher.addString(this.column);
+    codes.hashTableValued(this.resultSet, hasher);
   }
 }
 
@@ -139,27 +153,36 @@ export class RowMetadata extends RowReference {
     super(syntacticOrigin, resultSet);
   }
 
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
+  override equalsAssumingSamePrimaryResultSet(other: EqualsIgnoringPrimaryResultSet): boolean {
+    // Row metadata is always on the primary result set, so no need to hash the result set here.
     return other instanceof RowMetadata && other.kind == this.kind;
   }
 
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
+  override assumingSamePrimaryResultSetEqualityHashCode(_codes: TableValuedHashCodes, hasher: StableHasher): void {
     hasher.addString(`table.${this.kind}`);
   }
 }
 
-export class ConnectionParameter implements EqualsIgnoringResultSet {
+export class ConnectionParameter implements EqualsIgnoringPrimaryResultSet, Equatable {
   constructor(
     readonly syntacticOrigin: Expr,
     readonly source: ConnectionParameterSource
   ) {}
 
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
+  equals(other: unknown): boolean {
     return other instanceof ConnectionParameter && other.source == this.source;
   }
 
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
+  buildHash(hasher: StableHasher): void {
     hasher.addString(this.source);
+  }
+
+  equalsAssumingSamePrimaryResultSet(other: EqualsIgnoringPrimaryResultSet): boolean {
+    return this.equals(other);
+  }
+
+  assumingSamePrimaryResultSetEqualityHashCode(_codes: TableValuedHashCodes, hasher: StableHasher): void {
+    return this.buildHash(hasher);
   }
 }
 

--- a/packages/sync-rules/src/compiler/expression.ts
+++ b/packages/sync-rules/src/compiler/expression.ts
@@ -4,7 +4,7 @@ import { ExternalData, SqlExpression } from '../sync_plan/expression.js';
 import { ExpressionToSqlite } from '../sync_plan/expression_to_sql.js';
 import { RecursiveExpressionVisitor } from '../sync_plan/expression_visitor.js';
 import { ConnectionParameterSource } from '../sync_plan/plan.js';
-import { EqualsIgnoringPrimaryResultSet, TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
+import { EqualsIgnoringPrimaryResultSet, TableValuedFunctionEquality } from './compatibility.js';
 import { ParsingErrorListener } from './compiler.js';
 import { Equatable, StableHasher } from './equality.js';
 import { SourceResultSet } from './table.js';
@@ -65,18 +65,18 @@ export class SyncExpression implements EqualsIgnoringPrimaryResultSet {
 
   equalsAssumingSamePrimaryResultSet(
     other: EqualsIgnoringPrimaryResultSet,
-    identities: TableValuedIdentities
+    tableValued: TableValuedFunctionEquality
   ): boolean {
     return (
       other instanceof SyncExpression &&
       other.sql == this.sql &&
-      identities.orderedEquals(other.instantiation, this.instantiation)
+      tableValued.listEquality.equals(other.instantiation, this.instantiation)
     );
   }
 
-  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
+  assumingSamePrimaryResultSetEqualityHashCode(tableValued: TableValuedFunctionEquality, hasher: StableHasher): void {
     hasher.addString(this.sql);
-    codes.hashOrdered(this.instantiation, hasher);
+    tableValued.listEquality.hash(hasher, this.instantiation);
   }
 }
 
@@ -106,9 +106,12 @@ export abstract class RowReference implements EqualsIgnoringPrimaryResultSet {
 
   abstract equalsAssumingSamePrimaryResultSet(
     other: EqualsIgnoringPrimaryResultSet,
-    identities: TableValuedIdentities
+    tableValued: TableValuedFunctionEquality
   ): boolean;
-  abstract assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void;
+  abstract assumingSamePrimaryResultSetEqualityHashCode(
+    tableValued: TableValuedFunctionEquality,
+    hasher: StableHasher
+  ): void;
 }
 
 export class ColumnInRow extends RowReference {
@@ -122,18 +125,21 @@ export class ColumnInRow extends RowReference {
 
   override equalsAssumingSamePrimaryResultSet(
     other: EqualsIgnoringPrimaryResultSet,
-    identities: TableValuedIdentities
+    tableValued: TableValuedFunctionEquality
   ): boolean {
     return (
       other instanceof ColumnInRow &&
       other.column == this.column &&
-      identities.identityOf(other.resultSet) === identities.identityOf(this.resultSet)
+      tableValued.resultSetEquals(other.resultSet, this.resultSet)
     );
   }
 
-  override assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
+  override assumingSamePrimaryResultSetEqualityHashCode(
+    tableValued: TableValuedFunctionEquality,
+    hasher: StableHasher
+  ): void {
     hasher.addString(this.column);
-    codes.hashTableValued(this.resultSet, hasher);
+    tableValued.hashResultSet(hasher, this.resultSet);
   }
 }
 
@@ -158,7 +164,10 @@ export class RowMetadata extends RowReference {
     return other instanceof RowMetadata && other.kind == this.kind;
   }
 
-  override assumingSamePrimaryResultSetEqualityHashCode(_codes: TableValuedHashCodes, hasher: StableHasher): void {
+  override assumingSamePrimaryResultSetEqualityHashCode(
+    _tableValued: TableValuedFunctionEquality,
+    hasher: StableHasher
+  ): void {
     hasher.addString(`table.${this.kind}`);
   }
 }
@@ -181,7 +190,7 @@ export class ConnectionParameter implements EqualsIgnoringPrimaryResultSet, Equa
     return this.equals(other);
   }
 
-  assumingSamePrimaryResultSetEqualityHashCode(_codes: TableValuedHashCodes, hasher: StableHasher): void {
+  assumingSamePrimaryResultSetEqualityHashCode(_tableValued: TableValuedFunctionEquality, hasher: StableHasher): void {
     return this.buildHash(hasher);
   }
 }

--- a/packages/sync-rules/src/compiler/filter.ts
+++ b/packages/sync-rules/src/compiler/filter.ts
@@ -1,6 +1,6 @@
 import { NodeLocation } from 'pgsql-ast-parser';
 import { expandNodeLocations } from '../errors.js';
-import { EqualsIgnoringResultSet } from './compatibility.js';
+import { EqualsIgnoringPrimaryResultSet, TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
 import { StableHasher } from './equality.js';
 import { ExpressionInput, RowReference, SyncExpression } from './expression.js';
 import { BaseSourceResultSet, SourceResultSet } from './table.js';
@@ -29,7 +29,7 @@ export function isBaseTerm(value: unknown): value is BaseTerm {
 /**
  * A {@link SyncExpression} that only depends on a single result set or connection data.
  */
-export class SingleDependencyExpression implements EqualsIgnoringResultSet {
+export class SingleDependencyExpression implements EqualsIgnoringPrimaryResultSet {
   readonly expression: SyncExpression;
   /**
    * The single result set on which the expression depends on.
@@ -60,12 +60,18 @@ export class SingleDependencyExpression implements EqualsIgnoringResultSet {
     }
   }
 
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
-    return other instanceof SingleDependencyExpression && other.expression.equalsAssumingSameResultSet(this.expression);
+  equalsAssumingSamePrimaryResultSet(
+    other: EqualsIgnoringPrimaryResultSet,
+    identities: TableValuedIdentities
+  ): boolean {
+    return (
+      other instanceof SingleDependencyExpression &&
+      other.expression.equalsAssumingSamePrimaryResultSet(this.expression, identities)
+    );
   }
 
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
-    this.expression.assumingSameResultSetEqualityHashCode(hasher);
+  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
+    this.expression.assumingSamePrimaryResultSetEqualityHashCode(codes, hasher);
   }
 
   /**

--- a/packages/sync-rules/src/compiler/filter.ts
+++ b/packages/sync-rules/src/compiler/filter.ts
@@ -1,6 +1,6 @@
 import { NodeLocation } from 'pgsql-ast-parser';
 import { expandNodeLocations } from '../errors.js';
-import { EqualsIgnoringPrimaryResultSet, TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
+import { EqualsIgnoringPrimaryResultSet, TableValuedFunctionEquality } from './compatibility.js';
 import { StableHasher } from './equality.js';
 import { ExpressionInput, RowReference, SyncExpression } from './expression.js';
 import { BaseSourceResultSet, SourceResultSet } from './table.js';
@@ -62,16 +62,16 @@ export class SingleDependencyExpression implements EqualsIgnoringPrimaryResultSe
 
   equalsAssumingSamePrimaryResultSet(
     other: EqualsIgnoringPrimaryResultSet,
-    identities: TableValuedIdentities
+    tableValued: TableValuedFunctionEquality
   ): boolean {
     return (
       other instanceof SingleDependencyExpression &&
-      other.expression.equalsAssumingSamePrimaryResultSet(this.expression, identities)
+      other.expression.equalsAssumingSamePrimaryResultSet(this.expression, tableValued)
     );
   }
 
-  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
-    this.expression.assumingSamePrimaryResultSetEqualityHashCode(codes, hasher);
+  assumingSamePrimaryResultSetEqualityHashCode(tableValued: TableValuedFunctionEquality, hasher: StableHasher): void {
+    this.expression.assumingSamePrimaryResultSetEqualityHashCode(tableValued, hasher);
   }
 
   /**

--- a/packages/sync-rules/src/compiler/ir_to_sync_plan.ts
+++ b/packages/sync-rules/src/compiler/ir_to_sync_plan.ts
@@ -79,20 +79,8 @@ export class CompilerModelToSyncPlan {
   }
 
   private translatePartitionKey(value: rows.PartitionKey, context: rows.SourceRowProcessor): plan.PartitionKey {
-    let sourceExpression: SyncExpression;
-
-    // TODO: Unify scalar and table-valued partition keys in compiler IR?
-    if (value instanceof rows.ScalarPartitionKey) {
-      sourceExpression = value.expression.expression;
-      return { expr: this.translateExpression(value.expression.expression, context.syntacticSource) };
-    } else if (value instanceof rows.TableValuedPartitionKey) {
-      sourceExpression = value.output.expression;
-    } else {
-      throw new Error('Unhandled partition key');
-    }
-
     return {
-      expr: this.translateExpression(sourceExpression, context.syntacticSource, context.addedFunctions)
+      expr: this.translateExpression(value.expression.expression, context.syntacticSource, context.addedFunctions)
     };
   }
 

--- a/packages/sync-rules/src/compiler/querier_graph.ts
+++ b/packages/sync-rules/src/compiler/querier_graph.ts
@@ -10,7 +10,7 @@ import {
   ResolveBucket,
   StreamResolver
 } from './bucket_resolver.js';
-import { resultSetIgnoringEquality, TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
+import { TableValuedFunctionEquality } from './compatibility.js';
 import { ParsingErrorListener, SyncStreamsCompiler } from './compiler.js';
 import { HashMap, HashSet, StableHasher } from './equality.js';
 import { RowReference, SourceLocation } from './expression.js';
@@ -163,7 +163,7 @@ class PendingQuerierPath {
         syntacticSource: this.query.sourceTable,
         filters: state.filters,
         partitionBy: partitions,
-        addedFunctions: [...state.addedFunctions]
+        addedFunctions: [...state.addedFunctions()]
       })
     );
     this.processExistsOperators();
@@ -211,14 +211,20 @@ class PendingQuerierPath {
     return new PendingExpandingLookup({
       type: 'point',
       source: resultSet,
-      resultSet: resolved
+      resultSet: resolved,
+      tableValuedFunctionEquality: resolved.equality
     });
   }
 
   private resolveTableValuedLookup(resultSet: TableValuedResultSet): PendingExpandingLookup {
     const resolved = this.resolveResultSet(resultSet);
 
-    return new PendingExpandingLookup({ type: 'table_valued', source: resultSet, filters: resolved.filters });
+    return new PendingExpandingLookup({
+      type: 'table_valued',
+      source: resultSet,
+      filters: resolved.filters,
+      tableValuedFunctionEquality: TableValuedFunctionEquality.forSingleTableValuedFunction(resultSet)
+    });
   }
 
   private resolveExpandingLookup(resultSet: SourceResultSet): PendingExpandingLookup {
@@ -434,7 +440,7 @@ class PendingQuerierPath {
               filters: resultSet.filters,
               partitionBy: partitionKeys,
               result: lookup.usedOutputs,
-              addedFunctions: [...resultSet.addedFunctions]
+              addedFunctions: [...resultSet.addedFunctions()]
             })
           );
           lookupWithInputs = new ParameterLookup(canonicalized, partitionInputs);
@@ -452,20 +458,24 @@ class PendingQuerierPath {
 }
 
 class ResolvedResultSet {
-  readonly #functionHashes = new Map<TableValuedResultSet, number>();
-  readonly #functionSymbols = new Map<TableValuedResultSet, symbol>();
-  readonly #addedFunctions = new Map<SourceResultSet, SourceRowProcessorAddedTableValuedFunction>();
+  readonly #addedFunctions = new Map<SourceResultSet, [SourceRowProcessorAddedTableValuedFunction, number, symbol]>();
 
-  readonly #equality = resultSetIgnoringEquality(
-    new TableValuedHashCodes(this.#functionHashes),
-    new TableValuedIdentities(this.#functionSymbols)
-  ).equality;
+  readonly equality = TableValuedFunctionEquality.forSingleOwner(
+    {
+      get: (tableValued) => this.#addedFunctions.get(tableValued)?.[1]
+    },
+    {
+      get: (tableValued) => this.#addedFunctions.get(tableValued)?.[2]
+    }
+  );
 
   readonly filters: RowExpression[] = [];
-  readonly partition = new HashMap<PartitionKey, ParameterValue[]>(this.#equality);
+  readonly partition = new HashMap<PartitionKey, ParameterValue[]>(this.equality);
 
-  get addedFunctions() {
-    return this.#addedFunctions.values();
+  *addedFunctions(): Iterable<SourceRowProcessorAddedTableValuedFunction> {
+    for (const [added] of this.#addedFunctions.values()) {
+      yield added;
+    }
   }
 
   getOrAddTableValuedFunction(source: TableValuedResultSet) {
@@ -477,9 +487,11 @@ class ResolvedResultSet {
         source.tableValuedFunctionName,
         source.parameters.map((e) => new RowExpression(e))
       );
-      this.#addedFunctions.set(source, pendingFunction);
-      this.#functionHashes.set(source, StableHasher.hashWith(this.#equality, pendingFunction));
-      this.#functionSymbols.set(source, Symbol());
+      this.#addedFunctions.set(source, [
+        pendingFunction,
+        StableHasher.hashWith(this.equality, pendingFunction),
+        Symbol()
+      ]);
       return pendingFunction;
     }
   }
@@ -498,7 +510,7 @@ class ResolvedResultSet {
     // partition keys should be unordered: Instantiating a bucket is a `Map<Parameter, Value>` that just happens to be
     // encoded as `Value[]` since parameters are known from context.
     // To make it easier to merge buckets, we sort parameters by some stable hash.
-    entries.sort((a, b) => StableHasher.hashWith(this.#equality, a[0]) - StableHasher.hashWith(this.#equality, b[0]));
+    entries.sort((a, b) => StableHasher.hashWith(this.equality, a[0]) - StableHasher.hashWith(this.equality, b[0]));
 
     const keys: PartitionKey[] = [];
     const values: ParameterValue[] = [];
@@ -519,7 +531,7 @@ class PendingExpandingLookup {
   addOutput(param: RowExpression) {
     for (let i = 0; i < this.usedOutputs.length; i++) {
       const existing = this.usedOutputs[i];
-      if (existing.equalsAssumingSamePrimaryResultSet(param, TableValuedIdentities.empty)) {
+      if (existing.equalsAssumingSamePrimaryResultSet(param, this.data.tableValuedFunctionEquality)) {
         return i;
       }
     }
@@ -544,12 +556,14 @@ interface PendingPointLookup {
   type: 'point';
   source: PhysicalSourceResultSet;
   resultSet: ResolvedResultSet;
+  tableValuedFunctionEquality: TableValuedFunctionEquality;
 }
 
 interface PendingTableValuedFunctionLookup {
   type: 'table_valued';
   source: TableValuedResultSet;
   filters: RowExpression[];
+  tableValuedFunctionEquality: TableValuedFunctionEquality;
 }
 
 interface PendingStage {

--- a/packages/sync-rules/src/compiler/querier_graph.ts
+++ b/packages/sync-rules/src/compiler/querier_graph.ts
@@ -10,20 +10,13 @@ import {
   ResolveBucket,
   StreamResolver
 } from './bucket_resolver.js';
-import { equalsIgnoringResultSet } from './compatibility.js';
+import { resultSetIgnoringEquality, TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
 import { ParsingErrorListener, SyncStreamsCompiler } from './compiler.js';
 import { HashMap, HashSet, StableHasher } from './equality.js';
 import { RowReference, SourceLocation } from './expression.js';
 import { And, BaseTerm, EqualsClause, RequestExpression, RowExpression, SingleDependencyExpression } from './filter.js';
 import { ParsedStreamQuery } from './parser.js';
-import {
-  PartitionKey,
-  PointLookup,
-  RowEvaluator,
-  ScalarPartitionKey,
-  SourceRowProcessorAddedTableValuedFunction,
-  TableValuedPartitionKey
-} from './rows.js';
+import { PartitionKey, PointLookup, RowEvaluator, SourceRowProcessorAddedTableValuedFunction } from './rows.js';
 import { PhysicalSourceResultSet, SourceResultSet, TableValuedResultSet } from './table.js';
 
 /**
@@ -170,7 +163,7 @@ class PendingQuerierPath {
         syntacticSource: this.query.sourceTable,
         filters: state.filters,
         partitionBy: partitions,
-        addedFunctions: [...state.addedFunctions.values()]
+        addedFunctions: [...state.addedFunctions]
       })
     );
     this.processExistsOperators();
@@ -224,14 +217,6 @@ class PendingQuerierPath {
 
   private resolveTableValuedLookup(resultSet: TableValuedResultSet): PendingExpandingLookup {
     const resolved = this.resolveResultSet(resultSet);
-    if (!resolved.partition.isEmpty) {
-      // This function is only called for table-valued result sets operating on request data. Partitions are only
-      // supported for buckets and parameter lookups.
-      this.errors.report(
-        `This table-valued function depends on request data and can't be partitioned. If possible, try rewriting the query to not use = operators on this function and multiple other tables.`,
-        resultSet.source.origin
-      );
-    }
 
     return new PendingExpandingLookup({ type: 'table_valued', source: resultSet, filters: resolved.filters });
   }
@@ -323,6 +308,14 @@ class PendingQuerierPath {
           }
 
           this.removePendingExpression(expression);
+          if (source instanceof TableValuedResultSet) {
+            this.errors.report(
+              `This table-valued function depends on request data and can't be partitioned. If possible, try rewriting the query to not use = operators on this function and multiple other tables.`,
+              source.source.origin
+            );
+            return;
+          }
+
           const values = state.partition.putIfAbsent(key, () => []);
 
           if (otherResultSet != null) {
@@ -338,7 +331,7 @@ class PendingQuerierPath {
         };
 
         const partitionByScalar = (thisRow: SingleDependencyExpression, otherRow: SingleDependencyExpression) => {
-          const key = new ScalarPartitionKey(new RowExpression(thisRow));
+          const key = new PartitionKey(new RowExpression(thisRow));
           partitionBy(key, otherRow);
         };
 
@@ -347,8 +340,8 @@ class PendingQuerierPath {
           tableValuedOutput: RowExpression,
           otherRow: SingleDependencyExpression
         ) => {
-          const resolvedFunction = state.getOrAddTableValuedFunction(tableValued);
-          const key = new TableValuedPartitionKey(resolvedFunction, tableValuedOutput);
+          state.getOrAddTableValuedFunction(tableValued);
+          const key = new PartitionKey(tableValuedOutput);
           return partitionBy(key, otherRow);
         };
 
@@ -441,7 +434,7 @@ class PendingQuerierPath {
               filters: resultSet.filters,
               partitionBy: partitionKeys,
               result: lookup.usedOutputs,
-              addedFunctions: [...resultSet.addedFunctions.values()]
+              addedFunctions: [...resultSet.addedFunctions]
             })
           );
           lookupWithInputs = new ParameterLookup(canonicalized, partitionInputs);
@@ -459,20 +452,34 @@ class PendingQuerierPath {
 }
 
 class ResolvedResultSet {
+  readonly #functionHashes = new Map<TableValuedResultSet, number>();
+  readonly #functionSymbols = new Map<TableValuedResultSet, symbol>();
+  readonly #addedFunctions = new Map<SourceResultSet, SourceRowProcessorAddedTableValuedFunction>();
+
+  readonly #equality = resultSetIgnoringEquality(
+    new TableValuedHashCodes(this.#functionHashes),
+    new TableValuedIdentities(this.#functionSymbols)
+  ).equality;
+
   readonly filters: RowExpression[] = [];
-  readonly partition = new HashMap<PartitionKey, ParameterValue[]>(equalsIgnoringResultSet);
-  readonly addedFunctions = new Map<SourceResultSet, SourceRowProcessorAddedTableValuedFunction>();
+  readonly partition = new HashMap<PartitionKey, ParameterValue[]>(this.#equality);
+
+  get addedFunctions() {
+    return this.#addedFunctions.values();
+  }
 
   getOrAddTableValuedFunction(source: TableValuedResultSet) {
-    if (this.addedFunctions.has(source)) {
-      return this.addedFunctions.get(source)!;
+    if (this.#addedFunctions.has(source)) {
+      return this.#addedFunctions.get(source)!;
     } else {
       const pendingFunction = new SourceRowProcessorAddedTableValuedFunction(
         source,
         source.tableValuedFunctionName,
         source.parameters.map((e) => new RowExpression(e))
       );
-      this.addedFunctions.set(source, pendingFunction);
+      this.#addedFunctions.set(source, pendingFunction);
+      this.#functionHashes.set(source, StableHasher.hashWith(this.#equality, pendingFunction));
+      this.#functionSymbols.set(source, Symbol());
       return pendingFunction;
     }
   }
@@ -491,10 +498,7 @@ class ResolvedResultSet {
     // partition keys should be unordered: Instantiating a bucket is a `Map<Parameter, Value>` that just happens to be
     // encoded as `Value[]` since parameters are known from context.
     // To make it easier to merge buckets, we sort parameters by some stable hash.
-    entries.sort(
-      (a, b) =>
-        StableHasher.hashWith(equalsIgnoringResultSet, a[0]) - StableHasher.hashWith(equalsIgnoringResultSet, b[0])
-    );
+    entries.sort((a, b) => StableHasher.hashWith(this.#equality, a[0]) - StableHasher.hashWith(this.#equality, b[0]));
 
     const keys: PartitionKey[] = [];
     const values: ParameterValue[] = [];
@@ -515,7 +519,7 @@ class PendingExpandingLookup {
   addOutput(param: RowExpression) {
     for (let i = 0; i < this.usedOutputs.length; i++) {
       const existing = this.usedOutputs[i];
-      if (existing.equalsAssumingSameResultSet(param)) {
+      if (existing.equalsAssumingSamePrimaryResultSet(param, TableValuedIdentities.empty)) {
         return i;
       }
     }

--- a/packages/sync-rules/src/compiler/rows.ts
+++ b/packages/sync-rules/src/compiler/rows.ts
@@ -1,9 +1,10 @@
 import type { BucketDataSource, ParameterIndexLookupCreator } from '../BucketSource.js';
 import { ImplicitSchemaTablePattern } from '../TablePattern.js';
 import {
-  EqualsIgnoringResultSet,
-  equalsIgnoringResultSetList,
-  equalsIgnoringResultSetUnordered
+  EqualsIgnoringPrimaryResultSet,
+  resultSetIgnoringEquality,
+  TableValuedHashCodes,
+  TableValuedIdentities
 } from './compatibility.js';
 import { StableHasher } from './equality.js';
 import { RowExpression } from './filter.js';
@@ -15,53 +16,20 @@ import { PhysicalSourceResultSet, TableValuedResultSet } from './table.js';
  * When constructing buckets, a value needs to be passed for each such key.
  * When invoking parameter lookups, values need to be passed as inputs.
  */
-export abstract class PartitionKey implements EqualsIgnoringResultSet {
-  abstract equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean;
-  abstract assumingSameResultSetEqualityHashCode(hasher: StableHasher): void;
-}
+export class PartitionKey implements EqualsIgnoringPrimaryResultSet {
+  constructor(readonly expression: RowExpression) {}
 
-export class ScalarPartitionKey extends PartitionKey {
-  constructor(readonly expression: RowExpression) {
-    super();
-  }
-
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
+  equalsAssumingSamePrimaryResultSet(
+    other: EqualsIgnoringPrimaryResultSet,
+    identities: TableValuedIdentities
+  ): boolean {
     return (
-      other instanceof ScalarPartitionKey &&
-      other.expression.expression.equalsAssumingSameResultSet(this.expression.expression)
+      other instanceof PartitionKey && this.expression.equalsAssumingSamePrimaryResultSet(other.expression, identities)
     );
   }
 
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
-    this.expression.expression.assumingSameResultSetEqualityHashCode(hasher);
-  }
-}
-
-/**
- * A partition key derived from the output of a table-valued function added to a {@link SourceRowProcessor}.
- */
-export class TableValuedPartitionKey extends PartitionKey {
-  constructor(
-    readonly fromFunction: SourceRowProcessorAddedTableValuedFunction,
-    readonly output: RowExpression
-  ) {
-    super();
-  }
-
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
-    if (!(other instanceof TableValuedPartitionKey)) {
-      return false;
-    }
-
-    return (
-      other.fromFunction.equalsAssumingSameResultSet(this.fromFunction) &&
-      other.output.equalsAssumingSameResultSet(this.output)
-    );
-  }
-
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
-    this.fromFunction.assumingSameResultSetEqualityHashCode(hasher);
-    this.output.assumingSameResultSetEqualityHashCode(hasher);
+  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
+    this.expression.assumingSamePrimaryResultSetEqualityHashCode(codes, hasher);
   }
 }
 
@@ -95,11 +63,22 @@ abstract class BaseSourceRowProcessor {
   readonly partitionBy: PartitionKey[];
   readonly addedFunctions: SourceRowProcessorAddedTableValuedFunction[];
 
+  readonly #tableValuedFunctionToHashCode = new Map<TableValuedResultSet, number>();
+  protected readonly tableValuedHashCodes: TableValuedHashCodes;
+
   constructor(options: SourceProcessorOptions) {
     this.syntacticSource = options.syntacticSource;
     this.filters = options.filters;
     this.partitionBy = options.partitionBy;
     this.addedFunctions = options.addedFunctions;
+
+    this.tableValuedHashCodes = new TableValuedHashCodes(this.#tableValuedFunctionToHashCode);
+
+    for (const fn of options.addedFunctions) {
+      const hasher = new StableHasher();
+      fn.assumingSamePrimaryResultSetEqualityHashCode(this.tableValuedHashCodes, hasher);
+      this.#tableValuedFunctionToHashCode.set(fn.syntacticSource, hasher.buildHashCode());
+    }
   }
 
   /**
@@ -130,32 +109,63 @@ abstract class BaseSourceRowProcessor {
 
   protected addBaseHashCode(hasher: StableHasher) {
     hasher.add(this.tablePattern);
-    equalsIgnoringResultSetUnordered.hash(
+    const equality = resultSetIgnoringEquality(this.tableValuedHashCodes, TableValuedIdentities.empty);
+
+    equality.unorderedEquality.hash(
       hasher,
       this.filters.map((f) => f.expression)
     );
-    equalsIgnoringResultSetList.hash(hasher, this.partitionBy);
-    equalsIgnoringResultSetUnordered.hash(hasher, this.addedFunctions);
+    equality.listEquality.hash(hasher, this.partitionBy);
+    equality.unorderedEquality.hash(hasher, this.addedFunctions);
   }
 
   protected baseMatchesOther(other: BaseSourceRowProcessor) {
     if (!other.tablePattern.equals(this.tablePattern)) {
-      return false;
+      return null;
     }
 
-    if (!equalsIgnoringResultSetList.equals(other.partitionBy, this.partitionBy)) {
-      return false;
+    // Verify that table-valued functions on the two row processors are equal (in any order). Also, construct a mapping
+    // of functions in both processors to a unique symbol so that if two processors are equal, the mapping will report
+    // the exact same symbol. This allows expressions to compare references to table-valued functions across the two
+    // processors.
+    const symbolsForTableValuedFunctions = new Map<TableValuedResultSet, symbol>();
+    const identities = new TableValuedIdentities(symbolsForTableValuedFunctions);
+
+    {
+      const unmatchedLocalFunctions = new Set(this.addedFunctions);
+
+      other: for (const otherFunction of other.addedFunctions) {
+        const otherHash = other.#tableValuedFunctionToHashCode.get(otherFunction.syntacticSource);
+
+        for (const thisFunction of unmatchedLocalFunctions) {
+          const thisHash = this.#tableValuedFunctionToHashCode.get(thisFunction.syntacticSource);
+
+          if (thisHash === otherHash && thisFunction.equalsAssumingSamePrimaryResultSet(otherFunction, identities)) {
+            const symbol = Symbol();
+            symbolsForTableValuedFunctions.set(otherFunction.syntacticSource, symbol);
+            symbolsForTableValuedFunctions.set(thisFunction.syntacticSource, symbol);
+            unmatchedLocalFunctions.delete(thisFunction);
+
+            continue other;
+          }
+        }
+
+        // No match found for otherFunction
+        return null;
+      }
     }
 
-    if (!equalsIgnoringResultSetUnordered.equals(other.filters, this.filters)) {
-      return false;
+    const equality = resultSetIgnoringEquality(TableValuedHashCodes.empty, identities);
+
+    if (!equality.listEquality.equals(other.partitionBy, this.partitionBy)) {
+      return null;
     }
 
-    if (!equalsIgnoringResultSetUnordered.equals(other.addedFunctions, this.addedFunctions)) {
-      return false;
+    if (!equality.unorderedEquality.equals(other.filters, this.filters)) {
+      return null;
     }
 
-    return true;
+    return equality;
   }
 }
 
@@ -190,18 +200,20 @@ export class RowEvaluator extends BaseSourceRowProcessor {
 
   buildBehaviorHashCode(hasher: StableHasher): void {
     this.addBaseHashCode(hasher);
-    equalsIgnoringResultSetList.hash(hasher, this.columns);
+    this.tableValuedHashCodes.hashOrdered(this.columns, hasher);
     if (this.outputName) {
       hasher.addString(this.outputName);
     }
   }
 
   behavesIdenticalTo(other: RowEvaluator): boolean {
-    return (
-      this.baseMatchesOther(other) &&
-      equalsIgnoringResultSetList.equals(other.columns, this.columns) &&
-      other.outputName == this.outputName
-    );
+    if (other === this) return true;
+    if (other.outputName != this.outputName) return false;
+
+    const identities = this.baseMatchesOther(other);
+    if (identities == null) return false;
+
+    return identities.listEquality.equals(other.columns, this.columns);
   }
 }
 
@@ -227,11 +239,14 @@ export class PointLookup extends BaseSourceRowProcessor {
 
   buildBehaviorHashCode(hasher: StableHasher): void {
     this.addBaseHashCode(hasher);
-    equalsIgnoringResultSetList.hash(hasher, this.result);
+    this.tableValuedHashCodes.hashOrdered(this.result, hasher);
   }
 
   behavesIdenticalTo(other: PointLookup): boolean {
-    return this.baseMatchesOther(other) && equalsIgnoringResultSetList.equals(other.result, this.result);
+    if (other === this) return true;
+
+    const identities = this.baseMatchesOther(other);
+    return identities != null && identities.listEquality.equals(other.result, this.result);
   }
 }
 
@@ -240,57 +255,63 @@ export class PointLookup extends BaseSourceRowProcessor {
  *
  * When processing source rows, all attached table-valued functions are expanded as well.
  */
-export class SourceRowProcessorAddedTableValuedFunction implements EqualsIgnoringResultSet {
+export class SourceRowProcessorAddedTableValuedFunction implements EqualsIgnoringPrimaryResultSet {
   constructor(
     readonly syntacticSource: TableValuedResultSet,
     readonly functionName: string,
     readonly inputs: RowExpression[]
   ) {}
 
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
+  equalsAssumingSamePrimaryResultSet(
+    other: EqualsIgnoringPrimaryResultSet,
+    identities: TableValuedIdentities
+  ): boolean {
     if (!(other instanceof SourceRowProcessorAddedTableValuedFunction)) {
       return false;
     }
 
-    return other.functionName == this.functionName && equalsIgnoringResultSetList.equals(other.inputs, this.inputs);
+    return other.functionName == this.functionName && identities.orderedEquals(other.inputs, this.inputs);
   }
 
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
+  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
     hasher.addString(this.functionName);
-    equalsIgnoringResultSetList.hash(hasher, this.inputs);
+    codes.hashOrdered(this.inputs, hasher);
   }
 }
 
 export type ColumnSource = StarColumnSource | ExpressionColumnSource;
 
-export class StarColumnSource implements EqualsIgnoringResultSet {
+export class StarColumnSource implements EqualsIgnoringPrimaryResultSet {
   private constructor() {}
 
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
+  equalsAssumingSamePrimaryResultSet(other: EqualsIgnoringPrimaryResultSet): boolean {
     return other instanceof StarColumnSource;
   }
 
-  assumingSameResultSetEqualityHashCode(): void {}
+  assumingSamePrimaryResultSetEqualityHashCode(): void {}
 
   static readonly instance = new StarColumnSource();
 }
 
-export class ExpressionColumnSource implements EqualsIgnoringResultSet {
+export class ExpressionColumnSource implements EqualsIgnoringPrimaryResultSet {
   constructor(
     readonly expression: RowExpression,
     readonly alias: string
   ) {}
 
-  equalsAssumingSameResultSet(other: EqualsIgnoringResultSet): boolean {
+  equalsAssumingSamePrimaryResultSet(
+    other: EqualsIgnoringPrimaryResultSet,
+    identities: TableValuedIdentities
+  ): boolean {
     return (
       other instanceof ExpressionColumnSource &&
       other.alias == this.alias &&
-      other.expression.equalsAssumingSameResultSet(this.expression)
+      other.expression.equalsAssumingSamePrimaryResultSet(this.expression, identities)
     );
   }
 
-  assumingSameResultSetEqualityHashCode(hasher: StableHasher): void {
-    this.expression.assumingSameResultSetEqualityHashCode(hasher);
+  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
+    this.expression.assumingSamePrimaryResultSetEqualityHashCode(codes, hasher);
     hasher.addString(this.alias);
   }
 }

--- a/packages/sync-rules/src/compiler/rows.ts
+++ b/packages/sync-rules/src/compiler/rows.ts
@@ -1,11 +1,6 @@
 import type { BucketDataSource, ParameterIndexLookupCreator } from '../BucketSource.js';
 import { ImplicitSchemaTablePattern } from '../TablePattern.js';
-import {
-  EqualsIgnoringPrimaryResultSet,
-  resultSetIgnoringEquality,
-  TableValuedHashCodes,
-  TableValuedIdentities
-} from './compatibility.js';
+import { EqualsIgnoringPrimaryResultSet, TableValuedFunctionEquality } from './compatibility.js';
 import { StableHasher } from './equality.js';
 import { RowExpression } from './filter.js';
 import { PhysicalSourceResultSet, TableValuedResultSet } from './table.js';
@@ -21,15 +16,15 @@ export class PartitionKey implements EqualsIgnoringPrimaryResultSet {
 
   equalsAssumingSamePrimaryResultSet(
     other: EqualsIgnoringPrimaryResultSet,
-    identities: TableValuedIdentities
+    tableValued: TableValuedFunctionEquality
   ): boolean {
     return (
-      other instanceof PartitionKey && this.expression.equalsAssumingSamePrimaryResultSet(other.expression, identities)
+      other instanceof PartitionKey && this.expression.equalsAssumingSamePrimaryResultSet(other.expression, tableValued)
     );
   }
 
-  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
-    this.expression.assumingSamePrimaryResultSetEqualityHashCode(codes, hasher);
+  assumingSamePrimaryResultSetEqualityHashCode(tableValued: TableValuedFunctionEquality, hasher: StableHasher): void {
+    this.expression.assumingSamePrimaryResultSetEqualityHashCode(tableValued, hasher);
   }
 }
 
@@ -64,7 +59,7 @@ abstract class BaseSourceRowProcessor {
   readonly addedFunctions: SourceRowProcessorAddedTableValuedFunction[];
 
   readonly #tableValuedFunctionToHashCode = new Map<TableValuedResultSet, number>();
-  protected readonly tableValuedHashCodes: TableValuedHashCodes;
+  protected readonly tableValuedHashCodes: TableValuedFunctionEquality;
 
   constructor(options: SourceProcessorOptions) {
     this.syntacticSource = options.syntacticSource;
@@ -72,7 +67,7 @@ abstract class BaseSourceRowProcessor {
     this.partitionBy = options.partitionBy;
     this.addedFunctions = options.addedFunctions;
 
-    this.tableValuedHashCodes = new TableValuedHashCodes(this.#tableValuedFunctionToHashCode);
+    this.tableValuedHashCodes = TableValuedFunctionEquality.forHashCode(this.#tableValuedFunctionToHashCode);
 
     for (const fn of options.addedFunctions) {
       const hasher = new StableHasher();
@@ -109,14 +104,13 @@ abstract class BaseSourceRowProcessor {
 
   protected addBaseHashCode(hasher: StableHasher) {
     hasher.add(this.tablePattern);
-    const equality = resultSetIgnoringEquality(this.tableValuedHashCodes, TableValuedIdentities.empty);
 
-    equality.unorderedEquality.hash(
+    this.tableValuedHashCodes.unorderedEquality.hash(
       hasher,
       this.filters.map((f) => f.expression)
     );
-    equality.listEquality.hash(hasher, this.partitionBy);
-    equality.unorderedEquality.hash(hasher, this.addedFunctions);
+    this.tableValuedHashCodes.listEquality.hash(hasher, this.partitionBy);
+    this.tableValuedHashCodes.unorderedEquality.hash(hasher, this.addedFunctions);
   }
 
   protected baseMatchesOther(other: BaseSourceRowProcessor) {
@@ -129,7 +123,11 @@ abstract class BaseSourceRowProcessor {
     // will report the exact same symbol. This allows expressions to compare references to table-valued functions across
     // the two processors.
     const symbolsForTableValuedFunctions = new Map<TableValuedResultSet, symbol>();
-    const identities = new TableValuedIdentities(symbolsForTableValuedFunctions);
+    const identities = TableValuedFunctionEquality.mergeForEquality(
+      this.tableValuedHashCodes,
+      other.tableValuedHashCodes,
+      symbolsForTableValuedFunctions
+    );
 
     {
       const unmatchedLocalFunctions = new Set(this.addedFunctions);
@@ -153,19 +151,22 @@ abstract class BaseSourceRowProcessor {
         // No match found for otherFunction
         return null;
       }
+
+      if (unmatchedLocalFunctions.size > 0) {
+        // Local functions with no other function exist.
+        return null;
+      }
     }
 
-    const equality = resultSetIgnoringEquality(TableValuedHashCodes.empty, identities);
-
-    if (!equality.listEquality.equals(other.partitionBy, this.partitionBy)) {
+    if (!identities.listEquality.equals(other.partitionBy, this.partitionBy)) {
       return null;
     }
 
-    if (!equality.unorderedEquality.equals(other.filters, this.filters)) {
+    if (!identities.unorderedEquality.equals(other.filters, this.filters)) {
       return null;
     }
 
-    return equality;
+    return identities;
   }
 }
 
@@ -200,7 +201,7 @@ export class RowEvaluator extends BaseSourceRowProcessor {
 
   buildBehaviorHashCode(hasher: StableHasher): void {
     this.addBaseHashCode(hasher);
-    this.tableValuedHashCodes.hashOrdered(this.columns, hasher);
+    this.tableValuedHashCodes.listEquality.hash(hasher, this.columns);
     if (this.outputName) {
       hasher.addString(this.outputName);
     }
@@ -239,7 +240,7 @@ export class PointLookup extends BaseSourceRowProcessor {
 
   buildBehaviorHashCode(hasher: StableHasher): void {
     this.addBaseHashCode(hasher);
-    this.tableValuedHashCodes.hashOrdered(this.result, hasher);
+    this.tableValuedHashCodes.listEquality.hash(hasher, this.result);
   }
 
   behavesIdenticalTo(other: PointLookup): boolean {
@@ -264,18 +265,18 @@ export class SourceRowProcessorAddedTableValuedFunction implements EqualsIgnorin
 
   equalsAssumingSamePrimaryResultSet(
     other: EqualsIgnoringPrimaryResultSet,
-    identities: TableValuedIdentities
+    tableValued: TableValuedFunctionEquality
   ): boolean {
     if (!(other instanceof SourceRowProcessorAddedTableValuedFunction)) {
       return false;
     }
 
-    return other.functionName == this.functionName && identities.orderedEquals(other.inputs, this.inputs);
+    return other.functionName == this.functionName && tableValued.listEquality.equals(other.inputs, this.inputs);
   }
 
-  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
+  assumingSamePrimaryResultSetEqualityHashCode(tableValued: TableValuedFunctionEquality, hasher: StableHasher): void {
     hasher.addString(this.functionName);
-    codes.hashOrdered(this.inputs, hasher);
+    tableValued.listEquality.hash(hasher, this.inputs);
   }
 }
 
@@ -301,17 +302,17 @@ export class ExpressionColumnSource implements EqualsIgnoringPrimaryResultSet {
 
   equalsAssumingSamePrimaryResultSet(
     other: EqualsIgnoringPrimaryResultSet,
-    identities: TableValuedIdentities
+    tableValued: TableValuedFunctionEquality
   ): boolean {
     return (
       other instanceof ExpressionColumnSource &&
       other.alias == this.alias &&
-      other.expression.equalsAssumingSamePrimaryResultSet(this.expression, identities)
+      other.expression.equalsAssumingSamePrimaryResultSet(this.expression, tableValued)
     );
   }
 
-  assumingSamePrimaryResultSetEqualityHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
-    this.expression.assumingSamePrimaryResultSetEqualityHashCode(codes, hasher);
+  assumingSamePrimaryResultSetEqualityHashCode(tableValued: TableValuedFunctionEquality, hasher: StableHasher): void {
+    this.expression.assumingSamePrimaryResultSetEqualityHashCode(tableValued, hasher);
     hasher.addString(this.alias);
   }
 }

--- a/packages/sync-rules/src/compiler/rows.ts
+++ b/packages/sync-rules/src/compiler/rows.ts
@@ -125,9 +125,9 @@ abstract class BaseSourceRowProcessor {
     }
 
     // Verify that table-valued functions on the two row processors are equal (in any order). Also, construct a mapping
-    // of functions in both processors to a unique symbol so that if two processors are equal, the mapping will report
-    // the exact same symbol. This allows expressions to compare references to table-valued functions across the two
-    // processors.
+    // of functions in both processors to a unique symbol so that if two table-valued functions are equal, the mapping
+    // will report the exact same symbol. This allows expressions to compare references to table-valued functions across
+    // the two processors.
     const symbolsForTableValuedFunctions = new Map<TableValuedResultSet, symbol>();
     const identities = new TableValuedIdentities(symbolsForTableValuedFunctions);
 

--- a/packages/sync-rules/src/compiler/table.ts
+++ b/packages/sync-rules/src/compiler/table.ts
@@ -2,7 +2,7 @@ import { PGNode } from 'pgsql-ast-parser';
 import { ImplicitSchemaTablePattern, SourceSchemaTable } from '../index.js';
 import { SqlExpression } from '../sync_plan/expression.js';
 import { MapSourceVisitor, visitExpr } from '../sync_plan/expression_visitor.js';
-import { equalsIgnoringResultSetList } from './compatibility.js';
+import { TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
 import { StableHasher } from './equality.js';
 import { ColumnInRow, ExpressionInput, NodeLocations, RowMetadata, SyncExpression } from './expression.js';
 import { SingleDependencyExpression } from './filter.js';
@@ -166,15 +166,15 @@ export class TableValuedResultSet extends BaseSourceResultSet {
     }
   }
 
-  buildBehaviorHashCode(hasher: StableHasher) {
+  buildBehaviorHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
     hasher.addString(this.tableValuedFunctionName);
-    equalsIgnoringResultSetList.hash(hasher, this.parameters);
+    codes.hashOrdered(this.parameters, hasher);
   }
 
-  behavesIdenticalTo(other: TableValuedResultSet) {
+  behavesIdenticalTo(other: TableValuedResultSet, identities: TableValuedIdentities): boolean {
     return (
-      other.tableValuedFunctionName == this.tableValuedFunctionName &&
-      equalsIgnoringResultSetList.equals(other.parameters, this.parameters)
+      this.tableValuedFunctionName == other.tableValuedFunctionName &&
+      identities.orderedEquals(this.parameters, other.parameters)
     );
   }
 

--- a/packages/sync-rules/src/compiler/table.ts
+++ b/packages/sync-rules/src/compiler/table.ts
@@ -2,7 +2,7 @@ import { PGNode } from 'pgsql-ast-parser';
 import { ImplicitSchemaTablePattern, SourceSchemaTable } from '../index.js';
 import { SqlExpression } from '../sync_plan/expression.js';
 import { MapSourceVisitor, visitExpr } from '../sync_plan/expression_visitor.js';
-import { TableValuedHashCodes, TableValuedIdentities } from './compatibility.js';
+import { TableValuedFunctionEquality } from './compatibility.js';
 import { StableHasher } from './equality.js';
 import { ColumnInRow, ExpressionInput, NodeLocations, RowMetadata, SyncExpression } from './expression.js';
 import { SingleDependencyExpression } from './filter.js';
@@ -166,15 +166,15 @@ export class TableValuedResultSet extends BaseSourceResultSet {
     }
   }
 
-  buildBehaviorHashCode(codes: TableValuedHashCodes, hasher: StableHasher): void {
+  buildBehaviorHashCode(tableValued: TableValuedFunctionEquality, hasher: StableHasher): void {
     hasher.addString(this.tableValuedFunctionName);
-    codes.hashOrdered(this.parameters, hasher);
+    tableValued.listEquality.hash(hasher, this.parameters);
   }
 
-  behavesIdenticalTo(other: TableValuedResultSet, identities: TableValuedIdentities): boolean {
+  behavesIdenticalTo(other: TableValuedResultSet, tableValued: TableValuedFunctionEquality): boolean {
     return (
       this.tableValuedFunctionName == other.tableValuedFunctionName &&
-      identities.orderedEquals(this.parameters, other.parameters)
+      tableValued.listEquality.equals(this.parameters, other.parameters)
     );
   }
 

--- a/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
@@ -4,7 +4,7 @@ exports[`new sync stream features > IN operator with static left clause 1`] = `
 {
   "buckets": [
     {
-      "hash": 274764250,
+      "hash": 504882872,
       "sources": [
         0,
       ],
@@ -17,7 +17,7 @@ exports[`new sync stream features > IN operator with static left clause 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 466638588,
+      "hash": 252303259,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -56,7 +56,7 @@ exports[`new sync stream features > IN operator with static left clause 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 467461012,
+      "hash": 61622074,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -104,7 +104,7 @@ exports[`new sync stream features > IN operator with two static clauses 1`] = `
 {
   "buckets": [
     {
-      "hash": 274764250,
+      "hash": 504882872,
       "sources": [
         0,
       ],
@@ -117,7 +117,7 @@ exports[`new sync stream features > IN operator with two static clauses 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 466638588,
+      "hash": 252303259,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -196,7 +196,7 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
 {
   "buckets": [
     {
-      "hash": 2313189,
+      "hash": 215122439,
       "sources": [
         0,
       ],
@@ -209,7 +209,7 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 470455392,
+      "hash": 80560391,
       "outputTableName": "Scene",
       "partitionBy": [
         {
@@ -247,7 +247,7 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 469881182,
+      "hash": 331282873,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -287,7 +287,7 @@ exports[`new sync stream features > checking for existence in two CTEs 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 391349695,
+      "hash": 14791390,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -438,7 +438,7 @@ exports[`new sync stream features > circular references > at first level 1`] = `
 {
   "buckets": [
     {
-      "hash": 391555584,
+      "hash": 369605791,
       "sources": [
         0,
       ],
@@ -451,7 +451,7 @@ exports[`new sync stream features > circular references > at first level 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 322241169,
+      "hash": 258551590,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -482,7 +482,7 @@ exports[`new sync stream features > circular references > at first level 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 20765332,
+      "hash": 508315757,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -589,7 +589,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
 {
   "buckets": [
     {
-      "hash": 329617792,
+      "hash": 533534265,
       "sources": [
         0,
       ],
@@ -602,7 +602,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 215694379,
+      "hash": 501930921,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -633,7 +633,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 527378076,
+      "hash": 105317550,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -662,7 +662,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
     },
     {
       "filters": [],
-      "hash": 462853403,
+      "hash": 251179367,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -694,7 +694,7 @@ exports[`new sync stream features > circular references > nested 1`] = `
     },
     {
       "filters": [],
-      "hash": 307161944,
+      "hash": 350988327,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "2",
@@ -807,7 +807,7 @@ exports[`new sync stream features > circular references > table-valued 1`] = `
 {
   "buckets": [
     {
-      "hash": 250014934,
+      "hash": 108933878,
       "sources": [
         0,
       ],
@@ -820,7 +820,7 @@ exports[`new sync stream features > circular references > table-valued 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 50729839,
+      "hash": 309686539,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -864,7 +864,7 @@ exports[`new sync stream features > circular references > table-valued 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 321622908,
+      "hash": 311271245,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -942,7 +942,7 @@ exports[`new sync stream features > in array 1`] = `
 {
   "buckets": [
     {
-      "hash": 64262756,
+      "hash": 307632867,
       "sources": [
         0,
       ],
@@ -975,7 +975,7 @@ exports[`new sync stream features > in array 1`] = `
           "type": "scalar_in",
         },
       ],
-      "hash": 209438134,
+      "hash": 366938535,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -1012,7 +1012,7 @@ exports[`new sync stream features > in array and additional filter in subquery 1
 {
   "buckets": [
     {
-      "hash": 322018032,
+      "hash": 371862092,
       "sources": [
         0,
       ],
@@ -1025,7 +1025,7 @@ exports[`new sync stream features > in array and additional filter in subquery 1
         "star",
       ],
       "filters": [],
-      "hash": 526524156,
+      "hash": 25953646,
       "outputTableName": "notes",
       "partitionBy": [
         {
@@ -1066,7 +1066,7 @@ exports[`new sync stream features > in array and additional filter in subquery 1
           "type": "binary",
         },
       ],
-      "hash": 372404644,
+      "hash": 450331817,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1169,7 +1169,7 @@ exports[`new sync stream features > in json array 1`] = `
 {
   "buckets": [
     {
-      "hash": 28125559,
+      "hash": 267897099,
       "sources": [
         0,
       ],
@@ -1200,7 +1200,7 @@ exports[`new sync stream features > in json array 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 475318095,
+      "hash": 484392710,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -1247,7 +1247,7 @@ exports[`new sync stream features > joins feedback > response 1 1`] = `
 {
   "buckets": [
     {
-      "hash": 87224296,
+      "hash": 221193482,
       "sources": [
         0,
       ],
@@ -1260,7 +1260,7 @@ exports[`new sync stream features > joins feedback > response 1 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 5951378,
+      "hash": 97057433,
       "outputTableName": "u",
       "partitionBy": [
         {
@@ -1283,7 +1283,7 @@ exports[`new sync stream features > joins feedback > response 1 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 323715566,
+      "hash": 7102946,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1315,7 +1315,7 @@ exports[`new sync stream features > joins feedback > response 1 1`] = `
     },
     {
       "filters": [],
-      "hash": 302276225,
+      "hash": 96230619,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -1424,7 +1424,7 @@ exports[`new sync stream features > joins feedback > response 4 1`] = `
 {
   "buckets": [
     {
-      "hash": 514655288,
+      "hash": 499713123,
       "sources": [
         0,
       ],
@@ -1437,7 +1437,7 @@ exports[`new sync stream features > joins feedback > response 4 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 445379715,
+      "hash": 313970881,
       "outputTableName": "m",
       "partitionBy": [
         {
@@ -1475,7 +1475,7 @@ exports[`new sync stream features > joins feedback > response 4 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 64213188,
+      "hash": 478900091,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1568,7 +1568,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
 {
   "buckets": [
     {
-      "hash": 260926888,
+      "hash": 372337345,
       "sources": [
         0,
         1,
@@ -1582,7 +1582,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 353156391,
+      "hash": 62299225,
       "outputTableName": "users",
       "partitionBy": [
         {
@@ -1606,7 +1606,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 41817212,
+      "hash": 521704692,
       "outputTableName": "families",
       "partitionBy": [
         {
@@ -1629,7 +1629,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 143919389,
+      "hash": 381188991,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1661,7 +1661,7 @@ exports[`new sync stream features > joins feedback > response 5 1`] = `
     },
     {
       "filters": [],
-      "hash": 32571796,
+      "hash": 440281250,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -1770,7 +1770,7 @@ exports[`new sync stream features > joins feedback > response 8 1`] = `
 {
   "buckets": [
     {
-      "hash": 415757919,
+      "hash": 184379202,
       "sources": [
         0,
       ],
@@ -1783,7 +1783,7 @@ exports[`new sync stream features > joins feedback > response 8 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 166151257,
+      "hash": 29364994,
       "outputTableName": "events",
       "partitionBy": [
         {
@@ -1806,7 +1806,7 @@ exports[`new sync stream features > joins feedback > response 8 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 29987209,
+      "hash": 418216473,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1899,7 +1899,7 @@ exports[`new sync stream features > joins feedback > response 9 1`] = `
 {
   "buckets": [
     {
-      "hash": 243129021,
+      "hash": 206255983,
       "sources": [
         0,
       ],
@@ -1912,7 +1912,7 @@ exports[`new sync stream features > joins feedback > response 9 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 105399988,
+      "hash": 333904209,
       "outputTableName": "u",
       "partitionBy": [
         {
@@ -1935,7 +1935,7 @@ exports[`new sync stream features > joins feedback > response 9 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 88350941,
+      "hash": 1436015,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1967,7 +1967,7 @@ exports[`new sync stream features > joins feedback > response 9 1`] = `
     },
     {
       "filters": [],
-      "hash": 343817501,
+      "hash": 469586132,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -2076,7 +2076,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
 {
   "buckets": [
     {
-      "hash": 437667704,
+      "hash": 417667471,
       "sources": [
         0,
       ],
@@ -2089,7 +2089,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 268156404,
+      "hash": 329182865,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -2112,7 +2112,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 88350941,
+      "hash": 1436015,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2144,7 +2144,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
     },
     {
       "filters": [],
-      "hash": 343817501,
+      "hash": 469586132,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -2176,7 +2176,7 @@ exports[`new sync stream features > joins feedback > response 10 1`] = `
     },
     {
       "filters": [],
-      "hash": 392582824,
+      "hash": 434154687,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "2",
@@ -2301,7 +2301,7 @@ exports[`new sync stream features > joins feedback > response 11 1`] = `
 {
   "buckets": [
     {
-      "hash": 327475413,
+      "hash": 15255881,
       "sources": [
         0,
       ],
@@ -2314,7 +2314,7 @@ exports[`new sync stream features > joins feedback > response 11 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 259562331,
+      "hash": 334678181,
       "outputTableName": "t",
       "partitionBy": [
         {
@@ -2337,7 +2337,7 @@ exports[`new sync stream features > joins feedback > response 11 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 97816743,
+      "hash": 277446621,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2430,7 +2430,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
 {
   "buckets": [
     {
-      "hash": 160259622,
+      "hash": 242995705,
       "sources": [
         0,
       ],
@@ -2443,7 +2443,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 394681392,
+      "hash": 350236831,
       "outputTableName": "p",
       "partitionBy": [
         {
@@ -2466,7 +2466,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 531268250,
+      "hash": 225571037,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2547,7 +2547,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 296491538,
+      "hash": 395043210,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -2656,7 +2656,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
 {
   "buckets": [
     {
-      "hash": 27478573,
+      "hash": 188573007,
       "sources": [
         0,
       ],
@@ -2669,7 +2669,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 97931753,
+      "hash": 252506179,
       "outputTableName": "c",
       "partitionBy": [
         {
@@ -2692,7 +2692,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 153371152,
+      "hash": 438214067,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2739,7 +2739,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 382068356,
+      "hash": 5166607,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -2771,7 +2771,7 @@ exports[`new sync stream features > joins feedback > response 13 1`] = `
     },
     {
       "filters": [],
-      "hash": 503875718,
+      "hash": 305606865,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "2",
@@ -2896,7 +2896,7 @@ exports[`new sync stream features > json-each of cte 1`] = `
 {
   "buckets": [
     {
-      "hash": 385826507,
+      "hash": 156964455,
       "sources": [
         0,
       ],
@@ -2952,7 +2952,7 @@ exports[`new sync stream features > json-each of cte 1`] = `
         },
       ],
       "filters": [],
-      "hash": 288003166,
+      "hash": 452187534,
       "outputTableName": "Scene",
       "partitionBy": [
         {
@@ -3012,7 +3012,7 @@ exports[`new sync stream features > json-each of cte 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 133462033,
+      "hash": 98845667,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3230,7 +3230,7 @@ exports[`new sync stream features > not in array 1`] = `
 {
   "buckets": [
     {
-      "hash": 185054388,
+      "hash": 207301670,
       "sources": [
         0,
       ],
@@ -3267,7 +3267,7 @@ exports[`new sync stream features > not in array 1`] = `
           "type": "unary",
         },
       ],
-      "hash": 2294649,
+      "hash": 159147029,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -3304,7 +3304,7 @@ exports[`new sync stream features > not in json array 1`] = `
 {
   "buckets": [
     {
-      "hash": 464039641,
+      "hash": 52312721,
       "sources": [
         0,
       ],
@@ -3338,7 +3338,7 @@ exports[`new sync stream features > not in json array 1`] = `
           "type": "unary",
         },
       ],
-      "hash": 354655507,
+      "hash": 133622965,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -3375,7 +3375,7 @@ exports[`new sync stream features > order-independent parameters 1`] = `
 {
   "buckets": [
     {
-      "hash": 67514874,
+      "hash": 13101728,
       "sources": [
         0,
         1,
@@ -3389,7 +3389,7 @@ exports[`new sync stream features > order-independent parameters 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 440482107,
+      "hash": 486948174,
       "outputTableName": "stores",
       "partitionBy": [
         {
@@ -3421,7 +3421,7 @@ exports[`new sync stream features > order-independent parameters 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 272980298,
+      "hash": 516218655,
       "outputTableName": "products",
       "partitionBy": [
         {
@@ -3514,7 +3514,7 @@ exports[`new sync stream features > row metadata 1`] = `
 {
   "buckets": [
     {
-      "hash": 524705252,
+      "hash": 13444962,
       "sources": [
         0,
       ],
@@ -3536,7 +3536,7 @@ exports[`new sync stream features > row metadata 1`] = `
         },
       ],
       "filters": [],
-      "hash": 352817177,
+      "hash": 418226136,
       "outputTableName": "source",
       "partitionBy": [
         {
@@ -3602,7 +3602,7 @@ exports[`new sync stream features > table-valued functions > partition on data 1
 {
   "buckets": [
     {
-      "hash": 71456886,
+      "hash": 28022504,
       "sources": [
         0,
       ],
@@ -3615,7 +3615,7 @@ exports[`new sync stream features > table-valued functions > partition on data 1
         "star",
       ],
       "filters": [],
-      "hash": 81981113,
+      "hash": 332279886,
       "outputTableName": "posts",
       "partitionBy": [
         {
@@ -3694,7 +3694,7 @@ exports[`new sync stream features > table-valued functions > partition on parame
 {
   "buckets": [
     {
-      "hash": 445777469,
+      "hash": 457862451,
       "sources": [
         0,
       ],
@@ -3707,7 +3707,7 @@ exports[`new sync stream features > table-valued functions > partition on parame
         "star",
       ],
       "filters": [],
-      "hash": 75754117,
+      "hash": 102194264,
       "outputTableName": "users",
       "partitionBy": [
         {
@@ -3730,7 +3730,7 @@ exports[`new sync stream features > table-valued functions > partition on parame
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 310310455,
+      "hash": 368987341,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3836,7 +3836,7 @@ exports[`new sync stream features > table-valued functions > static filter 1`] =
 {
   "buckets": [
     {
-      "hash": 144538386,
+      "hash": 378144963,
       "sources": [
         0,
       ],
@@ -3865,7 +3865,7 @@ exports[`new sync stream features > table-valued functions > static filter 1`] =
           "type": "binary",
         },
       ],
-      "hash": 297403199,
+      "hash": 219838904,
       "outputTableName": "posts",
       "partitionBy": [],
       "table": {

--- a/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/advanced.test.ts.snap
@@ -807,7 +807,7 @@ exports[`new sync stream features > circular references > table-valued 1`] = `
 {
   "buckets": [
     {
-      "hash": 108933878,
+      "hash": 282829133,
       "sources": [
         0,
       ],
@@ -820,7 +820,7 @@ exports[`new sync stream features > circular references > table-valued 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 309686539,
+      "hash": 305649577,
       "outputTableName": "a",
       "partitionBy": [
         {
@@ -1066,7 +1066,7 @@ exports[`new sync stream features > in array and additional filter in subquery 1
           "type": "binary",
         },
       ],
-      "hash": 450331817,
+      "hash": 240610331,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1169,7 +1169,7 @@ exports[`new sync stream features > in json array 1`] = `
 {
   "buckets": [
     {
-      "hash": 267897099,
+      "hash": 5526323,
       "sources": [
         0,
       ],
@@ -1200,7 +1200,7 @@ exports[`new sync stream features > in json array 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 484392710,
+      "hash": 95074145,
       "outputTableName": "notes",
       "partitionBy": [],
       "table": {
@@ -2466,7 +2466,7 @@ exports[`new sync stream features > joins feedback > response 12 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 225571037,
+      "hash": 433960658,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3012,7 +3012,7 @@ exports[`new sync stream features > json-each of cte 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 98845667,
+      "hash": 364859438,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3602,7 +3602,7 @@ exports[`new sync stream features > table-valued functions > partition on data 1
 {
   "buckets": [
     {
-      "hash": 28022504,
+      "hash": 255270316,
       "sources": [
         0,
       ],
@@ -3615,7 +3615,7 @@ exports[`new sync stream features > table-valued functions > partition on data 1
         "star",
       ],
       "filters": [],
-      "hash": 332279886,
+      "hash": 424201067,
       "outputTableName": "posts",
       "partitionBy": [
         {
@@ -3730,7 +3730,7 @@ exports[`new sync stream features > table-valued functions > partition on parame
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 368987341,
+      "hash": 267281834,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3836,7 +3836,7 @@ exports[`new sync stream features > table-valued functions > static filter 1`] =
 {
   "buckets": [
     {
-      "hash": 378144963,
+      "hash": 338603392,
       "sources": [
         0,
       ],
@@ -3865,7 +3865,7 @@ exports[`new sync stream features > table-valued functions > static filter 1`] =
           "type": "binary",
         },
       ],
-      "hash": 219838904,
+      "hash": 499908229,
       "outputTableName": "posts",
       "partitionBy": [],
       "table": {

--- a/packages/sync-rules/test/src/compiler/__snapshots__/compatibility.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/compatibility.test.ts.snap
@@ -4,7 +4,7 @@ exports[`old streams test > OR in subquery 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -17,7 +17,7 @@ exports[`old streams test > OR in subquery 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -40,7 +40,7 @@ exports[`old streams test > OR in subquery 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -87,7 +87,7 @@ exports[`old streams test > OR in subquery 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 225195556,
+      "hash": 535568965,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -194,7 +194,7 @@ exports[`old streams test > in > on parameter data 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -207,7 +207,7 @@ exports[`old streams test > in > on parameter data 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -296,7 +296,7 @@ exports[`old streams test > in > on parameter data and table 1`] = `
 {
   "buckets": [
     {
-      "hash": 317489756,
+      "hash": 329503465,
       "sources": [
         0,
       ],
@@ -309,7 +309,7 @@ exports[`old streams test > in > on parameter data and table 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 19117565,
+      "hash": 24455521,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -340,7 +340,7 @@ exports[`old streams test > in > on parameter data and table 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -472,7 +472,7 @@ exports[`old streams test > in > parameter and auth match on same column 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -485,7 +485,7 @@ exports[`old streams test > in > parameter and auth match on same column 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -598,7 +598,7 @@ exports[`old streams test > in > parameter value in subquery 1`] = `
 {
   "buckets": [
     {
-      "hash": 274764250,
+      "hash": 504882872,
       "sources": [
         0,
       ],
@@ -611,7 +611,7 @@ exports[`old streams test > in > parameter value in subquery 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 466638588,
+      "hash": 252303259,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -632,7 +632,7 @@ exports[`old streams test > in > parameter value in subquery 1`] = `
           "type": "data",
         },
       ],
-      "hash": 195983547,
+      "hash": 417725376,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -709,7 +709,7 @@ exports[`old streams test > in > row value in subquery 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -722,7 +722,7 @@ exports[`old streams test > in > row value in subquery 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -745,7 +745,7 @@ exports[`old streams test > in > row value in subquery 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -838,7 +838,7 @@ exports[`old streams test > in > two subqueries 1`] = `
 {
   "buckets": [
     {
-      "hash": 445777469,
+      "hash": 457862451,
       "sources": [
         0,
       ],
@@ -851,7 +851,7 @@ exports[`old streams test > in > two subqueries 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 75754117,
+      "hash": 102194264,
       "outputTableName": "users",
       "partitionBy": [
         {
@@ -874,7 +874,7 @@ exports[`old streams test > in > two subqueries 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 199313316,
+      "hash": 504745499,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -906,7 +906,7 @@ exports[`old streams test > in > two subqueries 1`] = `
     },
     {
       "filters": [],
-      "hash": 73863455,
+      "hash": 231959447,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -1042,7 +1042,7 @@ exports[`old streams test > nested subqueries 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -1055,7 +1055,7 @@ exports[`old streams test > nested subqueries 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1085,7 +1085,7 @@ exports[`old streams test > nested subqueries 1`] = `
           "type": "data",
         },
       ],
-      "hash": 195983547,
+      "hash": 498096823,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1108,7 +1108,7 @@ exports[`old streams test > nested subqueries 1`] = `
     },
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -1197,14 +1197,14 @@ exports[`old streams test > normalization > distribute and 1`] = `
 {
   "buckets": [
     {
-      "hash": 493187891,
+      "hash": 61595621,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 323255266,
+      "hash": 207485264,
       "sources": [
         1,
       ],
@@ -1238,7 +1238,7 @@ exports[`old streams test > normalization > distribute and 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 238671398,
+      "hash": 166247159,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1283,7 +1283,7 @@ exports[`old streams test > normalization > distribute and 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 101128796,
+      "hash": 24294581,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -1297,7 +1297,7 @@ exports[`old streams test > normalization > distribute and 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1413,7 +1413,7 @@ exports[`old streams test > normalization > double negation 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -1426,7 +1426,7 @@ exports[`old streams test > normalization > double negation 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1449,7 +1449,7 @@ exports[`old streams test > normalization > double negation 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1542,14 +1542,14 @@ exports[`old streams test > normalization > negated and 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 33619584,
+      "hash": 26583447,
       "sources": [
         1,
       ],
@@ -1562,7 +1562,7 @@ exports[`old streams test > normalization > negated and 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1611,7 +1611,7 @@ exports[`old streams test > normalization > negated and 1`] = `
           "type": "unary",
         },
       ],
-      "hash": 198981493,
+      "hash": 348342576,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -1625,7 +1625,7 @@ exports[`old streams test > normalization > negated and 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1724,7 +1724,7 @@ exports[`old streams test > normalization > negated or 1`] = `
 {
   "buckets": [
     {
-      "hash": 184056576,
+      "hash": 479468891,
       "sources": [
         0,
       ],
@@ -1762,7 +1762,7 @@ exports[`old streams test > normalization > negated or 1`] = `
           "type": "unary",
         },
       ],
-      "hash": 86439904,
+      "hash": 272618088,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -1785,7 +1785,7 @@ exports[`old streams test > normalization > negated or 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -1878,14 +1878,14 @@ exports[`old streams test > or > parameter match or request condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 160843911,
+      "hash": 101052997,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 274764250,
+      "hash": 504882872,
       "sources": [
         1,
       ],
@@ -1898,7 +1898,7 @@ exports[`old streams test > or > parameter match or request condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 177858022,
+      "hash": 404544856,
       "outputTableName": "issues",
       "partitionBy": [
         {
@@ -1922,7 +1922,7 @@ exports[`old streams test > or > parameter match or request condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 466638588,
+      "hash": 252303259,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -2002,14 +2002,14 @@ exports[`old streams test > or > parameter match or row condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 160843911,
+      "hash": 101052997,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 302690008,
+      "hash": 50401802,
       "sources": [
         1,
       ],
@@ -2022,7 +2022,7 @@ exports[`old streams test > or > parameter match or row condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 177858022,
+      "hash": 404544856,
       "outputTableName": "issues",
       "partitionBy": [
         {
@@ -2067,7 +2067,7 @@ exports[`old streams test > or > parameter match or row condition 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 81581617,
+      "hash": 384031872,
       "outputTableName": "issues",
       "partitionBy": [],
       "table": {
@@ -2130,7 +2130,7 @@ exports[`old streams test > or > request condition or request condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 177103915,
+      "hash": 221375721,
       "sources": [
         0,
       ],
@@ -2143,7 +2143,7 @@ exports[`old streams test > or > request condition or request condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 38682893,
+      "hash": 276881970,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2217,14 +2217,14 @@ exports[`old streams test > or > row condition or parameter condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 177103915,
+      "hash": 221375721,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 232094228,
+      "hash": 329713050,
       "sources": [
         1,
       ],
@@ -2237,7 +2237,7 @@ exports[`old streams test > or > row condition or parameter condition 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 38682893,
+      "hash": 276881970,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2273,7 +2273,7 @@ exports[`old streams test > or > row condition or parameter condition 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 25054764,
+      "hash": 409210892,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2333,7 +2333,7 @@ exports[`old streams test > or > row condition or row condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 70511047,
+      "hash": 337635011,
       "sources": [
         0,
       ],
@@ -2391,7 +2391,7 @@ exports[`old streams test > or > row condition or row condition 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 288509552,
+      "hash": 329744546,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2428,14 +2428,14 @@ exports[`old streams test > or > subquery or token parameter 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
       "uniqueName": "stream|0",
     },
     {
-      "hash": 177103915,
+      "hash": 221375721,
       "sources": [
         1,
       ],
@@ -2448,7 +2448,7 @@ exports[`old streams test > or > subquery or token parameter 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -2472,7 +2472,7 @@ exports[`old streams test > or > subquery or token parameter 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 38682893,
+      "hash": 276881970,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2486,7 +2486,7 @@ exports[`old streams test > or > subquery or token parameter 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 291210660,
+      "hash": 266567027,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2602,7 +2602,7 @@ exports[`old streams test > overlap 1`] = `
 {
   "buckets": [
     {
-      "hash": 443096475,
+      "hash": 148726195,
       "sources": [
         0,
       ],
@@ -2615,7 +2615,7 @@ exports[`old streams test > overlap 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 499645457,
+      "hash": 448514192,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -2651,7 +2651,7 @@ exports[`old streams test > overlap 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 199313316,
+      "hash": 504745499,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -2744,7 +2744,7 @@ exports[`old streams test > row condition 1`] = `
 {
   "buckets": [
     {
-      "hash": 232094228,
+      "hash": 329713050,
       "sources": [
         0,
       ],
@@ -2778,7 +2778,7 @@ exports[`old streams test > row condition 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 25054764,
+      "hash": 409210892,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {
@@ -2815,7 +2815,7 @@ exports[`old streams test > row filter and stream parameter 1`] = `
 {
   "buckets": [
     {
-      "hash": 512760912,
+      "hash": 344674728,
       "sources": [
         0,
       ],
@@ -2849,7 +2849,7 @@ exports[`old streams test > row filter and stream parameter 1`] = `
           "type": "binary",
         },
       ],
-      "hash": 145057899,
+      "hash": 291356175,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -2915,7 +2915,7 @@ exports[`old streams test > stream parameter 1`] = `
 {
   "buckets": [
     {
-      "hash": 194406858,
+      "hash": 148156631,
       "sources": [
         0,
       ],
@@ -2928,7 +2928,7 @@ exports[`old streams test > stream parameter 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 4919221,
+      "hash": 506580987,
       "outputTableName": "comments",
       "partitionBy": [
         {
@@ -2994,7 +2994,7 @@ exports[`old streams test > table alias 1`] = `
 {
   "buckets": [
     {
-      "hash": 466037865,
+      "hash": 40253737,
       "sources": [
         0,
       ],
@@ -3007,7 +3007,7 @@ exports[`old streams test > table alias 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 265683697,
+      "hash": 215568770,
       "outputTableName": "outer",
       "partitionBy": [
         {
@@ -3030,7 +3030,7 @@ exports[`old streams test > table alias 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 84822844,
+      "hash": 105082585,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -3123,7 +3123,7 @@ exports[`old streams test > without filter 1`] = `
 {
   "buckets": [
     {
-      "hash": 177103915,
+      "hash": 221375721,
       "sources": [
         0,
       ],
@@ -3136,7 +3136,7 @@ exports[`old streams test > without filter 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 38682893,
+      "hash": 276881970,
       "outputTableName": "comments",
       "partitionBy": [],
       "table": {

--- a/packages/sync-rules/test/src/compiler/__snapshots__/compatibility.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/compatibility.test.ts.snap
@@ -2602,7 +2602,7 @@ exports[`old streams test > overlap 1`] = `
 {
   "buckets": [
     {
-      "hash": 148726195,
+      "hash": 238904010,
       "sources": [
         0,
       ],
@@ -2615,7 +2615,7 @@ exports[`old streams test > overlap 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 448514192,
+      "hash": 217410568,
       "outputTableName": "comments",
       "partitionBy": [
         {

--- a/packages/sync-rules/test/src/compiler/__snapshots__/cte.test.ts.snap
+++ b/packages/sync-rules/test/src/compiler/__snapshots__/cte.test.ts.snap
@@ -4,7 +4,7 @@ exports[`common table expressions > as data source 1`] = `
 {
   "buckets": [
     {
-      "hash": 68553592,
+      "hash": 175706552,
       "sources": [
         0,
       ],
@@ -34,7 +34,7 @@ exports[`common table expressions > as data source 1`] = `
         },
       ],
       "filters": [],
-      "hash": 472729660,
+      "hash": 210323829,
       "outputTableName": "organisations",
       "partitionBy": [
         {
@@ -57,7 +57,7 @@ exports[`common table expressions > as data source 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 283023369,
+      "hash": 505749374,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -150,7 +150,7 @@ exports[`common table expressions > as parameter query 1`] = `
 {
   "buckets": [
     {
-      "hash": 29476625,
+      "hash": 377732370,
       "sources": [
         0,
       ],
@@ -163,7 +163,7 @@ exports[`common table expressions > as parameter query 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 27460384,
+      "hash": 39898946,
       "outputTableName": "projects",
       "partitionBy": [
         {
@@ -186,7 +186,7 @@ exports[`common table expressions > as parameter query 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 283023369,
+      "hash": 505749374,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -218,7 +218,7 @@ exports[`common table expressions > as parameter query 1`] = `
     },
     {
       "filters": [],
-      "hash": 500582714,
+      "hash": 371913368,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -327,7 +327,7 @@ exports[`common table expressions > can reference CTE multiple times 1`] = `
 {
   "buckets": [
     {
-      "hash": 187425881,
+      "hash": 436886157,
       "sources": [
         0,
       ],
@@ -340,7 +340,7 @@ exports[`common table expressions > can reference CTE multiple times 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 6968780,
+      "hash": 365381597,
       "outputTableName": "tbl_a",
       "partitionBy": [
         {
@@ -371,7 +371,7 @@ exports[`common table expressions > can reference CTE multiple times 1`] = `
   "parameterIndexes": [
     {
       "filters": [],
-      "hash": 250920890,
+      "hash": 40997809,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "0",
@@ -403,7 +403,7 @@ exports[`common table expressions > can reference CTE multiple times 1`] = `
     },
     {
       "filters": [],
-      "hash": 215867003,
+      "hash": 91539928,
       "lookupScope": {
         "lookupName": "lookup",
         "queryId": "1",
@@ -545,7 +545,7 @@ exports[`common table expressions > multiple output references 1`] = `
 {
   "buckets": [
     {
-      "hash": 498511015,
+      "hash": 326810458,
       "sources": [
         0,
       ],
@@ -558,7 +558,7 @@ exports[`common table expressions > multiple output references 1`] = `
         "star",
       ],
       "filters": [],
-      "hash": 28119074,
+      "hash": 337175667,
       "outputTableName": "workspace",
       "partitionBy": [
         {

--- a/packages/sync-rules/test/src/compiler/advanced.test.ts
+++ b/packages/sync-rules/test/src/compiler/advanced.test.ts
@@ -353,4 +353,19 @@ streams:
     expect(serialized.version).toStrictEqual(2);
     expect(serialized).toMatchSnapshot();
   });
+
+  test('preserves table-valued-function bindings', () => {
+    const compiled = compileToSyncPlanWithoutErrors(`
+config:
+  edition: 3
+
+streams:
+  a:
+    queries:
+      - SELECT posts.* FROM posts, json_each(posts.a) AS ja, json_each(posts.b) AS jb WHERE ja.value = 'x' AND jb.value = 'y'
+      - SELECT posts.* FROM posts, json_each(posts.a) AS ja, json_each(posts.b) AS jb WHERE jb.value = 'x' AND ja.value = 'y'
+`);
+
+    expect(compiled.dataSources).toHaveLength(2);
+  });
 });

--- a/packages/sync-rules/test/src/compiler/reuse.test.ts
+++ b/packages/sync-rules/test/src/compiler/reuse.test.ts
@@ -82,4 +82,32 @@ streams:
 
     expect(compiled.parameterIndexes).toHaveLength(1);
   });
+
+  test('reuse with filter referencing a table-valued function column', () => {
+    const compiled = compileToSyncPlanWithoutErrors(`
+config:
+  edition: 3
+
+streams:
+  a:
+    query: SELECT posts.* FROM posts, json_each(posts.a) AS ja WHERE ja.value = 'x'
+  b:
+    query: SELECT posts.* FROM posts, json_each(posts.a) AS ja WHERE ja.value = 'x'
+`);
+
+    expect(compiled.dataSources).toHaveLength(1);
+  });
+
+  test('point lookup with same-named output columns from two different table-valued functions', () => {
+    const compiled = compileToSyncPlanWithoutErrors(`
+config:
+  edition: 3
+
+streams:
+  a:
+    query: SELECT users.* FROM users, orgs, json_each(orgs.a) as ja, json_each(orgs.b) as jb WHERE users.x = ja.value AND users.y = jb.value AND orgs.id = auth.parameter('org')
+`);
+
+    expect(compiled.parameterIndexes).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
When we compare SQL expressions for equality, we ignore the result set of referenced tables. This simplifies comparing expressions, and because Sync Streams are split into data and parameter processors which both work on a single table pattern as source, we can just compare that pattern there.

However, as codex found in https://github.com/powersync-ja/powersync-service/pull/777#discussion_r3871986237, this simplification is not sound because both data and parameter processors can have additional table-valued functions attached to them. Right now, `SELECT notes.* FROM notes, json_each(notes.tags) tags WHERE tags.value = subscription.parameter('tag')` would be considered equal to `SELECT notes.* FROM notes, json_each(notes.tags) tags WHERE notes.value = subscription.parameter('tag')` (as `tags.value` and `notes.value` are equal when the result set is ignored).

This applies the fix from https://github.com/powersync-ja/powersync-service/pull/777#issuecomment-5441163447: Expressions and other structures referencing tables

1. can only be hashed when a pre-computed mapping of table-valued functions to hash codes is injected, allowing us to cheaply include hashes of those wherever they're referenced.
2. can only be tested for equality if the caller passes a proof that all referenced table-valued functions are isomorphic. We then reduce table-valued functions to an equality symbol which is the same for two table-valued functions if they behave the same.

This also includes Steven's work of properly using the unordered equality for filters (where the order doesn't matter). Because we can correctly compare table-valued functions now, this also unifies `ScalarPartitionKey` and `TableValuedPartitionKey`.

AI use: Original issue found by Codex, approach and implementation mostly manual with Claude Code used to help simplify this and to write tests.