### PR TITLE
Fix some MySQL test stability issues

### DIFF
--- a/.changeset/pretty-snakes-knock.md
+++ b/.changeset/pretty-snakes-knock.md
@@ -1,0 +1,5 @@
+---
+'@powersync/service-module-mysql': patch
+---
+
+Fix MySQL queue drain when exceeding queue capacity.

--- a/modules/module-mysql/src/replication/zongji/BinLogListener.ts
+++ b/modules/module-mysql/src/replication/zongji/BinLogListener.ts
@@ -352,7 +352,11 @@ export class BinLogListener {
           `BinLog processing queue has reached its memory limit of [${this.connectionManager.options.binlog_queue_memory_limit}MB]. Pausing BinLog Listener.`
         );
         await this.stopZongji();
-        await this.processingQueue.drain();
+        // The queue may have drained while waiting for Zongji's stop acknowledgement.
+        // drain() only waits for future events, so do not wait on an already idle queue.
+        if (!this.processingQueue.idle()) {
+          await this.processingQueue.drain();
+        }
         this.logger.info(`BinLog processing queue backlog cleared. Resuming BinLog Listener.`);
         await this.restartZongji();
       }

--- a/modules/module-mysql/test/src/BinLogListener_queue.test.ts
+++ b/modules/module-mysql/test/src/BinLogListener_queue.test.ts
@@ -1,0 +1,62 @@
+import { ReplicatedGTID } from '@module/common/ReplicatedGTID.js';
+import { MySQLConnectionManager } from '@module/replication/MySQLConnectionManager.js';
+import { BinLogListener } from '@module/replication/zongji/BinLogListener.js';
+import { ZongJi } from '@powersync/mysql-zongji';
+import { EventEmitter } from 'node:events';
+import { setImmediate } from 'node:timers/promises';
+import { expect, test, vi } from 'vitest';
+import { TEST_CONNECTION_OPTIONS, TestBinLogEventHandler } from './util.js';
+
+test.each(['before', 'after'] as const)('restarts when the queue drains %s Zongji stops', async (drainOrder) => {
+  const manager = new MySQLConnectionManager({ ...TEST_CONNECTION_OPTIONS, binlog_queue_memory_limit: 1 }, {});
+  const stopStarted = Promise.withResolvers<void>();
+  const processEvent = Promise.withResolvers<void>();
+  // Control the external listener's stop acknowledgement independently of the
+  // real processing queue: MySQL can acknowledge KILL after the queue drains.
+  const zongji = Object.assign(new EventEmitter(), {
+    stopped: false,
+    ctrlConnection: {},
+    stop() {
+      this.stopped = true;
+      stopStarted.resolve();
+    }
+  });
+  vi.spyOn(manager, 'createBinlogListener').mockImplementation(() => zongji as unknown as ZongJi);
+  const handler = new TestBinLogEventHandler();
+  vi.spyOn(handler, 'onKeepAlive').mockImplementation(() => processEvent.promise);
+  const listener = new BinLogListener({
+    connectionManager: manager,
+    eventHandler: handler,
+    sourceTables: [],
+    serverId: 1,
+    activeServerUuid: 'test',
+    startGTID: ReplicatedGTID.ZERO('test')
+  });
+  const restart = vi.spyOn(listener, 'start').mockResolvedValue();
+
+  try {
+    const drained = listener.processingQueue.drain();
+    zongji.emit('binlog', { getEventName: () => 'heartbeat', size: 1024 * 1024 });
+    await stopStarted.promise;
+    if (drainOrder === 'before') {
+      processEvent.resolve();
+      await drained;
+      expect(listener.processingQueue.idle()).toBe(true);
+      zongji.emit('stopped');
+    } else {
+      zongji.emit('stopped');
+      // Let stopZongji return while the queue worker is still blocked.
+      await setImmediate();
+      expect(listener.processingQueue.running()).toBe(1);
+      expect(restart).not.toHaveBeenCalled();
+      processEvent.resolve();
+    }
+    await vi.waitFor(() => expect(restart).toHaveBeenCalledExactlyOnceWith(true));
+    expect(listener.queueMemoryUsage).toBe(0);
+  } finally {
+    processEvent.resolve();
+    zongji.emit('stopped');
+    await listener.stop();
+    await manager.end();
+  }
+});

