### PR TITLE
Increase default S3 concurrency

### DIFF
--- a/.changeset/slimy-bobcats-march.md
+++ b/.changeset/slimy-bobcats-march.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+---
+
+Increase default concurrent S3 uploads to 64 and tweak http connection pools.

--- a/modules/module-mongodb-storage/src/index.ts
+++ b/modules/module-mongodb-storage/src/index.ts
@@ -6,3 +6,5 @@ export * as storage from './storage/storage-index.js';
 export * from './types/types.js';
 export * as types from './types/types.js';
 export * as utils from './utils/utils-index.js';
+
+export * from './storage/implementation/v3/object-storage/S3ObjectStorage.js';

--- a/modules/module-mongodb-storage/src/index.ts
+++ b/modules/module-mongodb-storage/src/index.ts
@@ -6,5 +6,3 @@ export * as storage from './storage/storage-index.js';
 export * from './types/types.js';
 export * as types from './types/types.js';
 export * as utils from './utils/utils-index.js';
-
-export * from './storage/implementation/v3/object-storage/S3ObjectStorage.js';

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/S3ObjectStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/S3ObjectStorage.ts
@@ -19,10 +19,10 @@ import {
   type ObjectStoragePutMetadata
 } from './ObjectStorage.js';
 
-const DEFAULT_S3_OPERATION_CONCURRENCY = 16;
+const DEFAULT_S3_OPERATION_CONCURRENCY = 64;
 const S3_DELETE_PREFIX_BATCH_SIZE = 1000;
 /**
- * Slightly smaller than DEFAULT_S3_OPERATION_CONCURRENCY.
+ * Keep prefix deletion below the default shared limit to leave capacity for other operations.
  */
 const S3_DELETE_PREFIX_CONCURRENCY = 12;
 const MAX_S3_PREFIX_BYTES = 256;
@@ -55,11 +55,19 @@ const BASELINE_CONNECTION_TIMEOUT_MS = 3_100;
 const REQUEST_TIMEOUT_FACTOR = 5;
 const OPERATION_TIMEOUT_FACTOR = 2;
 /**
+ * Don't keep idle http sockets around for longer than this timeout.
+ *
+ * This covers the case where we have large bursts of activity during replication, followed by
+ * long periods of inactivity.
+ */
+const SOCKET_IDLE_TIMEOUT_MS = 60_000;
+
+/**
  * How long an operation may wait for a concurrency slot, as a multiple of the operation timeout.
  *
  * Every slot holder now releases within the operation timeout, so the queue always drains: this is
  * a backpressure limit rather than a deadlock guard. Waiting this long means at least
- * `factor * concurrencyLimit` operations ahead of us each took their full deadline - 64 at the
+ * `factor * concurrencyLimit` operations ahead of us each took their full deadline - 256 at the
  * default concurrency. Real operations complete in a fraction of the deadline, so the number of
  * queued operations this actually tolerates is far higher, well above the ~2000 uploads that the
  * largest possible replication flush (MAX_TRANSACTION_DOC_COUNT) can enqueue at once.
@@ -221,6 +229,15 @@ export class S3ObjectStorage implements ObjectStorage {
       forcePathStyle: options.forcePathStyle,
       defaultsMode,
       requestHandler: new NodeHttpHandler({
+        // Match the shared request limit instead of queuing again at the HTTP pool.
+        httpAgent: {
+          keepAlive: true,
+          maxSockets: concurrencyLimit,
+          // The timeout here is a little more general than an "idle timeout", but it does cover the
+          // case of closing idle sockets after a period of inactivity.
+          timeout: SOCKET_IDLE_TIMEOUT_MS
+        },
+        httpsAgent: { keepAlive: true, maxSockets: concurrencyLimit, timeout: SOCKET_IDLE_TIMEOUT_MS },
         connectionTimeout: this.timeouts.connectionTimeoutMs,
         requestTimeout: this.timeouts.requestTimeoutMs,
         // Without this, exceeding requestTimeout only logs a warning.

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/S3ObjectStorage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/S3ObjectStorage.ts
@@ -19,6 +19,9 @@ import {
   type ObjectStoragePutMetadata
 } from './ObjectStorage.js';
 
+// Never statically import (or re-export) this module!
+// We want to avoid loading the AWS SDK unless the user has configured S3 object storage, since it's a large dependency.
+
 const DEFAULT_S3_OPERATION_CONCURRENCY = 64;
 const S3_DELETE_PREFIX_BATCH_SIZE = 1000;
 /**


### PR DESCRIPTION
_This only affects `storage_version: 4`, with object storage enabled._

When replicating many small chunks, S3 latency can produce a lot of overhead.

For example, suppose we flush a batch of 2000 operations, 1KB each, spread over 125 buckets. That gives us 16KB per bucket, just enough to store on S3.

If we have an average latency of 100ms per PUT on S3, and a maximum of 16 concurrent S3 operations, that adds around to 800ms of latency for the batch.

By increasing the concurrency limit to 64, this reduces the theoretical S3 latency to around 200ms, at which point it's not the main bottleneck anymore. This also tweaks the http(s) agent settings to match the pool size to the S3 concurrency limit, and adds a timeout to close idle connections.

In some synthetic benchmarks with 4ms storage database latency and 100ms S3 latency, this increased my replication throughput from 2 450 rows/s to 4 900 rows/s (1kb each).

## AI Usage

Used Codex gpt-6-astra to help find the bottlenecks and settings to tweak. Manually reviewed.




