### PR TITLE
fix(postgres): skip replication-byte recorder in test-connection

### DIFF
--- a/.changeset/skip-test-connection-replication-metrics.md
+++ b/.changeset/skip-test-connection-replication-metrics.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-postgres': patch
+---
+
+Skip the PostgreSQL replication-byte metrics recorder in `test-connection` mode so the command can run without `DATA_REPLICATED_BYTES`.

--- a/modules/module-postgres/src/module/PostgresModule.ts
+++ b/modules/module-postgres/src/module/PostgresModule.ts
@@ -31,7 +31,7 @@ export class PostgresModule extends replication.ReplicationModule<types.Postgres
 
   async onInitialized(context: system.ServiceContextContainer): Promise<void> {
     // Record replicated bytes using global jpgwire metrics. Only registered if this module is replicating
-    if (context.replicationEngine) {
+    if (context.replicationEngine && context.serviceMode !== system.ServiceContextMode.TEST_CONNECTION) {
       jpgwire.setMetricsRecorder({
         addBytesRead(bytes) {
           context.metricsEngine.getCounter(ReplicationMetric.DATA_REPLICATED_BYTES).add(bytes);

--- a/modules/module-postgres/test/src/metrics_recorder.test.ts
+++ b/modules/module-postgres/test/src/metrics_recorder.test.ts
@@ -1,0 +1,40 @@
+import { system } from '@powersync/service-core';
+import * as jpgwire from '@powersync/service-jpgwire';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PostgresModule } from '../../src/module/PostgresModule.js';
+
+describe('PostgresModule metrics recorder', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not install a jpgwire recorder in TEST_CONNECTION mode', async () => {
+    const spy = vi.spyOn(jpgwire, 'setMetricsRecorder');
+    const mod = new PostgresModule();
+    await mod.onInitialized({
+      replicationEngine: {},
+      serviceMode: system.ServiceContextMode.TEST_CONNECTION,
+      metricsEngine: {
+        getCounter() {
+          throw new Error('DATA_REPLICATED_BYTES should not be read in test-connection');
+        }
+      }
+    } as unknown as system.ServiceContextContainer);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('installs a jpgwire recorder when replication metrics are available', async () => {
+    const spy = vi.spyOn(jpgwire, 'setMetricsRecorder');
+    const mod = new PostgresModule();
+    await mod.onInitialized({
+      replicationEngine: {},
+      serviceMode: system.ServiceContextMode.UNIFIED,
+      metricsEngine: {
+        getCounter: () => ({ add() {} })
+      }
+    } as unknown as system.ServiceContextContainer);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `test-connection` runs in `TEST_CONNECTION` mode, which never registers replication metrics.
- `PostgresModule` still installed a jpgwire recorder that reads `DATA_REPLICATED_BYTES`, so the CLI failed with `PSYNC_S0001` before the connection check ran.
- Skip that recorder in `TEST_CONNECTION` mode. Maintainer confirmed on #751 that metrics are not needed for this command.

Fixes #751

## Test plan
- [x] `pnpm --filter @powersync/service-module-postgres exec vitest run test/src/metrics_recorder.test.ts` (2 passed)
- [ ] `test-connection` against a valid PostgreSQL replication config reports the connection result instead of the missing-counter error