### PR TITLE
fix (MongoDB): Improve Schema detection

### DIFF
--- a/.changeset/mongodb-schema-aggregation.md
+++ b/.changeset/mongodb-schema-aggregation.md
@@ -5,3 +5,5 @@
 Infer MongoDB collection schemas using aggregation so large sampled documents are not transferred into service memory. Query each collection in its own database with up to four aggregations at a time, and limit each aggregation to 30 seconds of server execution time.
 
 Omit the aggregation collation option on Azure DocumentDB, which does not support it.
+
+Cache DocumentDB detection on the route adapter for schema discovery and checkpoint requests.

--- a/.changeset/mongodb-schema-aggregation.md
+++ b/.changeset/mongodb-schema-aggregation.md
@@ -3,3 +3,5 @@
 ---
 
 Infer MongoDB collection schemas using aggregation so large sampled documents are not transferred into service memory. Query each collection in its own database, process databases sequentially, and limit each aggregation to 30 seconds of server execution time.
+
+Omit the aggregation collation option on Azure DocumentDB, which does not support it.

--- a/.changeset/mongodb-schema-aggregation.md
+++ b/.changeset/mongodb-schema-aggregation.md
@@ -2,6 +2,6 @@
 '@powersync/service-module-mongodb': patch
 ---
 
-Infer MongoDB collection schemas using aggregation so large sampled documents are not transferred into service memory. Query each collection in its own database, process databases sequentially, and limit each aggregation to 30 seconds of server execution time.
+Infer MongoDB collection schemas using aggregation so large sampled documents are not transferred into service memory. Query each collection in its own database with up to four aggregations at a time, and limit each aggregation to 30 seconds of server execution time.
 
 Omit the aggregation collation option on Azure DocumentDB, which does not support it.

