### PR TITLE
Use MongoDB client-level bulkWrite where available

### DIFF
--- a/.changeset/wide-feet-reply.md
+++ b/.changeset/wide-feet-reply.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb-storage': minor
+---
+
+Use MongoDB client-level bulkWrite where available.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoBucketBatch.ts
@@ -36,6 +36,7 @@ import type { VersionedPowerSyncMongo } from './db.js';
 import { MAX_ROW_SIZE } from './MongoBucketBatchShared.js';
 import { MongoIdSequence } from './MongoIdSequence.js';
 import { MongoParsedSyncConfigSet } from './MongoParsedSyncConfigSet.js';
+import { MongoWriteBatch } from './MongoWriteBatch.js';
 import { OperationBatch, RecordOperation } from './OperationBatch.js';
 import { ObjectStorage } from './v3/object-storage/ObjectStorage.js';
 import { createObjectStorageUsageWriterId } from './v3/object-storage/ObjectStorageUsage.js';
@@ -239,11 +240,13 @@ export abstract class MongoBucketBatch
       if (this.write_checkpoint_batch.length > 0) {
         this.logger.info(`Writing ${this.write_checkpoint_batch.length} custom write checkpoints`);
         await this.batchCreateCustomWriteCheckpoints(session, opSeq.next());
-        this.write_checkpoint_batch = [];
       }
 
       last_op = opSeq.last();
     });
+
+    // Keep checkpoints available if the transaction retries after writing them.
+    this.write_checkpoint_batch = [];
 
     if (clearedError) {
       this.clearedError = true;
@@ -706,7 +709,9 @@ export abstract class MongoBucketBatch
 
       await callback(session, opSeq);
 
-      await this.db.op_id_sequence.updateOne(
+      const writes = this.db.createWriteBatch(session, { ordered: false });
+      writes.updateOne(
+        this.db.op_id_sequence,
         {
           _id: 'main'
         },
@@ -714,13 +719,11 @@ export abstract class MongoBucketBatch
           $set: {
             op_id: opSeq.last()
           }
-        },
-        {
-          session
         }
       );
 
-      await this.db.sync_rules.updateOne(
+      writes.updateOne(
+        this.db.sync_rules,
         {
           _id: this.replicationStreamId
         },
@@ -728,13 +731,13 @@ export abstract class MongoBucketBatch
           $set: {
             last_keepalive_ts: new Date()
           }
-        },
-        { session }
+        }
       );
 
       // Allow subclasses to persist additional flush-time state in the same transaction
       // (e.g. v3 advances the stream-level last_persisted_op).
-      await this.onReplicationTransactionFlush(session, opSeq.last());
+      this.onReplicationTransactionFlush(writes, opSeq.last());
+      await writes.execute();
       // We don't notify checkpoint here - we don't make any checkpoint updates directly
     });
   }
@@ -745,7 +748,7 @@ export abstract class MongoBucketBatch
    * The base implementation does nothing; v3 storage overrides this to `$max` the stream-level
    * `last_persisted_op` durably within the same transaction.
    */
-  protected async onReplicationTransactionFlush(_session: mongo.ClientSession, _lastOp: InternalOpId): Promise<void> {
+  protected onReplicationTransactionFlush(_writes: MongoWriteBatch, _lastOp: InternalOpId): void {
     // No-op by default (v1 behaviour unchanged).
   }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoStorageProvider.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoStorageProvider.ts
@@ -47,6 +47,8 @@ export class MongoStorageProvider implements storage.StorageProvider {
       maxPoolSize: resolvedConfig.storage.max_pool_size ?? 8
     });
 
+    const database = new PowerSyncMongo(client, { database: resolvedConfig.storage.database });
+
     let shuttingDown = false;
 
     // Explicitly connect on startup.
