### PR TITLE
Azure DocumentDB Updates

### DIFF
--- a/.changeset/fuzzy-cats-wait.md
+++ b/.changeset/fuzzy-cats-wait.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': patch
+---
+
+Remove the client-side `maxAwaitTimeMS` workaround for Azure DocumentDB.

--- a/.changeset/fuzzy-cats-wait.md
+++ b/.changeset/fuzzy-cats-wait.md
@@ -2,4 +2,4 @@
 '@powersync/service-module-mongodb': patch
 ---
 
-Remove the client-side `maxAwaitTimeMS` workaround for Azure DocumentDB.
+Remove the client-side `maxAwaitTimeMS` workaround for Azure DocumentDB and label DocumentDB support as alpha.

--- a/docs/documentdb/documentdb-limitations.md
+++ b/docs/documentdb/documentdb-limitations.md
@@ -4,7 +4,7 @@ PowerSync can replicate from Azure DocumentDB (formerly Azure Cosmos DB for Mong
 
 Internal implementation details (how checkpoints and LSNs work on DocumentDB) are documented separately in [documentdb-lsn-sentinel-checkpoints.md](./documentdb-lsn-sentinel-checkpoints.md).
 
-> **DocumentDB support is experimental.** APIs and behavior may change. We also can't yet guarantee continued support or long-term stability. This release is intended for early testing and to invite feedback. Your feedback will directly influence whether, and how, this integration evolve.
+> **DocumentDB support is in alpha.** APIs and behavior may change. We also can't yet guarantee continued support or long-term stability. This release is intended for early testing and to invite feedback. Your feedback will directly influence whether, and how, this integration evolves.
 
 ## Which Azure offering this supports
 

--- a/docs/documentdb/documentdb-limitations.md
+++ b/docs/documentdb/documentdb-limitations.md
@@ -60,18 +60,6 @@ DocumentDB delivers large change events much more slowly than standard MongoDB. 
 
 If your workload includes large documents (especially frequently-updated ones), validate replication latency against your cluster.
 
-### Temporary idle `getMore` workaround
-
-At the time of writing, Azure DocumentDB may return an empty idle `getMore` batch before `getMore.maxTimeMS` has elapsed. With small test values, DocumentDB may also surface timeout errors like:
-
-```text
-MongoServerError: Query exceeded command timeout of 200ms
-```
-
-PowerSync works around the early-empty-batch behavior in DocumentDB mode by still sending `maxTimeMS` on `getMore`, but also adding a capped local delay when an empty batch returns too quickly. This avoids tight idle polling while staying forwards-compatible with the server-side behavior once Microsoft releases the DocumentDB fix.
-
-The tradeoff in the initial version is higher latency for streaming updates after an idle period. Because DocumentDB does not reliably long-poll today, PowerSync may sleep locally before polling again. That local delay is capped at 1 second, so an update that arrives just after an empty batch can be delayed by up to roughly 1 second. This is expected to be fixed in an upcoming Azure DocumentDB release; after the fixed version is available on supported clusters, this workaround should be removed and the skipped `maxAwaitTimeMS` characterization test should be re-enabled.
-
 ## Operational note: the internal checkpoints collection
 
 PowerSync maintains a `_powersync_checkpoints` collection in the source database for replication bookkeeping. Do not drop it or delete its documents: doing so disrupts replication (dropping the collection forces a resync; the implementation defends against the sentinel counter document being deleted, but deleting it should still be avoided).

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -213,7 +213,7 @@ export class ChangeStream {
     this.isDocumentDb = await detectDocumentDb(this.defaultDb);
     if (this.isDocumentDb) {
       this.logger.warn(
-        'Azure DocumentDB support is experimental. APIs and behavior may change, and long-term stability is not yet guaranteed.'
+        'Azure DocumentDB support is in alpha. APIs and behavior may change, and long-term stability is not yet guaranteed.'
       );
     }
     this._checkpointImplementation = createCheckpointImplementation(this.isDocumentDb, {

--- a/modules/module-mongodb/src/replication/ChangeStream.ts
+++ b/modules/module-mongodb/src/replication/ChangeStream.ts
@@ -595,9 +595,6 @@ export class ChangeStream {
     return rawChangeStream(watchDb, pipeline, {
       batchSize: options.batchSize ?? this.snapshotChunkLength,
       maxAwaitTimeMS,
-      // maxAwaitTimeMS can be 0 for probe-style streams that do not want an idle wait.
-      // In that case there is no client-side wait to emulate for DocumentDB.
-      clientSideMaxAwaitTimeMS: this.isDocumentDb && maxAwaitTimeMS > 0,
       maxTimeMS: this.changeStreamTimeout,
 
       signal: options.signal,

--- a/modules/module-mongodb/src/replication/MongoSnapshotter.ts
+++ b/modules/module-mongodb/src/replication/MongoSnapshotter.ts
@@ -785,9 +785,6 @@ export class MongoSnapshotter {
     return rawChangeStream(watchDb, pipeline, {
       batchSize: options.batchSize ?? this.snapshotChunkLength,
       maxAwaitTimeMS,
-      // maxAwaitTimeMS can be 0 for probe-style streams that do not want an idle wait.
-      // In that case there is no client-side wait to emulate for DocumentDB.
-      clientSideMaxAwaitTimeMS: this.isDocumentDb && maxAwaitTimeMS > 0,
       maxTimeMS: this.changeStreamTimeout,
       signal: options.signal,
       logger: this.logger,

--- a/modules/module-mongodb/src/replication/RawChangeStream.ts
+++ b/modules/module-mongodb/src/replication/RawChangeStream.ts
@@ -14,6 +14,10 @@ export interface RawChangeStreamOptions {
   /**
    * How long to wait for new data per batch (max time for long-polling).
    * This is sent as maxTimeMS for the getMore command.
+   *
+   * A value of 0 removes the explicit await limit and leaves the server's
+   * default awaitData behavior in effect; it does not make getMore return
+   * immediately. Snapshot probes use 0 for this purpose.
    */
   maxAwaitTimeMS: number;
 

--- a/modules/module-mongodb/src/replication/RawChangeStream.ts
+++ b/modules/module-mongodb/src/replication/RawChangeStream.ts
@@ -6,13 +6,7 @@ import {
   ReplicationAssertionError
 } from '@powersync/lib-services-framework';
 import { PerformanceTracer } from '@powersync/service-core';
-import { performance } from 'node:perf_hooks';
-import { setTimeout as delay } from 'node:timers/promises';
 import { ChangeStreamInvalidatedError } from './ChangeStream.js';
-
-// Keep the DocumentDB idle-poll workaround from adding the full maxAwaitTimeMS
-// as local latency when an update arrives just after an empty batch.
-const CLIENT_SIDE_MAX_AWAIT_TIME_MS_DELAY_CAP_MS = 1_000;
 
 export interface RawChangeStreamOptions {
   signal?: AbortSignal;
@@ -20,21 +14,8 @@ export interface RawChangeStreamOptions {
   /**
    * How long to wait for new data per batch (max time for long-polling).
    * This is sent as maxTimeMS for the getMore command.
-   *
-   * A value of 0 is allowed for probe-style streams that do not want an idle
-   * wait; in that case PowerSync also skips the local empty-batch delay.
    */
   maxAwaitTimeMS: number;
-
-  /**
-   * Also enforce maxAwaitTimeMS on the client for empty getMore batches.
-   *
-   * Azure DocumentDB currently returns idle getMore calls before maxTimeMS. When
-   * this is enabled, empty batches are delayed locally (capped at 1s) to avoid
-   * tight polling. We still send maxTimeMS so this remains compatible with
-   * servers that handle maxAwaitTimeMS correctly.
-   */
-  clientSideMaxAwaitTimeMS?: boolean;
 
   /**
    * Timeout for the initial aggregate command.
@@ -230,17 +211,12 @@ async function* rawChangeStreamInner(
       options.signal?.throwIfAborted();
 
       using commandSpan = options.tracer?.span('changestream', 'getmore');
-      const getMoreStartedAt = performance.now();
       const getMoreCommand: mongo.Document = {
         getMore: cursorId,
         collection: nsCollection,
         batchSize: batchSizer.next(),
         maxTimeMS: options.maxAwaitTimeMS
       };
-      // Azure DocumentDB currently returns empty getMore batches before
-      // maxTimeMS expires. Keep maxTimeMS for forward compatibility with the
-      // server-side behavior, and when client-side mode is enabled, enforce the
-      // capped idle wait locally for empty batches below.
       const getMoreResult: mongo.Document = await db.command(getMoreCommand, { session, raw: true }).catch((e) => {
         if (isMongoServerError(e) && e.codeName == 'CursorKilled') {
           // This may be due to the killCursors command issued when aborting.
@@ -267,13 +243,6 @@ async function* rawChangeStreamInner(
         // Deviation from spec: We require that the server always returns a postBatchResumeToken.
         // postBatchResumeToken is returned in MongoDB 4.0.7 and later, and we support 6.0+
         throw new ReplicationAssertionError(`postBatchResumeToken from aggregate response`);
-      }
-      if (options.clientSideMaxAwaitTimeMS && nextBatch.length == 0) {
-        const remainingMaxAwaitTimeMS = Math.ceil(options.maxAwaitTimeMS - (performance.now() - getMoreStartedAt));
-        if (remainingMaxAwaitTimeMS > 0) {
-          const clientSideDelayMs = Math.min(remainingMaxAwaitTimeMS, CLIENT_SIDE_MAX_AWAIT_TIME_MS_DELAY_CAP_MS);
-          await delay(clientSideDelayMs, undefined, { signal: options.signal });
-        }
       }
       yield {
         events: nextBatch,

--- a/modules/module-mongodb/test/src/documentdb_mode.test.ts
+++ b/modules/module-mongodb/test/src/documentdb_mode.test.ts
@@ -759,8 +759,7 @@ bucket_definitions:
     expect(JSON.parse(lastOp.data as string)).toMatchObject({ description: 'after_keepalive' });
   });
 
-  // Skipped until Azure DocumentDB ships the server-side getMore maxAwaitTimeMS fix.
-  test.skip('respects maxAwaitTimeMS for idle getMore calls in documentDbMode', async () => {
+  test('respects maxAwaitTimeMS for idle getMore calls in documentDbMode', async () => {
     const maxAwaitTimeMS = 2_000;
 
     await using context = await openContext({

--- a/modules/module-mongodb/test/src/raw_change_stream.test.ts
+++ b/modules/module-mongodb/test/src/raw_change_stream.test.ts
@@ -5,7 +5,6 @@ import { getCursorBatchBytes } from '@module/replication/replication-index.js';
 import { mongo } from '@powersync/lib-service-mongodb';
 import { bson } from '@powersync/service-core';
 import { DATABASE_TYPE, DatabaseType } from './DatabaseType.js';
-import { testTimeout } from './test-timeouts.js';
 import { clearTestDb, connectMongoData, requireFailCommand } from './util.js';
 
 // DocumentDB only supports cluster-level change streams — collection- and
@@ -99,68 +98,6 @@ describe('internal mongodb utils', () => {
       expect(aggregate?.command.maxTimeMS).toEqual(1_000);
       expect(getMore?.command.batchSize).toEqual(10);
       expect(getMore?.command.maxTimeMS).toEqual(50);
-    }
-  );
-
-  test(
-    'keeps getMore maxTimeMS when client-side maxAwaitTimeMS is enabled',
-    { timeout: testTimeout(30_000, { cloudOverride: 150_000 }) },
-    async () => {
-      const { db, client } = await connectMongoData({ monitorCommands: true });
-      await using _ = { [Symbol.asyncDispose]: async () => await client.close() };
-      await clearTestDb(db);
-      const collection = db.collection('test_data');
-      // Keep the local Mongo path fast, but give Azure DocumentDB enough time
-      // for slow cloud change-stream delivery when maxTimeMS is sent to getMore.
-      const maxAwaitTimeMS = testTimeout(50, { cloudOverride: 10_000 });
-
-      const started: any[] = [];
-      client.on('commandStarted', (event) => {
-        if (event.commandName == 'aggregate' || event.commandName == 'getMore') {
-          started.push(event);
-        }
-      });
-
-      const stream = rawChangeStream(
-        DATABASE_TYPE == DatabaseType.DOCUMENTDB ? client.db('admin') : db,
-        [
-          {
-            $changeStream: {
-              fullDocument: 'updateLookup',
-              ...(DATABASE_TYPE == DatabaseType.DOCUMENTDB ? { allChangesForCluster: true } : {})
-            }
-          },
-          ...(DATABASE_TYPE == DatabaseType.DOCUMENTDB
-            ? [
-                {
-                  $match: {
-                    'ns.db': db.databaseName,
-                    'ns.coll': collection.collectionName
-                  }
-                }
-              ]
-            : [])
-        ],
-        {
-          batchSize: 10,
-          maxAwaitTimeMS,
-          clientSideMaxAwaitTimeMS: true,
-          maxTimeMS: 1_000
-        }
-      );
-
-      await stream.next();
-      await collection.insertOne({ test: 1 });
-      const nextBatch = await readUntilNonEmptyBatch(stream);
-      await stream.return?.();
-
-      expect(nextBatch.events).toHaveLength(1);
-
-      const aggregate = started.find((event) => event.commandName == 'aggregate');
-      const getMore = started.find((event) => event.commandName == 'getMore');
-
-      expect(aggregate?.command.maxTimeMS).toEqual(1_000);
-      expect(getMore?.command.maxTimeMS).toEqual(maxAwaitTimeMS);
     }
   );
 


### PR DESCRIPTION
The initial implementation of the Azure DocumentDB integration required a client side timeout in order to workaround `maxAwaitTimeMs` not being respected by DocumentDB instances.

DocumentDB now supports `maxAwaitTimeMs`. This removes the workarrounds.

This also updates the designation of the integration from `experimental` to  `alpha`.

Verified all DocumentDB integration tests passed: https://github.com/powersync-ja/powersync-service/actions/runs/33749276222/job/100628850424

AI use: Codex 5.6 implemented the changes. Manually verified.