### PR TITLE
Add version_label to metrics attributed to sync configs

### DIFF
--- a/.changeset/tiny-metrics-label.md
+++ b/.changeset/tiny-metrics-label.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+---
+
+Add the sync config version label to attributed storage metrics.

--- a/.changeset/tiny-metrics-label.md
+++ b/.changeset/tiny-metrics-label.md
@@ -3,4 +3,4 @@
 '@powersync/service-core': patch
 ---
 
-Add the sync config version label to attributed storage metrics.
+Add the sync config version label to attributed storage metrics while excluding it from shared OTLP telemetry.

--- a/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/MongoBucketStorage.ts
@@ -908,7 +908,7 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
       syncConfigIds.length == 0
         ? []
         : await v3Db.syncConfigDefinitions
-            .find({ _id: { $in: syncConfigIds } }, { projection: { _id: 1, rule_mapping: 1 } })
+            .find({ _id: { $in: syncConfigIds } }, { projection: { _id: 1, rule_mapping: 1, version_label: 1 } })
             .toArray();
     const syncConfigDefinitionsById = new Map(
       syncConfigDefinitions.map((definition) => [definition._id.toHexString(), definition])
@@ -966,6 +966,7 @@ export class MongoBucketStorage extends storage.BucketStorageFactory {
         syncConfigMetrics.push({
           sync_config_id: syncConfig._id.toHexString(),
           sync_config_state: String(syncConfig.state),
+          version_label: definition.version_label,
           attributed_bucket_data_bytes: sumCollectionSizes('bucket_data_', stream._id, bucketDefinitionIdSet),
           attributed_parameter_indexes_bytes: sumCollectionSizes('parameter_index_', stream._id, parameterIndexIdSet),
           attributed_source_records_bytes: replicationSize,

--- a/modules/module-mongodb-storage/test/src/storage_sync.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_sync.test.ts
@@ -1901,6 +1901,22 @@ streams:
     expect(metricsAfter.replication_size_bytes).toBeGreaterThan(metricsBefore.replication_size_bytes);
   });
 
+  test.runIf(storageVersion >= 3)('storage metrics include the sync config version label', async () => {
+    await using factory = await storageConfig.factory();
+    const syncRules = await factory.updateSyncRules(
+      updateSyncRulesFromYaml(MINIMAL_SYNC_RULES, { storageVersion, version_label: 'metrics-test' })
+    );
+
+    const metrics = await factory.getStorageMetrics();
+
+    expect(metrics.sync_config_metrics).toContainEqual(
+      expect.objectContaining({
+        sync_config_id: syncRules.syncConfigContent[0].syncConfigId,
+        version_label: 'metrics-test'
+      })
+    );
+  });
+
   test.runIf(storageVersion >= 3)(
     'loads parameter checkpoint changes across all v3 parameter index collections',
     async () => {

--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@js-sdsl/ordered-set": "^4.4.2",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^2.0.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
     "@opentelemetry/exporter-prometheus": "^0.203.0",
     "@opentelemetry/resources": "^2.0.1",

--- a/packages/service-core/src/metrics/open-telemetry/MetricAttributeFilteringExporter.ts
+++ b/packages/service-core/src/metrics/open-telemetry/MetricAttributeFilteringExporter.ts
@@ -1,0 +1,85 @@
+import { Attributes } from '@opentelemetry/api';
+import { ExportResult } from '@opentelemetry/core';
+import {
+  AggregationSelector,
+  AggregationTemporalitySelector,
+  DataPoint,
+  DataPointType,
+  MetricData,
+  PushMetricExporter,
+  ResourceMetrics
+} from '@opentelemetry/sdk-metrics';
+
+/**
+ * Decorates a push exporter and removes selected attributes from every metric data point before
+ * delegating the export. The input metrics are not mutated, so another reader can export the
+ * original attributes.
+ *
+ * This exporter deliberately does not merge data points when filtering makes their attribute sets
+ * identical. Both points are forwarded with the same attributes. There is no generally correct
+ * merge operation at this layer: gauges, counters, and histograms have different aggregation
+ * semantics. Callers must therefore ensure that an excluded attribute does not distinguish data
+ * points for the same metric, resource, and instrumentation scope. Otherwise, the resulting
+ * duplicate series identity may be rejected or interpreted unpredictably downstream.
+ *
+ * Lifecycle methods and aggregation selection are delegated unchanged to the wrapped exporter.
+ */
+export class MetricAttributeFilteringExporter implements PushMetricExporter {
+  readonly selectAggregation?: AggregationSelector;
+  readonly selectAggregationTemporality?: AggregationTemporalitySelector;
+
+  constructor(
+    /** The exporter that receives the filtered copy of the metrics. */
+    private readonly delegate: PushMetricExporter,
+    /** Attribute names to remove from every exported data point. */
+    private readonly excludedAttributes: ReadonlySet<string>
+  ) {
+    this.selectAggregation = delegate.selectAggregation?.bind(delegate);
+    this.selectAggregationTemporality = delegate.selectAggregationTemporality?.bind(delegate);
+  }
+
+  export(metrics: ResourceMetrics, resultCallback: (result: ExportResult) => void): void {
+    this.delegate.export(this.filterAttributes(metrics), resultCallback);
+  }
+
+  forceFlush(): Promise<void> {
+    return this.delegate.forceFlush();
+  }
+
+  shutdown(): Promise<void> {
+    return this.delegate.shutdown();
+  }
+
+  private filterAttributes(metrics: ResourceMetrics): ResourceMetrics {
+    return {
+      ...metrics,
+      scopeMetrics: metrics.scopeMetrics.map((scopeMetrics) => ({
+        ...scopeMetrics,
+        metrics: scopeMetrics.metrics.map((metric) => this.filterMetricAttributes(metric))
+      }))
+    };
+  }
+
+  private filterMetricAttributes(metric: MetricData): MetricData {
+    switch (metric.dataPointType) {
+      case DataPointType.SUM:
+      case DataPointType.GAUGE:
+        return { ...metric, dataPoints: metric.dataPoints.map((dataPoint) => this.filterDataPoint(dataPoint)) };
+      case DataPointType.HISTOGRAM:
+        return { ...metric, dataPoints: metric.dataPoints.map((dataPoint) => this.filterDataPoint(dataPoint)) };
+      case DataPointType.EXPONENTIAL_HISTOGRAM:
+        return { ...metric, dataPoints: metric.dataPoints.map((dataPoint) => this.filterDataPoint(dataPoint)) };
+    }
+  }
+
+  private filterDataPoint<T>(dataPoint: DataPoint<T>): DataPoint<T> {
+    return {
+      ...dataPoint,
+      attributes: this.filterDataPointAttributes(dataPoint.attributes)
+    };
+  }
+
+  private filterDataPointAttributes(attributes: Attributes): Attributes {
+    return Object.fromEntries(Object.entries(attributes).filter(([name]) => !this.excludedAttributes.has(name)));
+  }
+}

--- a/packages/service-core/src/metrics/open-telemetry/util.ts
+++ b/packages/service-core/src/metrics/open-telemetry/util.ts
@@ -4,6 +4,7 @@ import { MeterProvider, MetricReader, PeriodicExportingMetricReader } from '@ope
 import { logger } from '@powersync/lib-services-framework';
 import { ServiceContext } from '../../system/ServiceContext.js';
 import { MetricsFactory } from '../metrics-interfaces.js';
+import { MetricAttributeFilteringExporter } from './MetricAttributeFilteringExporter.js';
 import { OpenTelemetryMetricsFactory } from './OpenTelemetryMetricsFactory.js';
 
 import { resourceFromAttributes } from '@opentelemetry/resources';
@@ -29,10 +30,13 @@ export function createOpenTelemetryMetricsFactory(context: ServiceContext): Metr
   }
 
   if (!configuration.telemetry.disable_telemetry_sharing) {
+    const otlpExporter = new OTLPMetricExporter({
+      url: configuration.telemetry.internal_service_endpoint
+    });
     const periodicExporter = new PeriodicExportingMetricReader({
-      exporter: new OTLPMetricExporter({
-        url: configuration.telemetry.internal_service_endpoint
-      }),
+      // sync_config_id uniquely identifies these metric series after version_label is removed,
+      // so filtering cannot create duplicate data points.
+      exporter: new MetricAttributeFilteringExporter(otlpExporter, new Set(['version_label'])),
       exportIntervalMillis: 1000 * 60 * 5 // 5 minutes
     });
 

--- a/packages/service-core/src/storage/BucketStorageFactory.ts
+++ b/packages/service-core/src/storage/BucketStorageFactory.ts
@@ -163,6 +163,8 @@ export interface StorageMetrics {
 export interface StorageSyncConfigMetrics {
   sync_config_id: string;
   sync_config_state: string;
+  /** Optional operator-supplied label identifying this sync config version. */
+  version_label?: string;
   attributed_bucket_data_bytes: number;
   attributed_parameter_indexes_bytes: number;
   attributed_source_records_bytes: number;

--- a/packages/service-core/src/storage/storage-metrics.ts
+++ b/packages/service-core/src/storage/storage-metrics.ts
@@ -1,7 +1,7 @@
 import { logger } from '@powersync/lib-services-framework';
 import { StorageMetric } from '@powersync/service-types';
 import { MetricsEngine } from '../metrics/MetricsEngine.js';
-import { BucketStorageFactory, StorageMetrics } from './BucketStorageFactory.js';
+import { BucketStorageFactory, StorageMetrics, StorageSyncConfigMetrics } from './BucketStorageFactory.js';
 
 export function createCoreStorageMetrics(engine: MetricsEngine): void {
   engine.createObservableGauge({
@@ -74,6 +74,7 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
   type SyncConfigAttributes = {
     sync_config_id: string;
     sync_config_state: string;
+    version_label?: string;
   };
 
   /**
@@ -89,7 +90,13 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
   const reportedSyncConfigs = new Map<string, { attributes: SyncConfigAttributes; lastSeen: number }>();
 
   const syncConfigKey = (attributes: SyncConfigAttributes) =>
-    `${attributes.sync_config_id}|${attributes.sync_config_state}`;
+    JSON.stringify([attributes.sync_config_id, attributes.sync_config_state, attributes.version_label]);
+
+  const syncConfigAttributes = (syncConfig: StorageSyncConfigMetrics): SyncConfigAttributes => ({
+    sync_config_id: syncConfig.sync_config_id,
+    sync_config_state: syncConfig.sync_config_state,
+    ...(syncConfig.version_label == null ? {} : { version_label: syncConfig.version_label })
+  });
 
   const trackSyncConfigs = (metrics: StorageMetrics | null) => {
     if (metrics == null) {
@@ -98,10 +105,7 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     }
     const now = Date.now();
     for (const syncConfig of metrics.sync_config_metrics ?? []) {
-      const attributes = {
-        sync_config_id: syncConfig.sync_config_id,
-        sync_config_state: syncConfig.sync_config_state
-      };
+      const attributes = syncConfigAttributes(syncConfig);
       reportedSyncConfigs.set(syncConfigKey(attributes), { attributes, lastSeen: now });
     }
     for (const [key, entry] of reportedSyncConfigs) {
@@ -147,10 +151,7 @@ export function initializeCoreStorageMetrics(engine: MetricsEngine, storage: Buc
     const observations: { value: number; attributes?: Record<string, string> }[] = [];
     const present = new Set<string>();
     for (const syncConfig of metrics.sync_config_metrics ?? []) {
-      const attributes = {
-        sync_config_id: syncConfig.sync_config_id,
-        sync_config_state: syncConfig.sync_config_state
-      };
+      const attributes = syncConfigAttributes(syncConfig);
       present.add(syncConfigKey(attributes));
       observations.push({ value: nonNegative(syncConfig[key]), attributes });
     }

--- a/packages/service-core/test/src/MetricAttributeFilteringExporter.test.ts
+++ b/packages/service-core/test/src/MetricAttributeFilteringExporter.test.ts
@@ -1,0 +1,96 @@
+import { MetricAttributeFilteringExporter } from '@/metrics/open-telemetry/MetricAttributeFilteringExporter.js';
+import { Attributes } from '@opentelemetry/api';
+import { ExportResult } from '@opentelemetry/core';
+import { DataPointType, PushMetricExporter, ResourceMetrics } from '@opentelemetry/sdk-metrics';
+import { describe, expect, it, vi } from 'vitest';
+
+type ExportMetrics = (metrics: ResourceMetrics, resultCallback: (result: ExportResult) => void) => void;
+
+describe('MetricAttributeFilteringExporter', () => {
+  it('filters configured attributes without changing the collected metrics', () => {
+    const exportMetrics = vi.fn<ExportMetrics>();
+    const delegate = {
+      export: exportMetrics,
+      forceFlush: vi.fn(async () => {}),
+      shutdown: vi.fn(async () => {})
+    } satisfies PushMetricExporter;
+    const exporter = new MetricAttributeFilteringExporter(delegate, new Set(['version_label']));
+    const attributes: Attributes = {
+      sync_config_id: 'config-a',
+      sync_config_state: 'ACTIVE',
+      version_label: 'customer-version'
+    };
+    const metrics = {
+      resource: {},
+      scopeMetrics: [
+        {
+          scope: {},
+          metrics: [
+            {
+              dataPointType: DataPointType.GAUGE,
+              dataPoints: [{ attributes, value: 100 }]
+            }
+          ]
+        }
+      ]
+    } as unknown as ResourceMetrics;
+    const callback = vi.fn();
+
+    exporter.export(metrics, callback);
+
+    expect(exportMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeMetrics: [
+          expect.objectContaining({
+            metrics: [
+              expect.objectContaining({
+                dataPoints: [
+                  expect.objectContaining({
+                    attributes: { sync_config_id: 'config-a', sync_config_state: 'ACTIVE' }
+                  })
+                ]
+              })
+            ]
+          })
+        ]
+      }),
+      callback
+    );
+    expect(metrics.scopeMetrics[0].metrics[0].dataPoints[0].attributes).toBe(attributes);
+  });
+
+  it('forwards rather than merges data points whose attributes become identical', () => {
+    const exportMetrics = vi.fn<ExportMetrics>();
+    const delegate = {
+      export: exportMetrics,
+      forceFlush: vi.fn(async () => {}),
+      shutdown: vi.fn(async () => {})
+    } satisfies PushMetricExporter;
+    const exporter = new MetricAttributeFilteringExporter(delegate, new Set(['filtered']));
+    const metrics = {
+      resource: {},
+      scopeMetrics: [
+        {
+          scope: {},
+          metrics: [
+            {
+              dataPointType: DataPointType.GAUGE,
+              dataPoints: [
+                { attributes: { retained: 'same', filtered: 'a' }, value: 10 },
+                { attributes: { retained: 'same', filtered: 'b' }, value: 20 }
+              ]
+            }
+          ]
+        }
+      ]
+    } as unknown as ResourceMetrics;
+
+    exporter.export(metrics, vi.fn());
+
+    const exported = exportMetrics.mock.calls[0][0];
+    expect(exported.scopeMetrics[0].metrics[0].dataPoints).toMatchObject([
+      { attributes: { retained: 'same' }, value: 10 },
+      { attributes: { retained: 'same' }, value: 20 }
+    ]);
+  });
+});

--- a/packages/service-core/test/src/storage-metrics.test.ts
+++ b/packages/service-core/test/src/storage-metrics.test.ts
@@ -26,10 +26,11 @@ function testEngine() {
   return { engine, providers };
 }
 
-function syncConfigMetrics(id: string, state: string, bytes: number): StorageSyncConfigMetrics {
+function syncConfigMetrics(id: string, state: string, bytes: number, versionLabel?: string): StorageSyncConfigMetrics {
   return {
     sync_config_id: id,
     sync_config_state: state,
+    version_label: versionLabel,
     attributed_bucket_data_bytes: bytes,
     attributed_parameter_indexes_bytes: bytes,
     attributed_source_records_bytes: bytes,
@@ -90,7 +91,7 @@ describe('storage metrics', () => {
   });
 
   it('treats a state transition as a retired attribute set', async () => {
-    let current = storageMetrics([syncConfigMetrics('config-a', 'PROCESSING', 100)]);
+    let current = storageMetrics([syncConfigMetrics('config-a', 'PROCESSING', 100, 'v1')]);
     const storage = {
       getStorageMetrics: async () => current
     } as unknown as BucketStorageFactory;
@@ -101,12 +102,18 @@ describe('storage metrics', () => {
 
     await provider();
 
-    current = storageMetrics([syncConfigMetrics('config-a', 'ACTIVE', 120)]);
+    current = storageMetrics([syncConfigMetrics('config-a', 'ACTIVE', 120, 'v1')]);
     vi.setSystemTime(61_000);
 
     expect(await provider()).toEqual([
-      { value: 120, attributes: { sync_config_id: 'config-a', sync_config_state: 'ACTIVE' } },
-      { value: 0, attributes: { sync_config_id: 'config-a', sync_config_state: 'PROCESSING' } }
+      {
+        value: 120,
+        attributes: { sync_config_id: 'config-a', sync_config_state: 'ACTIVE', version_label: 'v1' }
+      },
+      {
+        value: 0,
+        attributes: { sync_config_id: 'config-a', sync_config_state: 'PROCESSING', version_label: 'v1' }
+      }
     ]);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,6 +657,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
+      '@opentelemetry/core':
+        specifier: ^2.0.1
+        version: 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/exporter-metrics-otlp-http':
         specifier: ^0.203.0
         version: 0.203.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
This combines #756 and #728: When `version_label` is defined, include it in metrics attributed to specific sync configs.

This does not increase the cardinality: Each unique (sync_config_id) will still have just one (sync_config_id, version_label) combination.

This required some additional work to exclude the version_label from the telemetry the service publishes, since this can potentially be considered non-anonymous data.

## AI Usage

Implemented using Codex gpt-5.6; manually checked.