@@ -56,7 +58,6 @@ export class MongoStorageProvider implements storage.StorageProvider {
     // Errors here will cause the process to exit.
     await client.connect();
 
-    const database = new PowerSyncMongo(client, { database: resolvedConfig.storage.database });
     const readPreference =
       decodedConfig.bulk_read_preference == null
         ? undefined

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoWriteBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoWriteBatch.ts
@@ -1,0 +1,153 @@
+import { mongo } from '@powersync/lib-service-mongodb';
+
+/**
+ * Explicitly groups writes with no intervening reads or result dependencies.
+ * Callers retain responsibility for transaction and ordering boundaries.
+ *
+ * On MongoDB 8.0+, this uses the client-level bulkWrite API.
+ *
+ * On MongoDB earlier versions, this uses the the collection-level bulkWrite API, or individual operations.
+ * This is less efficient, but produces the same results.
+ */
+export class MongoWriteBatch {
+  private readonly operations: mongo.AnyClientBulkWriteModel<mongo.Document>[] = [];
+  private readonly deleteChecks: { index: number; check: (count: number) => void }[] = [];
+  private readonly fallback: (() => Promise<unknown>)[] = [];
+
+  private readonly ordered: boolean;
+
+  constructor(
+    private readonly client: mongo.MongoClient,
+    private readonly supportsClientBulkWrite: () => boolean,
+    private readonly session: mongo.ClientSession | undefined,
+    options: { ordered: boolean }
+  ) {
+    this.ordered = options.ordered;
+  }
+
+  /**
+   * Perform a collection-level bulkWrite.
+   *
+   * On MongoDB 8.0+, these operations join the client-level bulkWrite with the batch's ordering.
+   * The driver may split commands to respect server batch limits.
+   *
+   * On earlier MongoDB versions, this always uses an unordered collection-level bulkWrite.
+   * Operations within this collection bulk must therefore be independent of their order.
+   */
+  bulkWriteUnordered<T extends mongo.Document>(
+    collection: mongo.Collection<T>,
+    operations: mongo.AnyBulkWriteOperation<T>[]
+  ): void {
+    if (operations.length === 0) return;
+    for (const operation of operations) {
+      // Collection and client models contain the same operation fields, with a
+      // different envelope. Keep the schema checked at the collection boundary.
+      const [name, model] = Object.entries(operation)[0];
+      this.operations.push({ ...model, name, namespace: collection.namespace });
+    }
+    this.fallback.push(() => collection.bulkWrite(operations, { ordered: false, session: this.session }));
+  }
+
+  insertOne<T extends mongo.Document>(collection: mongo.Collection<T>, document: mongo.OptionalUnlessRequiredId<T>) {
+    this.addModel<T>({ name: 'insertOne', namespace: collection.namespace, document: document as mongo.OptionalId<T> });
+    this.fallback.push(() => collection.insertOne(document, { session: this.session }));
+  }
+
+  insertMany<T extends mongo.Document>(
+    collection: mongo.Collection<T>,
+    documents: mongo.OptionalUnlessRequiredId<T>[]
+  ) {
+    if (documents.length === 0) return;
+    for (const document of documents) {
+      this.addModel<T>({
+        name: 'insertOne',
+        namespace: collection.namespace,
+        document: document as mongo.OptionalId<T>
+      });
+    }
+    this.fallback.push(() => collection.insertMany(documents, { session: this.session }));
+  }
+
+  deleteMany<T extends mongo.Document>(
+    collection: mongo.Collection<T>,
+    filter: mongo.Filter<T>,
+    checkDeletedCount?: (count: number) => void
+  ) {
+    if (checkDeletedCount) {
+      // Client-bulk results are checked after all writes execute. A failed
+      // invariant must roll back the entire batch, not leave later writes visible.
+      if (!this.session?.inTransaction()) throw new Error('Checked deletes require a transaction');
+      this.deleteChecks.push({ index: this.operations.length, check: checkDeletedCount });
+    }
+    this.addModel<T>({ name: 'deleteMany', namespace: collection.namespace, filter });
+    this.fallback.push(async () => {
+      const result = await collection.deleteMany(filter, { session: this.session });
+      checkDeletedCount?.(result.deletedCount);
+    });
+  }
+
+  updateOne<T extends mongo.Document>(
+    collection: mongo.Collection<T>,
+    filter: mongo.Filter<T>,
+    update: mongo.UpdateFilter<T> | mongo.Document[],
+    options: Pick<mongo.UpdateOptions, 'upsert' | 'arrayFilters'> = {}
+  ) {
+    this.addModel({ name: 'updateOne', namespace: collection.namespace, filter, update, ...options });
+    this.fallback.push(() => collection.updateOne(filter, update, { ...options, session: this.session }));
+  }
+
+  updateMany<T extends mongo.Document>(
+    collection: mongo.Collection<T>,
+    filter: mongo.Filter<T>,
+    update: mongo.UpdateFilter<T> | mongo.Document[],
+    options: Pick<mongo.UpdateOptions, 'upsert' | 'arrayFilters'> = {}
+  ) {
+    this.addModel({ name: 'updateMany', namespace: collection.namespace, filter, update, ...options });
+    this.fallback.push(() => collection.updateMany(filter, update, { ...options, session: this.session }));
+  }
+
+  private addModel<T extends mongo.Document>(operation: mongo.AnyClientBulkWriteModel<T>) {
+    // The collection-specific methods validate the schema before erasing it here.
+    this.operations.push(operation as unknown as mongo.AnyClientBulkWriteModel<mongo.Document>);
+  }
+
+  /**
+   * Execute the queued writes.
+   *
+   * On MongoDB 8.0+, this uses the client-level bulkWrite API, typically resulting in a single command.
+   * The command may be split if there are a large number of operations.
+   *
+   * On earlier MongoDB versions, this executes each queued operation individually.
+   *
+   * If no operations were queued, this is a no-op.
+   */
+  async execute(): Promise<void> {
+    if (this.operations.length === 0) return;
+    await this.client.connect();
+    if (!this.supportsClientBulkWrite()) {
+      // Sessions cannot execute concurrent operations within a transaction.
+      for (const write of this.fallback) await write();
+      return;
+    }
+
+    try {
+      const result = await this.client.bulkWrite(this.operations, {
+        session: this.session,
+        ordered: this.ordered,
+        verboseResults: this.deleteChecks.length > 0
+      });
+      for (const { index, check } of this.deleteChecks) {
+        const deleted = result.deleteResults?.get(index);
+        if (deleted == null) throw new Error('Missing client bulk delete result');
+        check(deleted.deletedCount);
+      }
+    } catch (error) {
+      // The driver wraps command failures without copying their error labels.
+      // Preserve withTransaction's retry handling for e.g. write conflicts.
+      if (error instanceof mongo.MongoClientBulkWriteError && error.cause instanceof mongo.MongoError) {
+        throw error.cause;
+      }
+      throw error;
+    }
+  }
+}

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoWriteBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoWriteBatch.ts
@@ -18,7 +18,7 @@ export class MongoWriteBatch {
 
   constructor(
     private readonly client: mongo.MongoClient,
-    private readonly supportsClientBulkWrite: () => boolean,
+    private readonly supportsClientBulkWrite: boolean,
     private readonly session: mongo.ClientSession | undefined,
     options: { ordered: boolean }
   ) {
@@ -39,18 +39,24 @@ export class MongoWriteBatch {
     operations: mongo.AnyBulkWriteOperation<T>[]
   ): void {
     if (operations.length === 0) return;
+    if (!this.supportsClientBulkWrite) {
+      this.fallback.push(() => collection.bulkWrite(operations, { ordered: false, session: this.session }));
+      return;
+    }
     for (const operation of operations) {
       // Collection and client models contain the same operation fields, with a
       // different envelope. Keep the schema checked at the collection boundary.
       const [name, model] = Object.entries(operation)[0];
       this.operations.push({ ...model, name, namespace: collection.namespace });
     }
-    this.fallback.push(() => collection.bulkWrite(operations, { ordered: false, session: this.session }));
   }
 
   insertOne<T extends mongo.Document>(collection: mongo.Collection<T>, document: mongo.OptionalUnlessRequiredId<T>) {
+    if (!this.supportsClientBulkWrite) {
+      this.fallback.push(() => collection.insertOne(document, { session: this.session }));
+      return;
+    }
     this.addModel<T>({ name: 'insertOne', namespace: collection.namespace, document: document as mongo.OptionalId<T> });
-    this.fallback.push(() => collection.insertOne(document, { session: this.session }));
   }
 
   insertMany<T extends mongo.Document>(
@@ -58,6 +64,10 @@ export class MongoWriteBatch {
     documents: mongo.OptionalUnlessRequiredId<T>[]
   ) {
     if (documents.length === 0) return;
+    if (!this.supportsClientBulkWrite) {
+      this.fallback.push(() => collection.insertMany(documents, { session: this.session }));
+      return;
+    }
     for (const document of documents) {
       this.addModel<T>({
         name: 'insertOne',
@@ -65,7 +75,6 @@ export class MongoWriteBatch {
         document: document as mongo.OptionalId<T>
       });
     }
-    this.fallback.push(() => collection.insertMany(documents, { session: this.session }));
   }
 
   deleteMany<T extends mongo.Document>(
@@ -77,13 +86,18 @@ export class MongoWriteBatch {
       // Client-bulk results are checked after all writes execute. A failed
       // invariant must roll back the entire batch, not leave later writes visible.
       if (!this.session?.inTransaction()) throw new Error('Checked deletes require a transaction');
+    }
+    if (!this.supportsClientBulkWrite) {
+      this.fallback.push(async () => {
+        const result = await collection.deleteMany(filter, { session: this.session });
+        checkDeletedCount?.(result.deletedCount);
+      });
+      return;
+    }
+    if (checkDeletedCount) {
       this.deleteChecks.push({ index: this.operations.length, check: checkDeletedCount });
     }
     this.addModel<T>({ name: 'deleteMany', namespace: collection.namespace, filter });
-    this.fallback.push(async () => {
-      const result = await collection.deleteMany(filter, { session: this.session });
-      checkDeletedCount?.(result.deletedCount);
-    });
   }
 
   updateOne<T extends mongo.Document>(
@@ -92,8 +106,11 @@ export class MongoWriteBatch {
     update: mongo.UpdateFilter<T> | mongo.Document[],
     options: Pick<mongo.UpdateOptions, 'upsert' | 'arrayFilters'> = {}
   ) {
+    if (!this.supportsClientBulkWrite) {
+      this.fallback.push(() => collection.updateOne(filter, update, { ...options, session: this.session }));
+      return;
+    }
     this.addModel({ name: 'updateOne', namespace: collection.namespace, filter, update, ...options });
-    this.fallback.push(() => collection.updateOne(filter, update, { ...options, session: this.session }));
   }
 
   updateMany<T extends mongo.Document>(
@@ -102,8 +119,11 @@ export class MongoWriteBatch {
     update: mongo.UpdateFilter<T> | mongo.Document[],
     options: Pick<mongo.UpdateOptions, 'upsert' | 'arrayFilters'> = {}
   ) {
+    if (!this.supportsClientBulkWrite) {
+      this.fallback.push(() => collection.updateMany(filter, update, { ...options, session: this.session }));
+      return;
+    }
     this.addModel({ name: 'updateMany', namespace: collection.namespace, filter, update, ...options });
-    this.fallback.push(() => collection.updateMany(filter, update, { ...options, session: this.session }));
   }
 
   private addModel<T extends mongo.Document>(operation: mongo.AnyClientBulkWriteModel<T>) {
@@ -122,13 +142,12 @@ export class MongoWriteBatch {
    * If no operations were queued, this is a no-op.
    */
   async execute(): Promise<void> {
-    if (this.operations.length === 0) return;
-    await this.client.connect();
-    if (!this.supportsClientBulkWrite()) {
+    if (!this.supportsClientBulkWrite) {
       // Sessions cannot execute concurrent operations within a transaction.
       for (const write of this.fallback) await write();
       return;
     }
+    if (this.operations.length === 0) return;
 
     try {
       const result = await this.client.bulkWrite(this.operations, {

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoWriteCheckpointAPI.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoWriteCheckpointAPI.ts
@@ -95,7 +95,8 @@ export class MongoWriteCheckpointAPI implements storage.WriteCheckpointAPI {
             },
             upsert: true
           }
-        }))
+        })),
+        { ordered: false }
       );
 
       const userIds = generatedCheckpoints.map((checkpoint) => checkpoint.user_id);
@@ -180,7 +181,8 @@ export class MongoWriteCheckpointAPI implements storage.WriteCheckpointAPI {
             upsert: true
           }
         };
-      })
+      }),
+      { ordered: false }
     );
 
     // Fetch the final ids separately so stale requests can still return the

