### PR TITLE
Avoid forcing chunk compaction after initial replication

### DIFF
--- a/.changeset/ready-bananas-thank.md
+++ b/.changeset/ready-bananas-thank.md
@@ -1,0 +1,6 @@
+---
+'@powersync/service-module-mongodb-storage': patch
+'@powersync/service-core': patch
+---
+
+Skip chunk-merge compact for small buckets after initial replication.

--- a/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/MongoCompactor.ts
@@ -16,6 +16,8 @@ export interface MongoCompactOptions extends storage.CompactOptions {
    * the lightweight pass.
    */
   compactChunksOnly?: boolean;
+  /** Internal/testing use: bypass the new-chunk threshold during chunk-only compaction. */
+  forceChunkCompaction?: boolean;
 }
 
 const DEFAULT_CLEAR_BATCH_LIMIT = 5000;

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/MongoCompactorV3.ts
@@ -1,18 +1,11 @@
 import { mongo } from '@powersync/lib-service-mongodb';
 import { ReplicationAssertionError, ServiceAssertionError } from '@powersync/lib-services-framework';
-import {
-  acquireSemaphoreAbortable,
-  addChecksums,
-  formatBytes,
-  InternalOpId,
-  storage,
-  utils
-} from '@powersync/service-core';
+import { acquireSemaphoreAbortable, addChecksums, formatBytes, InternalOpId, utils } from '@powersync/service-core';
 import { BucketDefinitionId } from '@powersync/service-sync-rules';
 import { setImmediate } from 'node:timers/promises';
 import { BucketDataDoc } from '../common/BucketDataDoc.js';
 import { BucketDataKey } from '../models.js';
-import { ConcurrentCompactionError, MongoCompactor } from '../MongoCompactor.js';
+import { ConcurrentCompactionError, MongoCompactOptions, MongoCompactor } from '../MongoCompactor.js';
 import { MongoWriteBatch } from '../MongoWriteBatch.js';
 import { cacheKey } from '../OperationBatch.js';
 import { loadBucketDataDocument, maxOpId, serializeBucketData } from './bucket-format.js';