--- a/.changeset/mongodb-schema-aggregation.md
+++ b/.changeset/mongodb-schema-aggregation.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mongodb': patch
+---
+
+Infer MongoDB collection schemas using aggregation so large sampled documents are not transferred into service memory. Query each collection in its own database, process databases sequentially, and limit each aggregation to 30 seconds of server execution time.

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -226,6 +226,7 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
   }
 
   async getConnectionSchema(): Promise<service_types.DatabaseSchema[]> {
+    const isDocumentDb = await detectDocumentDb(this.db);
     const databases = await this.db.admin().listDatabases({ nameOnly: true });
     const filteredDatabases = databases.databases.filter((db) => {
       return !['local', 'admin', 'config'].includes(db.name);
@@ -263,7 +264,10 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
           continue;
         }
         try {
-          const columns = await inferCollectionSchema(this.client.db(db.name).collection(collection.name));
+          const columns = await inferCollectionSchema(
+            this.client.db(db.name).collection(collection.name),
+            isDocumentDb
+          );
           tables.push({ name: collection.name, columns });
         } catch (e) {
           if (lib_mongo.isMongoServerError(e) && e.codeName == 'Unauthorized') {

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -8,10 +8,10 @@ import { logger } from '@powersync/lib-services-framework';
 import { CheckpointImplementation } from '../replication/checkpoints/CheckpointImplementation.js';
 import { createCheckpointImplementation } from '../replication/checkpoints/create-checkpoint-implementation.js';
 import { MongoManager } from '../replication/MongoManager.js';
-import { constructAfterRecord } from '../replication/MongoRelation.js';
 import { CHECKPOINTS_COLLECTION, detectDocumentDb } from '../replication/replication-utils.js';
 import * as types from '../types/types.js';
 import { escapeRegExp } from '../utils.js';
+import { inferCollectionSchema } from './infer-collection-schema.js';
 
 export class MongoRouteAPIAdapter implements api.RouteAPI {
   protected client: mongo.MongoClient;
@@ -226,159 +226,59 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
   }
 
   async getConnectionSchema(): Promise<service_types.DatabaseSchema[]> {
-    const sampleSize = 50;
-
     const databases = await this.db.admin().listDatabases({ nameOnly: true });
     const filteredDatabases = databases.databases.filter((db) => {
       return !['local', 'admin', 'config'].includes(db.name);
     });
-    const databaseSchemas = await Promise.all(
-      filteredDatabases.map(async (db) => {
-        /**
-         * Filtering the list of database with `authorizedDatabases: true`
-         * does not produce the full list of databases under some circumstances.
-         * This catches any potential auth errors.
-         */
-        let collections: mongo.CollectionInfo[];
+    const databaseSchemas: service_types.DatabaseSchema[] = [];
+    // Infer one database at a time to avoid accumulating concurrent aggregation results.
+    for (const db of filteredDatabases) {
+      /**
+       * Filtering the list of database with `authorizedDatabases: true`
+       * does not produce the full list of databases under some circumstances.
+       * This catches any potential auth errors.
+       */
+      let collections: mongo.CollectionInfo[];
+      try {
+        collections = await this.client.db(db.name).listCollections().toArray();
+      } catch (e) {
+        if (lib_mongo.isMongoServerError(e) && e.codeName == 'Unauthorized') {
+          // Ignore databases we're not authorized to query
+          continue;
+        }
+        throw e;
+      }
+
+      let tables: service_types.TableSchema[] = [];
+      for (let collection of collections) {
+        if ([CHECKPOINTS_COLLECTION].includes(collection.name)) {
+          continue;
+        }
+        if (collection.name.startsWith('system.')) {
+          // system.views, system.js, system.profile, system.buckets
+          // https://www.mongodb.com/docs/manual/reference/system-collections/
+          continue;
+        }
+        if (collection.type == 'view') {
+          continue;
+        }
         try {
-          collections = await this.client.db(db.name).listCollections().toArray();
+          const columns = await inferCollectionSchema(this.client.db(db.name).collection(collection.name));
+          tables.push({ name: collection.name, columns });
         } catch (e) {
           if (lib_mongo.isMongoServerError(e) && e.codeName == 'Unauthorized') {
-            // Ignore databases we're not authorized to query
-            return null;
+            // Ignore collections we're not authorized to query
+            continue;
           }
           throw e;
         }
-
-        let tables: service_types.TableSchema[] = [];
-        for (let collection of collections) {
-          if ([CHECKPOINTS_COLLECTION].includes(collection.name)) {
-            continue;
-          }
-          if (collection.name.startsWith('system.')) {
-            // system.views, system.js, system.profile, system.buckets
-            // https://www.mongodb.com/docs/manual/reference/system-collections/
-            continue;
-          }
-          if (collection.type == 'view') {
-            continue;
-          }
-          try {
-            const sampleDocuments = await this.db
-              .collection(collection.name)
-              .aggregate([{ $sample: { size: sampleSize } }])
-              .toArray();
-
-            if (sampleDocuments.length > 0) {
-              const columns = this.getColumnsFromDocuments(sampleDocuments);
-
-              tables.push({
-                name: collection.name,
-                // Since documents are sampled in a random order, we need to sort
-                // to get a consistent order
-                columns: columns.sort((a, b) => a.name.localeCompare(b.name))
-              });
-            } else {
-              tables.push({
-                name: collection.name,
-                columns: []
-              });
-            }
-          } catch (e) {
-            if (lib_mongo.isMongoServerError(e) && e.codeName == 'Unauthorized') {
-              // Ignore collections we're not authorized to query
-              continue;
-            }
-            throw e;
-          }
-        }
-
-        return {
-          name: db.name,
-          tables: tables
-        } satisfies service_types.DatabaseSchema;
-      })
-    );
-    return databaseSchemas.filter((schema) => !!schema);
-  }
-
-  private getColumnsFromDocuments(documents: mongo.BSON.Document[]) {
-    let columns = new Map<string, { sqliteType: sync_rules.ExpressionType; bsonTypes: Set<string> }>();
-    for (const document of documents) {
-      const parsed = constructAfterRecord(document);
-      for (const key in parsed) {
-        const value = parsed[key];
-        const type = sync_rules.sqliteTypeOf(value);
-        const sqliteType = sync_rules.ExpressionType.fromTypeText(type);
-        let entry = columns.get(key);
-        if (entry == null) {
-          entry = { sqliteType, bsonTypes: new Set() };
-          columns.set(key, entry);
-        } else {
-          entry.sqliteType = entry.sqliteType.or(sqliteType);
-        }
-        const bsonType = this.getBsonType(document[key]);
-        if (bsonType != null) {
-          entry.bsonTypes.add(bsonType);
-        }
       }
-    }
-    return [...columns.entries()].map(([key, value]) => {
-      const internal_type = value.bsonTypes.size == 0 ? '' : [...value.bsonTypes].join(' | ');
-      return {
-        name: key,
-        type: internal_type,
-        sqlite_type: value.sqliteType.typeFlags,
-        internal_type,
-        pg_type: internal_type
-      };
-    });
-  }
 
-  private getBsonType(data: any): string | null {
-    if (data == null) {
-      // null or undefined
-      return 'Null';
-    } else if (typeof data == 'string') {
-      return 'String';
-    } else if (typeof data == 'number') {
-      if (Number.isInteger(data)) {
-        return 'Integer';
-      } else {
-        return 'Double';
-      }
-    } else if (typeof data == 'bigint') {
-      return 'Long';
-    } else if (typeof data == 'boolean') {
-      return 'Boolean';
-    } else if (data instanceof mongo.ObjectId) {
-      return 'ObjectId';
-    } else if (data instanceof mongo.UUID) {
-      return 'UUID';
-    } else if (data instanceof Date) {
-      return 'Date';
-    } else if (data instanceof mongo.Timestamp) {
-      return 'Timestamp';
-    } else if (data instanceof mongo.Binary) {
-      return 'Binary';
-    } else if (data instanceof mongo.Long) {
-      return 'Long';
-    } else if (data instanceof RegExp) {
-      return 'RegExp';
-    } else if (data instanceof mongo.MinKey) {
-      return 'MinKey';
-    } else if (data instanceof mongo.MaxKey) {
-      return 'MaxKey';
-    } else if (data instanceof mongo.Decimal128) {
-      return 'Decimal';
-    } else if (Array.isArray(data)) {
-      return 'Array';
-    } else if (data instanceof Uint8Array) {
-      return 'Binary';
-    } else if (typeof data == 'object') {
-      return 'Object';
-    } else {
-      return null;
+      databaseSchemas.push({
+        name: db.name,
+        tables: tables
+      });
     }
+    return databaseSchemas;
   }
 }

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -13,6 +13,8 @@ import * as types from '../types/types.js';
 import { escapeRegExp } from '../utils.js';
 import { inferCollectionSchema } from './infer-collection-schema.js';
 
+const SCHEMA_INFERENCE_CONCURRENCY = 4;
+
 export class MongoRouteAPIAdapter implements api.RouteAPI {
   protected client: mongo.MongoClient;
   public db: mongo.Db;
@@ -232,7 +234,6 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
       return !['local', 'admin', 'config'].includes(db.name);
     });
     const databaseSchemas: service_types.DatabaseSchema[] = [];
-    // Infer one database at a time to avoid accumulating concurrent aggregation results.
     for (const db of filteredDatabases) {
       /**
        * Filtering the list of database with `authorizedDatabases: true`
@@ -250,37 +251,64 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
         throw e;
       }
 
-      let tables: service_types.TableSchema[] = [];
-      for (let collection of collections) {
-        if ([CHECKPOINTS_COLLECTION].includes(collection.name)) {
-          continue;
-        }
-        if (collection.name.startsWith('system.')) {
-          // system.views, system.js, system.profile, system.buckets
-          // https://www.mongodb.com/docs/manual/reference/system-collections/
-          continue;
-        }
-        if (collection.type == 'view') {
-          continue;
-        }
-        try {
-          const columns = await inferCollectionSchema(
-            this.client.db(db.name).collection(collection.name),
-            isDocumentDb
-          );
-          tables.push({ name: collection.name, columns });
-        } catch (e) {
-          if (lib_mongo.isMongoServerError(e) && e.codeName == 'Unauthorized') {
-            // Ignore collections we're not authorized to query
+      const tables: (service_types.TableSchema | undefined)[] = new Array(collections.length);
+      const pendingCollections = collections.entries();
+      let failed = false;
+      const inferCollections = async () => {
+        // Reading from the iterator automatically manages the queue
+        for (const [index, collection] of pendingCollections) {
+          if (failed) {
+            return;
+          }
+          if ([CHECKPOINTS_COLLECTION].includes(collection.name)) {
             continue;
           }
-          throw e;
+          if (collection.name.startsWith('system.')) {
+            // system.views, system.js, system.profile, system.buckets
+            // https://www.mongodb.com/docs/manual/reference/system-collections/
+            continue;
+          }
+          if (collection.type == 'view') {
+            continue;
+          }
+          try {
+            const columns = await inferCollectionSchema(
+              this.client.db(db.name).collection(collection.name),
+              isDocumentDb
+            );
+            // Preserve collection order even when queries finish out of order.
+            tables[index] = { name: collection.name, columns };
+          } catch (e) {
+            if (lib_mongo.isMongoServerError(e) && e.codeName == 'Unauthorized') {
+              // Ignore collections we're not authorized to query
+              continue;
+            }
+            // Fail the whole request on unexpected errors: the response cannot indicate
+            // partial results, so omitting a collection would make an incomplete schema
+            // appear complete and could produce an incorrect generated client schema.
+            failed = true;
+            throw e;
+          }
         }
+      };
+
+      // Each worker holds only schema metadata, with a bounded number of source queries.
+      const workers = Array.from(
+        { length: Math.min(SCHEMA_INFERENCE_CONCURRENCY, collections.length) },
+        inferCollections
+      );
+      try {
+        await Promise.all(workers);
+      } catch (e) {
+        // Finish in-flight queries before rejecting the request. Workers stop taking
+        // new collections as soon as one encounters a non-authorization error.
+        await Promise.allSettled(workers);
+        throw e;
       }
 
       databaseSchemas.push({
         name: db.name,
-        tables: tables
+        tables: tables.filter((table) => table != null)
       });
     }
     return databaseSchemas;

--- a/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
+++ b/modules/module-mongodb/src/api/MongoRouteAPIAdapter.ts
@@ -23,6 +23,7 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
   defaultSchema: string;
 
   private checkpointImplementation: CheckpointImplementation | null = null;
+  private documentDbDetection: Promise<boolean> | null = null;
 
   constructor(protected config: types.ResolvedConnectionConfig) {
     const manager = new MongoManager(config);
@@ -208,9 +209,18 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
     return checkpointImplementation.createReplicationHead(callback);
   }
 
+  private isDocumentDb(): Promise<boolean> {
+    // Share in-flight detection and cache its result for this adapter's lifetime.
+    return (this.documentDbDetection ??= detectDocumentDb(this.db).catch((error) => {
+      // Allow a later request to retry after a transient connection error.
+      this.documentDbDetection = null;
+      throw error;
+    }));
+  }
+
   private async getCheckpointImplementation(): Promise<CheckpointImplementation> {
     if (this.checkpointImplementation == null) {
-      const isDocumentDb = await detectDocumentDb(this.db);
+      const isDocumentDb = await this.isDocumentDb();
       this.checkpointImplementation = createCheckpointImplementation(isDocumentDb, {
         client: this.client,
         db: this.db,
@@ -228,7 +238,7 @@ export class MongoRouteAPIAdapter implements api.RouteAPI {
   }
 
   async getConnectionSchema(): Promise<service_types.DatabaseSchema[]> {
-    const isDocumentDb = await detectDocumentDb(this.db);
+    const isDocumentDb = await this.isDocumentDb();
     const databases = await this.db.admin().listDatabases({ nameOnly: true });
     const filteredDatabases = databases.databases.filter((db) => {
       return !['local', 'admin', 'config'].includes(db.name);

--- a/modules/module-mongodb/src/api/infer-collection-schema.ts
+++ b/modules/module-mongodb/src/api/infer-collection-schema.ts
@@ -32,7 +32,10 @@ const BSON_TYPES: Record<string, { name: string; sqliteType: ExpressionType }> =
  * Infer top-level fields without transferring sampled document values to the service.
  * Memory on the service scales with the inferred schema, not the size of those values.
  */
-export async function inferCollectionSchema(collection: mongo.Collection): Promise<TableSchema['columns']> {
+export async function inferCollectionSchema(
+  collection: mongo.Collection,
+  isDocumentDb: boolean
+): Promise<TableSchema['columns']> {
   const fields = await collection
     .aggregate<{ _id: string; types: string[] }>(
       [
@@ -102,7 +105,8 @@ export async function inferCollectionSchema(collection: mongo.Collection): Promi
         // memory limit, instead of failing schema inference.
         allowDiskUse: true,
         // Field names are case-sensitive even when the collection's default collation isn't.
-        collation: { locale: 'simple' }
+        // DocumentDB rejects the collation option, including simple collation.
+        ...(isDocumentDb ? {} : { collation: { locale: 'simple' } })
       }
     )
     .toArray();

--- a/modules/module-mongodb/src/api/infer-collection-schema.ts
+++ b/modules/module-mongodb/src/api/infer-collection-schema.ts
@@ -100,10 +100,10 @@ export async function inferCollectionSchema(
         // Bound execution per collection below the default 60-second socket timeout
         // so MongoDB can return a query timeout before the connection times out.
         maxTimeMS: 30_000,
-        // When $sample can't use a random cursor, it sorts full documents before the
-        // projection. Allow that sort to spill to disk if large documents exceed its
-        // memory limit, instead of failing schema inference.
-        allowDiskUse: true,
+        // Small collections can require $sample to sort full documents. Disable
+        // disk spill explicitly so concurrent schema queries fail at the memory
+        // limit without adding temporary-file I/O on the source database.
+        allowDiskUse: false,
         // Field names are case-sensitive even when the collection's default collation isn't.
         // DocumentDB rejects the collation option, including simple collation.
         ...(isDocumentDb ? {} : { collation: { locale: 'simple' } })

--- a/modules/module-mongodb/src/api/infer-collection-schema.ts
+++ b/modules/module-mongodb/src/api/infer-collection-schema.ts
@@ -1,0 +1,123 @@
+import { mongo } from '@powersync/lib-service-mongodb';
+import { ExpressionType } from '@powersync/service-sync-rules';
+import { TableSchema } from '@powersync/service-types';
+
+// Match the types exposed after BSON deserialization and conversion to sync rules values.
+const BSON_TYPES: Record<string, { name: string; sqliteType: ExpressionType }> = {
+  int: { name: 'Integer', sqliteType: ExpressionType.INTEGER },
+  long: { name: 'Long', sqliteType: ExpressionType.INTEGER },
+  double: { name: 'Double', sqliteType: ExpressionType.REAL },
+  decimal: { name: 'Decimal', sqliteType: ExpressionType.TEXT },
+  string: { name: 'String', sqliteType: ExpressionType.TEXT },
+  symbol: { name: 'String', sqliteType: ExpressionType.TEXT },
+  bool: { name: 'Boolean', sqliteType: ExpressionType.INTEGER },
+  objectId: { name: 'ObjectId', sqliteType: ExpressionType.TEXT },
+  uuid: { name: 'UUID', sqliteType: ExpressionType.TEXT },
+  binData: { name: 'Binary', sqliteType: ExpressionType.BLOB },
+  date: { name: 'Date', sqliteType: ExpressionType.TEXT },
+  timestamp: { name: 'Timestamp', sqliteType: ExpressionType.INTEGER },
+  regex: { name: 'RegExp', sqliteType: ExpressionType.TEXT },
+  object: { name: 'Object', sqliteType: ExpressionType.TEXT },
+  array: { name: 'Array', sqliteType: ExpressionType.TEXT },
+  javascript: { name: 'Object', sqliteType: ExpressionType.TEXT },
+  javascriptWithScope: { name: 'Object', sqliteType: ExpressionType.TEXT },
+  dbPointer: { name: 'Object', sqliteType: ExpressionType.TEXT },
+  null: { name: 'Null', sqliteType: ExpressionType.NONE },
+  undefined: { name: 'Null', sqliteType: ExpressionType.NONE },
+  minKey: { name: 'MinKey', sqliteType: ExpressionType.NONE },
+  maxKey: { name: 'MaxKey', sqliteType: ExpressionType.NONE }
+};
+
+/**
+ * Infer top-level fields without transferring sampled document values to the service.
+ * Memory on the service scales with the inferred schema, not the size of those values.
+ */
+export async function inferCollectionSchema(collection: mongo.Collection): Promise<TableSchema['columns']> {
+  const fields = await collection
+    .aggregate<{ _id: string; types: string[] }>(
+      [
+        // Keep this first so MongoDB can use its random cursor on large collections.
+        { $sample: { size: 50 } },
+        {
+          $project: {
+            _id: 0,
+            fields: {
+              $map: {
+                input: { $objectToArray: '$$ROOT' },
+                as: 'field',
+                in: {
+                  name: '$$field.k',
+                  type: {
+                    $let: {
+                      vars: { bsonType: { $type: '$$field.v' } },
+                      in: {
+                        $switch: {
+                          branches: [
+                            {
+                              case: { $eq: ['$$bsonType', 'double'] },
+                              // Whole-number doubles are replicated as SQLite integers.
+                              then: { $cond: [{ $eq: [{ $mod: ['$$field.v', 1] }, 0] }, 'int', 'double'] }
+                            },
+                            {
+                              case: { $eq: ['$$bsonType', 'binData'] },
+                              then: {
+                                $cond: [
+                                  // BinData compares by length, then subtype, then bytes. Only
+                                  // 16-byte values of subtype 4 fall within this UUID range.
+                                  // This works without transferring binary values or requiring
+                                  // the newer MongoDB binary conversion operators.
+                                  // https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/#bindata
+                                  {
+                                    $and: [
+                                      { $gte: ['$$field.v', new mongo.UUID('00000000-0000-0000-0000-000000000000')] },
+                                      { $lte: ['$$field.v', new mongo.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff')] }
+                                    ]
+                                  },
+                                  'uuid',
+                                  'binData'
+                                ]
+                              }
+                            }
+                          ],
+                          default: '$$bsonType'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        // Discard values before unwinding so large documents aren't duplicated per field.
+        { $unwind: '$fields' },
+        { $group: { _id: '$fields.name', types: { $addToSet: '$fields.type' } } }
+      ],
+      {
+        // Bound execution per collection below the default 60-second socket timeout
+        // so MongoDB can return a query timeout before the connection times out.
+        maxTimeMS: 30_000,
+        // When $sample can't use a random cursor, it sorts full documents before the
+        // projection. Allow that sort to spill to disk if large documents exceed its
+        // memory limit, instead of failing schema inference.
+        allowDiskUse: true,
+        // Field names are case-sensitive even when the collection's default collation isn't.
+        collation: { locale: 'simple' }
+      }
+    )
+    .toArray();
+
+  return fields
+    .map(({ _id: name, types }) => {
+      let sqliteType = ExpressionType.NONE;
+      const bsonTypes = new Set<string>();
+      for (const type of types) {
+        const inferred = BSON_TYPES[type];
+        sqliteType = sqliteType.or(inferred.sqliteType);
+        bsonTypes.add(inferred.name);
+      }
+      const internal_type = [...bsonTypes].sort().join(' | ');
+      return { name, type: internal_type, sqlite_type: sqliteType.typeFlags, internal_type, pg_type: internal_type };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/modules/module-mongodb/test/src/schema.test.ts
+++ b/modules/module-mongodb/test/src/schema.test.ts
@@ -1,0 +1,209 @@
+import { mongo } from '@powersync/lib-service-mongodb';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { inferCollectionSchema } from '@module/api/infer-collection-schema.js';
+import { MongoRouteAPIAdapter } from '@module/api/MongoRouteAPIAdapter.js';
+import { DATABASE_TYPE, DatabaseType } from './DatabaseType.js';
+import { connectMongoData, requireFailCommand, TEST_CONNECTION_OPTIONS } from './util.js';
+
+describe('collection schema inference', () => {
+  let client: mongo.MongoClient;
+  let db: mongo.Db;
+
+  beforeEach(async () => {
+    ({ client } = await connectMongoData({ monitorCommands: true }));
+    db = client.db(`${TEST_CONNECTION_OPTIONS.database}_schema`);
+    await db.dropDatabase();
+  });
+
+  afterEach(async () => {
+    await db.dropDatabase();
+    await client.close();
+  });
+
+  test('merges types across documents and only infers top-level fields', async () => {
+    const collection = db.collection('mixed');
+    await collection.insertMany([
+      {
+        _id: 1 as any,
+        value: null,
+        whole: new mongo.Double(42),
+        huge: new mongo.Double(1e100),
+        fractional: new mongo.Double(-1.25),
+        nan: NaN,
+        positiveInfinity: Infinity,
+        negativeInfinity: -Infinity,
+        long: mongo.Long.fromString('9007199254740993'),
+        array: [{ nested: 'value' }],
+        object: { nested: true }
+      },
+      { _id: 2 as any, value: 'text', whole: new mongo.Int32(-42), array: [] },
+      { _id: 3 as any, value: 42, whole: new mongo.Double(-0) },
+      { _id: 4 as any, value: 1.25 },
+      { _id: 5 as any, value: new mongo.Double(42) }
+    ]);
+
+    expect(await inferCollectionSchema(collection)).toMatchObject([
+      { name: '_id', sqlite_type: 4, internal_type: 'Integer' },
+      { name: 'array', sqlite_type: 2, internal_type: 'Array' },
+      { name: 'fractional', sqlite_type: 8, internal_type: 'Double' },
+      { name: 'huge', sqlite_type: 4, internal_type: 'Integer' },
+      { name: 'long', sqlite_type: 4, internal_type: 'Long' },
+      { name: 'nan', sqlite_type: 8, internal_type: 'Double' },
+      { name: 'negativeInfinity', sqlite_type: 8, internal_type: 'Double' },
+      { name: 'object', sqlite_type: 2, internal_type: 'Object' },
+      { name: 'positiveInfinity', sqlite_type: 8, internal_type: 'Double' },
+      { name: 'value', sqlite_type: 14, internal_type: 'Double | Integer | Null | String' },
+      { name: 'whole', sqlite_type: 4, internal_type: 'Integer' }
+    ]);
+  });
+
+  test('distinguishes UUIDs from binary values by subtype and length', async () => {
+    const collection = db.collection('binary');
+    await collection.insertMany([
+      {
+        _id: 1 as any,
+        uuid: new mongo.UUID('00000000-0000-0000-0000-000000000000'),
+        binary: new mongo.Binary(Buffer.alloc(16)),
+        mixed: new mongo.UUID()
+      },
+      {
+        _id: 2 as any,
+        uuid: new mongo.UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
+        binary: new mongo.Binary(Buffer.alloc(16, 255)),
+        mixed: new mongo.Binary(Buffer.alloc(16), mongo.Binary.SUBTYPE_UUID_OLD)
+      },
+      {
+        _id: 3 as any,
+        uuid: new mongo.UUID(),
+        binary: new mongo.Binary(Buffer.alloc(16), mongo.Binary.SUBTYPE_MD5)
+      },
+      { _id: 4 as any, binary: new mongo.Binary(Buffer.alloc(15, 255), mongo.Binary.SUBTYPE_USER_DEFINED) },
+      { _id: 5 as any, binary: new mongo.Binary(Buffer.alloc(17)) },
+      { _id: 6 as any, binary: new mongo.Binary(Buffer.alloc(0)) }
+    ]);
+
+    expect(await inferCollectionSchema(collection)).toMatchObject([
+      { name: '_id', sqlite_type: 4, internal_type: 'Integer' },
+      { name: 'binary', sqlite_type: 1, internal_type: 'Binary' },
+      { name: 'mixed', sqlite_type: 3, internal_type: 'Binary | UUID' },
+      { name: 'uuid', sqlite_type: 2, internal_type: 'UUID' }
+    ]);
+  });
+
+  test('handles empty collections and documents with only an id', async () => {
+    const collection = await db.createCollection('empty');
+    expect(await inferCollectionSchema(collection)).toEqual([]);
+
+    await collection.insertOne({});
+    expect(await inferCollectionSchema(collection)).toEqual([
+      { name: '_id', sqlite_type: 2, type: 'ObjectId', internal_type: 'ObjectId', pg_type: 'ObjectId' }
+    ]);
+  });
+
+  test.skipIf(DATABASE_TYPE == DatabaseType.DOCUMENTDB)(
+    'preserves field names with a non-simple collation',
+    async () => {
+      const collection = await db.createCollection('collation', { collation: { locale: 'en', strength: 1 } });
+      await collection.insertOne({ Name: 'text', name: 1, 'with.dot': true, $field: [] });
+
+      const columns = await inferCollectionSchema(collection);
+      expect(columns).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Name', sqlite_type: 2 }),
+          expect.objectContaining({ name: 'name', sqlite_type: 4 }),
+          expect.objectContaining({ name: 'with.dot', sqlite_type: 4 }),
+          expect.objectContaining({ name: '$field', internal_type: 'Array' })
+        ])
+      );
+      expect(columns).toHaveLength(5);
+    }
+  );
+
+  test('returns only small schema metadata for multi-megabyte documents', async () => {
+    const collection = db.collection('large');
+    const largeString = 'x'.repeat(2 * 1024 * 1024);
+    for (let i = 0; i < 4; i++) {
+      await collection.insertOne({ text: largeString, binary: Buffer.alloc(2 * 1024 * 1024), array: [largeString] });
+    }
+
+    const responseSizes: number[] = [];
+    const executionLimits: number[] = [];
+    client.on('commandStarted', (event: mongo.CommandStartedEvent) => {
+      if (event.commandName == 'aggregate') {
+        executionLimits.push(event.command.maxTimeMS);
+      }
+    });
+    client.on('commandSucceeded', (event: mongo.CommandSucceededEvent) => {
+      if (event.commandName == 'aggregate' || event.commandName == 'getMore') {
+        responseSizes.push(mongo.BSON.calculateObjectSize(event.reply as mongo.Document));
+      }
+    });
+
+    expect(await inferCollectionSchema(collection)).toMatchObject([
+      { name: '_id', sqlite_type: 2, internal_type: 'ObjectId' },
+      { name: 'array', sqlite_type: 2, internal_type: 'Array' },
+      { name: 'binary', sqlite_type: 1, internal_type: 'Binary' },
+      { name: 'text', sqlite_type: 2, internal_type: 'String' }
+    ]);
+    expect(responseSizes.length).toBeGreaterThan(0);
+    expect(Math.max(...responseSizes)).toBeLessThan(4096);
+    expect(executionLimits).toEqual([30_000]);
+  });
+
+  test.skipIf(DATABASE_TYPE == DatabaseType.DOCUMENTDB)('fails schema inference on a query timeout', async (ctx) => {
+    await db.collection('timeout').insertOne({ value: 'text' });
+    await using adapter = new MongoRouteAPIAdapter({
+      type: 'mongodb',
+      ...TEST_CONNECTION_OPTIONS,
+      database: db.databaseName
+    });
+    await using failCommand = await requireFailCommand(client, ctx);
+    await failCommand.configure({
+      mode: { times: 1 },
+      data: {
+        failCommands: ['aggregate'],
+        errorCode: 50 // MaxTimeMSExpired
+      }
+    });
+
+    // Exercise the real server/driver error path without waiting for the full timeout.
+    await expect(adapter.getConnectionSchema()).rejects.toMatchObject({
+      name: 'MongoServerError',
+      code: 50,
+      codeName: 'MaxTimeMSExpired'
+    });
+  });
+
+  test('queries collections in their own database', async () => {
+    const otherDb = client.db(`${db.databaseName}_other`);
+    try {
+      await otherDb.dropDatabase();
+      await db.collection('shared').insertOne({ local: true });
+      await otherDb.collection('shared').insertOne({ remote: 'text' });
+      await otherDb.createCollection('empty');
+      await using adapter = new MongoRouteAPIAdapter({
+        type: 'mongodb',
+        ...TEST_CONNECTION_OPTIONS,
+        database: db.databaseName
+      });
+
+      const schema = await adapter.getConnectionSchema();
+      expect(schema.find((database) => database.name == db.databaseName)?.tables).toMatchObject([
+        {
+          name: 'shared',
+          columns: [{ name: '_id' }, { name: 'local', sqlite_type: 4 }]
+        }
+      ]);
+      const tables = schema.find((database) => database.name == otherDb.databaseName)?.tables;
+      expect(tables).toHaveLength(2);
+      expect(tables?.find((table) => table.name == 'shared')?.columns).toMatchObject([
+        { name: '_id' },
+        { name: 'remote', sqlite_type: 2 }
+      ]);
+      expect(tables?.find((table) => table.name == 'empty')?.columns).toEqual([]);
+    } finally {
+      await otherDb.dropDatabase();
+    }
+  });
+});

--- a/modules/module-mongodb/test/src/schema.test.ts
+++ b/modules/module-mongodb/test/src/schema.test.ts
@@ -177,36 +177,4 @@ describe('collection schema inference', { timeout: testTimeout(20_000) }, () => 
       codeName: 'MaxTimeMSExpired'
     });
   });
-
-  test('queries collections in their own database', async () => {
-    const otherDb = client.db(`${db.databaseName}_other`);
-    try {
-      await otherDb.dropDatabase();
-      await db.collection('shared').insertOne({ local: true });
-      await otherDb.collection('shared').insertOne({ remote: 'text' });
-      await otherDb.createCollection('empty');
-      await using adapter = new MongoRouteAPIAdapter({
-        type: 'mongodb',
-        ...TEST_CONNECTION_OPTIONS,
-        database: db.databaseName
-      });
-
-      const schema = await adapter.getConnectionSchema();
-      expect(schema.find((database) => database.name == db.databaseName)?.tables).toMatchObject([
-        {
-          name: 'shared',
-          columns: [{ name: '_id' }, { name: 'local', sqlite_type: 4 }]
-        }
-      ]);
-      const tables = schema.find((database) => database.name == otherDb.databaseName)?.tables;
-      expect(tables).toHaveLength(2);
-      expect(tables?.find((table) => table.name == 'shared')?.columns).toMatchObject([
-        { name: '_id' },
-        { name: 'remote', sqlite_type: 2 }
-      ]);
-      expect(tables?.find((table) => table.name == 'empty')?.columns).toEqual([]);
-    } finally {
-      await otherDb.dropDatabase();
-    }
-  });
 });

--- a/modules/module-mongodb/test/src/schema.test.ts
+++ b/modules/module-mongodb/test/src/schema.test.ts
@@ -4,9 +4,12 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { inferCollectionSchema } from '@module/api/infer-collection-schema.js';
 import { MongoRouteAPIAdapter } from '@module/api/MongoRouteAPIAdapter.js';
 import { DATABASE_TYPE, DatabaseType } from './DatabaseType.js';
+import { testTimeout } from './test-timeouts.js';
 import { connectMongoData, requireFailCommand, TEST_CONNECTION_OPTIONS } from './util.js';
 
-describe('collection schema inference', () => {
+const isDocumentDb = DATABASE_TYPE == DatabaseType.DOCUMENTDB;
+
+describe('collection schema inference', { timeout: testTimeout(20_000) }, () => {
   let client: mongo.MongoClient;
   let db: mongo.Db;
 
@@ -43,7 +46,7 @@ describe('collection schema inference', () => {
       { _id: 5 as any, value: new mongo.Double(42) }
     ]);
 
-    expect(await inferCollectionSchema(collection)).toMatchObject([
+    expect(await inferCollectionSchema(collection, isDocumentDb)).toMatchObject([
       { name: '_id', sqlite_type: 4, internal_type: 'Integer' },
       { name: 'array', sqlite_type: 2, internal_type: 'Array' },
       { name: 'fractional', sqlite_type: 8, internal_type: 'Double' },
@@ -83,7 +86,7 @@ describe('collection schema inference', () => {
       { _id: 6 as any, binary: new mongo.Binary(Buffer.alloc(0)) }
     ]);
 
-    expect(await inferCollectionSchema(collection)).toMatchObject([
+    expect(await inferCollectionSchema(collection, isDocumentDb)).toMatchObject([
       { name: '_id', sqlite_type: 4, internal_type: 'Integer' },
       { name: 'binary', sqlite_type: 1, internal_type: 'Binary' },
       { name: 'mixed', sqlite_type: 3, internal_type: 'Binary | UUID' },
@@ -93,10 +96,10 @@ describe('collection schema inference', () => {
 
   test('handles empty collections and documents with only an id', async () => {
     const collection = await db.createCollection('empty');
-    expect(await inferCollectionSchema(collection)).toEqual([]);
+    expect(await inferCollectionSchema(collection, isDocumentDb)).toEqual([]);
 
     await collection.insertOne({});
-    expect(await inferCollectionSchema(collection)).toEqual([
+    expect(await inferCollectionSchema(collection, isDocumentDb)).toEqual([
       { name: '_id', sqlite_type: 2, type: 'ObjectId', internal_type: 'ObjectId', pg_type: 'ObjectId' }
     ]);
   });
@@ -107,7 +110,7 @@ describe('collection schema inference', () => {
       const collection = await db.createCollection('collation', { collation: { locale: 'en', strength: 1 } });
       await collection.insertOne({ Name: 'text', name: 1, 'with.dot': true, $field: [] });
 
-      const columns = await inferCollectionSchema(collection);
+      const columns = await inferCollectionSchema(collection, isDocumentDb);
       expect(columns).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ name: 'Name', sqlite_type: 2 }),
@@ -140,7 +143,7 @@ describe('collection schema inference', () => {
       }
     });
 
-    expect(await inferCollectionSchema(collection)).toMatchObject([
+    expect(await inferCollectionSchema(collection, isDocumentDb)).toMatchObject([
       { name: '_id', sqlite_type: 2, internal_type: 'ObjectId' },
       { name: 'array', sqlite_type: 2, internal_type: 'Array' },
       { name: 'binary', sqlite_type: 1, internal_type: 'Binary' },


### PR DESCRIPTION
Previously, schema detection fetched full MongoDB documents and inspected them in the service.

With large documents, even a small sample could use a lot of memory just to work out the field names and types.

This moves schema detection into a MongoDB aggregation query, so the service only receives the field names and detected types. Memory usage in the service now scales with the inferred schema rather than the size of the sampled documents.

AI Usage: Implemented with Codex gpt-6. Manually tested and verified. 