--- a/modules/module-mongodb-storage/src/storage/implementation/common/PersistedBatch.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/common/PersistedBatch.ts
@@ -8,6 +8,7 @@ import { JSONBig } from '@powersync/service-jsonbig';
 import { mongoTableId, replicaIdToSubkey } from '../../../utils/util.js';
 import { currentBucketKey, MAX_ROW_SIZE } from '../MongoBucketBatchShared.js';
 import { MongoIdSequence } from '../MongoIdSequence.js';
+import { MongoWriteBatch } from '../MongoWriteBatch.js';
 import type { VersionedPowerSyncMongo } from '../db.js';
 import { TaggedBucketParameterDocument } from '../models.js';
 import { ObjectStorage } from '../v3/object-storage/ObjectStorage.js';
@@ -216,13 +217,13 @@ export abstract class PersistedBatch {
 
   protected abstract get currentDataCount(): number;
 
-  protected abstract flushBucketData(session: mongo.ClientSession): Promise<void>;
+  protected abstract queueBucketData(writes: MongoWriteBatch): Promise<void>;
 
-  protected abstract flushBucketParameters(session: mongo.ClientSession): Promise<void>;
+  protected abstract queueBucketParameters(writes: MongoWriteBatch): void;
 
-  protected abstract flushCurrentData(session: mongo.ClientSession): Promise<void>;
+  protected abstract queueCurrentData(writes: MongoWriteBatch): void;
 
-  protected abstract flushBucketStates(session: mongo.ClientSession): Promise<void>;
+  protected abstract queueBucketStates(writes: MongoWriteBatch): void;
 
   protected abstract resetCurrentData(): void;
 
@@ -348,23 +349,26 @@ export abstract class PersistedBatch {
   async flush(session: mongo.ClientSession, options?: storage.BucketBatchCommitOptions) {
     const startAt = performance.now();
     let flushedSomething = false;
+    const writes = this.db.createWriteBatch(session, { ordered: false });
     if (this.bucketDataCount > 0) {
       flushedSomething = true;
-      await this.flushBucketData(session);
+      await this.queueBucketData(writes);
     }
     if (this.bucketParameters.length > 0) {
       flushedSomething = true;
-      await this.flushBucketParameters(session);
+      this.queueBucketParameters(writes);
     }
     if (this.currentDataCount > 0) {
       flushedSomething = true;
-      await this.flushCurrentData(session);
+      this.queueCurrentData(writes);
     }
 
     if (this.bucketStates.size > 0) {
       flushedSomething = true;
-      await this.flushBucketStates(session);
+      this.queueBucketStates(writes);
     }
+
+    await writes.execute();
 
     if (flushedSomething) {
       const duration = Math.round(performance.now() - startAt);

--- a/modules/module-mongodb-storage/src/storage/implementation/common/VersionedPowerSyncMongoBase.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/common/VersionedPowerSyncMongoBase.ts
@@ -58,6 +58,10 @@ export abstract class BaseVersionedPowerSyncMongo {
     return this.upstream.notifyCheckpoint();
   }
 
+  createWriteBatch(session: mongo.ClientSession | undefined, options: { ordered: boolean }) {
+    return this.upstream.createWriteBatch(session, options);
+  }
+
   protected sourceRecordsCollectionName(replicationStreamId: number, sourceTableId: mongo.ObjectId) {
     return this.upstream.sourceRecordsCollectionName(replicationStreamId, sourceTableId);
   }

--- a/modules/module-mongodb-storage/src/storage/implementation/db.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/db.ts
@@ -55,25 +55,22 @@ export class PowerSyncMongo {
 
   readonly client: mongo.MongoClient;
   readonly db: mongo.Db;
-  private clientBulkWriteSupport = false;
+  private get clientBulkWriteSupport(): boolean {
+    // The driver exposes topology at runtime, but omits this internal property
+    // from its public types. Reuse its handshake results without another command.
+    const client = this.client as mongo.MongoClient & { topology?: { description: mongo.TopologyDescription } };
+    const servers = [...(client.topology?.description.servers.values() ?? [])];
+    // MongoDB 8.0 introduced client bulkWrite at wire version 25. Unknown / mixed-version
+    // topologies use collection writes until all known servers support it.
+    return servers.length > 0 && servers.every((server) => server.maxWireVersion >= 25);
+  }
 
   createWriteBatch(session: mongo.ClientSession | undefined, options: { ordered: boolean }): MongoWriteBatch {
-    return new MongoWriteBatch(this.client, () => this.clientBulkWriteSupport, session, options);
+    return new MongoWriteBatch(this.client, this.clientBulkWriteSupport, session, options);
   }
 
   constructor(client: mongo.MongoClient, options?: PowerSyncMongoOptions) {
     this.client = client;
-
-    // Register before connecting to reuse the driver's handshakes. MongoDB 8.0
-    // introduced client bulkWrite at wire version 25. Unknown / mixed-version
-    // topologies use collection writes until all known servers support it.
-    client.on('topologyDescriptionChanged', ({ newDescription }) => {
-      const servers = [...newDescription.servers.values()];
-      this.clientBulkWriteSupport = servers.length > 0 && servers.every((server) => server.maxWireVersion >= 25);
-    });
-    client.on('topologyClosed', () => {
-      this.clientBulkWriteSupport = false;
-    });
 
     const db = client.db(options?.database, {
       ...storage.BSON_DESERIALIZE_INTERNAL_OPTIONS

--- a/modules/module-mongodb-storage/src/storage/implementation/db.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/db.ts
@@ -17,6 +17,7 @@ import {
   SyncRuleDocumentBase,
   WriteCheckpointDocument
 } from './models.js';
+import { MongoWriteBatch } from './MongoWriteBatch.js';
 import {
   BucketDataDocumentV1,
   BucketParameterDocument,
@@ -54,9 +55,25 @@ export class PowerSyncMongo {
 
   readonly client: mongo.MongoClient;
   readonly db: mongo.Db;
+  private clientBulkWriteSupport = false;
+
+  createWriteBatch(session: mongo.ClientSession | undefined, options: { ordered: boolean }): MongoWriteBatch {
+    return new MongoWriteBatch(this.client, () => this.clientBulkWriteSupport, session, options);
+  }
 
   constructor(client: mongo.MongoClient, options?: PowerSyncMongoOptions) {
     this.client = client;
+
+    // Register before connecting to reuse the driver's handshakes. MongoDB 8.0
+    // introduced client bulkWrite at wire version 25. Unknown / mixed-version
+    // topologies use collection writes until all known servers support it.
+    client.on('topologyDescriptionChanged', ({ newDescription }) => {
+      const servers = [...newDescription.servers.values()];
+      this.clientBulkWriteSupport = servers.length > 0 && servers.every((server) => server.maxWireVersion >= 25);
+    });
+    client.on('topologyClosed', () => {
+      this.clientBulkWriteSupport = false;
+    });
 
     const db = client.db(options?.database, {
       ...storage.BSON_DESERIALIZE_INTERNAL_OPTIONS

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoBucketBatchV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoBucketBatchV1.ts
@@ -55,8 +55,15 @@ export class MongoBucketBatchV1 extends MongoBucketBatch {
     session: mongo.ClientSession,
     opId: InternalOpId
   ): Promise<void> {
+    // Only the final checkpoint per user/stream is visible after this transaction.
+    const checkpoints = new Map(
+      this.write_checkpoint_batch.map((checkpoint) => [
+        JSON.stringify([checkpoint.sync_rules_id, checkpoint.user_id]),
+        checkpoint
+      ])
+    );
     await this.db.custom_write_checkpoints.bulkWrite(
-      this.write_checkpoint_batch.map((checkpointOptions) => {
+      [...checkpoints.values()].map((checkpointOptions) => {
         const set: Record<string, unknown> = {
           checkpoint: checkpointOptions.checkpoint,
           sync_rules_id: checkpointOptions.sync_rules_id,
@@ -77,7 +84,7 @@ export class MongoBucketBatchV1 extends MongoBucketBatch {
           }
         };
       }),
-      { session }
+      { session, ordered: false }
     );
   }
 
@@ -462,7 +469,9 @@ export class MongoBucketBatchV1 extends MongoBucketBatch {
     const ids = tables.map((table) => mongoTableId(table.id));
 
     await this.withTransaction(async () => {
-      await this.db.sourceTablesV1(this.replicationStreamId).updateMany(
+      const writes = this.db.createWriteBatch(session, { ordered: false });
+      writes.updateMany(
+        this.db.sourceTablesV1(this.replicationStreamId),
         { _id: { $in: ids } },
         {
           $set: {
@@ -471,12 +480,12 @@ export class MongoBucketBatchV1 extends MongoBucketBatch {
           $unset: {
             snapshot_status: 1
           }
-        },
-        { session }
+        }
       );
 
       if (no_checkpoint_before_lsn != null) {
-        await this.db.sync_rules.updateOne(
+        writes.updateOne(
+          this.db.sync_rules,
           {
             _id: this.replicationStreamId
           },
@@ -487,10 +496,10 @@ export class MongoBucketBatchV1 extends MongoBucketBatch {
             $max: {
               no_checkpoint_before: no_checkpoint_before_lsn
             }
-          },
-          { session: this.session }
+          }
         );
       }
+      await writes.execute();
     });
     return tables.map((table) => {
       const copy = table.clone();

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/MongoCompactorV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/MongoCompactorV1.ts
@@ -13,6 +13,7 @@ import { BucketDefinitionId } from '@powersync/service-sync-rules';
 import { BucketDataDoc } from '../common/BucketDataDoc.js';
 import { BucketStateDocumentBase, LEGACY_BUCKET_DATA_DEFINITION_ID } from '../models.js';
 import { MongoCompactOptions, MongoCompactor } from '../MongoCompactor.js';
+import { MongoWriteBatch } from '../MongoWriteBatch.js';
 import { cacheKey } from '../OperationBatch.js';
 import { BucketDataDocumentV1, BucketStateDocumentV1 } from './models.js';
 import type { MongoSyncBucketStorageV1 } from './MongoSyncBucketStorageV1.js';
@@ -296,11 +297,10 @@ export class MongoCompactorV1 extends MongoCompactor {
   }
 
   private async flushBucketStateUpdates() {
-    if (this.bucketStateUpdates.length > 0) {
-      this.logger.info(`Updating ${this.bucketStateUpdates.length} bucket states`);
-      await this.writeBucketStateUpdates();
-      this.bucketStateUpdates = [];
-    }
+    const writes = this.db.createWriteBatch(undefined, { ordered: false });
+    this.writeBucketStateUpdates(writes);
+    await writes.execute();
+    this.bucketStateUpdates = [];
   }
 
   private async updateChecksumsBatch(buckets: Pick<DirtyBucket, 'bucket' | 'definitionId'>[]) {
@@ -340,10 +340,12 @@ export class MongoCompactorV1 extends MongoCompactor {
     await this.flushBucketStateUpdates();
   }
 
-  protected async writeBucketStateUpdates(): Promise<void> {
-    await this.db.bucketStateV1.bulkWrite(
-      this.bucketStateUpdates as mongo.AnyBulkWriteOperation<BucketStateDocumentV1>[],
-      { ordered: false }
+  protected writeBucketStateUpdates(writes: MongoWriteBatch): void {
+    if (this.bucketStateUpdates.length === 0) return;
+    this.logger.info(`Updating ${this.bucketStateUpdates.length} bucket states`);
+    writes.bulkWriteUnordered(
+      this.db.bucketStateV1,
+      this.bucketStateUpdates as mongo.AnyBulkWriteOperation<BucketStateDocumentV1>[]
     );
   }
 
@@ -541,17 +543,19 @@ export class MongoCompactorV1 extends MongoCompactor {
   }
 
   private async flush(bucketContext: SingleBucketStoreV1) {
+    // Persist data changes before advertising the resulting bucket state.
+    const writes = this.db.createWriteBatch(undefined, { ordered: true });
     if (this.updates.length > 0) {
       this.logger.info(`Compacting ${this.updates.length} ops`);
-      await bucketContext.collection.bulkWrite(this.updates, {
-        // Order is not important. Since checksums are not affected, these operations can happen in any order,
-        // and it's fine if the operations are partially applied. Each individual operation is atomic.
-        ordered: false
-      });
-      this.updates = [];
+      // Order is not important. Since checksums are not affected, these operations can happen in any order,
+      // and it's fine if the operations are partially applied. Each individual operation is atomic.
+      writes.bulkWriteUnordered(bucketContext.collection, this.updates);
     }
 
-    await this.flushBucketStateUpdates();
+    this.writeBucketStateUpdates(writes);
+    await writes.execute();
+    this.updates = [];
+    this.bucketStateUpdates = [];
   }
 
   /**
@@ -622,15 +626,13 @@ export class MongoCompactorV1 extends MongoCompactor {
             }
 
             this.logger.info(`Flushing CLEAR for ${numberOfOpsToClear} ops at ${lastOp?.o}`);
-            await bucketContext.collection.deleteMany(
-              {
-                _id: {
-                  $gte: bucketContext.minId,
-                  $lte: bucketContext.docId(lastOp!.o)
-                }
-              },
-              { session }
-            );
+            const writes = this.db.createWriteBatch(session, { ordered: true });
+            writes.deleteMany(bucketContext.collection, {
+              _id: {
+                $gte: bucketContext.minId,
+                $lte: bucketContext.docId(lastOp!.o)
+              }
+            });
 
             const op = bucketContext.toPersistedDocument({
               o: lastOp!.o,
@@ -639,7 +641,8 @@ export class MongoCompactorV1 extends MongoCompactor {
               data: null,
               target_op: targetOp
             });
-            await bucketContext.collection.insertOne(op, { session });
+            writes.insertOne(bucketContext.collection, op);
+            await writes.execute();
 
             opCountDiff = -numberOfOpsToClear + 1;
           },

--- a/modules/module-mongodb-storage/src/storage/implementation/v1/PersistedBatchV1.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v1/PersistedBatchV1.ts
@@ -6,6 +6,7 @@ import * as bson from 'bson';
 import { BucketDataSource, BucketDefinitionId } from '@powersync/service-sync-rules';
 import { mongoTableId } from '../../../utils/util.js';
 import { EMPTY_DATA } from '../MongoBucketBatchShared.js';
+import { MongoWriteBatch } from '../MongoWriteBatch.js';
 import {
   BucketStateUpdate,
   PersistedBatch,
@@ -25,7 +26,9 @@ import {
 export class PersistedBatchV1 extends PersistedBatch {
   declare protected readonly db: VersionedPowerSyncMongoV1;
 
-  currentData: mongo.AnyBulkWriteOperation<CurrentDataDocument>[] = [];
+  // Each upsert supplies the complete source-record state. Only its final
+  // state matters within a flush; bucket and parameter history is kept separately.
+  currentData = new Map<string, mongo.AnyBulkWriteOperation<CurrentDataDocument>>();
 
   protected checkDefinitionId(_definitionId: BucketDefinitionId | null): BucketDefinitionId {
     // V1 storage doesn't persist the id, and we don't use it.
@@ -94,7 +97,7 @@ export class PersistedBatchV1 extends PersistedBatch {
   }
 
   hardDeleteCurrentData(sourceTableId: bson.ObjectId, replicaId: storage.ReplicaId) {
-    this.currentData.push({
+    this.currentData.set(this.currentDataKey(sourceTableId, replicaId), {
       deleteOne: {
         filter: { _id: this.currentDataId(sourceTableId, replicaId) }
       }
@@ -124,7 +127,7 @@ export class PersistedBatchV1 extends PersistedBatch {
       return lookup.lookup;
     });
 
-    this.currentData.push({
+    this.currentData.set(this.currentDataKey(values.sourceTableId, values.replicaId), {
       updateOne: {
         filter: { _id: this.currentDataId(values.sourceTableId, values.replicaId) },
         update: {
@@ -141,57 +144,45 @@ export class PersistedBatchV1 extends PersistedBatch {
   }
 
   protected get currentDataCount() {
-    return this.currentData.length;
+    return this.currentData.size;
   }
 
-  protected async flushBucketData(session: mongo.ClientSession) {
-    await this.db.bucketDataV1.bulkWrite(
+  protected async queueBucketData(writes: MongoWriteBatch) {
+    writes.bulkWriteUnordered(
+      this.db.bucketDataV1,
       this.bucketData.map((document) => ({
         insertOne: {
           document: serializeBucketDataV1(document)
         }
-      })),
-      {
-        session,
-        ordered: false
-      }
+      }))
     );
   }
 
-  protected async flushBucketParameters(session: mongo.ClientSession) {
-    await this.db.parameterIndexV1.bulkWrite(
+  protected queueBucketParameters(writes: MongoWriteBatch): void {
+    writes.bulkWriteUnordered(
+      this.db.parameterIndexV1,
       this.bucketParameters.map((document) => ({
         insertOne: {
           document: taggedBucketParameterDocumentToV1(document)
         }
-      })),
-      {
-        session,
-        ordered: false
-      }
+      }))
     );
   }
 
-  protected async flushCurrentData(session: mongo.ClientSession) {
-    if (this.currentData.length == 0) {
+  protected queueCurrentData(writes: MongoWriteBatch): void {
+    if (this.currentData.size == 0) {
       return;
     }
 
-    await this.db.sourceRecordsV1.bulkWrite(this.currentData, {
-      session,
-      ordered: true
-    });
+    writes.bulkWriteUnordered(this.db.sourceRecordsV1, [...this.currentData.values()]);
   }
 
-  protected async flushBucketStates(session: mongo.ClientSession) {
-    await this.db.bucketStateV1.bulkWrite(this.getBucketStateUpdates(), {
-      session,
-      ordered: false
-    });
+  protected queueBucketStates(writes: MongoWriteBatch): void {
+    writes.bulkWriteUnordered(this.db.bucketStateV1, this.getBucketStateUpdates());
   }
 
   protected resetCurrentData() {
-    this.currentData = [];
+    this.currentData.clear();
   }
 
   private getBucketStateUpdates(): mongo.AnyBulkWriteOperation<BucketStateDocumentV1>[] {
@@ -217,6 +208,10 @@ export class PersistedBatchV1 extends PersistedBatch {
         }
       } satisfies mongo.AnyBulkWriteOperation<BucketStateDocumentV1>;
     });
+  }
+
+  private currentDataKey(sourceTableId: bson.ObjectId, replicaId: storage.ReplicaId): string {
+    return Buffer.from(bson.serialize({ t: sourceTableId, k: replicaId })).toString('base64');
   }
 
   private currentDataId(sourceTableId: bson.ObjectId, replicaId: storage.ReplicaId): SourceKey {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoBucketBatchV3.ts
@@ -7,6 +7,7 @@ import { mongoTableId } from '../../../utils/util.js';
 import { canCheckpointState } from '../CheckpointState.js';
 import { MongoBucketBatch, MongoBucketBatchOptions } from '../MongoBucketBatch.js';
 import { MongoParsedSyncConfigSet } from '../MongoParsedSyncConfigSet.js';
+import { MongoWriteBatch } from '../MongoWriteBatch.js';
 import { stopReplicationStreamPipeline } from '../SyncRuleStateUpdate.js';
 import { PersistedBatch } from '../common/PersistedBatch.js';
 import { SourceRecordStore } from '../common/SourceRecordStore.js';
@@ -60,14 +61,12 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
     return this.store;
   }
 
-  protected override async onReplicationTransactionFlush(
-    session: lib_mongo.mongo.ClientSession,
-    lastOp: bigint
-  ): Promise<void> {
+  protected override onReplicationTransactionFlush(writes: MongoWriteBatch, lastOp: bigint): void {
     // Durably advance the stream-level head of persisted ops within the flush transaction.
     // This ensures a checkpoint created later (even by an empty commit, or by a freshly-appended
     // config that replicates nothing) covers all ops persisted before a potential crash.
-    await this.db.sync_rules.updateOne(
+    writes.updateOne(
+      this.db.sync_rules,
       {
         _id: this.replicationStreamId
       },
@@ -75,8 +74,7 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
         $max: {
           last_persisted_op: lastOp
         }
-      },
-      { session }
+      }
     );
   }
 
@@ -652,7 +650,9 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
     const syncConfigIds = this.relevantSyncConfigIdsForTables(tables);
 
     await this.withTransaction(async () => {
-      await this.db.sourceTables(this.replicationStreamId).updateMany(
+      const writes = this.db.createWriteBatch(session, { ordered: false });
+      writes.updateMany(
+        this.db.sourceTables(this.replicationStreamId),
         { _id: { $in: ids } },
         {
           $set: {
@@ -661,12 +661,12 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
           $unset: {
             snapshot_status: 1
           }
-        },
-        { session }
+        }
       );
 
       if (no_checkpoint_before_lsn != null && syncConfigIds.length > 0) {
-        await this.db.sync_rules.updateOne(
+        writes.updateOne(
+          this.db.sync_rules,
           {
             _id: this.replicationStreamId,
             'sync_configs._id': { $in: syncConfigIds }
@@ -680,12 +680,12 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
             }
           },
           {
-            session: this.session,
             // Only set for sync configs that use this table
             arrayFilters: [{ 'config._id': { $in: syncConfigIds } }]
           }
         );
       }
+      await writes.execute();
     });
     return tables.map((table) => {
       const copy = table.clone();
@@ -706,9 +706,11 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
       this.validateCustomCheckpointEventId(checkpoint.event_id)
     );
 
+    const writes = this.db.createWriteBatch(session, { ordered: false });
     for (const [eventId, checkpoints] of checkpointsByEvent) {
-      await this.batchCreateEventCustomWriteCheckpoints(session, opId, eventId, checkpoints);
+      this.batchCreateEventCustomWriteCheckpoints(writes, opId, eventId, checkpoints);
     }
+    await writes.execute();
   }
 
   protected override async prepareCustomWriteCheckpoints(): Promise<void> {
@@ -741,48 +743,48 @@ export class MongoBucketBatchV3 extends MongoBucketBatch {
     return eventId;
   }
 
-  private async batchCreateEventCustomWriteCheckpoints(
-    session: lib_mongo.mongo.ClientSession,
+  private batchCreateEventCustomWriteCheckpoints(
+    writes: MongoWriteBatch,
     opId: InternalOpId,
     eventId: EventDefinitionId,
     checkpoints: storage.CustomWriteCheckpointOptions[]
-  ): Promise<void> {
-    await this.db
-      .customCheckpointRequests({
+  ): void {
+    // A repeated user within an event replaces the complete checkpoint state.
+    const uniqueCheckpoints = new Map(checkpoints.map((checkpoint) => [checkpoint.user_id, checkpoint]));
+    writes.bulkWriteUnordered(
+      this.db.customCheckpointRequests({
         eventId,
         replicationStreamId: this.replicationStreamId
-      })
-      .bulkWrite(
-        checkpoints.map((checkpointOptions) => {
-          const set: Partial<CustomCheckpointRequestDocumentV3> = {
-            user_id: checkpointOptions.user_id,
-            checkpoint: checkpointOptions.checkpoint,
-            op_id: opId
-          };
-          if (checkpointOptions.checkpoint_requested_at != null) {
-            set.checkpoint_requested_at = checkpointOptions.checkpoint_requested_at;
-          }
+      }),
+      [...uniqueCheckpoints.values()].map((checkpointOptions) => {
+        const set: Partial<CustomCheckpointRequestDocumentV3> = {
+          user_id: checkpointOptions.user_id,
+          checkpoint: checkpointOptions.checkpoint,
+          op_id: opId
+        };
+        if (checkpointOptions.checkpoint_requested_at != null) {
+          set.checkpoint_requested_at = checkpointOptions.checkpoint_requested_at;
+        }
 
-          return {
-            updateOne: {
-              filter: {
-                user_id: checkpointOptions.user_id
-              },
-              update: {
-                $set: set,
-                ...(checkpointOptions.checkpoint_requested_at == null
-                  ? {
-                      $unset: {
-                        checkpoint_requested_at: 1
-                      }
+        return {
+          updateOne: {
+            filter: {
+              user_id: checkpointOptions.user_id
+            },
+            update: {
+              $set: set,
+              ...(checkpointOptions.checkpoint_requested_at == null
+                ? {
+                    $unset: {
+                      checkpoint_requested_at: 1
                     }
-                  : {})
-              },
-              upsert: true
-            }
-          };
-        }),
-        { session }
-      );
+                  }
+                : {})
+            },
+            upsert: true
+          }
+        };
+      })
+    );
   }
 }

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
@@ -5,6 +5,7 @@ import { BucketDefinitionId } from '@powersync/service-sync-rules';
 import { BucketDataDoc } from '../common/BucketDataDoc.js';
 import { BucketDataKey } from '../models.js';
 import { ConcurrentCompactionError, MongoCompactor } from '../MongoCompactor.js';
+import { MongoWriteBatch } from '../MongoWriteBatch.js';
 import { cacheKey } from '../OperationBatch.js';
 import { loadBucketDataDocument, maxOpId, serializeBucketData } from './bucket-format.js';
 import { BucketDataContextV3 } from './BucketDataContextV3.js';
@@ -987,10 +988,13 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
             );
           }
 
-          await bucketContext.collection.deleteMany({ _id: { $in: idsToDelete } }, { session });
-          await bucketContext.collection.insertMany(documents, { session });
-          await this.finishObjectStorageReplacement(oldStoragePaths, newStoragePaths, uploads, session);
-          await this.recordObjectStorageReplacement(oldStorageBytes, documents, context.definitionId, session);
+          // Replacement documents can reuse deleted IDs, so retain delete-before-insert ordering.
+          const writes = this.db.createWriteBatch(session, { ordered: true });
+          writes.deleteMany(bucketContext.collection, { _id: { $in: idsToDelete } });
+          writes.insertMany(bucketContext.collection, documents);
+          this.finishObjectStorageReplacement(oldStoragePaths, newStoragePaths, uploads, writes);
+          this.recordObjectStorageReplacement(oldStorageBytes, documents, context.definitionId, writes);
+          await writes.execute();
         },
         {
           writeConcern: { w: 'majority' },
@@ -1165,15 +1169,13 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
 
         prepared ??= await this.prepareCompactionUploads(bucket, context, [lastNotPut]);
         this.logger.info(`Flushing CLEAR for ${clearedOpCount} ops at ${lastDocId?.o}`);
-        await collection.deleteMany(
-          {
-            _id: {
-              $gte: bucketContext.minId,
-              $lte: lastDocId!
-            }
-          },
-          { session }
-        );
+        const writes = this.db.createWriteBatch(session, { ordered: true });
+        writes.deleteMany(collection, {
+          _id: {
+            $gte: bucketContext.minId,
+            $lte: lastDocId!
+          }
+        });
 
         const clearOp = {
           bucketKey: { ...context, bucket },
@@ -1185,9 +1187,10 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
         const persisted = await this.persistBucketData(bucket, [[clearOp]], context, prepared, {
           targetOp: maxTargetOp
         });
-        await collection.insertOne(persisted.documents[0], { session });
-        await this.finishObjectStorageReplacement(oldStoragePaths, persisted.storagePaths, persisted.uploads, session);
-        await this.recordObjectStorageReplacement(oldStorageBytes, persisted.documents, context.definitionId, session);
+        writes.insertOne(collection, persisted.documents[0]);
+        this.finishObjectStorageReplacement(oldStoragePaths, persisted.storagePaths, persisted.uploads, writes);
+        this.recordObjectStorageReplacement(oldStorageBytes, persisted.documents, context.definitionId, writes);
+        await writes.execute();
 
         opCountDiff = -clearedOpCount + 1;
         before = inputStats;
@@ -1307,15 +1310,13 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
         }
 
         this.logger.info(`Flushing CLEAR for ${clearedOpCount} ops at ${lastNotPut}`);
-        await collection.deleteMany(
-          {
-            _id: {
-              $gte: bucketContext.minId,
-              $lte: boundaryDocId
-            }
-          },
-          { session }
-        );
+        const writes = this.db.createWriteBatch(session, { ordered: true });
+        writes.deleteMany(collection, {
+          _id: {
+            $gte: bucketContext.minId,
+            $lte: boundaryDocId
+          }
+        });
 
         const clearOp = {
           bucketKey: { ...context, bucket },
@@ -1333,9 +1334,10 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
         const persisted = await this.persistBucketData(bucket, chunks, context, prepared, {
           targetOp: maxTargetOp ?? undefined
         });
-        await collection.insertMany(persisted.documents, { session });
-        await this.finishObjectStorageReplacement(oldStoragePaths, persisted.storagePaths, persisted.uploads, session);
-        await this.recordObjectStorageReplacement(oldStorageBytes, persisted.documents, context.definitionId, session);
+        writes.insertMany(collection, persisted.documents);
+        this.finishObjectStorageReplacement(oldStoragePaths, persisted.storagePaths, persisted.uploads, writes);
+        this.recordObjectStorageReplacement(oldStorageBytes, persisted.documents, context.definitionId, writes);
+        await writes.execute();
 
         opCountDiff = -clearedOpCount + 1;
         before = inputStats;
@@ -1374,28 +1376,28 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
   }
 
   /** Publish replacement uploads and retire superseded objects in the same transaction. */
-  private async finishObjectStorageReplacement(
+  private finishObjectStorageReplacement(
     oldStoragePaths: Iterable<string>,
     newStoragePaths: Set<string>,
     uploads: PreparedObjectStorageUpload[],
-    session: mongo.ClientSession
-  ): Promise<void> {
+    writes: MongoWriteBatch
+  ): void {
     if (!this.storage.objectStorage) {
       return;
     }
-    await this.objectStorageLifecycle.publishUploads(uploads, session);
-    await this.objectStorageLifecycle.retire(
+    this.objectStorageLifecycle.publishUploads(uploads, writes);
+    this.objectStorageLifecycle.retire(
       Array.from(oldStoragePaths).filter((path) => !newStoragePaths.has(path)),
-      session
+      writes
     );
   }
 
-  private async recordObjectStorageReplacement(
+  private recordObjectStorageReplacement(
     oldBytes: bigint,
     newDocuments: Iterable<Pick<BucketDataDocumentV3, 'storage_ref'>>,
     definitionId: BucketDefinitionId,
-    session: mongo.ClientSession
-  ): Promise<void> {
+    writes: MongoWriteBatch
+  ): void {
     if (!this.storage.objectStorage) {
       return;
     }
@@ -1403,7 +1405,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
     for (const document of newDocuments) {
       newBytes += ObjectStorageUsage.bytes(document);
     }
-    await this.objectStorageUsage.applyDelta(definitionId, newBytes - oldBytes, session);
+    this.objectStorageUsage.applyDelta(definitionId, newBytes - oldBytes, writes);
   }
 
   private async persistBucketData(

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/PersistedBatchV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/PersistedBatchV3.ts
@@ -13,6 +13,7 @@ import {
   UpsertCurrentDataOptions
 } from '../common/PersistedBatch.js';
 import { SourceRecordLookupState } from '../common/SourceRecordStore.js';
+import { MongoWriteBatch } from '../MongoWriteBatch.js';
 import { serializeBucketData } from './bucket-format.js';
 import { chunkBucketData } from './chunking.js';
 import { DEFAULT_MIN_COMPACT_CHUNK_INTERVAL_MS } from './compaction-constants.js';
@@ -28,8 +29,15 @@ import { ObjectStorageLifecycle } from './object-storage/ObjectStorageLifecycle.
 import { ObjectStorageUsage } from './object-storage/ObjectStorageUsage.js';
 import { VersionedPowerSyncMongoV3 } from './VersionedPowerSyncMongoV3.js';
 
+interface SourceRecordWrite {
+  sourceTableId: bson.ObjectId;
+  operation: mongo.AnyBulkWriteOperation<CurrentDataDocumentV3>;
+}
+
 export class PersistedBatchV3 extends PersistedBatch {
-  currentData: { sourceTableId: bson.ObjectId; operation: mongo.AnyBulkWriteOperation<CurrentDataDocumentV3> }[] = [];
+  // Upserts and soft deletes supply the complete source-record state, including
+  // pending_delete. Keep the final state per key, without removing any history.
+  currentData = new Map<string, SourceRecordWrite>();
   sourceTablePendingDeletes = new Map<string, InternalOpId>();
   protected readonly objectStorageLifecycle?: ObjectStorageLifecycle;
   protected readonly objectStorageUsage?: ObjectStorageUsage;
@@ -131,7 +139,7 @@ export class PersistedBatchV3 extends PersistedBatch {
   }
 
   hardDeleteCurrentData(sourceTableId: bson.ObjectId, replicaId: storage.ReplicaId) {
-    this.currentData.push({
+    this.currentData.set(this.currentDataKey(sourceTableId, replicaId), {
       sourceTableId,
       operation: {
         deleteOne: {
@@ -147,7 +155,7 @@ export class PersistedBatchV3 extends PersistedBatch {
     replicaId: storage.ReplicaId,
     checkpointGreaterThan: InternalOpId
   ) {
-    this.currentData.push({
+    this.currentData.set(this.currentDataKey(sourceTableId, replicaId), {
       sourceTableId,
       operation: {
         updateOne: {
@@ -195,7 +203,7 @@ export class PersistedBatchV3 extends PersistedBatch {
       };
     });
 
-    this.currentData.push({
+    this.currentData.set(this.currentDataKey(values.sourceTableId, values.replicaId), {
       sourceTableId: values.sourceTableId,
       operation: {
         updateOne: {
@@ -216,12 +224,12 @@ export class PersistedBatchV3 extends PersistedBatch {
   }
 
   protected get currentDataCount() {
-    return this.currentData.length;
+    return this.currentData.size;
   }
 
   // Flush methods
 
-  protected async flushBucketData(session: mongo.ClientSession) {
+  protected async queueBucketData(writes: MongoWriteBatch) {
     const operationsByDefinition = new Map<BucketDefinitionId, BucketDataDoc[]>();
     for (const document of this.bucketData) {
       const existing = operationsByDefinition.get(document.bucketKey.definitionId) ?? [];
@@ -284,10 +292,10 @@ export class PersistedBatchV3 extends PersistedBatch {
     // S3ObjectStorage applies one shared concurrency limit across all callers,
     // so replication can schedule its uploads together without creating a
     // separate limiter here.
-    const writes = await createAllInserts();
+    const bucketWrites = await createAllInserts();
 
     const usageDeltas = this.objectStorageUsage == null ? undefined : new Map<BucketDefinitionId, bigint>();
-    for (const { definitionId, inserts } of writes) {
+    for (const { definitionId, inserts } of bucketWrites) {
       if (usageDeltas != null) {
         const delta = inserts.reduce(
           (sum, operation) => sum + ObjectStorageUsage.bytes(operation.insertOne.document),
@@ -298,18 +306,15 @@ export class PersistedBatchV3 extends PersistedBatch {
         }
       }
       if (inserts.length > 0) {
-        await this.db.bucketData(this.group_id, definitionId).bulkWrite(inserts, {
-          session,
-          ordered: false
-        });
+        writes.bulkWriteUnordered(this.db.bucketData(this.group_id, definitionId), inserts);
       }
     }
     if (usageDeltas != null) {
-      await this.objectStorageUsage!.applyDeltas(usageDeltas, session);
+      this.objectStorageUsage!.applyDeltas(usageDeltas, writes);
     }
   }
 
-  protected async flushBucketParameters(session: mongo.ClientSession) {
+  protected queueBucketParameters(writes: MongoWriteBatch): void {
     const operationsByIndex = new Map<string, typeof this.bucketParameters>();
     for (const document of this.bucketParameters) {
       const existing = operationsByIndex.get(document.index) ?? [];
@@ -318,23 +323,20 @@ export class PersistedBatchV3 extends PersistedBatch {
     }
 
     for (const [indexId, documents] of operationsByIndex.entries()) {
-      await this.db.parameterIndex(this.group_id, indexId).bulkWrite(
+      writes.bulkWriteUnordered(
+        this.db.parameterIndex(this.group_id, indexId),
         documents.map((document) => ({
           insertOne: {
             document: taggedBucketParameterDocumentToTagged(document)
           }
-        })),
-        {
-          session,
-          ordered: false
-        }
+        }))
       );
     }
   }
 
-  protected async flushCurrentData(session: mongo.ClientSession) {
-    const operationsBySourceTable = new Map<string, typeof this.currentData>();
-    for (const operation of this.currentData) {
+  protected queueCurrentData(writes: MongoWriteBatch): void {
+    const operationsBySourceTable = new Map<string, SourceRecordWrite[]>();
+    for (const operation of this.currentData.values()) {
       const sourceTableId = operation.sourceTableId.toHexString();
       const existing = operationsBySourceTable.get(sourceTableId) ?? [];
       existing.push(operation);
@@ -357,31 +359,29 @@ export class PersistedBatchV3 extends PersistedBatch {
     });
 
     if (sourceTableUpdates.length > 0) {
-      await this.db.sourceTables(this.group_id).bulkWrite(sourceTableUpdates, { session, ordered: false });
+      writes.bulkWriteUnordered(this.db.sourceTables(this.group_id), sourceTableUpdates);
     }
 
     for (const operations of operationsBySourceTable.values()) {
       const sourceTableId = operations[0]!.sourceTableId;
-      await this.db.sourceRecords(this.group_id, sourceTableId).bulkWrite(
-        operations.map((entry) => entry.operation),
-        {
-          session,
-          ordered: true
-        }
+      writes.bulkWriteUnordered(
+        this.db.sourceRecords(this.group_id, sourceTableId),
+        operations.map((entry) => entry.operation)
       );
     }
   }
 
-  protected async flushBucketStates(session: mongo.ClientSession) {
-    await this.db.bucketState(this.group_id).bulkWrite(this.getBucketStateUpdates(), {
-      session,
-      ordered: false
-    });
+  protected queueBucketStates(writes: MongoWriteBatch): void {
+    writes.bulkWriteUnordered(this.db.bucketState(this.group_id), this.getBucketStateUpdates());
   }
 
   protected resetCurrentData() {
-    this.currentData = [];
+    this.currentData.clear();
     this.sourceTablePendingDeletes.clear();
+  }
+
+  private currentDataKey(sourceTableId: bson.ObjectId, replicaId: storage.ReplicaId): string {
+    return Buffer.from(bson.serialize({ t: sourceTableId, k: replicaId })).toString('base64');
   }
 
   private getBucketStateUpdates(): mongo.AnyBulkWriteOperation<BucketStateDocumentV3>[] {

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageLifecycle.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageLifecycle.ts
@@ -1,7 +1,7 @@
-import { mongo } from '@powersync/lib-service-mongodb';
 import { Logger } from '@powersync/lib-services-framework';
 import * as bson from 'bson';
 import { createHash, randomUUID } from 'node:crypto';
+import { MongoWriteBatch } from '../../MongoWriteBatch.js';
 import { ObjectStorageDeletionMarker } from '../models.js';
 import { VersionedPowerSyncMongoV3 } from '../VersionedPowerSyncMongoV3.js';
 import { BucketDataObjectStorage } from './BucketDataObjectStorage.js';
@@ -93,7 +93,7 @@ export class ObjectStorageLifecycle {
    *
    * Call this in the same transaction as the one creating the references.
    */
-  async publishUploads(uploads: PreparedObjectStorageUpload[], session: mongo.ClientSession): Promise<void> {
+  publishUploads(uploads: PreparedObjectStorageUpload[], writes: MongoWriteBatch): void {
     for (const upload of uploads) {
       if (!this.canPublish(upload)) {
         throw new Error(`Object storage publication lease expired for ${upload.path}`);
@@ -103,12 +103,13 @@ export class ObjectStorageLifecycle {
       return;
     }
 
-    const result = await this.db
-      .pendingObjectStorageDeletes(this.replicationStreamId)
-      .deleteMany({ _id: { $in: uploads.map((upload) => upload.markerId) } }, { session });
-    if (result.deletedCount !== uploads.length) {
-      throw new Error(`Missing object storage publication markers`);
-    }
+    writes.deleteMany(
+      this.db.pendingObjectStorageDeletes(this.replicationStreamId),
+      { _id: { $in: uploads.map((upload) => upload.markerId) } },
+      (deletedCount) => {
+        if (deletedCount !== uploads.length) throw new Error('Missing object storage publication markers');
+      }
+    );
   }
 
   /**
@@ -122,14 +123,14 @@ export class ObjectStorageLifecycle {
    *
    * Call this in the same transaction as the one removing the references to these files.
    */
-  async retire(paths: Iterable<string>, session: mongo.ClientSession, now = new Date()): Promise<void> {
+  retire(paths: Iterable<string>, writes: MongoWriteBatch, now = new Date()): void {
     const markers: ObjectStorageDeletionMarker[] = Array.from(paths, (path) => ({
       _id: new bson.ObjectId(),
       path,
       delete_after: new Date(now.getTime() + OBJECT_STORAGE_REFERENCE_GRACE_MS)
     }));
     if (markers.length) {
-      await this.db.pendingObjectStorageDeletes(this.replicationStreamId).insertMany(markers, { session });
+      writes.insertMany(this.db.pendingObjectStorageDeletes(this.replicationStreamId), markers);
     }
   }
 

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/object-storage/ObjectStorageUsage.ts
@@ -3,6 +3,7 @@ import { mongo } from '@powersync/lib-service-mongodb';
 import { ReplicationAssertionError } from '@powersync/lib-services-framework';
 import { BucketDefinitionId } from '@powersync/service-sync-rules';
 import { randomUUID } from 'node:crypto';
+import { MongoWriteBatch } from '../../MongoWriteBatch.js';
 import { BucketDataDocumentV3, ObjectStorageUsageDocument } from '../models.js';
 import { VersionedPowerSyncMongoV3 } from '../VersionedPowerSyncMongoV3.js';
 
@@ -93,11 +94,11 @@ export class ObjectStorageUsage {
     });
   }
 
-  async applyDelta(definitionId: BucketDefinitionId, delta: bigint, session: mongo.ClientSession): Promise<void> {
-    await this.applyDeltas(new Map([[definitionId, delta]]), session);
+  applyDelta(definitionId: BucketDefinitionId, delta: bigint, writes: MongoWriteBatch): void {
+    this.applyDeltas(new Map([[definitionId, delta]]), writes);
   }
 
-  async applyDeltas(deltas: ReadonlyMap<BucketDefinitionId, bigint>, session: mongo.ClientSession): Promise<void> {
+  applyDeltas(deltas: ReadonlyMap<BucketDefinitionId, bigint>, writes: MongoWriteBatch): void {
     if (this.writerId == null) {
       throw new ReplicationAssertionError('A writer id is required to apply object-storage usage');
     }
@@ -113,13 +114,11 @@ export class ObjectStorageUsage {
       return;
     }
 
-    await this.db.objectStorageUsage.updateOne(
+    writes.updateOne(
+      this.db.objectStorageUsage,
       { _id: this.documentId() },
-      {
-        $inc: increments,
-        $currentDate: { updated_at: true }
-      },
-      { upsert: true, session }
+      { $inc: increments, $currentDate: { updated_at: true } },
+      { upsert: true }
     );
   }
 

--- a/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
+++ b/modules/module-mongodb-storage/test/src/object_storage_usage.test.ts
@@ -123,14 +123,18 @@ describe('ObjectStorageUsage', () => {
       await expect(
         withTransaction(db, async (session) => {
           await bucketData.insertOne(document, { session });
-          await usage.applyDelta(definitionId, 123n, session);
+          const writes = db.createWriteBatch(session, { ordered: false });
+          usage.applyDelta(definitionId, 123n, writes);
+          await writes.execute();
           throw new Error('abort this attempt');
         })
       ).rejects.toThrow('abort this attempt');
 
       await withTransaction(db, async (session) => {
         await bucketData.insertOne(document, { session });
-        await usage.applyDelta(definitionId, 123n, session);
+        const writes = db.createWriteBatch(session, { ordered: false });
+        usage.applyDelta(definitionId, 123n, writes);
+        await writes.execute();
       });
 
       expect(await bucketData.countDocuments({ storage_ref: { $exists: true } })).toBe(1);
@@ -182,7 +186,11 @@ describe('ObjectStorageUsage', () => {
       const writerId = 'reused-writer';
       const usage = new ObjectStorageUsage(db, replicationStreamId, writerId);
 
-      await withTransaction(db, (session) => usage.applyDelta(definitionId, 10n, session));
+      await withTransaction(db, async (session) => {
+        const writes = db.createWriteBatch(session, { ordered: false });
+        usage.applyDelta(definitionId, 10n, writes);
+        await writes.execute();
+      });
       await db.objectStorageUsage.updateOne(
         { _id: { g: replicationStreamId, w: writerId } },
         { $set: { updated_at: new Date(0) } }
@@ -191,7 +199,11 @@ describe('ObjectStorageUsage', () => {
 
       // The folder committed first and deleted the writer shard. The writer's
       // next transaction must recreate it through the upsert.
-      await withTransaction(db, (session) => usage.applyDelta(definitionId, 4n, session));
+      await withTransaction(db, async (session) => {
+        const writes = db.createWriteBatch(session, { ordered: false });
+        usage.applyDelta(definitionId, 4n, writes);
+        await writes.execute();
+      });
       expect((await readUsageEntries(db, replicationStreamId))[0].active_bytes).toBe(14n);
 
       await db.objectStorageUsage.updateOne(


### PR DESCRIPTION
This uses the new client-level [bulkWrite](https://www.mongodb.com/docs/v8.0/reference/command/bulkWrite/#mongodb-dbcommand-dbcmd.bulkWrite) command for storage operations on MongoDB 8.0+.

This is different from the connection-level bulkWrite command:
1. The same command can be used for writes across multiple collections.
2. Different operation types such as insertOne and updateMany can be used in the same wire command, even with `ordered: true`.

The collection-level bulkWrite command could do only one operation type at a time. So if you had an ordered bulkWrite with say `insertOne, updateOne, insertOne, insertOne`, it would send 3 wire-level commands instead of 1, which can add significant latency.

In addition to using the client-level bulkWrite when available, this now de-duplicates all records client-side, so we never need a collection-level bulkWrite with `ordered: true`, even on older MongoDB versions.

We still keep our implementation compatible with MongoDB 6 and 7, by falling back to individual operations and collection-level bulkWrite.

We can expect some replication latency improvements here, especially with `storage_version: 4` on many different bucket definitions. We can also expect minor replication throughput improvements due to the decrease in latency.

## Expected changes on MongoDB 8.0

_V1 = `storage_version: 2`; V3 = `storage_version: 4`, we match the implementation names here._

| Modified operation                                                                                           | Before → after                                |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
| V1 replication flush, including transaction tail                                                             | **5–6 → 2**                                   |
| V3 inline replication flush, including transaction tail                                                      | **6–8 → 2**                                   |
| V3 with S3 replication flush, including transaction tail                                                          | **7–9 → 2**                                   |
| V1/V3 mark tables’ snapshots complete, including checkpoint barrier                                          | **2 → 1**                                     |
| V3 replicated custom checkpoints across E event collections                                                  | **E → 1**                                     |
| V1 replicated custom checkpoints                                                                             | **1 → 1**, fewer operations when users repeat |
| Managed-checkpoint creation, generated or supplied IDs                                                       | **1 → 1**, now unordered                      |
| V1 compaction: flush data changes and bucket state                                                           | **2–3 → 1**                                   |
| V1 compaction: replace operations with CLEAR                                                                 | **2 → 1**                                     |
| V3 inline compaction: replacement, leading CLEAR, or boundary CLEAR                                          | **2 → 1**                                     |
| V3 with S3 compaction: those same three operations, including publication/retirement markers and usage accounting | **Up to 5 → 1**                               |

The replication figures assume one persisted-data flush, one bucket definition,
and one source table. The ranges reflect optional parameter writes and V3
delete-watermark updates. Additional V3 collections increase the old count while
still fitting into one new data bulk.

Previously, V1 ordered source-record bulks could split into many commands when
updates and deletes alternated. This is the main case affected by previously-ordered collection-level bulkWrite. Client-side de-duplication now eliminate that extra fragmentation.

MongoDB 6/7 retain separate collection commands, but still benefit from deduplication and unordered writes. Large requests can require multiple commands;
client-bulk result cursors can also require additional `getMore` commands.

## Implementation

A new `MongoWriteBatch` class handles the client-level bulkWrite command with fallback support.

No new tests added - the implementation is covered by existing regression tests.

For source-record writes and write checkpoints, we now de-duplicate operations before doing a bulkWrite, allowing us to use unordered writes. For the rest, we mostly preserve the previous behavior.

## AI Usage

Implemented using Codex gpt-6-astra. Manually checked all changes. The above table is also generated using Codex.
