### PR TITLE
fix(module-postgres-storage): only resnapshot rows with missing TOAST values

### DIFF
--- a/.changeset/resnapshot-only-toasted-rows.md
+++ b/.changeset/resnapshot-only-toasted-rows.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-postgres-storage': patch
+---
+
+Only resnapshot rows with missing TOAST values when a streamed update has no stored record, as the MongoDB storage already does. A complete row is evaluated and stored anyway, so the resnapshot was redundant. On a bulk update to rows not yet snapshotted this queued one resnapshot per row and kept confirmed_flush_lsn from advancing.

--- a/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
+++ b/modules/module-postgres-storage/src/storage/batch/PostgresBucketBatch.ts
@@ -1060,9 +1060,9 @@ export class PostgresBucketBatch
         // Not an error if we re-apply a transaction
         existingBuckets = [];
         existingLookups = [];
-        // Log to help with debugging if there was a consistency issue
-
-        if (storeCurrentData) {
+        // A complete row is evaluated and stored in current_data below, so a resnapshot is only
+        // needed when TOAST values are missing.
+        if (!utils.isCompleteRow(storeCurrentData, after!)) {
           if (this.markRecordUnavailable != null) {
             // This will trigger a "resnapshot" of the record.
             // This is not relevant if storeCurrentData is false, since we'll get the full row

--- a/packages/service-core-tests/src/tests/register-data-storage-data-tests.ts
+++ b/packages/service-core-tests/src/tests/register-data-storage-data-tests.ts
@@ -649,6 +649,87 @@ bucket_definitions:
     ]);
   });
 
+  test('update without stored record only resnapshots when TOAST values are missing', async () => {
+    await using factory = await generateStorageFactory();
+    const { stream: replicationStream, content: syncRules } = await test_utils.deploySyncRules(
+      factory,
+      updateSyncRulesFromYaml(
+        `
+bucket_definitions:
+  global:
+    data:
+      - SELECT id, description FROM "%"
+`,
+        { storageVersion }
+      )
+    );
+    const bucketStorage = factory.getInstance(replicationStream);
+    const unavailable: storage.SaveUpdate[] = [];
+    await using writer = await bucketStorage.createWriter({
+      ...test_utils.BATCH_OPTIONS,
+      markRecordUnavailable: (record) => {
+        unavailable.push(record);
+      }
+    });
+    const sourceTable = await test_utils.resolveTestTable(writer, 'test', ['id'], config);
+    await writer.markAllSnapshotDone('1/1');
+
+    // Complete row for a record we have no current_data for, e.g. streamed before the
+    // snapshot reached it. It can be evaluated and stored as-is, so no resnapshot is needed.
+    await writer.save({
+      sourceTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      after: {
+        id: 'test1',
+        description: 'test1'
+      },
+      afterReplicaId: test_utils.rid('test1')
+    });
+    await writer.flush();
+    expect(unavailable).toEqual([]);
+
+    // The stored copy is then used to fill in TOAST values on later updates.
+    await writer.save({
+      sourceTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      after: {
+        id: 'test1',
+        description: undefined
+      },
+      afterReplicaId: test_utils.rid('test1')
+    });
+
+    // Partial row for a record we have no current_data for: cannot be evaluated, must be resnapshotted.
+    await writer.save({
+      sourceTable,
+      tag: storage.SaveOperationTag.UPDATE,
+      after: {
+        id: 'test2',
+        description: undefined
+      },
+      afterReplicaId: test_utils.rid('test2')
+    });
+    await writer.commit('1/1');
+
+    expect(unavailable.map((record) => record.after.id)).toEqual(['test2']);
+
+    const checkpoint = await bucketStorage.getCheckpoint();
+    const request = bucketRequest(syncRules, 'global[]');
+    const batch = await test_utils.getBatchArray(bucketStorage.getBucketDataBatch(checkpoint, [request]));
+    const data = batch[0].chunkData.data.map((d) => {
+      return {
+        op: d.op,
+        object_id: d.object_id,
+        data: normalizeOplogData(d.data)
+      };
+    });
+
+    expect(data).toEqual([
+      { op: 'PUT', object_id: 'test1', data: JSON.stringify({ id: 'test1', description: 'test1' }) },
+      { op: 'PUT', object_id: 'test1', data: JSON.stringify({ id: 'test1', description: 'test1' }) }
+    ]);
+  });
+
   test('batch with overlapping replica ids', async () => {
     // This test checks that we get the correct output when processing rows with:
     // 1. changing replica ids


### PR DESCRIPTION
### Problem

`PostgresBucketBatch.saveOperation()` handles a streamed UPDATE for a row with no `current_data` entry by calling `markRecordUnavailable()` whenever `storeCurrentData` is true, which queues a targeted resnapshot of that row. It does this even when the row arrived complete from the WAL. The complete row is evaluated and written to `current_data` on the same pass (the `isCompleteRow` gate before evaluation, then the unconditional `upsertCurrentData`), so the resnapshot re-reads a row the service already has: a query on a separate snapshot connection, a keepalive, and a wait for the next consistent checkpoint before `confirmed_flush_lsn` moves again.

The MongoDB storage only resnapshots when the row is incomplete (`!isCompleteRow(storeCurrentData, after)` in `MongoBucketBatch`). That guard came with #655, which also touched `PostgresBucketBatch` but left this branch on the old condition. The same reasoning appears in the #655 review: a row that arrives complete needs no targeted resnapshot (https://github.com/powersync-ja/powersync-service/pull/655#discussion_r3340308451).

We hit this with a backfill that updated about a million rows on tables whose snapshot had not reached them yet. Every one of those rows queued a resnapshot; the queue drained in batches over close to an hour, and the slot's `confirmed_flush_lsn` stayed put until it did. The cost is paid once per row (the first UPDATE while the row is missing from storage), so it self-limits, but it repeats on every large backfill or onboarding.

### Fix

Gate the resnapshot on `isCompleteRow(storeCurrentData, after)`, matching the MongoDB storage. Rows with missing TOAST values still go through resnapshot as before; complete rows take the normal path and are stored directly. With `storeCurrentData` false the guard is never entered, same as today.

### Tests

New test in the shared storage suite (`register-data-storage-data-tests.ts`), so it runs against both storages: an UPDATE with a complete row for a record not in storage must not call `markRecordUnavailable`, a following partial UPDATE on the same record must be filled from the stored copy, and a partial UPDATE for another missing record must be marked. It fails on Postgres storage v1 and v2 without the fix and passes with it; it passes unchanged on the MongoDB storage suite. The module-postgres-storage suite passes against real Postgres (174 tests). Changeset included (patch).