@@ -23,6 +16,7 @@ import {
   bucketStats,
   BucketStatsWithChecksum,
   chooseCompactionKind,
+  chooseRequestedCompactionKind,
   combineAdjacentStats,
   combineChunkStats,
   CompactIntervalConfig,
@@ -33,7 +27,6 @@ import {
   CompactTargetConfig,
   emptyBucketStats,
   firstUncompactedWrite,
-  forcedCompactionKind,
   PendingCompactionGroup,
   readCompactionBatch,
   ScheduledCompactionOptions,
@@ -78,15 +71,17 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
   readonly maxCompactFullIntervalMs: number;
   readonly compactLeaseDurationMs: number;
   readonly maxOpIdCap: InternalOpId | undefined;
+  readonly forceChunkCompaction: boolean;
   private readonly objectStorageUsage: ObjectStorageUsage;
 
-  constructor(bucketStorage: MongoSyncBucketStorageV3, db: VersionedPowerSyncMongoV3, options: storage.CompactOptions) {
+  constructor(bucketStorage: MongoSyncBucketStorageV3, db: VersionedPowerSyncMongoV3, options: MongoCompactOptions) {
     super(bucketStorage, db, options);
     this.minCompactChunkIntervalMs = options.minCompactChunkIntervalMs ?? DEFAULT_MIN_COMPACT_CHUNK_INTERVAL_MS;
     this.minCompactFullIntervalMs = options.minCompactFullIntervalMs ?? DEFAULT_MIN_COMPACT_FULL_INTERVAL_MS;
     this.maxCompactFullIntervalMs = options.maxCompactFullIntervalMs ?? DEFAULT_MAX_COMPACT_FULL_INTERVAL_MS;
     this.compactLeaseDurationMs = options.compactLeaseDurationMs ?? DEFAULT_COMPACT_LEASE_DURATION_MS;
     this.maxOpIdCap = options.maxOpId;
+    this.forceChunkCompaction = options.forceChunkCompaction ?? false;
     this.objectStorageUsage = new ObjectStorageUsage(this.db, this.group_id, createObjectStorageUsageWriterId());
   }
 
@@ -113,7 +108,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
       // processes the work that existed when it started.
       await this.compactScheduledBuckets({
         dueAheadMs: DEFAULT_MIN_COMPACT_CHUNK_INTERVAL_MS,
-        forceKind: CompactionKind.Chunks
+        requestedKind: CompactionKind.Chunks
       });
     } else {
       await this.compactScheduledBuckets();
@@ -187,7 +182,7 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
     // the exact initial-replication interval.
     const jobStartedAt = await this.readCompactionTime();
     const dueBefore = new Date(jobStartedAt.getTime() + (options.dueAheadMs ?? 0));
-    const forceKind = options.forceKind;
+    const requestedKind = options.requestedKind;
     const rescheduleNotBefore = new Date(dueBefore.getTime() + 1);
     // Keep accounting documents bounded by workers, not buckets or scan batches.
     const workerUsage = Array.from(
@@ -207,31 +202,31 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
       const scheduled: {
         state: BucketStateDocumentV3;
         decision: CompactionDecision;
-        forcedKind: CompactionKind | null;
+        selectedKind: CompactionKind | null;
       }[] = [];
       for (const state of states) {
         try {
           scheduled.push({
             state,
             decision: chooseCompactionKind(state, batchStartedAt, this),
-            forcedKind: forcedCompactionKind(state, forceKind, this)
+            selectedKind: chooseRequestedCompactionKind(state, requestedKind, this)
           });
         } catch (error) {
           await this.rescheduleFailedBucket(state, rescheduleNotBefore, error);
         }
       }
       const noOpStates = scheduled.filter(
-        ({ state, decision, forcedKind }) =>
-          state.compact_lease == null && (forceKind == null ? decision.kind : forcedKind) == null
+        ({ state, decision, selectedKind }) =>
+          state.compact_lease == null && (requestedKind == null ? decision.kind : selectedKind) == null
       );
       await this.rescheduleUnclaimedBuckets(noOpStates, rescheduleNotBefore);
 
       const processBucket = async (
-        { state, decision, forcedKind }: (typeof scheduled)[number],
+        { state, decision, selectedKind }: (typeof scheduled)[number],
         objectStorageUsage: ObjectStorageUsage,
         chunksOnly = false
       ) => {
-        const kind = forceKind == null ? decision.kind : forcedKind;
+        const kind = requestedKind == null ? decision.kind : selectedKind;
         if (state.compact_lease == null && kind == null) {
           return;
         }
@@ -243,7 +238,9 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
           }
           const claimedDecision = chooseCompactionKind(lease.state, lease.startedAt, this);
           const claimedKind =
-            forceKind == null ? claimedDecision.kind : forcedCompactionKind(lease.state, forceKind, this);
+            requestedKind == null
+              ? claimedDecision.kind
+              : chooseRequestedCompactionKind(lease.state, requestedKind, this);
           if (chunksOnly && claimedKind === CompactionKind.Full) {
             // The decision changed after scanning. Release the lease without
             // rescheduling; the next batch will classify it with a fresh timestamp.
@@ -275,10 +272,10 @@ export class MongoCompactorV3 extends MongoCompactor implements CompactIntervalC
       };
 
       const chunkBuckets = scheduled.filter(
-        ({ decision, forcedKind }) => (forceKind == null ? decision.kind : forcedKind) === CompactionKind.Chunks
+        ({ decision, selectedKind }) => (requestedKind == null ? decision.kind : selectedKind) === CompactionKind.Chunks
       );
       const sequentialBuckets = scheduled.filter(
-        ({ decision, forcedKind }) => (forceKind == null ? decision.kind : forcedKind) !== CompactionKind.Chunks
+        ({ decision, selectedKind }) => (requestedKind == null ? decision.kind : selectedKind) !== CompactionKind.Chunks
       );
       await this.runChunkCompactionWorkers(chunkBuckets, workerUsage, (entry, usage) =>
         processBucket(entry, usage, true)

--- a/modules/module-mongodb-storage/src/storage/implementation/v3/compact-utils.ts
+++ b/modules/module-mongodb-storage/src/storage/implementation/v3/compact-utils.ts
@@ -35,6 +35,7 @@ export interface CompactIntervalConfig {
 }
 export interface CompactTargetConfig {
   readonly maxOpIdCap: InternalOpId | undefined;
+  readonly forceChunkCompaction?: boolean;
 }
 
 export enum CompactionKind {
@@ -51,7 +52,7 @@ export interface ScheduledCompactionOptions {
   /** Process checks scheduled this far after the captured job start. */
   dueAheadMs?: number;
   /** Used by initial replication, which must not run a full compact. */
-  forceKind?: CompactionKind;
+  requestedKind?: CompactionKind;
 }
 
 export class CompactionContext {
@@ -243,8 +244,7 @@ export function chooseCompactionKind(
   // not wake before the exact full-compaction condition is true.
   const fullCheckWithMargin = new Date(fullCheckAt.getTime() + FULL_COMPACT_RESCHEDULE_MARGIN_MS);
   const compacted = state.compacted_state;
-  const chunksSinceCompact = Math.max(0, state.bucket_stats.chunks - (compacted?.chunks ?? 0));
-  const shouldCompactChunks = chunksSinceCompact >= MERGE_CHUNKS_THRESHOLD;
+  const shouldCompactChunks = hasEnoughChunksToMerge(state);
   const canCheckChunks =
     compacted == null || now.getTime() - compacted.at.getTime() >= config.minCompactChunkIntervalMs;
   // Too few new chunks cannot make chunk compaction eligible. Do not poll this
@@ -269,16 +269,25 @@ export function chooseCompactionKind(
   };
 }
 
-export function forcedCompactionKind(
+export function chooseRequestedCompactionKind(
   state: BucketStateDocumentV3,
-  forceKind: CompactionKind | undefined,
+  requestedKind: CompactionKind | undefined,
   config: CompactTargetConfig
 ): CompactionKind | null {
-  if (forceKind == null) {
+  if (requestedKind == null) {
+    return null;
+  }
+  // Initial replication bypasses the interval and never runs full compaction,
+  // but small buckets should still use the normal bulk-rescheduling path.
+  if (requestedKind == CompactionKind.Chunks && !config.forceChunkCompaction && !hasEnoughChunksToMerge(state)) {
     return null;
   }
   const maxOpId = config.maxOpIdCap == null || state.last_op < config.maxOpIdCap ? state.last_op : config.maxOpIdCap;
-  return state.compacted_state == null || state.compacted_state.op_id < maxOpId ? forceKind : null;
+  return state.compacted_state == null || state.compacted_state.op_id < maxOpId ? requestedKind : null;
+}
+
+function hasEnoughChunksToMerge(state: BucketStateDocumentV3): boolean {
+  return state.bucket_stats.chunks - (state.compacted_state?.chunks ?? 0) >= MERGE_CHUNKS_THRESHOLD;
 }
 
 /**

--- a/modules/module-mongodb-storage/test/src/compact-utils.test.ts
+++ b/modules/module-mongodb-storage/test/src/compact-utils.test.ts
@@ -3,12 +3,12 @@ import {
   applyStatsReplacement,
   bucketStats,
   chooseCompactionKind,
+  chooseRequestedCompactionKind,
   combineAdjacentStats,
   combineChunkStats,
   CompactIntervalConfig,
   CompactionKind,
   emptyBucketStats,
-  forcedCompactionKind,
   fullCompactionCheckAt,
   statsForDocument,
   statsForDocuments
@@ -130,44 +130,69 @@ describe('V3 compact utilities', () => {
   test.each([
     {
       name: 'does not force an unspecified kind',
-      forceKind: undefined,
+      requestedKind: undefined,
       compactedOpId: undefined,
       maxOpIdCap: undefined,
       expected: null
     },
     {
       name: 'forces work without previous compacted state',
-      forceKind: CompactionKind.Chunks,
+      requestedKind: CompactionKind.Chunks,
       compactedOpId: undefined,
       maxOpIdCap: undefined,
       expected: CompactionKind.Chunks
     },
     {
       name: 'skips work already compacted through the cap',
-      forceKind: CompactionKind.Chunks,
+      requestedKind: CompactionKind.Chunks,
       compactedOpId: 5n,
       maxOpIdCap: 5n,
       expected: null
     },
     {
       name: 'skips work already compacted through the bucket head',
-      forceKind: CompactionKind.Chunks,
+      requestedKind: CompactionKind.Chunks,
       compactedOpId: 10n,
       maxOpIdCap: undefined,
       expected: null
     },
     {
       name: 'forces work beyond the compacted state',
-      forceKind: CompactionKind.Chunks,
+      requestedKind: CompactionKind.Chunks,
       compactedOpId: 5n,
       maxOpIdCap: 6n,
       expected: CompactionKind.Chunks
     }
-  ])('$name', ({ forceKind, compactedOpId, maxOpIdCap, expected }) => {
+  ])('$name', ({ requestedKind, compactedOpId, maxOpIdCap, expected }) => {
     const state = bucketState({
+      bucket_stats: { count: 10, bytes: 100n, chunks: 9 },
       compacted_state: compactedOpId == null ? undefined : compactedState({ op_id: compactedOpId })
     });
-    expect(forcedCompactionKind(state, forceKind, { maxOpIdCap })).toBe(expected);
+    expect(chooseRequestedCompactionKind(state, requestedKind, { maxOpIdCap })).toBe(expected);
+  });
+
+  test.each([undefined, compactedState({ at: new Date() })])(
+    'initial chunk compaction requires eight new chunks, regardless of the interval: %o',
+    (compacted) => {
+      for (const newChunks of [1, 7, 8]) {
+        const state = bucketState({
+          bucket_stats: { count: 10, bytes: 100n, chunks: (compacted?.chunks ?? 0) + newChunks },
+          compacted_state: compacted
+        });
+        expect(chooseRequestedCompactionKind(state, CompactionKind.Chunks, { maxOpIdCap: undefined })).toBe(
+          newChunks < 8 ? null : CompactionKind.Chunks
+        );
+      }
+    }
+  );
+
+  test('the testing override bypasses the chunk threshold but preserves the compaction watermark', () => {
+    const state = bucketState();
+    const config = { maxOpIdCap: undefined, forceChunkCompaction: true };
+    expect(chooseRequestedCompactionKind(state, CompactionKind.Chunks, config)).toBe(CompactionKind.Chunks);
+    expect(chooseRequestedCompactionKind(state, undefined, config)).toBeNull();
+    state.compacted_state = compactedState({ op_id: state.last_op });
+    expect(chooseRequestedCompactionKind(state, CompactionKind.Chunks, config)).toBeNull();
   });
 
   test('derives and combines bucket statistics', () => {

--- a/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
+++ b/modules/module-mongodb-storage/test/src/storage_compacting.test.ts
@@ -170,9 +170,10 @@ bucket_definitions:
       await populate(bucketStorage, 2);
       const { checkpoint } = await bucketStorage.getCheckpoint();
 
-      // V3's initial lite pass processes every bucket with no prior compact state.
+      // Force V3's initial lite pass to process these small buckets for cache verification.
       // Earlier storage versions use the default minimum-change threshold.
       const result0 = await bucketStorage.compactInitialReplication({
+        forceChunkCompaction: true,
         maxOpId: checkpoint
       });
       expect(result0.buckets).toEqual(storageVersion >= storage.STORAGE_VERSION_3 ? 2 : 0);
@@ -180,6 +181,7 @@ bucket_definitions:
       // For V1/V2, lower the threshold to populate the checksum cache. V3 has
       // already updated its compacted state, so another initial pass is a no-op.
       const result1 = await bucketStorage.compactInitialReplication({
+        forceChunkCompaction: true,
         maxOpId: checkpoint,
         minBucketChanges: 1
       });
@@ -187,6 +189,7 @@ bucket_definitions:
 
       // Repeating it stays a no-op.
       const result2 = await bucketStorage.compactInitialReplication({
+        forceChunkCompaction: true,
         maxOpId: checkpoint,
         minBucketChanges: 1
       });
@@ -214,6 +217,7 @@ bucket_definitions:
         .createMongoCompactor({
           maxOpId: checkpoint,
           compactChunksOnly: true,
+          forceChunkCompaction: true,
           minCompactChunkIntervalMs: 1
         })
         .compact();
@@ -223,7 +227,10 @@ bucket_definitions:
 
     test('v3 repeated initial chunk compaction reschedules overdue full work beyond the current run', async () => {
       const { bucketStorage, checkpoint } = await setup(storage.STORAGE_VERSION_3);
-      const firstResult = await bucketStorage.compactInitialReplication({ maxOpId: checkpoint });
+      const firstResult = await bucketStorage.compactInitialReplication({
+        forceChunkCompaction: true,
+        maxOpId: checkpoint
+      });
       expect(firstResult.buckets).toBe(2);
 
       const bucketStateCollection = (bucketStorage.db as VersionedPowerSyncMongoV3).bucketState(
@@ -243,6 +250,7 @@ bucket_definitions:
         .aggregate<{ now: Date }>([{ $documents: [{}] }, { $project: { _id: 0, now: '$$NOW' } }])
         .toArray();
       const result = await bucketStorage.compactInitialReplication({
+        forceChunkCompaction: true,
         maxOpId: checkpoint,
         signal: AbortSignal.timeout(2_000)
       });
@@ -388,6 +396,91 @@ bucket_definitions:
     });
   }
 
+  test.each([1, 7])(
+    'initial compaction bulk-reschedules buckets with %s chunks without reading data',
+    async (chunks) => {
+      const { bucketStorage, collection, bucketStateCollection, ctx, sourceTableId, db } = await setupV3Storage();
+      const documents = Array.from({ length: chunks }, (_, index) =>
+        serializeBucketData(BUCKET, [makeOp(index + 1, String(index), 'data', ctx, sourceTableId)])
+      );
+      await insertDocs(collection, documents);
+      await bucketStateCollection.insertOne({
+        _id: { d: ctx.definitionId, b: BUCKET },
+        last_op: BigInt(chunks),
+        next_compact_check: new Date(0),
+        // Even overdue full compaction must not force a small initial chunk merge.
+        first_uncompacted_write: new Date(0),
+        bucket_stats: { count: chunks, bytes: BigInt(documents.reduce((sum, doc) => sum + doc.size, 0)), chunks }
+      });
+      const claim = vi.spyOn(CompactionLease, 'claim');
+      const data = vi.spyOn(db, 'bucketData');
+      try {
+        expect(await bucketStorage.compactInitialReplication({ maxOpId: BigInt(chunks) })).toEqual({ buckets: 0 });
+        expect(claim).not.toHaveBeenCalled();
+        expect(data).not.toHaveBeenCalled();
+        const state = await bucketStateCollection.findOne({ _id: { d: ctx.definitionId, b: BUCKET } });
+        expect(state?.compacted_state).toBeUndefined();
+        expect(state?.compact_lease).toBeUndefined();
+        expect(state?.last_full_compact).toBeUndefined();
+        expect(state!.next_compact_check!.getTime()).toBeGreaterThan(Date.now());
+        expect(await collection.find().toArray()).toEqual(documents);
+      } finally {
+        claim.mockRestore();
+        data.mockRestore();
+      }
+    }
+  );
+
+  test('initial compaction rechecks the chunk threshold after claiming', async () => {
+    const { bucketStorage, collection, bucketStateCollection, ctx, sourceTableId, db } = await setupV3Storage();
+    const documents = Array.from({ length: 8 }, (_, index) =>
+      serializeBucketData(BUCKET, [makeOp(index + 1, String(index), 'data', ctx, sourceTableId)])
+    );
+    await insertDocs(collection, documents);
+    const bytes = BigInt(documents.reduce((sum, doc) => sum + doc.size, 0));
+    await bucketStateCollection.insertOne({
+      _id: { d: ctx.definitionId, b: BUCKET },
+      last_op: 8n,
+      next_compact_check: new Date(0),
+      first_uncompacted_write: new Date(),
+      bucket_stats: { count: 8, bytes, chunks: 8 }
+    });
+    const originalClaim = CompactionLease.claim.bind(CompactionLease);
+    const claim = vi.spyOn(CompactionLease, 'claim').mockImplementationOnce(async (...args) => {
+      // Another compactor finishes before we acquire the lease, leaving one
+      // new chunk beyond its cached prefix instead of the eight we selected.
+      await bucketStateCollection.updateOne(
+        { _id: { d: ctx.definitionId, b: BUCKET } },
+        {
+          $set: {
+            compacted_state: {
+              op_id: 7n,
+              checksum: 196n,
+              count: 7,
+              bytes: bytes - BigInt(documents[7].size),
+              chunks: 7,
+              at: new Date()
+            }
+          }
+        }
+      );
+      return originalClaim(...args);
+    });
+    const data = vi.spyOn(db, 'bucketData');
+    try {
+      expect(await bucketStorage.compactInitialReplication({ maxOpId: 8n })).toEqual({ buckets: 0 });
+      expect(claim).toHaveBeenCalledTimes(1);
+      expect(data).not.toHaveBeenCalled();
+      const state = await bucketStateCollection.findOne({ _id: { d: ctx.definitionId, b: BUCKET } });
+      expect(state?.compacted_state?.op_id).toBe(7n);
+      expect(state?.compact_lease).toBeUndefined();
+      expect(state!.next_compact_check!.getTime()).toBeGreaterThan(Date.now());
+    } finally {
+      claim.mockRestore();
+      data.mockRestore();
+    }
+  });
+
   test('a successful lease renewal clears a transient renewal error', async () => {
     const { bucketStateCollection, ctx } = await setupV3Storage();
     await insertBucketState(bucketStateCollection, ctx.definitionId, 1n);
@@ -449,7 +542,7 @@ bucket_definitions:
     );
 
     await (bucketStorage as MongoSyncBucketStorage)
-      .createMongoCompactor({ maxOpId: 2n, compactChunksOnly: true })
+      .createMongoCompactor({ maxOpId: 2n, compactChunksOnly: true, forceChunkCompaction: true })
       .compact();
 
     const [badState, goodState] = await Promise.all([
@@ -493,6 +586,7 @@ bucket_definitions:
         .createMongoCompactor({
           maxOpId: 2n,
           compactChunksOnly: true,
+          forceChunkCompaction: true,
           signal: abortController.signal,
           logger: testLogger
         })
@@ -1752,6 +1846,29 @@ bucket_definitions:
     expect(state?.bucket_stats).toEqual({ count: 4, bytes, chunks: documents.length });
   }
 
+  test('initial compaction merges eight chunks immediately without full compaction', async () => {
+    const { bucketStorage, collection, bucketStateCollection, ctx, sourceTableId } = await setupV3();
+    const inputs = Array.from({ length: 8 }, (_, index) =>
+      serializeBucketData(BUCKET, [makeOp(index + 1, 'A', 'data', ctx, sourceTableId)])
+    );
+    await insertDocs(collection, inputs);
+    await bucketStateCollection.insertOne({
+      _id: { d: ctx.definitionId, b: BUCKET },
+      last_op: 8n,
+      next_compact_check: new Date(),
+      first_uncompacted_write: new Date(0),
+      bucket_stats: { count: 8, bytes: BigInt(inputs.reduce((sum, doc) => sum + doc.size, 0)), chunks: 8 }
+    });
+
+    expect(await bucketStorage.compactInitialReplication({ maxOpId: 8n })).toEqual({ buckets: 1 });
+    const documents = await collection.find({ '_id.b': BUCKET }).toArray();
+    expect(documents).toHaveLength(1);
+    expect(documents[0].ops!.map((op) => op.o)).toEqual([1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n]);
+    const state = await bucketStateCollection.findOne({ _id: { d: ctx.definitionId, b: BUCKET } });
+    expect(state?.compacted_state).toMatchObject({ op_id: 8n, count: 8, checksum: 252n });
+    expect(state?.last_full_compact).toBeUndefined();
+  });
+
   test('initial compaction merges small chunks and refreshes bucket metadata', async () => {
     const { bucketStorage, collection, bucketStateCollection, ctx, sourceTableId } = await setupV3();
     await insertDocs(collection, [
@@ -1760,7 +1877,7 @@ bucket_definitions:
     ]);
     await insertBucketState(bucketStateCollection, ctx.definitionId, 4n);
 
-    const result = await bucketStorage.compactInitialReplication({ maxOpId: 4n });
+    const result = await bucketStorage.compactInitialReplication({ forceChunkCompaction: true, maxOpId: 4n });
 
     expect(result).toEqual({ buckets: 1 });
     const documents = await collection.find({ '_id.b': BUCKET }).sort({ '_id.o': 1 }).toArray();
@@ -1827,7 +1944,7 @@ bucket_definitions:
       Array.from({ length: 2 }, () =>
         bucketStorage.factory
           .getInstance(syncRules)
-          .compactInitialReplication({ maxOpId: 2n, signal: controller.signal })
+          .compactInitialReplication({ forceChunkCompaction: true, maxOpId: 2n, signal: controller.signal })
       )
     ).finally(() => {
       settled = true;
@@ -1858,7 +1975,9 @@ bucket_definitions:
       expect(results.every((result) => result.status === 'rejected')).toBe(true);
       expect(await bucketStateCollection.countDocuments({ compact_lease: { $exists: true } })).toBe(0);
       // Cancellation must return all worker slots.
-      expect(await bucketStorage.compactInitialReplication({ maxOpId: 2n })).toEqual({ buckets: bucketCount });
+      expect(await bucketStorage.compactInitialReplication({ forceChunkCompaction: true, maxOpId: 2n })).toEqual({
+        buckets: bucketCount
+      });
     } else {
       expect(results.every((result) => result.status === 'fulfilled')).toBe(true);
       expect(results.reduce((sum, result) => sum + (result.status === 'fulfilled' ? result.value.buckets : 0), 0)).toBe(
@@ -2048,7 +2167,7 @@ bucket_definitions:
       }
     });
 
-    const result = await bucketStorage.compactInitialReplication({ maxOpId: 4n });
+    const result = await bucketStorage.compactInitialReplication({ forceChunkCompaction: true, maxOpId: 4n });
 
     expect(result).toEqual({ buckets: 1 });
     const expectedStats = {
@@ -2167,9 +2286,9 @@ bucket_definitions:
       bucket_stats: { count: 4, bytes: 200n, chunks: 4 }
     });
 
-    await expect(bucketStorage.createMongoCompactor({ maxOpId: 4n, compactChunksOnly: true }).compact()).resolves.toBe(
-      1
-    );
+    await expect(
+      bucketStorage.createMongoCompactor({ maxOpId: 4n, compactChunksOnly: true, forceChunkCompaction: true }).compact()
+    ).resolves.toBe(1);
 
     const currentDocuments = await collection.find({ '_id.b': BUCKET }).sort({ '_id.o': 1 }).toArray();
     expect(currentDocuments.flatMap((document) => document.ops!.map((op) => op.o))).toEqual([1n, 3n, 4n]);
@@ -2189,7 +2308,8 @@ bucket_definitions:
     const { bucketStorage, collection, bucketStateCollection, ctx } = await setupCompactedTail();
     const failedCompactor = bucketStorage.createMongoCompactor({
       maxOpId: 4n,
-      compactChunksOnly: true
+      compactChunksOnly: true,
+      forceChunkCompaction: true
     });
     const originalFlush = (failedCompactor as any).flushCompactionGroup.bind(failedCompactor);
     const flushSpy = vi
@@ -2210,7 +2330,9 @@ bucket_definitions:
       { $set: { next_compact_check: new Date(0) } }
     );
 
-    const result = await bucketStorage.createMongoCompactor({ maxOpId: 4n, compactChunksOnly: true }).compact();
+    const result = await bucketStorage
+      .createMongoCompactor({ maxOpId: 4n, compactChunksOnly: true, forceChunkCompaction: true })
+      .compact();
 
     expect(result).toBe(1);
     await expectRecoveredCompactedTail(collection, bucketStateCollection, ctx.definitionId);

--- a/packages/service-core/src/storage/SyncRulesBucketStorage.ts
+++ b/packages/service-core/src/storage/SyncRulesBucketStorage.ts
@@ -402,6 +402,8 @@ export interface CompactOptions {
 }
 
 export interface CompactInitialReplicationOptions {
+  /** Internal/testing use: bypass the new-chunk threshold in MongoDB V3/V4 storage. */
+  forceChunkCompaction?: boolean;
   /**
    * Compact data up to this op id.
    *


### PR DESCRIPTION
The initial implementation of chunk-merge compaction conflated two intentions:
1. Chunk-merge compact after initial replication should ignore the minimum window before compacting.
2. Compact tests want to ignore the window _and_ ignore the 8-chunk threshold.

The same flag was used for both, meaning initial replication performed a chunk-merge compact for every replicated bucket. This is at minimum 3x mongodb operations with the current implementation: acquire a lease for the bucket; read the bucket data; update the bucket state. When we have millions of tiny buckets, this can take significantly longer than the initial replication itself.

The increased concurrency in #793 helps, but it doesn't remove the core problem: We're doing a lot of work here that we don't need.

This fixes the check to skip the window, but still take into account the 8-chunk threshold before deciding to chunk-merge compact a bucket after initial replication.

## AI Usage

Implemented using Codex gpt-6-astra. Manually reviewed.