--- a/modules/module-mysql/test/src/schema-changes.test.ts
+++ b/modules/module-mysql/test/src/schema-changes.test.ts
@@ -319,10 +319,11 @@ function defineTests(config: storage.TestStorageConfig) {
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t1','test1')`);
 
     await context.replicateSnapshot();
-    await context.startStreaming();
 
     await connectionManager.query(`ALTER TABLE test_data ADD COLUMN new_column TEXT`);
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t2','test2')`);
+    // Replay the DDL after the insert commits so the replacement snapshot includes it.
+    await context.startStreaming();
 
     const data = await context.getBucketData('global[]');
 
@@ -349,43 +350,54 @@ function defineTests(config: storage.TestStorageConfig) {
     ]);
   });
 
-  test('Change Replication Identity from full to index by adding a unique constraint', async () => {
-    await using context = await BinlogStreamTestContext.open(factory);
-    // Change replica id full by adding a unique index that can serve as the replication id
+  test.each([true, false])(
+    'Change Replication Identity from full to index by adding a unique constraint (insert in snapshot: %s)',
+    async (insertInSnapshot) => {
+      await using context = await BinlogStreamTestContext.open(factory);
+      // Change replica id full by adding a unique index that can serve as the replication id
 
-    await context.updateSyncRules(BASIC_SYNC_RULES);
+      await context.updateSyncRules(BASIC_SYNC_RULES);
 
-    const { connectionManager } = context;
-    // No primary key, no unique column, so full replication identity will be used
-    await connectionManager.query(`CREATE TABLE test_data (id CHAR(36), description TEXT)`);
-    await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t1','test1')`);
+      const { connectionManager } = context;
+      // No primary key, no unique column, so full replication identity will be used
+      await connectionManager.query(`CREATE TABLE test_data (id CHAR(36), description TEXT)`);
+      await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t1','test1')`);
 
-    await context.replicateSnapshot();
-    await context.startStreaming();
+      await context.replicateSnapshot();
 
-    await connectionManager.query(`ALTER TABLE test_data ADD UNIQUE (id)`);
-    await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t2','test2')`);
+      await connectionManager.query(`ALTER TABLE test_data ADD UNIQUE (id)`);
+      if (!insertInSnapshot) {
+        await context.startStreaming();
+        // Wait for the replacement snapshot before inserting the new row.
+        await context.getCheckpoint();
+      }
+      await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t2','test2')`);
+      if (insertInSnapshot) {
+        // Commit the insert before replaying the DDL so the snapshot must include it.
+        await context.startStreaming();
+      }
 
-    const data = await context.getBucketData('global[]');
-    const reduced = test_utils.reduceBucket(data).slice(1);
-    expect(reduced.sort(compareIds)).toMatchObject([PUT_T1, PUT_T2]);
+      const data = await context.getBucketData('global[]');
+      const reduced = test_utils.reduceBucket(data).slice(1);
+      expect(reduced.sort(compareIds)).toMatchObject([PUT_T1, PUT_T2]);
 
-    expect(data.slice(0, 2)).toMatchObject([
-      // Initial inserts
-      PUT_T1,
-      // Truncate
-      REMOVE_T1
-    ]);
+      expect(data.slice(0, 2)).toMatchObject([
+        // Initial inserts
+        PUT_T1,
+        // Truncate
+        REMOVE_T1
+      ]);
 
-    // Snapshot - order doesn't matter
-    expect(data.slice(2)).toMatchObject([
-      // Snapshot inserts
-      PUT_T1,
-      PUT_T2,
-      // Replicated insert
-      PUT_T2
-    ]);
-  });
+      // Snapshot - order doesn't matter
+      expect(data.slice(2)).toMatchObject([
+        // Snapshot inserts
+        PUT_T1,
+        ...(insertInSnapshot ? [PUT_T2] : []),
+        // Replicated insert
+        PUT_T2
+      ]);
+    }
+  );
 
   test('Change Replication Identity from full to index by adding a unique index', async () => {
     await using context = await BinlogStreamTestContext.open(factory);
@@ -398,10 +410,11 @@ function defineTests(config: storage.TestStorageConfig) {
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t1','test1')`);
 
     await context.replicateSnapshot();
-    await context.startStreaming();
 
     await connectionManager.query(`CREATE UNIQUE INDEX id_idx ON test_data (id)`);
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t2','test2')`);
+    // Replay the DDL after the insert commits so the replacement snapshot includes it.
+    await context.startStreaming();
 
     const data = await context.getBucketData('global[]');
     const reduced = test_utils.reduceBucket(data).slice(1);
@@ -436,10 +449,11 @@ function defineTests(config: storage.TestStorageConfig) {
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t1','test1')`);
 
     await context.replicateSnapshot();
-    await context.startStreaming();
 
     await connectionManager.query(`ALTER TABLE test_data DROP INDEX id`);
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t2','test2')`);
+    // Replay the DDL after the insert commits so the replacement snapshot includes it.
+    await context.startStreaming();
 
     const data = await context.getBucketData('global[]');
     const reduced = test_utils.reduceBucket(data).slice(1);
@@ -471,10 +485,11 @@ function defineTests(config: storage.TestStorageConfig) {
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t1','test1')`);
 
     await context.replicateSnapshot();
-    await context.startStreaming();
 
     await connectionManager.query(`ALTER TABLE test_data MODIFY COLUMN id VARCHAR(36)`);
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t2','test2')`);
+    // Replay the DDL after the insert commits so the replacement snapshot includes it.
+    await context.startStreaming();
 
     const data = await context.getBucketData('global[]');
     const reduced = test_utils.reduceBucket(data).slice(1);
@@ -513,8 +528,11 @@ function defineTests(config: storage.TestStorageConfig) {
     await context.startStreaming();
 
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t2','test2')`);
+    await context.getCheckpoint();
 
     await connectionManager.query(`ALTER TABLE test_data MODIFY COLUMN id VARCHAR(36)`);
+    // Finish the replacement snapshot before inserting t3, which is streamed once.
+    await context.getCheckpoint();
     await connectionManager.query(`INSERT INTO test_data(id, description) VALUES('t3','test3')`);
 
     const data = await context.getBucketData('global[]');
@@ -535,9 +553,9 @@ function defineTests(config: storage.TestStorageConfig) {
     ]);
 
     // Snapshot - order doesn't matter
-    expect(data.slice(4, 7).sort(compareIds)).toMatchObject([PUT_T1, PUT_T2, PUT_T3]);
+    expect(data.slice(4, 6).sort(compareIds)).toMatchObject([PUT_T1, PUT_T2]);
 
-    expect(data.slice(7).sort(compareIds)).toMatchObject([
+    expect(data.slice(6).sort(compareIds)).toMatchObject([
       // Replicated insert
       PUT_T3
     ]);


### PR DESCRIPTION
While debugging different test stability issues, Codex also found these MySQL test issues.

One issue is a real bug: `queue.drain()` doesn't return if there is nothing in the queue to process. This is unexpected, but is mentioned as the intended behavior: [#1833](https://github.com/caolan/async/issues/1833#issuecomment-1114344864). Actually triggering this in production is likely rare in practice:
1. Incoming events reach the queue limit of 50MB, so we stop the binlog reader to let processing catch up.
2. Stopping is asynchronous: we wait for Zongji’s stop acknowledgement while queued events continue processing.
3. The queue finishes processing before that acknowledgement arrives.
4. The old code then calls `await queue.drain()`, which waits for another drain event.
5. The reader is stopped, so no new events arrive to produce that event. The restart is never reached.

What makes this unlikely is that we'd need to process 50MB of data in the time it takes to stop Zongji, but it is theoretically possible. In the tests we use 1 MB limit and a test event handler, which makes it much more likely to happen.

The other issues are primarily around event ordering in tests. The changes here make the test ordering more predictable. By starting streaming replication later, it effectively tests fewer combinations now, but it now always hits the case we are testing for.

## AI Usage

Issues found and fixed using Codex gpt-6-astra. Manually reviewed.